### PR TITLE
Improve stringAppend performance

### DIFF
--- a/runtime/src/lib/strings.js
+++ b/runtime/src/lib/strings.js
@@ -8,7 +8,7 @@ export function stringAppend(s1, s2) {
   assertString(s2);
   s1 = grainToJSVal(s1);
   s2 = grainToJSVal(s2);
-  let appended = s1.concat(s2);
+  let appended = s1 + s2;
   let ret = JSToGrainVal(appended);
   return ret;
 }


### PR DESCRIPTION
Problem: String `concat()` method is [very slow](https://jsperf.com/concat-vs-plus-vs-join)
Solution: replace String `concat()` method with the assignment operator