### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # dockerignore
+.git
 *.dockerfile
 docker-compose.yml
 Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# dockerignore
+*.dockerfile
+docker-compose.yml
+Dockerfile
+
+# gitignore
+main
+*.install
+output/*.o
+output/*.run
+output/*.s
+output/*.dSYM
+script/node_modules
+.installed-pkgs
+*.sw*
+*~
+*.o
+*.log
+_build/*
+.installed-pkgs
+notes.org
+**/node_modules/**/*
+*.wasm
+*.wasm.wast
+*.wasm.modsig
+.tern-port
+setup.data
+setup.ml
+myocamlbuild.ml
+.merlin
+runtime/dist
+script/public/javascripts/grain-runtime.js
+script/public/javascripts/grain-runtime-browser.js
+/*.gr

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ RUN npm install && \
 
 # SETUP FOR END USER
 WORKDIR /root
-ENTRYPOINT ["/bin/bash"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# TEMPORARY CONTAINER USED TO BUILD GRAIN
+FROM ocaml/opam2:4.05 as compiler
+
+# INSTALL SYSTEM DEPENDECIES
+USER root
+RUN apt-get install m4 -y
+
+# COPY REPOSITORY INTO IMAGE
+WORKDIR /opt/grain
+COPY . .
+RUN chown -R opam .
+USER opam
+
+# INSTALL OPAM DEPENDECIES
+RUN eval $(opam env) && opam install . --deps-only -y
+
+# BUILD GRAIN COMPILER DEPENDECIES
+RUN eval $(opam env) && make
+
+# SWITCH TO NODE IMAGE
+FROM node:10.7
+
+# COPY ONLY NEEDED FILES TO THIS IMAGE
+WORKDIR /opt/grain
+COPY --from=compiler /opt/grain/cli ./cli
+COPY --from=compiler /opt/grain/runtime ./runtime
+COPY --from=compiler /opt/grain/_build ./_build
+
+# ADD COMPILER TO PATH
+ENV PATH="/opt/grain/_build/install/default/bin:${PATH}"
+
+# INSTALL RUNTIME
+WORKDIR /opt/grain/runtime
+RUN npm install
+RUN npm run build
+
+# INSTALL CLI
+WORKDIR /opt/grain/cli
+RUN npm install
+RUN ln -s $PWD/bin/grain.js ../grain
+ENV PATH="/opt/grain:${PATH}"
+
+# SETUP FOR END USER
+WORKDIR /root
+RUN echo '3 + 3' > test.gr
+RUN grainc test.gr
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# TEMPORARY CONTAINER USED TO BUILD GRAIN
+# TEMPORARY IMAGE USED TO BUILD GRAIN
 FROM ocaml/opam2:4.05 as compiler
 
 # INSTALL SYSTEM DEPENDECIES
@@ -20,28 +20,30 @@ RUN eval $(opam env) && make
 # SWITCH TO NODE IMAGE
 FROM node:10.7
 
+# ADD EDITOR FOR CONVENIENCE
+RUN apt-get update && \
+    apt-get install -y vim && \
+    rm -rf /var/lib/apt/lists/*
+
 # COPY ONLY NEEDED FILES TO THIS IMAGE
 WORKDIR /opt/grain
-COPY --from=compiler /opt/grain/cli ./cli
-COPY --from=compiler /opt/grain/runtime ./runtime
 COPY --from=compiler /opt/grain/_build ./_build
+COPY ./cli ./cli
+COPY ./runtime ./runtime
 
 # ADD COMPILER TO PATH
 ENV PATH="/opt/grain/_build/install/default/bin:${PATH}"
 
 # INSTALL RUNTIME
 WORKDIR /opt/grain/runtime
-RUN npm install
-RUN npm run build
+RUN npm install && \
+    npm run build
 
 # INSTALL CLI
 WORKDIR /opt/grain/cli
-RUN npm install
-RUN ln -s $PWD/bin/grain.js ../grain
-ENV PATH="/opt/grain:${PATH}"
+RUN npm install && \
+    npm link
 
 # SETUP FOR END USER
 WORKDIR /root
-RUN echo '3 + 3' > test.gr
-RUN grainc test.gr
 ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ grain test.gr
 For your convience, a Docker image is avaible with the following tools installed: `grainc`, `grain`, `node`, `npm`, and `vim`. To run the image,
 
 ```sh
-docker run --rm -it nickbreaton/grain
+docker run --rm -it grain-lang/grain
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Alternatively, you can use the CLI to run your program on Node:
 grain test.gr
 ```
 
+### Docker
+
+For your convience, a Docker image is avaible with the following tools installed: `grainc`, `grain`, `node`, `npm`, and `vim`. To run the image,
+
+```sh
+docker run --rm -it nickbreaton/grain
+```
+
+
 Copyright ©️ 2017-2018 Philip Blair and Oscar Spencer.
 
 [philip]: https://github.com/belph

--- a/cli/bin/compile.js
+++ b/cli/bin/compile.js
@@ -1,8 +1,9 @@
 const { execSync } = require('child_process');
+const locatorPath = require('./locator-path');
 
 module.exports = (file) => {
   try {
-    execSync(`grainc -I _build/install/default/lib/grain/stdlib ${file}`);
+    execSync(`grainc -I ${locatorPath} ${file}`);
     return file.replace(/\.gr$/, '.wasm')
   } catch (e) {
     console.log(e.stdout.toString());

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -1,4 +1,4 @@
-#!node --harmony
+#!/usr/bin/env node
 
 let program = require('commander');
 let compile = require('./compile.js');
@@ -16,7 +16,7 @@ program
 program.on('--help', () => {
   console.log('\n\n  File can be either a Grain (.gr) or WebAssembly (.wasm) file.\n');
 });
-  
+
 program.parse(process.argv);
 
 let wasmFile;

--- a/cli/bin/locator-path.js
+++ b/cli/bin/locator-path.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+const relativePath = '_build/install/default/lib/grain/stdlib';
+const absolutePath = path.resolve(__dirname, '../../', relativePath);
+
+module.exports = absolutePath;

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -1,5 +1,6 @@
 let runtime = require('../../runtime/dist/grain-runtime.js');
-let locator = runtime.defaultFileLocator('_build/install/default/lib/grain/stdlib');
+let locatorPath = require('./locator-path');
+let locator = runtime.defaultFileLocator(locatorPath);
 let GrainRunner = runtime.buildGrainRunner(locator);
 
 module.exports = async function run(path) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  grain:
+    build: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,0 @@
-version: '3'
-services:
-  grain:
-    build: ./


### PR DESCRIPTION
Hello all. I was struggling a couple days ago to get grain running, especially since I'm unfamiliar with the ocaml ecosystem. I really wanted to just jump in and see what it could do, however this proved challenging.

To help others get up and running quickly, I've made a docker image that contains the compiler and CLI runtime. To be clear, this is intended to help people *use* the compiler and runtime, not for development of the compiler or runtime.

If you'd like to go ahead and try it out, I have it up on dockerhub building off of my fork. Just be sure you have docker on your system and run,

```sh
docker run --rm -it nickbreaton/grain
```

Once inside the shell, you will have `grainc` and `grain` available to you to start playing around. I have also installed `vim` to make it easy to create and modify `.gr` files within the running container. Since the image is based on the node image, `node` and `npm` are also available.

I understand if you don't want to include this in the main repository, and if not, I will just continue to use it for personal use, however if you do, this PR should contain all that is needed. I did have to make a small number of modifications to the grain CLI, but I will explain those in comments.

I would also be more than happy to setup an organization on dockerhub for grain-lang, and create a continuous deployment system. That way the above build command will look like,

```
docker run --rm -it grain-lang/grain
```

