### PR TITLE
Update project to work with OCaml 4.08 and 4.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 install: echo "Begin install"
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.08
 os:
   - linux
   

--- a/grain.opam
+++ b/grain.opam
@@ -15,18 +15,19 @@ run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
   "ocamlfind" {build & >= "1.7.3" }
   "ocamlbuild" {build & >= "0.12.0" }
+  "conf-openssl" { >= "2" }
   "dune" {build & >= "1.0" }
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "core" { >= "0.11.2" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_parsing"

--- a/grain.opam
+++ b/grain.opam
@@ -27,7 +27,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_parsing"

--- a/grain_codegen.opam
+++ b/grain_codegen.opam
@@ -25,7 +25,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_middle_end"

--- a/grain_codegen.opam
+++ b/grain_codegen.opam
@@ -19,13 +19,13 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_middle_end"

--- a/grain_middle_end.opam
+++ b/grain_middle_end.opam
@@ -19,13 +19,13 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_parsing"

--- a/grain_middle_end.opam
+++ b/grain_middle_end.opam
@@ -25,7 +25,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "grain_utils"
   "grain_parsing"

--- a/grain_parsing.opam
+++ b/grain_parsing.opam
@@ -19,14 +19,14 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "core" { >= "0.11.2" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "grain_utils"
 ]

--- a/grain_parsing.opam
+++ b/grain_parsing.opam
@@ -26,7 +26,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "grain_utils"
 ]

--- a/grain_typed.opam
+++ b/grain_typed.opam
@@ -26,7 +26,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "yojson"
   "ppx_deriving_yojson"

--- a/grain_typed.opam
+++ b/grain_typed.opam
@@ -19,14 +19,14 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "core" { >= "0.11.2" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "yojson"
   "ppx_deriving_yojson"

--- a/grain_utils.opam
+++ b/grain_utils.opam
@@ -19,12 +19,12 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
 ]

--- a/grain_utils.opam
+++ b/grain_utils.opam
@@ -25,6 +25,6 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
 ]

--- a/grainc.opam
+++ b/grainc.opam
@@ -26,7 +26,7 @@ depends: [
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "grain_wasm_spec"
+  "grain_wasm_spec" { = "0.1" }
   "stdint" { >= "0.5.0" }
   "grain"
 ]

--- a/grainc.opam
+++ b/grainc.opam
@@ -19,14 +19,14 @@ depends: [
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"
-  "dypgen"
+  "grain_dypgen" { = "0.1" }
   "core" { >= "0.11.2" }
   "ounit" { >= "2.0.0" }
   "extlib" { >= "1.7.2" }
   "batteries" { >= "2.8.0" }
   "cmdliner" { >= "1.0.2" }
   "ocamlgraph" {>= "1.8.8" }
-  "wasm" { = "1.0" }
+  "grain_wasm_spec"
   "stdint" { >= "0.5.0" }
   "grain"
 ]

--- a/grainc/grainc.ml
+++ b/grainc/grainc.ml
@@ -15,7 +15,7 @@ let () =
         let buf = Buffer.create 512 in
         let formatter = Format.formatter_of_buffer buf in
         Format.fprintf formatter "@[%a@]@." Grain_parsing.Location.report_error err;
-        Format.pp_flush_formatter formatter;
+        Format.pp_print_flush formatter ();
         let s = Buffer.contents buf in
         Buffer.reset buf;
         Some (s))

--- a/grainc/root_utils.ml
+++ b/grainc/root_utils.ml
@@ -33,8 +33,8 @@ let path_var_sep = if Sys.os_type = "Win32" then ';' else ':'
 
 let infer_root_from_argv() =
   match Sys.argv.(0) with
-  | x when not(BatString.ends_with x "grainc") -> false
-  | exec_path when exec_path <> "grainc" ->
+  | x when not((BatString.ends_with x "grainc") || (BatString.ends_with x "grain-root")) -> false
+  | exec_path when exec_path <> "grainc" && exec_path <> "grain-root" ->
     (* Ends with 'grainc' and isn't 'grainc'. Likely an absolute or relative path *)
     try_infer_grain_root exec_path
   | _ -> (* argv[0] is exactly 'grainc'. Look for it on $PATH *)

--- a/src/parsing/location.ml
+++ b/src/parsing/location.ml
@@ -395,7 +395,8 @@ let () =
           Some (errorf ~loc:(in_file !input_name)
                 "I/O error: %s" msg)
 
-      (* | Misc.HookExnWrapper {error = e; hook_name;
+      (* [This exception was removed in OCaml 4.09, so we need to decide if we want to add back support for it] 
+         | Misc.HookExnWrapper {error = e; hook_name;
                              hook_info={Misc.sourcefile}} ->
           let sub = match error_of_exn e with
             | None | Some `Already_displayed -> error (Printexc.to_string e)

--- a/src/parsing/location.ml
+++ b/src/parsing/location.ml
@@ -43,7 +43,7 @@ let sexp_of_position (p : position) =
     ];
   ]
 
-let position_to_yojson (p : position) : Yojson.Safe.json =
+let position_to_yojson (p : position) : Yojson.Safe.t =
   `Assoc [
     "file", (`String p.pos_fname);
     "line", (`Int p.pos_lnum);
@@ -74,7 +74,7 @@ let position_of_sexp (sexp : Sexplib.Sexp.t) =
   | List _ -> of_sexp_error "position_of_sexp: invalid s-expression" sexp
 
 
-let position_of_yojson (yj : Yojson.Safe.json) : (position, string) result =
+let position_of_yojson (yj : Yojson.Safe.t) : (position, string) result =
   match yj with
   | `Assoc contents ->
     begin
@@ -395,7 +395,7 @@ let () =
           Some (errorf ~loc:(in_file !input_name)
                 "I/O error: %s" msg)
 
-      | Misc.HookExnWrapper {error = e; hook_name;
+      (* | Misc.HookExnWrapper {error = e; hook_name;
                              hook_info={Misc.sourcefile}} ->
           let sub = match error_of_exn e with
             | None | Some `Already_displayed -> error (Printexc.to_string e)
@@ -404,7 +404,7 @@ let () =
           Some
             (errorf ~loc:(in_file sourcefile)
                "In hook %S:" hook_name
-               ~sub:[sub])
+               ~sub:[sub]) *)
       | _ -> None
     )
 

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -20,7 +20,7 @@ let when_debug ?n thunk =
         thunk()
   | None -> ()
 
-let prerr_string s = when_debug ~n:1 (fun () -> Pervasives.prerr_string s)
+let prerr_string s = when_debug ~n:1 (fun () -> Stdlib.prerr_string s)
 
 let debug_print_state () =
   when_debug !last_state_printer

--- a/src/typed/cmi_format.ml
+++ b/src/typed/cmi_format.ml
@@ -70,12 +70,12 @@ let input_cmi ic =
   | Result.Error e -> raise (Invalid_argument e)
 
 let deserialize_cmi bytes =
-  match cmi_infos_of_yojson @@ Yojson.Safe.from_string bytes with
+  match cmi_infos_of_yojson @@ Yojson.Safe.from_string (Bytes.to_string bytes) with
   | Result.Ok x -> x
   | Result.Error e -> raise (Invalid_argument e)
 
 let serialize_cmi ({cmi_name=name; cmi_sign=sign; cmi_crcs=crcs; cmi_flags=flags} as cmi_info) =
-  Yojson.Safe.to_string @@ cmi_infos_to_yojson cmi_info
+  Bytes.of_string @@ Yojson.Safe.to_string @@ cmi_infos_to_yojson cmi_info
 
 module CmiBinarySection = BinarySection(struct
     type t = cmi_infos

--- a/src/typed/env.ml
+++ b/src/typed/env.ml
@@ -15,6 +15,7 @@
 (**************************************************************************)
 
 open Grain_parsing
+open Grain_utils
 open Sexplib.Conv
 open Cmi_format
 open Path
@@ -565,6 +566,8 @@ let compilation_in_progress =
 
 (* Consistency between persistent structures *)
 
+module Consistbl = Consistbl.Make (Misc.Stdlib.String)
+
 let crc_units = Consistbl.create()
 
 module StringSet =
@@ -759,7 +762,7 @@ let acknowledge_pers_struct check modname
               let unit_name, _ = get_unit() in
               error (Need_recursive_types(ps.ps_name, unit_name))
         | Unsafe_string ->
-            if Config.safe_string then
+            if !Config.safe_string then
               let unit_name, _ = get_unit() in
               error (Depend_on_unsafe_string_unit (ps.ps_name, unit_name));
         | Opaque -> add_imported_opaque modname)
@@ -849,7 +852,7 @@ let check_pers_struct ~loc name filename =
        whether the check succeeds, to help make builds more
        deterministic. *)
     add_import name;
-    if (Warnings.is_active (Warnings.No_cmi_file("", None))) then
+    if (Warnings.is_active (Warnings.NoCmiFile("", None))) then
       !add_delayed_check_forward
         (fun () -> check_pers_struct ~loc name filename)
   end

--- a/src/typed/env.mli
+++ b/src/typed/env.mli
@@ -146,6 +146,10 @@ val is_imported_opaque: string -> bool
 
 (* Direct access to the table of imported compilation units with their CRC *)
 
+module Consistbl : module type of struct
+  include Grain_utils.Consistbl.Make (Misc.Stdlib.String)
+end
+
 val crc_units: Consistbl.t
 val add_import: string -> unit
 

--- a/src/typed/ident.ml
+++ b/src/typed/ident.ml
@@ -69,7 +69,7 @@ let same i1 i2 = i1 = i2
        then i1.stamp = i2.stamp
        else i2.stamp = 0 && i1.name = i2.name *)
 
-let compare i1 i2 = Pervasives.compare i1 i2
+let compare i1 i2 = Stdlib.compare i1 i2
 
 let binding_time i = i.stamp
 

--- a/src/typed/includemod.ml
+++ b/src/typed/includemod.ml
@@ -16,6 +16,7 @@
 (* Inclusion checks for the module language *)
 
 open Grain_parsing
+open Grain_utils
 open Misc
 open Path
 open Typedtree

--- a/src/typed/parmatch.ml
+++ b/src/typed/parmatch.ml
@@ -222,17 +222,17 @@ let first_column simplified_matrix =
 let const_compare x y =
   match x, y with
   | Const_float f1, Const_float f2 ->
-    Pervasives.compare (float_of_string f1) (float_of_string f2)
+    Stdlib.compare (float_of_string f1) (float_of_string f2)
   | Const_string (s1), Const_string (s2) ->
     String.compare s1 s2
   | Const_bool b1, Const_bool b2 ->
-    Pervasives.compare (if b1 then 1 else 0) (if b2 then 1 else 0)
+    Stdlib.compare (if b1 then 1 else 0) (if b2 then 1 else 0)
   | (Const_int _
     | Const_string _
     | Const_float _
     | Const_bool _
     | Const_int32 _
-    | Const_int64 _), _ -> Pervasives.compare x y
+    | Const_int64 _), _ -> Stdlib.compare x y
 
 module Compat
     (Constr:sig

--- a/src/typed/subst.ml
+++ b/src/typed/subst.ml
@@ -16,6 +16,7 @@
 
 (* Substitutions *)
 open Grain_parsing
+open Grain_utils
 open Misc
 open Path
 open Types

--- a/src/typed/typemod.ml
+++ b/src/typed/typemod.ml
@@ -22,6 +22,8 @@ open Parsetree
 open Types
 open Format
 
+module String = Misc.Stdlib.String
+
 type error =
     Cannot_apply of module_type
   | Not_included of Includemod.error list
@@ -115,12 +117,12 @@ let type_open ?toplevel env sod =
 
 let simplify_signature sg =
   let rec aux = function
-    | [] -> [], StringSet.empty
+    | [] -> [], String.Set.empty
     | (TSigValue(id, _descr) as component) :: sg ->
         let (sg, val_names) as k = aux sg in
         let name = Ident.name id in
-        if StringSet.mem name val_names then k
-        else (component :: sg, StringSet.add name val_names)
+        if String.Set.mem name val_names then k
+        else (component :: sg, String.Set.add name val_names)
     | component :: sg ->
         let (sg, val_names) = aux sg in
         (component :: sg, val_names)

--- a/src/typed/typepat.ml
+++ b/src/typed/typepat.ml
@@ -151,7 +151,7 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty =
 let sort_pattern_variables vs =
   List.sort
     (fun (x,_,_,_,_) (y,_,_,_,_) ->
-      Pervasives.compare (Ident.name x) (Ident.name y))
+      Stdlib.compare (Ident.name x) (Ident.name y))
     vs
 
 let enter_orpat_variables loc env  p1_vs p2_vs =

--- a/src/typed/typetexp.ml
+++ b/src/typed/typetexp.ml
@@ -17,6 +17,7 @@
 
 (* Typechecking of type expressions for the core language *)
 open Grain_parsing
+open Grain_utils
 open Asttypes
 open Misc
 open Parsetree

--- a/src/utils/config.ml
+++ b/src/utils/config.ml
@@ -162,6 +162,9 @@ let strict_sequence = toggle_flag
     ~doc:"Enable strict sequencing"
     false
 
+(* For now, leave this as true *)
+let safe_string = ref true
+
 let parser_debug_level = opt
     ~names:["parser-debug-level"]
     ~conv:Cmdliner.Arg.int

--- a/src/utils/config.mli
+++ b/src/utils/config.mli
@@ -49,6 +49,9 @@ val unsound_optimizations : bool ref
 
 (*** Internal options (no command line flags) *)
 
+val safe_string : bool ref
+(** Whether to use safe string representations (always true for now) *)
+
 val output_enabled : bool ref
 (** Whether to enable file writes. This is useful for testing. *)
 

--- a/src/utils/consistbl.ml
+++ b/src/utils/consistbl.ml
@@ -1,0 +1,89 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 2002 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Consistency tables: for checking consistency of module CRCs *)
+
+open Misc
+
+module Make (Module_name : sig
+  type t
+  module Set : Set.S with type elt = t
+  module Map : Map.S with type key = t
+  module Tbl : Hashtbl.S with type key = t
+  val compare : t -> t -> int
+end) = struct
+  type t = (Digest.t * filepath) Module_name.Tbl.t
+
+  let create () = Module_name.Tbl.create 13
+
+  let clear = Module_name.Tbl.clear
+
+  exception Inconsistency of Module_name.t * filepath * filepath
+
+  exception Not_available of Module_name.t
+
+  let check tbl name crc source =
+    try
+      let (old_crc, old_source) = Module_name.Tbl.find tbl name in
+      if crc <> old_crc then raise(Inconsistency(name, source, old_source))
+    with Not_found ->
+      Module_name.Tbl.add tbl name (crc, source)
+
+  let check_noadd tbl name crc source =
+    try
+      let (old_crc, old_source) = Module_name.Tbl.find tbl name in
+      if crc <> old_crc then raise(Inconsistency(name, source, old_source))
+    with Not_found ->
+      raise (Not_available name)
+
+  let set tbl name crc source = Module_name.Tbl.add tbl name (crc, source)
+
+  let source tbl name = snd (Module_name.Tbl.find tbl name)
+
+  let extract l tbl =
+    let l = List.sort_uniq Module_name.compare l in
+    List.fold_left
+      (fun assc name ->
+         try
+           let (crc, _) = Module_name.Tbl.find tbl name in
+             (name, Some crc) :: assc
+         with Not_found ->
+           (name, None) :: assc)
+      [] l
+
+  let extract_map mod_names tbl =
+    Module_name.Set.fold
+      (fun name result ->
+         try
+           let (crc, _) = Module_name.Tbl.find tbl name in
+           Module_name.Map.add name (Some crc) result
+         with Not_found ->
+           Module_name.Map.add name None result)
+      mod_names
+      Module_name.Map.empty
+
+  let filter p tbl =
+    let to_remove = ref [] in
+    Module_name.Tbl.iter
+      (fun name _ ->
+        if not (p name) then to_remove := name :: !to_remove)
+      tbl;
+    List.iter
+      (fun name ->
+         while Module_name.Tbl.mem tbl name do
+           Module_name.Tbl.remove tbl name
+         done)
+      !to_remove
+end

--- a/src/utils/consistbl.ml
+++ b/src/utils/consistbl.ml
@@ -17,6 +17,8 @@
 
 open Misc
 
+type filepath = string
+
 module Make (Module_name : sig
   type t
   module Set : Set.S with type elt = t

--- a/src/utils/consistbl.mli
+++ b/src/utils/consistbl.mli
@@ -1,0 +1,79 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 2002 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Consistency tables: for checking consistency of module CRCs
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+*)
+
+open Misc
+
+module Make (Module_name : sig
+  type t
+  module Set : Set.S with type elt = t
+  module Map : Map.S with type key = t
+  module Tbl : Hashtbl.S with type key = t
+  val compare : t -> t -> int
+end) : sig
+  type t
+
+  val create: unit -> t
+
+  val clear: t -> unit
+
+  val check: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* [check tbl name crc source]
+             checks consistency of ([name], [crc]) with infos previously
+             stored in [tbl].  If no CRC was previously associated with
+             [name], record ([name], [crc]) in [tbl].
+             [source] is the name of the file from which the information
+             comes from.  This is used for error reporting. *)
+
+  val check_noadd: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* Same as [check], but raise [Not_available] if no CRC was previously
+             associated with [name]. *)
+
+  val set: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* [set tbl name crc source] forcefully associates [name] with
+           [crc] in [tbl], even if [name] already had a different CRC
+           associated with [name] in [tbl]. *)
+
+  val source: t -> Module_name.t -> filepath
+        (* [source tbl name] returns the file name associated with [name]
+           if the latter has an associated CRC in [tbl].
+           Raise [Not_found] otherwise. *)
+
+  val extract: Module_name.t list -> t -> (Module_name.t * Digest.t option) list
+        (* [extract tbl names] returns an associative list mapping each string
+           in [names] to the CRC associated with it in [tbl]. If no CRC is
+           associated with a name then it is mapped to [None]. *)
+
+  val extract_map : Module_name.Set.t -> t -> Digest.t option Module_name.Map.t
+        (* Like [extract] but with a more sophisticated type. *)
+
+  val filter: (Module_name.t -> bool) -> t -> unit
+        (* [filter pred tbl] removes from [tbl] table all (name, CRC) pairs
+           such that [pred name] is [false]. *)
+
+  exception Inconsistency of Module_name.t * filepath * filepath
+        (* Raised by [check] when a CRC mismatch is detected.
+           First string is the name of the compilation unit.
+           Second string is the source that caused the inconsistency.
+           Third string is the source that set the CRC. *)
+
+  exception Not_available of Module_name.t
+        (* Raised by [check_noadd] when a name doesn't have an associated
+           CRC. *)
+end

--- a/src/utils/consistbl.mli
+++ b/src/utils/consistbl.mli
@@ -20,6 +20,8 @@
 
 open Misc
 
+type filepath = string
+
 module Make (Module_name : sig
   type t
   module Set : Set.S with type elt = t

--- a/src/utils/tbl.ml
+++ b/src/utils/tbl.ml
@@ -1,0 +1,123 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('k, 'v) t =
+    Empty
+  | Node of ('k, 'v) t * 'k * 'v * ('k, 'v) t * int
+
+let empty = Empty
+
+let height = function
+    Empty -> 0
+  | Node(_,_,_,_,h) -> h
+
+let create l x d r =
+  let hl = height l and hr = height r in
+  Node(l, x, d, r, (if hl >= hr then hl + 1 else hr + 1))
+
+let bal l x d r =
+  let hl = height l and hr = height r in
+  if hl > hr + 1 then
+    match l with
+    | Node (ll, lv, ld, lr, _) when height ll >= height lr ->
+        create ll lv ld (create lr x d r)
+    | Node (ll, lv, ld, Node (lrl, lrv, lrd, lrr, _), _) ->
+        create (create ll lv ld lrl) lrv lrd (create lrr x d r)
+    | _ -> assert false
+  else if hr > hl + 1 then
+    match r with
+    | Node (rl, rv, rd, rr, _) when height rr >= height rl ->
+        create (create l x d rl) rv rd rr
+    | Node (Node (rll, rlv, rld, rlr, _), rv, rd, rr, _) ->
+        create (create l x d rll) rlv rld (create rlr rv rd rr)
+    | _ -> assert false
+  else
+    create l x d r
+
+let rec add x data = function
+    Empty ->
+      Node(Empty, x, data, Empty, 1)
+  | Node(l, v, d, r, h) ->
+      let c = compare x v in
+      if c = 0 then
+        Node(l, x, data, r, h)
+      else if c < 0 then
+        bal (add x data l) v d r
+      else
+        bal l v d (add x data r)
+
+let rec find x = function
+    Empty ->
+      raise Not_found
+  | Node(l, v, d, r, _) ->
+      let c = compare x v in
+      if c = 0 then d
+      else find x (if c < 0 then l else r)
+
+let rec find_str (x : string) = function
+    Empty ->
+      raise Not_found
+  | Node(l, v, d, r, _) ->
+      let c = compare x v in
+      if c = 0 then d
+      else find_str x (if c < 0 then l else r)
+
+let rec mem x = function
+    Empty -> false
+  | Node(l, v, _d, r, _) ->
+      let c = compare x v in
+      c = 0 || mem x (if c < 0 then l else r)
+
+let rec merge t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (Node(l1, v1, d1, r1, _h1), Node(l2, v2, d2, r2, _h2)) ->
+      bal l1 v1 d1 (bal (merge r1 l2) v2 d2 r2)
+
+let rec remove x = function
+    Empty ->
+      Empty
+  | Node(l, v, d, r, _h) ->
+      let c = compare x v in
+      if c = 0 then
+        merge l r
+      else if c < 0 then
+        bal (remove x l) v d r
+      else
+        bal l v d (remove x r)
+
+let rec iter f = function
+    Empty -> ()
+  | Node(l, v, d, r, _) ->
+      iter f l; f v d; iter f r
+
+let rec map f = function
+    Empty -> Empty
+  | Node(l, v, d, r, h) -> Node(map f l, v, f v d, map f r, h)
+
+let rec fold f m accu =
+  match m with
+  | Empty -> accu
+  | Node(l, v, d, r, _) ->
+      fold f r (f v d (fold f l accu))
+
+open Format
+
+let print print_key print_data ppf tbl =
+  let print_tbl ppf tbl =
+    iter (fun k d -> fprintf ppf "@[<2>%a ->@ %a;@]@ " print_key k print_data d)
+      tbl in
+  fprintf ppf "@[<hv 2>[[%a]]@]" print_tbl tbl

--- a/src/utils/tbl.mli
+++ b/src/utils/tbl.mli
@@ -1,0 +1,35 @@
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Association tables from any ordered type to any type.
+   We use the generic ordering to compare keys. *)
+
+type ('k, 'v) t
+
+val empty: ('k, 'v) t
+val add: 'k -> 'v -> ('k, 'v) t -> ('k, 'v) t
+val find: 'k -> ('k, 'v) t -> 'v
+val find_str: string -> (string, 'v) t -> 'v
+val mem: 'k -> ('k, 'v) t -> bool
+val remove: 'k -> ('k,  'v) t -> ('k, 'v) t
+val iter: ('k -> 'v -> unit) -> ('k, 'v) t -> unit
+val map: ('k -> 'v1 -> 'v2) -> ('k, 'v1) t -> ('k, 'v2) t
+val fold: ('k -> 'v -> 'acc -> 'acc) -> ('k, 'v) t -> 'acc -> 'acc
+
+open Format
+
+val print: (formatter -> 'k -> unit) -> (formatter -> 'v -> unit) ->
+           formatter -> ('k, 'v) t -> unit

--- a/src/utils/warnings.ml
+++ b/src/utils/warnings.ml
@@ -20,6 +20,7 @@ type t =
   | UnusedPat
   | UnreachableCase
   | ShadowConstructor of string
+  | NoCmiFile of string * string option
 
 let number = function
   | LetRecNonFunction _ -> 1
@@ -35,8 +36,9 @@ let number = function
   | UnusedPat -> 11
   | UnreachableCase -> 12
   | ShadowConstructor _ -> 13
+  | NoCmiFile _ -> 14
 
-let last_warning_number = 13
+let last_warning_number = 14
 
 let message = function
   | LetRecNonFunction(name) ->
@@ -77,6 +79,8 @@ let message = function
   | UnusedPat -> "this sub-pattern is unused."
   | UnreachableCase -> "this mach case is unreachable."
   | ShadowConstructor s -> "the pattern variable " ^ s ^ " shadows a constructor of the same name."
+  | NoCmiFile(name, None) -> "no cmi file was found in path for module " ^ name
+  | NoCmiFile(name, Some msg) -> Printf.sprintf "no valid cmi file was found in path for module %s. %s" name msg
 
 let sub_locs = function
   | _ -> []

--- a/src/utils/warnings.mli
+++ b/src/utils/warnings.mli
@@ -34,6 +34,7 @@ type t =
   | UnusedPat
   | UnreachableCase
   | ShadowConstructor of string
+  | NoCmiFile of string * string option
 
 val is_active : t -> bool;;
 val is_error : t -> bool;;

--- a/test/runner.ml
+++ b/test/runner.ml
@@ -103,7 +103,7 @@ let read_stream cstream =
     Bytes.set buf !i c;
     incr i
   ) cstream;
-  Bytes.sub buf 0 !i
+  Bytes.to_string @@ Bytes.sub buf 0 !i
 
 let run_output cstate test_ctxt =
   let wasm = Wasm.Encode.encode (extract_wasm cstate) in

--- a/test/test.ml
+++ b/test/test.ml
@@ -11,7 +11,7 @@ let () =
         let buf = Buffer.create 512 in
         let formatter = Format.formatter_of_buffer buf in
         Format.fprintf formatter "@[%a@]@." Grain_parsing.Location.report_error err;
-        Format.pp_flush_formatter formatter;
+        Format.pp_print_flush formatter ();
         let s = Buffer.contents buf in
         Buffer.reset buf;
         Some (s))


### PR DESCRIPTION
(**NOTE:** CI build will fail until ocaml/opam-repository#15313 is merged)
# OCaml 4.08+ Support
This pull request adds support for building Grain with OCaml 4.08.x and 4.09.x. Most of these changes are caused by updates to the OCaml standard library, but this PR is also updated to use Grain repackagings of both `dypgen` and the WASM spec (woo, updated spec!). 

This branch has been successfully built on my machine with OCaml 4.08.1 and 4.09.0.
## Bug Fixes 🎉
- `typed/env.ml` has been updated to use the `Grain_utils` version of `Warnings` and friends (it was using the OCaml default ones by mistake).
- A bug has been fixed in the `grain-root` runtime library to properly find the root when running outside of `grainc`.

## Migrating to OCaml 4.08+ ⬆️
To migrate your system locally, perform the following steps (steps shown are for 4.08.1; the workflow is identical for 4.09.0):

Switch your OPAM to the new OCaml version:
```
# if needed (or wanted), create a new switch
$ opam switch create grain-dev 4.08.1
$ opam switch grain-dev
$ eval $(opam env)
```
Then, follow the installation steps in the README.
