### PR TITLE
Quality-of-life syntax adjustments

### DIFF
--- a/runtime/src/core/primitives.js
+++ b/runtime/src/core/primitives.js
@@ -1,2 +1,3 @@
 export const GRAIN_TRUE = 0xFFFFFFFF | 0;
 export const GRAIN_FALSE = 0x7FFFFFFF | 0;
+export const GRAIN_VOID = 0x6FFFFFFF | 0;

--- a/runtime/src/core/tags.js
+++ b/runtime/src/core/tags.js
@@ -10,11 +10,16 @@ import {
   GRAIN_ERR_NOT_ADT_VAL_GENERIC,
 } from '../errors/error-codes';
 
+import { 
+  GRAIN_TRUE, 
+  GRAIN_FALSE 
+} from './primitives';
+
 export const GRAIN_NUMBER_TAG_MASK = 0b0001;
 export const GRAIN_TUPLE_TAG_MASK = 0b0111;
 
 export const GRAIN_NUMBER_TAG_TYPE       = 0b0000;
-export const GRAIN_BOOLEAN_TAG_TYPE      = 0b1111;
+export const GRAIN_CONST_TAG_TYPE        = 0b1111;
 export const GRAIN_TUPLE_TAG_TYPE        = 0b0001;
 export const GRAIN_LAMBDA_TAG_TYPE       = 0b0101;
 export const GRAIN_GENERIC_HEAP_TAG_TYPE = 0b0011;
@@ -47,8 +52,14 @@ function assertGrainHeapTag(tag, n, err) {
   }
 }
 
+export const assertBoolean = (n, err) => {
+  assertGrainTag(GRAIN_CONST_TAG_TYPE, n, err || GRAIN_ERR_NOT_BOOLEAN_GENERIC);
+  if (n !== GRAIN_TRUE && n !== GRAIN_FALSE) {
+    throwGrainError(err, n, 0);
+  }
+}
+
 export const assertNumber = (n, err) => assertGrainTag(GRAIN_NUMBER_TAG_TYPE, n, err || GRAIN_ERR_NOT_NUMBER_GENERIC);
-export const assertBoolean = (n, err) => assertGrainTag(GRAIN_BOOLEAN_TAG_TYPE, n, err || GRAIN_ERR_NOT_BOOLEAN_GENERIC);
 export const assertTuple = (n, err) => assertGrainTag(GRAIN_TUPLE_TAG_TYPE, n, err || GRAIN_ERR_NOT_TUPLE_GENERIC);
 export const assertLambda = (n, err) => assertGrainTag(GRAIN_LAMBDA_TAG_TYPE, n, err || GRAIN_ERR_NOT_LAMBDA_GENERIC);
 export const assertString = (n, err) => assertGrainHeapTag(GRAIN_STRING_HEAP_TAG, n, err || GRAIN_ERR_NOT_STRING_GENERIC);

--- a/runtime/src/lib/print.js
+++ b/runtime/src/lib/print.js
@@ -1,14 +1,15 @@
 import { grainToString } from '../utils/utils';
+import { GRAIN_VOID } from '../core/primitives';
 
 export function print(v) {
   console.log(grainToString(null, v));
-  return v;
+  return GRAIN_VOID;
 }
 
 export function makePrint(boundGrainToString) {
   return v => {
     console.log(boundGrainToString(v));
-    return v;
+    return GRAIN_VOID;
   }
 }
 

--- a/runtime/src/utils/utils.js
+++ b/runtime/src/utils/utils.js
@@ -14,6 +14,12 @@ import {
   GRAIN_RECORD_HEAP_TAG
 } from '../core/tags';
 
+import { 
+  GRAIN_TRUE, 
+  GRAIN_FALSE,
+  GRAIN_VOID
+} from '../core/primitives';
+
 export function grainHeapValueToString(runtime, n) {
   switch (view[n / 4]) {
     case GRAIN_STRING_HEAP_TAG: {
@@ -112,10 +118,12 @@ export function grainToString(runtime, n) {
     return "<lambda>";
   } else if ((n & 7) === GRAIN_GENERIC_HEAP_TAG_TYPE) {
     return grainHeapValueToString(runtime, n ^ 3);
-  } else if ((n === -1)) {
+  } else if ((n === GRAIN_TRUE)) {
     return "true";
-  } else if (n === 0x7FFFFFFF) {
+  } else if (n === GRAIN_FALSE) {
     return "false";
+  } else if (n === GRAIN_VOID) {
+    return "void";
   } else {
     return `<Unknown value: 0x${n}>`;
   }

--- a/runtime/src/utils/utils.js
+++ b/runtime/src/utils/utils.js
@@ -220,10 +220,12 @@ export function grainToJSVal(runtime, x) {
     return grainHeapValToJSVal(runtime, x ^ 3);
   } else if ((x & 7) === GRAIN_TUPLE_TAG_TYPE) {
     return grainTupleToJSVal(runtime, x ^ GRAIN_TUPLE_TAG_TYPE);
-  } else if ((x === -1)) {
+  } else if ((x === GRAIN_TRUE)) {
     return true;
-  } else if (x === 0x7FFFFFFF) {
+  } else if (x === GRAIN_FALSE) {
     return false;
+  } else if (x === GRAIN_VOID) {
+    return null;
   } else {
     console.warn(`Unknown Grain value: ${x} (0x${x.toString(16)})`);
     return undefined;

--- a/src/codegen/compcore.ml
+++ b/src/codegen/compcore.ml
@@ -152,6 +152,7 @@ let rec compile_const c : Wasm.Values.value =
 (* Translate constants to WASM *)
 let const_true = add_dummy_loc @@ compile_const const_true
 let const_false = add_dummy_loc @@ compile_const const_false
+let const_void = add_dummy_loc @@ compile_const const_void
 
 (* WebAssembly helpers *)
 
@@ -374,6 +375,7 @@ let compile_prim1 env p1 arg : Wasm.Ast.instr' Concatlist.t =
       Ast.Const(const_int32 0x80000000);
       Ast.Binary(Values.I32 Ast.IntOp.Xor);
     ]
+  | Ignore -> singleton (Ast.Const const_void)
   | Box -> failwith "Unreachable case; should never get here: Box"
   | Unbox -> failwith "Unreachable case; should never get here: Unbox"
   | IsBool -> failwith "Unsupported (compcore): IsBool"
@@ -850,7 +852,7 @@ and compile_instr env instr =
                Concatlist.mapped_list_of_t add_dummy_loc @@ 
                singleton (Ast.Loop([Types.I32Type],
                           Concatlist.mapped_list_of_t add_dummy_loc @@
-                          singleton (Ast.Const const_false) @
+                          singleton (Ast.Const const_void) @
                           compiled_cond @
                           decode_bool +@
                           [Ast.Test(Values.I32 Ast.IntOp.Eqz); 

--- a/src/codegen/mashtree.ml
+++ b/src/codegen/mashtree.ml
@@ -27,6 +27,7 @@ type prim1 = Parsetree.prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 
 type prim2 = Parsetree.prim2 =
   | Plus
@@ -187,3 +188,4 @@ type mash_program = {
 
 let const_true =  MConstLiteral (MConstI32 (Int32.of_int 0xFFFFFFFF))
 let const_false = MConstLiteral (MConstI32 (Int32.of_int 0x7FFFFFFF))
+let const_void = MConstLiteral (MConstI32 (Int32.of_int 0x6FFFFFFF))

--- a/src/codegen/value_tags.ml
+++ b/src/codegen/value_tags.ml
@@ -24,7 +24,7 @@ let heap_tag_type_of_tag_val = function
 
 type tag_type =
   | NumberTagType
-  | BooleanTagType
+  | ConstTagType
   | TupleTagType
   | LambdaTagType
   | GenericHeapType of heap_tag_type option
@@ -32,14 +32,14 @@ type tag_type =
 
 let and_mask_of_tag_type = function
   | NumberTagType     -> 0b0001
-  | BooleanTagType    -> 0b1111
+  | ConstTagType      -> 0b1111
   | TupleTagType      -> 0b0111
   | LambdaTagType     -> 0b0111
   | GenericHeapType _ -> 0b0111
 
 let tag_val_of_tag_type = function
   | NumberTagType     -> 0b0000
-  | BooleanTagType    -> 0b1111
+  | ConstTagType      -> 0b1111
   | TupleTagType      -> 0b0001
   | LambdaTagType     -> 0b0101
   | GenericHeapType _ -> 0b0011

--- a/src/grain-stdlib/lists.gr
+++ b/src/grain-stdlib/lists.gr
@@ -40,7 +40,7 @@ let rec append = (l1, l2) => {
 let rec contains = (e, l) => {
   match (l) {
     | Empty => false
-    | Cons(hd, tl) => (hd == e) or contains(e, tl)
+    | Cons(hd, tl) => (hd == e) || contains(e, tl)
   }
 }
 

--- a/src/grain-stdlib/lists.gr
+++ b/src/grain-stdlib/lists.gr
@@ -1,24 +1,24 @@
 # Standard library for list functionality
 
-export *;
+export *
 
 data List<a> =
   | Empty
-  | Cons(a, List<a>);
+  | Cons(a, List<a>)
 
 let rec length = (lst) => {
   match (lst) {
     | Empty => 0
     | Cons(hd, tl) => 1 + length(tl)
   }
-};
+}
 
 let rec sum = (lst) => {
   match (lst) {
     | Empty => 0
     | Cons(hd, tl) => hd + sum(tl)
   }
-};
+}
 
 let reverse = (lst) => {
   let rec help = (l, acc) => {
@@ -26,41 +26,41 @@ let reverse = (lst) => {
       | Empty => acc
       | Cons(hd, tl) => help(tl, Cons(hd, acc))
     }
-  };
+  }
   help(lst, Empty)
-};
+}
 
 let rec append = (l1, l2) => {
   match (l1) {
     | Empty => l2
     | Cons(hd, tl) => Cons(hd, append(tl, l2))
   }
-};
+}
 
 let rec contains = (e, l) => {
   match (l) {
     | Empty => false
     | Cons(hd, tl) => (hd == e) or contains(e, tl)
   }
-};
+}
 
 let rec fold_left = (f, b, l) => {
   match (l) {
     | Empty => b
     | Cons(hd, tl) => fold_left(f, f(b, hd), tl)
   }
-};
+}
 
 let rec fold_right = (f, b, l) => {
   match (l) {
     | Empty => b
     | Cons(hd, tl) => f(hd, fold_right(f, b, tl))
   }
-};
+}
 
 let rec map = (f, l) => {
   match (l) {
     | Empty => Empty
     | Cons(hd, tl) => Cons(f(hd), map(f, tl))
   }
-};
+}

--- a/src/grain-stdlib/pervasives.gr
+++ b/src/grain-stdlib/pervasives.gr
@@ -4,7 +4,7 @@ export *
 foreign wasm grainBuiltins print : a -> a
 
 # Checks the given items for structural equality.
-foreign wasm grainBuiltins equal : (a, a) -> Bool;
+foreign wasm grainBuiltins equal : (a, a) -> Bool
 
 # Converts the given value to a string
 foreign wasm grainBuiltins toString : a -> String

--- a/src/grain-stdlib/pervasives.gr
+++ b/src/grain-stdlib/pervasives.gr
@@ -1,7 +1,7 @@
 export *
 
 # Prints the given value to the console.
-foreign wasm grainBuiltins print : a -> a
+foreign wasm grainBuiltins print : a -> Void
 
 # Checks the given items for structural equality.
 foreign wasm grainBuiltins equal : (a, a) -> Bool

--- a/src/grain-stdlib/pervasives.gr
+++ b/src/grain-stdlib/pervasives.gr
@@ -1,16 +1,16 @@
-export *;
+export *
 
 # Prints the given value to the console.
-foreign wasm grainBuiltins print : a -> a;
+foreign wasm grainBuiltins print : a -> a
 
 # Checks the given items for structural equality.
 foreign wasm grainBuiltins equal : (a, a) -> Bool;
 
 # Converts the given value to a string
-foreign wasm grainBuiltins toString : a -> String;
+foreign wasm grainBuiltins toString : a -> String
 
 # TODO: These should be in a separate WASM module
 
-foreign wasm grainBuiltins stringAppend : (String, String) -> String;
+foreign wasm grainBuiltins stringAppend : (String, String) -> String
 
-foreign wasm grainBuiltins stringSlice : (String, Number, Number) -> String;
+foreign wasm grainBuiltins stringSlice : (String, Number, Number) -> String

--- a/src/middle_end/anftree.ml
+++ b/src/middle_end/anftree.ml
@@ -21,6 +21,7 @@ type prim1 = Parsetree.prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 
 type prim2 = Parsetree.prim2 =
   | Plus

--- a/src/middle_end/anftree.mli
+++ b/src/middle_end/anftree.mli
@@ -21,6 +21,7 @@ type prim1 = Parsetree.prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 
 type prim2 = Parsetree.prim2 =
   | Plus

--- a/src/parsing/ast_helper.ml
+++ b/src/parsing/ast_helper.ml
@@ -111,7 +111,7 @@ module Exp = struct
     let loc = match loc with
       | None -> (!default_loc_src)()
       | Some l -> l in
-    {pexp_desc=d; pexp_loc=loc}
+    {pexp_desc=d; pexp_ignored=false; pexp_loc=loc}
   let ident ?loc a = mk ?loc (PExpId a)
   let constant ?loc a = mk ?loc (PExpConstant a)
   let tuple ?loc a = mk ?loc (PExpTuple a)
@@ -123,6 +123,7 @@ module Exp = struct
   let prim2 ?loc a b c = mk ?loc (PExpPrim2(a, b, c))
   let if_ ?loc a b c = mk ?loc (PExpIf(a, b, c))
   let while_ ?loc a b = mk ?loc (PExpWhile(a, b))
+  let constraint_ ?loc a b = mk ?loc (PExpConstraint(a, b))
   let assign ?loc a b = mk ?loc (PExpAssign(a, b))
   let lambda ?loc a b = mk ?loc (PExpLambda(a, b))
   let apply ?loc a b = mk ?loc (PExpApp(a, b))

--- a/src/parsing/ast_helper.ml
+++ b/src/parsing/ast_helper.ml
@@ -107,33 +107,33 @@ module Pat = struct
 end
 
 module Exp = struct
-  let mk ?loc ?ignored d =
+  let mk ?loc d =
     let loc = match loc with
       | None -> (!default_loc_src)()
       | Some l -> l in
-    let ignored = match ignored with
-      | None -> TypeKept
-      | Some i -> i in
-    {pexp_desc=d; pexp_ignored=ignored; pexp_loc=loc}
+    {pexp_desc=d; pexp_loc=loc}
+  let ident ?loc a = mk ?loc (PExpId a)
+  let constant ?loc a = mk ?loc (PExpConstant a)
+  let tuple ?loc a = mk ?loc (PExpTuple a)
+  let record ?loc a = mk ?loc (PExpRecord a)
+  let record_get ?loc a b = mk ?loc (PExpRecordGet(a, b))
+  let let_ ?loc a b c = mk ?loc (PExpLet(a, b, c))
+  let match_ ?loc a b = mk ?loc (PExpMatch(a, b))
+  let prim1 ?loc a b = mk ?loc (PExpPrim1(a, b))
+  let prim2 ?loc a b c = mk ?loc (PExpPrim2(a, b, c))
+  let if_ ?loc a b c = mk ?loc (PExpIf(a, b, c))
+  let while_ ?loc a b = mk ?loc (PExpWhile(a, b))
+  let constraint_ ?loc a b = mk ?loc (PExpConstraint(a, b))
+  let assign ?loc a b = mk ?loc (PExpAssign(a, b))
+  let lambda ?loc a b = mk ?loc (PExpLambda(a, b))
+  let apply ?loc a b = mk ?loc (PExpApp(a, b))
+  let block ?loc a = mk ?loc (PExpBlock a)
+  let null ?loc () = mk ?loc PExpNull
+
   let ignore e = 
-    {e with pexp_ignored=TypeIgnored}
-  let ident ?loc ?ignored a = mk ?loc ?ignored (PExpId a)
-  let constant ?loc ?ignored a = mk ?loc ?ignored (PExpConstant a)
-  let tuple ?loc ?ignored a = mk ?loc ?ignored (PExpTuple a)
-  let record ?loc ?ignored a = mk ?loc ?ignored (PExpRecord a)
-  let record_get ?loc ?ignored a b = mk ?loc ?ignored (PExpRecordGet(a, b))
-  let let_ ?loc ?ignored a b c = mk ?loc ?ignored (PExpLet(a, b, c))
-  let match_ ?loc ?ignored a b = mk ?loc ?ignored (PExpMatch(a, b))
-  let prim1 ?loc ?ignored a b = mk ?loc ?ignored (PExpPrim1(a, b))
-  let prim2 ?loc ?ignored a b c = mk ?loc ?ignored (PExpPrim2(a, b, c))
-  let if_ ?loc ?ignored a b c = mk ?loc ?ignored (PExpIf(a, b, c))
-  let while_ ?loc ?ignored a b = mk ?loc ?ignored (PExpWhile(a, b))
-  let constraint_ ?loc ?ignored a b = mk ?loc ?ignored (PExpConstraint(a, b))
-  let assign ?loc ?ignored a b = mk ?loc ?ignored (PExpAssign(a, b))
-  let lambda ?loc ?ignored a b = mk ?loc ?ignored (PExpLambda(a, b))
-  let apply ?loc ?ignored a b = mk ?loc ?ignored (PExpApp(a, b))
-  let block ?loc ?ignored a = mk ?loc ?ignored (PExpBlock a)
-  let null ?loc ?ignored () = mk ?loc ?ignored PExpNull
+    match e.pexp_desc with
+      | PExpLet _ -> e
+      | _ -> prim1 ~loc:e.pexp_loc Ignore e
 end
 
 module Top = struct

--- a/src/parsing/ast_helper.ml
+++ b/src/parsing/ast_helper.ml
@@ -107,28 +107,33 @@ module Pat = struct
 end
 
 module Exp = struct
-  let mk ?loc d =
+  let mk ?loc ?ignored d =
     let loc = match loc with
       | None -> (!default_loc_src)()
       | Some l -> l in
-    {pexp_desc=d; pexp_ignored=false; pexp_loc=loc}
-  let ident ?loc a = mk ?loc (PExpId a)
-  let constant ?loc a = mk ?loc (PExpConstant a)
-  let tuple ?loc a = mk ?loc (PExpTuple a)
-  let record ?loc a = mk ?loc (PExpRecord a)
-  let record_get ?loc a b = mk ?loc (PExpRecordGet(a, b))
-  let let_ ?loc a b c = mk ?loc (PExpLet(a, b, c))
-  let match_ ?loc a b = mk ?loc (PExpMatch(a, b))
-  let prim1 ?loc a b = mk ?loc (PExpPrim1(a, b))
-  let prim2 ?loc a b c = mk ?loc (PExpPrim2(a, b, c))
-  let if_ ?loc a b c = mk ?loc (PExpIf(a, b, c))
-  let while_ ?loc a b = mk ?loc (PExpWhile(a, b))
-  let constraint_ ?loc a b = mk ?loc (PExpConstraint(a, b))
-  let assign ?loc a b = mk ?loc (PExpAssign(a, b))
-  let lambda ?loc a b = mk ?loc (PExpLambda(a, b))
-  let apply ?loc a b = mk ?loc (PExpApp(a, b))
-  let block ?loc a = mk ?loc (PExpBlock a)
-  let null ?loc () = mk ?loc PExpNull
+    let ignored = match ignored with
+      | None -> TypeKept
+      | Some i -> i in
+    {pexp_desc=d; pexp_ignored=ignored; pexp_loc=loc}
+  let ignore e = 
+    {e with pexp_ignored=TypeIgnored}
+  let ident ?loc ?ignored a = mk ?loc ?ignored (PExpId a)
+  let constant ?loc ?ignored a = mk ?loc ?ignored (PExpConstant a)
+  let tuple ?loc ?ignored a = mk ?loc ?ignored (PExpTuple a)
+  let record ?loc ?ignored a = mk ?loc ?ignored (PExpRecord a)
+  let record_get ?loc ?ignored a b = mk ?loc ?ignored (PExpRecordGet(a, b))
+  let let_ ?loc ?ignored a b c = mk ?loc ?ignored (PExpLet(a, b, c))
+  let match_ ?loc ?ignored a b = mk ?loc ?ignored (PExpMatch(a, b))
+  let prim1 ?loc ?ignored a b = mk ?loc ?ignored (PExpPrim1(a, b))
+  let prim2 ?loc ?ignored a b c = mk ?loc ?ignored (PExpPrim2(a, b, c))
+  let if_ ?loc ?ignored a b c = mk ?loc ?ignored (PExpIf(a, b, c))
+  let while_ ?loc ?ignored a b = mk ?loc ?ignored (PExpWhile(a, b))
+  let constraint_ ?loc ?ignored a b = mk ?loc ?ignored (PExpConstraint(a, b))
+  let assign ?loc ?ignored a b = mk ?loc ?ignored (PExpAssign(a, b))
+  let lambda ?loc ?ignored a b = mk ?loc ?ignored (PExpLambda(a, b))
+  let apply ?loc ?ignored a b = mk ?loc ?ignored (PExpApp(a, b))
+  let block ?loc ?ignored a = mk ?loc ?ignored (PExpBlock a)
+  let null ?loc ?ignored () = mk ?loc ?ignored PExpNull
 end
 
 module Top = struct

--- a/src/parsing/ast_helper.mli
+++ b/src/parsing/ast_helper.mli
@@ -89,6 +89,7 @@ module Exp: sig
   val prim2: ?loc:loc -> prim2 -> expression -> expression -> expression
   val if_: ?loc:loc -> expression -> expression -> expression -> expression
   val while_: ?loc:loc -> expression -> expression -> expression
+  val constraint_: ?loc:loc -> expression -> parsed_type -> expression
   val assign: ?loc:loc -> expression -> expression -> expression
   val lambda: ?loc:loc -> pattern list -> expression -> expression
   val apply: ?loc:loc -> expression -> expression list -> expression

--- a/src/parsing/ast_helper.mli
+++ b/src/parsing/ast_helper.mli
@@ -77,25 +77,25 @@ module Pat : sig
 end
 
 module Exp: sig
-  val mk: ?loc:loc -> ?ignored:ignored -> expression_desc -> expression
+  val mk: ?loc:loc -> expression_desc -> expression
+  val ident: ?loc:loc -> id -> expression
+  val constant: ?loc:loc -> constant -> expression
+  val tuple: ?loc:loc -> expression list -> expression
+  val record: ?loc:loc -> (id * expression) list -> expression
+  val record_get: ?loc:loc -> expression -> id -> expression
+  val let_: ?loc:loc -> rec_flag -> value_binding list -> expression -> expression
+  val match_: ?loc:loc -> expression -> match_branch list -> expression
+  val prim1: ?loc:loc -> prim1 -> expression -> expression
+  val prim2: ?loc:loc -> prim2 -> expression -> expression -> expression
+  val if_: ?loc:loc -> expression -> expression -> expression -> expression
+  val while_: ?loc:loc -> expression -> expression -> expression
+  val constraint_: ?loc:loc -> expression -> parsed_type -> expression
+  val assign: ?loc:loc -> expression -> expression -> expression
+  val lambda: ?loc:loc -> pattern list -> expression -> expression
+  val apply: ?loc:loc -> expression -> expression list -> expression
+  val block: ?loc:loc -> expression list -> expression
+  val null: ?loc:loc -> unit -> expression
   val ignore: expression -> expression
-  val ident: ?loc:loc -> ?ignored:ignored -> id -> expression
-  val constant: ?loc:loc -> ?ignored:ignored -> constant -> expression
-  val tuple: ?loc:loc -> ?ignored:ignored -> expression list -> expression
-  val record: ?loc:loc -> ?ignored:ignored -> (id * expression) list -> expression
-  val record_get: ?loc:loc -> ?ignored:ignored -> expression -> id -> expression
-  val let_: ?loc:loc -> ?ignored:ignored -> rec_flag -> value_binding list -> expression -> expression
-  val match_: ?loc:loc -> ?ignored:ignored -> expression -> match_branch list -> expression
-  val prim1: ?loc:loc -> ?ignored:ignored -> prim1 -> expression -> expression
-  val prim2: ?loc:loc -> ?ignored:ignored -> prim2 -> expression -> expression -> expression
-  val if_: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression -> expression
-  val while_: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression
-  val constraint_: ?loc:loc -> ?ignored:ignored -> expression -> parsed_type -> expression
-  val assign: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression
-  val lambda: ?loc:loc -> ?ignored:ignored -> pattern list -> expression -> expression
-  val apply: ?loc:loc -> ?ignored:ignored -> expression -> expression list -> expression
-  val block: ?loc:loc -> ?ignored:ignored -> expression list -> expression
-  val null: ?loc:loc -> ?ignored:ignored -> unit -> expression
 end
 
 module Top: sig

--- a/src/parsing/ast_helper.mli
+++ b/src/parsing/ast_helper.mli
@@ -77,24 +77,25 @@ module Pat : sig
 end
 
 module Exp: sig
-  val mk: ?loc:loc -> expression_desc -> expression
-  val ident: ?loc:loc -> id -> expression
-  val constant: ?loc:loc -> constant -> expression
-  val tuple: ?loc:loc -> expression list -> expression
-  val record: ?loc:loc -> (id * expression) list -> expression
-  val record_get: ?loc:loc -> expression -> id -> expression
-  val let_: ?loc:loc -> rec_flag -> value_binding list -> expression -> expression
-  val match_: ?loc:loc -> expression -> match_branch list -> expression
-  val prim1: ?loc:loc -> prim1 -> expression -> expression
-  val prim2: ?loc:loc -> prim2 -> expression -> expression -> expression
-  val if_: ?loc:loc -> expression -> expression -> expression -> expression
-  val while_: ?loc:loc -> expression -> expression -> expression
-  val constraint_: ?loc:loc -> expression -> parsed_type -> expression
-  val assign: ?loc:loc -> expression -> expression -> expression
-  val lambda: ?loc:loc -> pattern list -> expression -> expression
-  val apply: ?loc:loc -> expression -> expression list -> expression
-  val block: ?loc:loc -> expression list -> expression
-  val null: ?loc:loc -> unit -> expression
+  val mk: ?loc:loc -> ?ignored:ignored -> expression_desc -> expression
+  val ignore: expression -> expression
+  val ident: ?loc:loc -> ?ignored:ignored -> id -> expression
+  val constant: ?loc:loc -> ?ignored:ignored -> constant -> expression
+  val tuple: ?loc:loc -> ?ignored:ignored -> expression list -> expression
+  val record: ?loc:loc -> ?ignored:ignored -> (id * expression) list -> expression
+  val record_get: ?loc:loc -> ?ignored:ignored -> expression -> id -> expression
+  val let_: ?loc:loc -> ?ignored:ignored -> rec_flag -> value_binding list -> expression -> expression
+  val match_: ?loc:loc -> ?ignored:ignored -> expression -> match_branch list -> expression
+  val prim1: ?loc:loc -> ?ignored:ignored -> prim1 -> expression -> expression
+  val prim2: ?loc:loc -> ?ignored:ignored -> prim2 -> expression -> expression -> expression
+  val if_: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression -> expression
+  val while_: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression
+  val constraint_: ?loc:loc -> ?ignored:ignored -> expression -> parsed_type -> expression
+  val assign: ?loc:loc -> ?ignored:ignored -> expression -> expression -> expression
+  val lambda: ?loc:loc -> ?ignored:ignored -> pattern list -> expression -> expression
+  val apply: ?loc:loc -> ?ignored:ignored -> expression -> expression list -> expression
+  val block: ?loc:loc -> ?ignored:ignored -> expression list -> expression
+  val null: ?loc:loc -> ?ignored:ignored -> unit -> expression
 end
 
 module Top: sig

--- a/src/parsing/ast_iterator.ml
+++ b/src/parsing/ast_iterator.ml
@@ -42,6 +42,7 @@ module E = struct
     | PExpAssign(be, e) -> sub.expr sub be; sub.expr sub e
     | PExpIf(c, t, f) -> sub.expr sub c; sub.expr sub t; sub.expr sub f
     | PExpWhile(c, b) -> sub.expr sub c; sub.expr sub b
+    | PExpConstraint(e, t) -> sub.expr sub e; sub.typ sub t
     | PExpLambda(pl, e) -> List.iter (sub.pat sub) pl; sub.expr sub e
     | PExpApp(e, el) -> sub.expr sub e; List.iter (sub.expr sub) el
     | PExpBlock(el) -> List.iter (sub.expr sub) el

--- a/src/parsing/ast_mapper.ml
+++ b/src/parsing/ast_mapper.ml
@@ -28,28 +28,27 @@ module Cnst = struct
 end
 
 module E = struct
-  let map sub {pexp_desc = desc; pexp_loc = loc; pexp_ignored = ignored} =
+  let map sub {pexp_desc = desc; pexp_loc = loc} =
     let open Exp in
     let loc = sub.location sub loc in
     match desc with
-      | PExpId(i) -> ident ~loc ~ignored (map_loc sub i)
-      | PExpConstant(c) -> constant ~loc ~ignored (sub.constant sub c)
-      | PExpTuple(es) -> tuple ~loc ~ignored (List.map (sub.expr sub) es)
-      | PExpRecord(es) -> record ~loc ~ignored (List.map (fun (name, expr) -> map_loc sub name, (sub.expr sub expr)) es)
-      | PExpRecordGet(e, f) -> record_get ~loc ~ignored (sub.expr sub e) (map_loc sub f)
-      | PExpLet(r, vbs, e) -> let_ ~loc ~ignored r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
-      | PExpMatch(e, mbs) -> match_ ~loc ~ignored (sub.expr sub e) (List.map (sub.match_branch sub) mbs)
-      | PExpPrim1(p1, e) -> prim1 ~loc ~ignored p1 (sub.expr sub e)
-      | PExpPrim2(p2, e1, e2) -> prim2 ~loc ~ignored p2 (sub.expr sub e1) (sub.expr sub e2)
-      | PExpAssign(be, e) -> assign ~loc ~ignored (sub.expr sub be) (sub.expr sub e)
-      | PExpIf(c, t, f) -> if_ ~loc ~ignored (sub.expr sub c) (sub.expr sub t) (sub.expr sub f)
-      | PExpWhile(c, e) -> while_ ~loc ~ignored (sub.expr sub c) (sub.expr sub e)
-      | PExpConstraint(e, t) -> constraint_ ~loc ~ignored (sub.expr sub e) (sub.typ sub t)
-      | PExpLambda(pl, e) -> lambda ~loc ~ignored (List.map (sub.pat sub) pl) (sub.expr sub e)
-      | PExpApp(e, el) -> apply ~loc ~ignored (sub.expr sub e) (List.map (sub.expr sub) el)
-      | PExpBlock(el) -> block ~loc ~ignored (List.map (sub.expr sub) el)
-      | PExpNull -> null ~loc ~ignored ()
-      | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
+    | PExpId(i) -> ident ~loc (map_loc sub i)
+    | PExpConstant(c) -> constant ~loc (sub.constant sub c)
+    | PExpTuple(es) -> tuple ~loc (List.map (sub.expr sub) es)
+    | PExpRecord(es) -> record ~loc (List.map (fun (name, expr) -> map_loc sub name, (sub.expr sub expr)) es)
+    | PExpRecordGet(e, f) -> record_get ~loc (sub.expr sub e) (map_loc sub f)
+    | PExpLet(r, vbs, e) -> let_ ~loc r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
+    | PExpMatch(e, mbs) -> match_ ~loc (sub.expr sub e) (List.map (sub.match_branch sub) mbs)
+    | PExpPrim1(p1, e) -> prim1 ~loc p1 (sub.expr sub e)
+    | PExpPrim2(p2, e1, e2) -> prim2 ~loc p2 (sub.expr sub e1) (sub.expr sub e2)
+    | PExpAssign(be, e) -> assign ~loc (sub.expr sub be) (sub.expr sub e)
+    | PExpIf(c, t, f) -> if_ ~loc (sub.expr sub c) (sub.expr sub t) (sub.expr sub f)
+    | PExpWhile(c, e) -> while_ ~loc (sub.expr sub c) (sub.expr sub e)
+    | PExpLambda(pl, e) -> lambda ~loc (List.map (sub.pat sub) pl) (sub.expr sub e)
+    | PExpApp(e, el) -> apply ~loc (sub.expr sub e) (List.map (sub.expr sub) el)
+    | PExpBlock(el) -> block ~loc (List.map (sub.expr sub) el)
+    | PExpNull -> null ~loc ()
+    | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
 end
 
 module P = struct

--- a/src/parsing/ast_mapper.ml
+++ b/src/parsing/ast_mapper.ml
@@ -28,28 +28,28 @@ module Cnst = struct
 end
 
 module E = struct
-  let map sub {pexp_desc = desc; pexp_loc = loc} =
+  let map sub {pexp_desc = desc; pexp_loc = loc; pexp_ignored = ignored} =
     let open Exp in
     let loc = sub.location sub loc in
     match desc with
-    | PExpId(i) -> ident ~loc (map_loc sub i)
-    | PExpConstant(c) -> constant ~loc (sub.constant sub c)
-    | PExpTuple(es) -> tuple ~loc (List.map (sub.expr sub) es)
-    | PExpRecord(es) -> record ~loc (List.map (fun (name, expr) -> map_loc sub name, (sub.expr sub expr)) es)
-    | PExpRecordGet(e, f) -> record_get ~loc (sub.expr sub e) (map_loc sub f)
-    | PExpLet(r, vbs, e) -> let_ ~loc r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
-    | PExpMatch(e, mbs) -> match_ ~loc (sub.expr sub e) (List.map (sub.match_branch sub) mbs)
-    | PExpPrim1(p1, e) -> prim1 ~loc p1 (sub.expr sub e)
-    | PExpPrim2(p2, e1, e2) -> prim2 ~loc p2 (sub.expr sub e1) (sub.expr sub e2)
-    | PExpAssign(be, e) -> assign ~loc (sub.expr sub be) (sub.expr sub e)
-    | PExpIf(c, t, f) -> if_ ~loc (sub.expr sub c) (sub.expr sub t) (sub.expr sub f)
-    | PExpWhile(c, e) -> while_ ~loc (sub.expr sub c) (sub.expr sub e)
-    | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
-    | PExpLambda(pl, e) -> lambda ~loc (List.map (sub.pat sub) pl) (sub.expr sub e)
-    | PExpApp(e, el) -> apply ~loc (sub.expr sub e) (List.map (sub.expr sub) el)
-    | PExpBlock(el) -> block ~loc (List.map (sub.expr sub) el)
-    | PExpNull -> null ~loc ()
-    | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
+      | PExpId(i) -> ident ~loc ~ignored (map_loc sub i)
+      | PExpConstant(c) -> constant ~loc ~ignored (sub.constant sub c)
+      | PExpTuple(es) -> tuple ~loc ~ignored (List.map (sub.expr sub) es)
+      | PExpRecord(es) -> record ~loc ~ignored (List.map (fun (name, expr) -> map_loc sub name, (sub.expr sub expr)) es)
+      | PExpRecordGet(e, f) -> record_get ~loc ~ignored (sub.expr sub e) (map_loc sub f)
+      | PExpLet(r, vbs, e) -> let_ ~loc ~ignored r (List.map (sub.value_binding sub) vbs) (sub.expr sub e)
+      | PExpMatch(e, mbs) -> match_ ~loc ~ignored (sub.expr sub e) (List.map (sub.match_branch sub) mbs)
+      | PExpPrim1(p1, e) -> prim1 ~loc ~ignored p1 (sub.expr sub e)
+      | PExpPrim2(p2, e1, e2) -> prim2 ~loc ~ignored p2 (sub.expr sub e1) (sub.expr sub e2)
+      | PExpAssign(be, e) -> assign ~loc ~ignored (sub.expr sub be) (sub.expr sub e)
+      | PExpIf(c, t, f) -> if_ ~loc ~ignored (sub.expr sub c) (sub.expr sub t) (sub.expr sub f)
+      | PExpWhile(c, e) -> while_ ~loc ~ignored (sub.expr sub c) (sub.expr sub e)
+      | PExpConstraint(e, t) -> constraint_ ~loc ~ignored (sub.expr sub e) (sub.typ sub t)
+      | PExpLambda(pl, e) -> lambda ~loc ~ignored (List.map (sub.pat sub) pl) (sub.expr sub e)
+      | PExpApp(e, el) -> apply ~loc ~ignored (sub.expr sub e) (List.map (sub.expr sub) el)
+      | PExpBlock(el) -> block ~loc ~ignored (List.map (sub.expr sub) el)
+      | PExpNull -> null ~loc ~ignored ()
+      | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
 end
 
 module P = struct

--- a/src/parsing/ast_mapper.ml
+++ b/src/parsing/ast_mapper.ml
@@ -44,10 +44,12 @@ module E = struct
     | PExpAssign(be, e) -> assign ~loc (sub.expr sub be) (sub.expr sub e)
     | PExpIf(c, t, f) -> if_ ~loc (sub.expr sub c) (sub.expr sub t) (sub.expr sub f)
     | PExpWhile(c, e) -> while_ ~loc (sub.expr sub c) (sub.expr sub e)
+    | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
     | PExpLambda(pl, e) -> lambda ~loc (List.map (sub.pat sub) pl) (sub.expr sub e)
     | PExpApp(e, el) -> apply ~loc (sub.expr sub e) (List.map (sub.expr sub) el)
     | PExpBlock(el) -> block ~loc (List.map (sub.expr sub) el)
     | PExpNull -> null ~loc ()
+    | PExpConstraint(e, t) -> constraint_ ~loc (sub.expr sub e) (sub.typ sub t)
 end
 
 module P = struct

--- a/src/parsing/lexer.mll
+++ b/src/parsing/lexer.mll
@@ -144,9 +144,9 @@ rule token = parse
   | "*" { STAR }
   | "<=" { LESSEQ }
   | ">=" { GREATEREQ }
-  | "and" { AND }
-  | "or" { OR }
-  | "not" { NOT }
+  | "&&" { AMPAMP }
+  | "||" { PIPEPIPE }
+  | "!" { NOT }
   | '"'   { read_dquote_str (Buffer.create 16) lexbuf }
   | '\'' { read_squote_str (Buffer.create 16) lexbuf }
   | "_" { UNDERSCORE }

--- a/src/parsing/lexer.mll
+++ b/src/parsing/lexer.mll
@@ -88,7 +88,7 @@ let oct_esc = "\\" oct_digit (oct_digit oct_digit?)?
 let num_esc = (unicode_esc | hex_esc | oct_esc)
 
 let newline_char = ("\r\n"|"\n\r"|'\n'|'\r')
-let newline_chars = newline_char (newline_char | blank)*
+let newline_chars = (newline_char | blank)* newline_char
 
 let comment = '#' ((([^'|'])[^ '\r' '\n']*(newline_chars | eof)) | (newline_chars | eof))
 

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -404,7 +404,7 @@ match_branch :
   | pattern thickarrow expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 match_branches :
-  | [pipe match_branch EOL? {$2}]* pipe match_branch { $1 @ [$3] }
+  | pipe? match_branch [EOL? pipe match_branch {$3}]* { $2::$3 }
 
 match_expr :
   | MATCH lparen expr rparen lbrace match_branches rbrace { Exp.match_ ~loc:(symbol_rloc dyp) $3 $6 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -95,23 +95,23 @@ let fix_blocks ({statements; body} as prog) =
    statements=List.map (mapper.toplevel mapper) statements;
    body=mapper.expr mapper body}
 
-let block_resembles_record exprs =
+let no_record_block exprs =
   match exprs with
-  | {pexp_desc=PExpId {txt=IdentName _}}::[] -> true
-  | _ -> false
+  | [{pexp_desc=PExpId {txt=IdentName _}}] -> raise Dyp.Giveup
+  | _ -> ()
 
-let is_brace_expr expr =
+let no_brace_expr expr =
   match expr.pexp_desc with
   | PExpBlock _
-  | PExpRecord _ -> true
-  | _ -> false
+  | PExpRecord _ -> raise Dyp.Giveup
+  | _ -> ()
 
-let is_uppercase_ident expr =
+let no_uppercase_ident expr =
   match expr.pexp_desc with
   | PExpId {txt=id} ->
     let first_char = String.get (Identifier.last id) 0 in
-    first_char = BatChar.uppercase first_char
-  | _ -> false
+    if first_char = BatChar.uppercase first_char then raise Dyp.Giveup
+  | _ -> ()
 
 
 let mkid ns =
@@ -373,7 +373,7 @@ simple_expr :
   | id_expr { $1 }
 
 block_expr :
-  | lbrace block_body rbrace { if block_resembles_record $2 then raise Dyp.Giveup else Exp.block ~loc:(symbol_rloc dyp) $2 }
+  | lbrace block_body rbrace { no_record_block $2; Exp.block ~loc:(symbol_rloc dyp) $2 }
 
 block :
   | lbrace block_body rbrace { Exp.block ~loc:(symbol_rloc dyp) $2 }
@@ -383,9 +383,9 @@ lam_args :
 
 lam_expr :
   | lparen lam_args rparen thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
-  | lparen lam_args rparen thickarrow binop_expr { if is_brace_expr $5 then raise Dyp.Giveup else Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen lam_args rparen thickarrow binop_expr { no_brace_expr $5; Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
   | ID thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
-  | ID thickarrow binop_expr { if is_brace_expr $3 then raise Dyp.Giveup else Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
+  | ID thickarrow binop_expr { no_brace_expr $3; Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 let_expr :
   | LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Recursive $3 (Exp.block []) }
@@ -434,7 +434,7 @@ tuple_exprs :
   | expr [comma expr {$2}]+ { $1::$2 }
 
 record_get :
-  | non_binop_expr dot simple_id { if is_uppercase_ident $1 then raise Dyp.Giveup else Exp.record_get $1 $3 }
+  | non_binop_expr dot simple_id { no_uppercase_ident $1; Exp.record_get $1 $3 }
 
 record_field :
   | id colon expr { $1, $3 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -394,8 +394,8 @@ let_expr :
   | LET value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Nonrecursive $2 (Exp.block []) }
 
 if_expr :
-  | IF lparen expr rparen EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 (Exp.block []) }
-  | IF lparen expr rparen EOL? block ELSE EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 $9 }
+  | IF lparen expr rparen EOL? block_or_expr { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 (Exp.block []) }
+  | IF lparen expr rparen EOL? block_or_expr ELSE EOL? block_or_expr { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 $9 }
 
 while_expr :
   | WHILE lparen expr rparen block { Exp.while_ ~loc:(symbol_rloc dyp) $3 $5 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -235,6 +235,7 @@ binop_expr :
   | binop_expr(<=pc) EOL? GREATEREQ EOL? binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) GreaterEq $1 $5 } pc
   | binop_expr(<=pb) EOL? AND EOL?       binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $5 } pb
   | binop_expr(<=pb) EOL? OR EOL?        binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $5 } pb
+  | binop_expr colon typ { Exp.constraint_ ~loc:(symbol_rloc dyp) $1 $3 } pe
   | non_assign_expr { $1 } pe
   | assign_expr { $1 } pa
 

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -416,6 +416,10 @@ block_body_expr :
   | let_expr    { $1 }
   | expr  { $1 }
 
+block_body_stmt :
+  | block_body_expr SEMI EOL? { Exp.ignore $1 }
+  | block_body_expr EOL { $1 }
+
 tuple_exprs :
   | expr comma { [$1] }
   | expr [comma expr {$2}]+ { $1::$2 }
@@ -433,7 +437,8 @@ record_exprs :
   | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* {$1::$2}
 
 block_body :
-  | block_body_expr [eos block_body_expr {$2}]* eos? { $1::$2 }
+  | block_body_stmt+ block_body_expr? { $1 @ (match $2 with Some(e) -> [e] | None -> []) }
+  | block_body_expr { [$1] }
 
 file_path :
   | STRING { Location.mkloc $1 (symbol_rloc dyp) }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -97,7 +97,13 @@ let fix_blocks ({statements; body} as prog) =
 
 let block_resembles_record exprs =
   match exprs with
-  | {pexp_desc=PExpId {txt=IdentName _}}::_ -> true
+  | {pexp_desc=PExpId {txt=IdentName _}}::[] -> true
+  | _ -> false
+
+let is_brace_expr expr =
+  match expr.pexp_desc with
+  | PExpBlock _
+  | PExpRecord _ -> true
   | _ -> false
 
 let is_uppercase_ident expr =
@@ -132,7 +138,7 @@ let make_program statements body =
 
 }
 
-%relation pe<pt<pp<pb<pc<pa
+%relation pe<pt<pp<pb<pc<pa<pl
 
 %token <int> NUM
 %token <string> ID
@@ -236,6 +242,7 @@ binop_expr :
   | binop_expr(<=pb) EOL? AND EOL?       binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $5 } pb
   | binop_expr(<=pb) EOL? OR EOL?        binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $5 } pb
   | binop_expr colon typ { Exp.constraint_ ~loc:(symbol_rloc dyp) $1 $3 } pe
+  | lam_expr { $1 } pl
   | non_assign_expr { $1 } pe
   | assign_expr { $1 } pa
 
@@ -376,6 +383,7 @@ lam_args :
 
 lam_expr :
   | lparen lam_args rparen thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen lam_args rparen thickarrow binop_expr { if is_brace_expr $5 then raise Dyp.Giveup else Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
 
 let_expr :
   | LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Recursive $3 (Exp.block []) }
@@ -407,7 +415,6 @@ non_assign_expr :
   | record_get  { $1 }
   | paren_expr  { $1 }
   | block_expr  { $1 }
-  | lam_expr    { $1 }
   | if_expr     { $1 }
   | while_expr  { $1 }
   | match_expr  { $1 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -156,11 +156,54 @@ let make_program statements body =
 
 %token DATA IMPORT EXPORT FOREIGN WASM 
 %token EXCEPT FROM
-%token EOF
+%token EOL EOF
 
 %start <Parsetree.parsed_program> program
 
 %parser
+
+eos :
+  | EOL { None }
+  | SEMI EOL? { None }
+
+lparen : 
+  | LPAREN EOL? { () }
+
+rparen : 
+  | EOL? RPAREN { () }
+
+lbrace : 
+  | LBRACE EOL? { () }
+
+rbrace : 
+  | EOL? RBRACE { () }
+
+lcaret : 
+  | LCARET EOL? { () }
+
+rcaret : 
+  | EOL? RCARET { () }
+
+comma :
+  | EOL? COMMA EOL? { () }
+
+colon :
+  | EOL? COLON EOL? { () }
+
+dot :
+  | EOL? DOT EOL? { () }
+
+arrow :
+  | EOL? ARROW EOL? { () }
+
+thickarrow :
+  | EOL? THICKARROW EOL? { () }
+
+pipe :
+  | EOL? PIPE EOL? { () }
+
+equal :
+  | EOL? EQUAL EOL? { () }
 
 const :
   | NUM { Const.int $1 }
@@ -182,16 +225,16 @@ expr :
   binop_expr
 
 binop_expr :
-  | binop_expr(<=pp) PLUS      binop_expr(<pp) { prerr_string "\nbinop_expr_plus\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.prim2 ~loc:(symbol_rloc dyp) Plus $1 $3 } pp
-  | binop_expr(<=pp) DASH     binop_expr(<pp) { Exp.prim2 ~loc:(symbol_rloc dyp) Minus $1 $3 } pp
-  | binop_expr(<=pt) STAR     binop_expr(<pt) { Exp.prim2 ~loc:(symbol_rloc dyp) Times $1 $3 } pt
-  | binop_expr(<=pc) EQEQ      binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Eq $1 $3 } pc
-  | binop_expr(<=pc) LCARET    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Less $1 $3 } pc
-  | binop_expr(<=pc) RCARET    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Greater $1 $3 } pc
-  | binop_expr(<=pc) LESSEQ    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) LessEq $1 $3 } pc
-  | binop_expr(<=pc) GREATEREQ binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) GreaterEq $1 $3 } pc
-  | binop_expr(<=pb) AND       binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $3 } pb
-  | binop_expr(<=pb) OR        binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $3 } pb
+  | binop_expr(<=pp) EOL? PLUS EOL?      binop_expr(<pp) { prerr_string "\nbinop_expr_plus\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.prim2 ~loc:(symbol_rloc dyp) Plus $1 $5 } pp
+  | binop_expr(<=pp) EOL? DASH EOL?      binop_expr(<pp) { Exp.prim2 ~loc:(symbol_rloc dyp) Minus $1 $5 } pp
+  | binop_expr(<=pt) EOL? STAR EOL?      binop_expr(<pt) { Exp.prim2 ~loc:(symbol_rloc dyp) Times $1 $5 } pt
+  | binop_expr(<=pc) EOL? EQEQ EOL?      binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Eq $1 $5 } pc
+  | binop_expr(<=pc) EOL? LCARET EOL?    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Less $1 $5 } pc
+  | binop_expr(<=pc) EOL? RCARET EOL?    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Greater $1 $5 } pc
+  | binop_expr(<=pc) EOL? LESSEQ EOL?    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) LessEq $1 $5 } pc
+  | binop_expr(<=pc) EOL? GREATEREQ EOL? binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) GreaterEq $1 $5 } pc
+  | binop_expr(<=pb) EOL? AND EOL?       binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $5 } pb
+  | binop_expr(<=pb) EOL? OR EOL?        binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $5 } pb
   | non_assign_expr { $1 } pe
   | assign_expr { $1 } pa
 
@@ -200,112 +243,111 @@ non_binop_expr :
   | assign_expr { $1 } pa
 
 pattern :
-  | pattern COLON typ { Pat.constraint_ ~loc:(symbol_rloc dyp) $1 $3 }
+  | pattern colon typ { Pat.constraint_ ~loc:(symbol_rloc dyp) $1 $3 }
   | UNDERSCORE { Pat.any ~loc:(symbol_rloc dyp) () }
   /* If the pattern uses an external ID, we know it's a constructor, not a variable */
   | ext_constructor { Pat.construct ~loc:(symbol_rloc dyp) $1 [] }
   | ID { Pat.var ~loc:(symbol_rloc dyp) (mkstr dyp $1) }
-  | LPAREN tuple_patterns RPAREN { Pat.tuple ~loc:(symbol_rloc dyp) $2 }
-  | LPAREN pattern RPAREN { $2 }
-  | LBRACE record_patterns RBRACE { Pat.record ~loc:(symbol_rloc dyp) $2 }
-  | type_id LPAREN tuple_patterns RPAREN { Pat.construct ~loc:(symbol_rloc dyp) $1 $3 }
+  | lparen tuple_patterns rparen { Pat.tuple ~loc:(symbol_rloc dyp) $2 }
+  | lparen pattern rparen { $2 }
+  | lbrace record_patterns rbrace { Pat.record ~loc:(symbol_rloc dyp) $2 }
+  | type_id lparen tuple_patterns rparen { Pat.construct ~loc:(symbol_rloc dyp) $1 $3 }
   | type_id { Pat.construct ~loc:(symbol_rloc dyp) $1 [] }
 
 patterns :
-  | pattern [COMMA pattern {$2}]* { $1::$2 }
+  | pattern [comma pattern {$2}]* { $1::$2 }
 
 tuple_patterns :
-  | pattern COMMA { [$1] }
-  | pattern [COMMA pattern {$2}]+ { $1::$2 }
+  | pattern comma { [$1] }
+  | pattern [comma pattern {$2}]+ { $1::$2 }
 
 record_patterns :
-  | record_pattern [COMMA record_pattern {$2}]* { $1::$2 }
+  | record_pattern [comma record_pattern {$2}]* { $1::$2 }
 
 record_pattern :
   | UNDERSCORE { None, Open }
-  | id COLON pattern { Some($1, $3), Closed }
+  | id colon pattern { Some($1, $3), Closed }
   | id { Some($1, Pat.var ~loc:(symbol_rloc dyp) (mkstr dyp (Identifier.last $1.txt))), Closed }
 
 data_typ :
-  | type_id LCARET typ [COMMA typ {$2}]* RCARET { Typ.constr $1 ($3::$4) }
+  | type_id lcaret typ [comma typ {$2}]* rcaret { Typ.constr $1 ($3::$4) }
   | type_id { Typ.constr $1 [] }
 
 typ :
   /* Convenience: Parens optional for single-argument functions */
-  | data_typ ARROW typ { Typ.arrow ~loc:(symbol_rloc dyp) [$1] $3 }
-  | ID ARROW typ { Typ.arrow ~loc:(symbol_rloc dyp) [(Typ.var $1)] $3 }
-  | LPAREN typs RPAREN ARROW typ { Typ.arrow ~loc:(symbol_rloc dyp) $2 $5 }
-  | LPAREN tuple_typs RPAREN { Typ.tuple ~loc:(symbol_rloc dyp) $2 }
-  | LPAREN typ RPAREN { $2 }
+  | data_typ arrow typ { Typ.arrow ~loc:(symbol_rloc dyp) [$1] $3 }
+  | ID arrow typ { Typ.arrow ~loc:(symbol_rloc dyp) [(Typ.var $1)] $3 }
+  | lparen typs rparen arrow typ { Typ.arrow ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen tuple_typs rparen { Typ.tuple ~loc:(symbol_rloc dyp) $2 }
+  | lparen typ rparen { $2 }
   | ID { Typ.var $1 }
   | data_typ
 
 typs :
-  | [typ [COMMA typ {$2}]* {$1::$2}]? { Option.default [] $1 }
+  | [typ [comma typ {$2}]* {$1::$2}]? { Option.default [] $1 }
 
 tuple_typs :
-  | typ COMMA { [$1] }
-  | typ [COMMA typ {$2}]+ { $1::$2 }
+  | typ comma { [$1] }
+  | typ [comma typ {$2}]+ { $1::$2 }
 
 value_bind :
-  | pattern EQUAL expr { Vb.mk ~loc:(symbol_rloc dyp) $1 $3 }
+  | pattern equal expr { Vb.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 value_binds :
-  | value_bind [COMMA value_bind {$2}]* { $1::$2 }
+  | value_bind [comma value_bind {$2}]* { $1::$2 }
 
 import_shape :
   | id { PImportModule, Some $1 }
-  | STAR [EXCEPT LBRACE id [COMMA id {$2}]* RBRACE {$3::$4}]? [AS id {$2}]? { PImportAllExcept (Option.default [] $2), $3 }
-  | LBRACE [id [AS id {$2}]? [COMMA id [AS id {$2}]? {($2, $3)}]* {($1, $2)::$3}]? RBRACE [AS id {$2}]? { PImportValues (Option.default [] $2), $4 }
+  | STAR [EXCEPT lbrace id [comma id {$2}]* rbrace {$3::$4}]? [AS id {$2}]? { PImportAllExcept (Option.default [] $2), $3 }
+  | lbrace [id [AS id {$2}]? [comma id [AS id {$2}]? {($2, $3)}]* {($1, $2)::$3}]? rbrace [AS id {$2}]? { PImportValues (Option.default [] $2), $4 }
 
 import_stmt :
-  | IMPORT import_shape [COMMA import_shape {$2}]* FROM file_path { Imp.mk ($2::$3) $5 }
+  | IMPORT import_shape [comma import_shape {$2}]* FROM file_path { Imp.mk ($2::$3) $5 }
 
 export_stmt :
   | EXPORT LET REC value_binds { Top.let_ Exported Recursive $4 }
   | EXPORT LET value_binds { Top.let_ Exported Nonrecursive $3 }
   | EXPORT foreign_stmt { Top.foreign ~loc:(symbol_rloc dyp) Exported $2 }
   | EXPORT data_declaration { Top.data Exported $2 }
-  | EXPORT any_id_str [AS any_id_str {$2}]? [COMMA any_id_str [AS any_id_str {$2}]? {$2, $3}]* { Top.export ~loc:(symbol_rloc dyp) (Ex.mk ~loc:(symbol_rloc dyp) (($2, $3)::$4)) }
-  | EXPORT STAR [EXCEPT export_id_str [COMMA export_id_str {$2}]* {$2::$3}]? { Top.export_all ~loc:(symbol_rloc dyp) (Option.default [] $3) }
+  | EXPORT any_id_str [AS any_id_str {$2}]? [comma any_id_str [AS any_id_str {$2}]? {$2, $3}]* { Top.export ~loc:(symbol_rloc dyp) (Ex.mk ~loc:(symbol_rloc dyp) (($2, $3)::$4)) }
+  | EXPORT STAR [EXCEPT export_id_str [comma export_id_str {$2}]* {$2::$3}]? { Top.export_all ~loc:(symbol_rloc dyp) (Option.default [] $3) }
 
 data_constructor :
   | TYPEID { CDecl.singleton ~loc:(symbol_rloc dyp) (mkstr dyp $1) }
-  | TYPEID LPAREN typs RPAREN { CDecl.tuple ~loc:(symbol_rloc dyp) (mkstr dyp $1) $3 }
+  | TYPEID lparen typs rparen { CDecl.tuple ~loc:(symbol_rloc dyp) (mkstr dyp $1) $3 }
 
 data_constructors :
-  | data_constructor [PIPE data_constructor {$2}]* { $1::$2 }
-  | [PIPE data_constructor {$2}]+ { $1 }
+  | [PIPE EOL?]? data_constructor [pipe data_constructor {$2}]* { $2::$3 }
 
 data_label :
-  | simple_id COLON typ { LDecl.mk ~loc:(symbol_rloc dyp) $1 $3 }
+  | simple_id colon typ { LDecl.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 data_labels :
-  | LBRACE data_label [COMMA data_label {$2}]* RBRACE { $2::$3 }
+  | lbrace data_label [comma data_label {$2}]* rbrace { $2::$3 }
 
 data_declaration :
-  | DATA TYPEID [LCARET ID [COMMA ID {$2}]* RCARET {$2::$3}]? EQUAL data_constructors { Dat.variant ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
-  | DATA TYPEID [LCARET ID [COMMA ID {$2}]* RCARET {$2::$3}]? EQUAL data_labels { Dat.record ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
+  | DATA TYPEID [lcaret ID [comma ID {$2}]* rcaret {$2::$3}]? equal data_constructors { Dat.variant ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
+  | DATA TYPEID [lcaret ID [comma ID {$2}]* rcaret {$2::$3}]? equal data_labels { Dat.record ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
 
 prim1_expr :
-  | prim1 LPAREN expr RPAREN { Exp.prim1 ~loc:(symbol_rloc dyp) $1 $3 }
+  | prim1 lparen expr rparen { Exp.prim1 ~loc:(symbol_rloc dyp) $1 $3 }
 
 paren_expr :
-  | LPAREN expr RPAREN { $2 }
+  | lparen expr rparen { $2 }
 
 app_arg_exprs :
-  | [expr [COMMA expr {$2}]* { $1::$2 }]? { Option.default [] $1 }
+  | [expr [comma expr {$2}]* { $1::$2 }]? { Option.default [] $1 }
 
 app_expr :
-  | id_expr LPAREN app_arg_exprs RPAREN { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
-  | paren_expr LPAREN app_arg_exprs RPAREN { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
-  | app_expr LPAREN app_arg_exprs RPAREN { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | id_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | paren_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | app_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
 
 ext_constructor :
-  | TYPEID [DOT TYPEID {$2}]+ { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid ($1::$2)) (symbol_rloc dyp) }
+  | TYPEID [dot TYPEID {$2}]+ { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid ($1::$2)) (symbol_rloc dyp) }
 
 id :
-  | [TYPEID DOT {$1}]* [ID | TYPEID] { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid (List.append $1 [$2])) (symbol_rloc dyp) }
+  | [TYPEID dot {$1}]* [ID | TYPEID] { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid (List.append $1 [$2])) (symbol_rloc dyp) }
 
 simple_id :
   | ID { (mkid [$1]) (symbol_rloc dyp) }
@@ -318,44 +360,44 @@ id_expr :
 
 simple_expr :
   | const { Exp.constant ~loc:(symbol_rloc dyp) $1 }
-  | LPAREN tuple_exprs RPAREN { Exp.tuple ~loc:(symbol_rloc dyp) $2 }
-  | LBRACE record_exprs RBRACE { Exp.record ~loc:(symbol_rloc dyp) $2 }
+  | lparen tuple_exprs rparen { Exp.tuple ~loc:(symbol_rloc dyp) $2 }
+  | lbrace record_exprs rbrace { Exp.record ~loc:(symbol_rloc dyp) $2 }
   | id_expr { $1 }
 
 block_expr :
-  | LBRACE block_body RBRACE { if block_resembles_record $2 then raise Dyp.Giveup else Exp.block ~loc:(symbol_rloc dyp) $2 }
+  | lbrace block_body rbrace { if block_resembles_record $2 then raise Dyp.Giveup else Exp.block ~loc:(symbol_rloc dyp) $2 }
 
 block :
-  | LBRACE block_body RBRACE { Exp.block ~loc:(symbol_rloc dyp) $2 }
+  | lbrace block_body rbrace { Exp.block ~loc:(symbol_rloc dyp) $2 }
 
 lam_args :
   | patterns? { Option.default [] $1 }
 
 lam_expr :
-  | LPAREN lam_args RPAREN THICKARROW block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen lam_args rparen thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
 
 let_expr :
   | LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Recursive $3 (Exp.block []) }
   | LET value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Nonrecursive $2 (Exp.block []) }
 
 if_expr :
-  | IF expr block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $3 (Exp.block []) }
-  | IF expr block ELSE block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $3 $5 }
+  | IF expr EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $4 (Exp.block []) }
+  | IF expr EOL? block ELSE EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $4 $7 }
 
 while_expr :
-  | WHILE LPAREN expr RPAREN block { Exp.while_ ~loc:(symbol_rloc dyp) $3 $5 }
+  | WHILE lparen expr rparen block { Exp.while_ ~loc:(symbol_rloc dyp) $3 $5 }
 
 match_branch :
-  | pattern THICKARROW expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $3 }
+  | pattern thickarrow expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 match_branches :
-  | [PIPE match_branch {$2}]+ { $1 }
+  | [pipe match_branch {$2}]+ { $1 }
 
 match_expr :
-  | MATCH LPAREN expr RPAREN LBRACE match_branches RBRACE { Exp.match_ ~loc:(symbol_rloc dyp) $3 $6 }
+  | MATCH lparen expr rparen lbrace match_branches rbrace { Exp.match_ ~loc:(symbol_rloc dyp) $3 $6 }
 
 assign_expr :
-  | expr GETS expr { Exp.assign ~loc:(symbol_rloc dyp) $1 $3 }
+  | expr EOL? GETS EOL? expr { Exp.assign ~loc:(symbol_rloc dyp) $1 $5 }
 
 non_assign_expr :
   | app_expr    { prerr_string "\nexpr_app_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); $1 }
@@ -374,23 +416,23 @@ block_body_expr :
   | expr  { $1 }
 
 tuple_exprs :
-  | expr COMMA { [$1] }
-  | expr [COMMA expr {$2}]+ { $1::$2 }
+  | expr comma { [$1] }
+  | expr [comma expr {$2}]+ { $1::$2 }
 
 record_get :
-  | non_binop_expr DOT simple_id { if is_uppercase_ident $1 then raise Dyp.Giveup else Exp.record_get $1 $3 }
+  | non_binop_expr dot simple_id { if is_uppercase_ident $1 then raise Dyp.Giveup else Exp.record_get $1 $3 }
 
 record_field :
-  | id COLON expr { $1, $3 }
+  | id colon expr { $1, $3 }
 
 record_pun :
   | ID { mkid [$1] (symbol_rloc dyp), Exp.ident ~loc:(symbol_rloc dyp) (mkid [$1] (symbol_rloc dyp)) }
 
 record_exprs :
-  | [record_field | record_pun] [COMMA [record_field | record_pun] {$2}]* {$1::$2}
+  | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* {$1::$2}
 
 block_body :
-  | block_body_expr [SEMI block_body_expr {$2}]* { $1::$2 }
+  | block_body_expr [eos block_body_expr {$2}]* eos? { $1::$2 }
 
 file_path :
   | STRING { Location.mkloc $1 (symbol_rloc dyp) }
@@ -410,7 +452,7 @@ export_id_str :
   | type_id_str { ExportExceptData $1 }
 
 foreign_stmt :
-  | FOREIGN WASM id_str id_str COLON typ { Val.mk ~loc:(symbol_rloc dyp) ~mod_:$3 ~name:$4 ~typ:$6 ~prim:[$4.txt] }
+  | FOREIGN WASM id_str id_str colon typ { Val.mk ~loc:(symbol_rloc dyp) ~mod_:$3 ~name:$4 ~typ:$6 ~prim:[$4.txt] }
 
 toplevel_stmt :
   | LET REC value_binds { Top.let_ Nonexported Recursive $3 }
@@ -421,12 +463,12 @@ toplevel_stmt :
   | data_declaration { Top.data Nonexported $1 }
 
 toplevel_stmts :
-  | toplevel_stmt [SEMI toplevel_stmt {$2}]* { $1::$2 }
+  | toplevel_stmt [eos toplevel_stmt {$2}]* { $1::$2 }
 
 program :
-  | toplevel_stmts SEMI EOF { make_program $1 (Exp.null ~loc:dummy_loc ()) }
-  | toplevel_stmts SEMI expr EOF { make_program $1 $3 }
-  | expr EOF { prerr_string "\nprogram\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); make_program [] $1 }
+  | EOL? toplevel_stmts eos? EOF { make_program $2 (Exp.null ~loc:dummy_loc ()) }
+  | EOL? toplevel_stmts eos expr eos? EOF { make_program $2 $4 }
+  | EOL? expr eos? EOF { prerr_string "\nprogram\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); make_program [] $2 }
 
 %%
 

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -200,7 +200,7 @@ thickarrow :
   | EOL? THICKARROW EOL? { () }
 
 pipe :
-  | EOL? PIPE EOL? { () }
+  | PIPE EOL? { () }
 
 equal :
   | EOL? EQUAL EOL? { () }
@@ -318,7 +318,7 @@ data_constructor :
   | TYPEID lparen typs rparen { CDecl.tuple ~loc:(symbol_rloc dyp) (mkstr dyp $1) $3 }
 
 data_constructors :
-  | [PIPE EOL?]? data_constructor [pipe data_constructor {$2}]* { $2::$3 }
+  | pipe? data_constructor [EOL? pipe data_constructor {$3}]* { $2::$3 }
 
 data_label :
   | simple_id colon typ { LDecl.mk ~loc:(symbol_rloc dyp) $1 $3 }
@@ -392,7 +392,7 @@ match_branch :
   | pattern thickarrow expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 match_branches :
-  | [pipe match_branch {$2}]+ { $1 }
+  | [pipe match_branch EOL? {$2}]* pipe match_branch { $1 @ [$3] }
 
 match_expr :
   | MATCH lparen expr rparen lbrace match_branches rbrace { Exp.match_ ~loc:(symbol_rloc dyp) $3 $6 }
@@ -437,8 +437,8 @@ record_exprs :
   | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* {$1::$2}
 
 block_body :
-  | block_body_stmt+ block_body_expr? { $1 @ (match $2 with Some(e) -> [e] | None -> []) }
-  | block_body_expr { [$1] }
+  | block_body_stmt* block_body_expr SEMI { $1 @ [Exp.ignore $2] }
+  | block_body_stmt* block_body_expr { $1 @ [$2] }
 
 file_path :
   | STRING { Location.mkloc $1 (symbol_rloc dyp) }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -158,7 +158,7 @@ let make_program statements body =
 %token TRUE FALSE
 
 %token LET REC IF ELSE MATCH WHILE
-%token AND OR NOT
+%token AMPAMP PIPEPIPE NOT
 
 %token DATA IMPORT EXPORT FOREIGN WASM 
 %token EXCEPT FROM
@@ -220,7 +220,6 @@ const :
 prim1 :
   | ADD1 { Add1 }
   | SUB1 { Sub1 }
-  | NOT { Not }
   | BOX { Box }
   | UNBOX { Unbox }
   | ISBOOL { IsBool }
@@ -239,8 +238,8 @@ binop_expr :
   | binop_expr(<=pc) EOL? RCARET EOL?    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) Greater $1 $5 } pc
   | binop_expr(<=pc) EOL? LESSEQ EOL?    binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) LessEq $1 $5 } pc
   | binop_expr(<=pc) EOL? GREATEREQ EOL? binop_expr(<pc) { Exp.prim2 ~loc:(symbol_rloc dyp) GreaterEq $1 $5 } pc
-  | binop_expr(<=pb) EOL? AND EOL?       binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $5 } pb
-  | binop_expr(<=pb) EOL? OR EOL?        binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $5 } pb
+  | binop_expr(<=pb) EOL? AMPAMP EOL?    binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) And $1 $5 } pb
+  | binop_expr(<=pb) EOL? PIPEPIPE EOL?  binop_expr(<pb) { Exp.prim2 ~loc:(symbol_rloc dyp) Or $1 $5 } pb
   | binop_expr colon typ { Exp.constraint_ ~loc:(symbol_rloc dyp) $1 $3 } pe
   | lam_expr { $1 } pl
   | non_assign_expr { $1 } pe
@@ -339,6 +338,7 @@ data_declaration :
 
 prim1_expr :
   | prim1 lparen expr rparen { Exp.prim1 ~loc:(symbol_rloc dyp) $1 $3 }
+  | NOT expr { Exp.prim1 ~loc:(symbol_rloc dyp) Not $2 }
 
 paren_expr :
   | lparen expr rparen { $2 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -384,6 +384,8 @@ lam_args :
 lam_expr :
   | lparen lam_args rparen thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
   | lparen lam_args rparen thickarrow binop_expr { if is_brace_expr $5 then raise Dyp.Giveup else Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | ID thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
+  | ID thickarrow binop_expr { if is_brace_expr $3 then raise Dyp.Giveup else Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 let_expr :
   | LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Recursive $3 (Exp.block []) }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -381,8 +381,8 @@ let_expr :
   | LET value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Nonrecursive $2 (Exp.block []) }
 
 if_expr :
-  | IF expr EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $4 (Exp.block []) }
-  | IF expr EOL? block ELSE EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $2 $4 $7 }
+  | IF lparen expr rparen EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 (Exp.block []) }
+  | IF lparen expr rparen EOL? block ELSE EOL? block { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 $9 }
 
 while_expr :
   | WHILE lparen expr rparen block { Exp.while_ ~loc:(symbol_rloc dyp) $3 $5 }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -378,14 +378,16 @@ block_expr :
 block :
   | lbrace block_body rbrace { Exp.block ~loc:(symbol_rloc dyp) $2 }
 
+block_or_expr :
+  | block { $1 }
+  | expr { no_brace_expr $1; $1 }
+
 lam_args :
   | patterns? { Option.default [] $1 }
 
 lam_expr :
-  | lparen lam_args rparen thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
-  | lparen lam_args rparen thickarrow binop_expr { no_brace_expr $5; Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
-  | ID thickarrow block { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
-  | ID thickarrow binop_expr { no_brace_expr $3; Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
+  | lparen lam_args rparen thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | ID thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 let_expr :
   | LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) Recursive $3 (Exp.block []) }

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -113,10 +113,12 @@ type prim2 =
   | Or
 [@@deriving sexp]
 
+type ignored = TypeKept | TypeIgnored [@@deriving sexp]
+
 (** Type for expressions (i.e. things which evaluate to something) *)
 type expression = {
   pexp_desc: expression_desc;
-  pexp_ignored: bool;
+  pexp_ignored: ignored;
   pexp_loc: Location.t [@sexp_drop_if fun _ -> not !Grain_utils.Config.sexp_locs_enabled];
 } [@@deriving sexp]
 

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -116,6 +116,7 @@ type prim2 =
 (** Type for expressions (i.e. things which evaluate to something) *)
 type expression = {
   pexp_desc: expression_desc;
+  pexp_ignored: bool;
   pexp_loc: Location.t [@sexp_drop_if fun _ -> not !Grain_utils.Config.sexp_locs_enabled];
 } [@@deriving sexp]
 
@@ -131,6 +132,7 @@ and expression_desc =
   | PExpPrim2 of prim2 * expression * expression
   | PExpIf of expression * expression * expression
   | PExpWhile of expression * expression
+  | PExpConstraint of expression * parsed_type
   | PExpLambda of pattern list * expression
   | PExpApp of expression * expression list
   | PExpBlock of expression list

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -97,6 +97,7 @@ type prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 [@@deriving sexp]
 
 (** Two-argument operators *)
@@ -113,12 +114,9 @@ type prim2 =
   | Or
 [@@deriving sexp]
 
-type ignored = TypeKept | TypeIgnored [@@deriving sexp]
-
 (** Type for expressions (i.e. things which evaluate to something) *)
 type expression = {
   pexp_desc: expression_desc;
-  pexp_ignored: ignored;
   pexp_loc: Location.t [@sexp_drop_if fun _ -> not !Grain_utils.Config.sexp_locs_enabled];
 } [@@deriving sexp]
 

--- a/src/typed/typecore.ml
+++ b/src/typed/typecore.ml
@@ -85,6 +85,9 @@ let prim1_type = function
   | Unbox ->  
     let var = newvar ~name:"a" () in
     Builtin_types.type_box var, var
+  | Ignore ->  
+    let var = newvar ~name:"a" () in
+    var, Builtin_types.type_void
   | IsNum
   | IsBool
   | IsTuple -> newvar ~name:"prim1" (), Builtin_types.type_bool
@@ -362,10 +365,6 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected_explained 
   let loc = sexp.pexp_loc in
   (* Record the expression type before unifying it with the expected type *)
   let with_explanation = with_explanation explanation in
-  let re exp =
-    if sexp.pexp_ignored = TypeIgnored
-    then re {exp with exp_type = Builtin_types.type_void}
-    else re exp in
   let rue exp =
     with_explanation (fun () ->
       unify_exp env (re exp) (instance env ty_expected));

--- a/src/typed/typecore.ml
+++ b/src/typed/typecore.ml
@@ -631,6 +631,20 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected_explained 
       exp_type = Builtin_types.type_void;
       exp_env = env
     }
+  | PExpConstraint (sarg, styp) ->
+    begin_def ();
+    let cty = Typetexp.transl_simple_type env false styp in
+    let ty = cty.ctyp_type in
+    end_def ();
+    generalize_structure ty;
+    let (arg, ty') = (List.hd @@ type_arguments env [sarg] [ty] [(instance env ty)], instance env ty) in
+    rue {
+      exp_desc = arg.exp_desc;
+      exp_loc = arg.exp_loc;
+      exp_type = ty';
+      exp_env = env;
+      exp_extra = (TExpConstraint cty, loc) :: arg.exp_extra;
+    }
   | PExpBlock([]) -> failwith "Internal error: type_expect_ block was empty"
   | PExpBlock(es) ->
     let rec process_es rem =

--- a/src/typed/typedtree.ml
+++ b/src/typed/typedtree.ml
@@ -33,6 +33,7 @@ type prim1 = Parsetree.prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 
 type prim2 = Parsetree.prim2 =
   | Plus

--- a/src/typed/typedtree.mli
+++ b/src/typed/typedtree.mli
@@ -32,6 +32,7 @@ type prim1 = Parsetree.prim1 =
   | IsNum
   | IsBool
   | IsTuple
+  | Ignore
 
 type prim2 = Parsetree.prim2 =
   | Plus

--- a/src/typed/typemod.ml
+++ b/src/typed/typemod.ml
@@ -358,7 +358,7 @@ let type_module ?(toplevel=false) funct_body anchor env sstr (*scope*) =
       let bind_name = { txt=exported_name; loc } in
       {
         pvb_pat={ppat_desc=PPatVar(bind_name); ppat_loc=loc};
-        pvb_expr={pexp_loc=loc; pexp_ignored=false; pexp_desc=PExpId name};
+        pvb_expr={pexp_loc=loc; pexp_ignored=TypeKept; pexp_desc=PExpId name};
         pvb_loc=loc;
       }
     ) exports in

--- a/src/typed/typemod.ml
+++ b/src/typed/typemod.ml
@@ -358,7 +358,7 @@ let type_module ?(toplevel=false) funct_body anchor env sstr (*scope*) =
       let bind_name = { txt=exported_name; loc } in
       {
         pvb_pat={ppat_desc=PPatVar(bind_name); ppat_loc=loc};
-        pvb_expr={pexp_loc=loc; pexp_desc=PExpId name};
+        pvb_expr={pexp_loc=loc; pexp_ignored=false; pexp_desc=PExpId name};
         pvb_loc=loc;
       }
     ) exports in

--- a/src/typed/typemod.ml
+++ b/src/typed/typemod.ml
@@ -358,7 +358,7 @@ let type_module ?(toplevel=false) funct_body anchor env sstr (*scope*) =
       let bind_name = { txt=exported_name; loc } in
       {
         pvb_pat={ppat_desc=PPatVar(bind_name); ppat_loc=loc};
-        pvb_expr={pexp_loc=loc; pexp_ignored=TypeKept; pexp_desc=PExpId name};
+        pvb_expr={pexp_loc=loc; pexp_desc=PExpId name};
         pvb_loc=loc;
       }
     ) exports in

--- a/test/input/counter.gr
+++ b/test/input/counter.gr
@@ -1,14 +1,12 @@
 let counter = {
   let count = box(0)
   let rec counterHelp = () => {
-    count := unbox(count) + 1;
+    count := unbox(count) + 1
   }
   counterHelp
 }
 {
-  # TODO: This should either have some equivalent of OCaml's ignore(...) or print needs a different type...
-  #       We need to discuss to figure this out [philip] [oscar]
-  print(counter());
-  print(counter());
+  print(counter())
+  print(counter())
   print(counter())
 }

--- a/test/input/counter.gr
+++ b/test/input/counter.gr
@@ -1,10 +1,10 @@
 let counter = {
-  let count = box(0);
-  let rec counter_help = () => {
-    count := unbox(count) + 1
-  };
-  counter_help
-};
+  let count = box(0)
+  let rec counterHelp = () => {
+    count := unbox(count) + 1;
+  }
+  counterHelp
+}
 {
   # TODO: This should either have some equivalent of OCaml's ignore(...) or print needs a different type...
   #       We need to discuss to figure this out [philip] [oscar]

--- a/test/input/forward-decl.gr
+++ b/test/input/forward-decl.gr
@@ -4,7 +4,7 @@ let rec isEvenHelp = (n, b) => {
   if (n == 0) {
     b
   } else {
-    isOddHelp(n - 1, not(b))
+    isOddHelp(n - 1, !b)
   }
 },
 
@@ -12,7 +12,7 @@ isOddHelp = (n, b) => {
   if (n == 1) {
     b
   } else {
-    isEvenHelp(n - 1, not(b))
+    isEvenHelp(n - 1, !b)
   }
 };
 

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -83,12 +83,14 @@ let basic_functionality_tests = [
   t "complex1" "
     let x = 2, y = 3, z = if (true) { 4 } else { 5 };
     if (true) {
-      print(y) - (z + x)
+      print(y)
+      y - (z + x)
     } else {
       print(8)
+      8
     }
     "  "3\n-3";
-  t "complex2" "print(2) + print(3)" "2\n3\n5";
+  t "complex2" "print(2 + 3)" "5\n5";
 
   t "binop1" "2 + 2" "4";
   t "binop2" "2 - 2" "0";

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -186,6 +186,8 @@ let function_tests = [
 
   t "shorthand_1" "let foo = (x) => x; foo(1)" "1";
   t "shorthand_2" "let foo = (x) => x + 3; foo(1)" "4";
+  t "shorthand_3" "let foo = x => x; foo(1)" "1";
+  t "shorthand_4" "let foo = x => x + 3; foo(1)" "4";
 
   t "lambda_1" "print((x) => {x})" "<lambda>\n<lambda>";
   t "app_1" "((x) => {x})(1)" "1";

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -95,15 +95,15 @@ let basic_functionality_tests = [
   t "binop3" "2 - 4" "-2";
   t "binop4" "2 * 3" "6";
 
-  t "and1" "true and true" "true";
-  t "and2" "true and false" "false";
-  t "and3" "false and true" "false";
-  t "and4" "false and false" "false";
+  t "and1" "true && true" "true";
+  t "and2" "true && false" "false";
+  t "and3" "false && true" "false";
+  t "and4" "false && false" "false";
 
-  t "or1" "true or true" "true";
-  t "or2" "true or false" "true";
-  t "or3" "false or true" "true";
-  t "or4" "false or false" "false";
+  t "or1" "true || true" "true";
+  t "or2" "true || false" "true";
+  t "or3" "false || true" "true";
+  t "or4" "false || false" "false";
 
   t "comp1" "if (2 < 3) {true} else {false}" "true";
   te "comp1e" "if (2 < 3) {true} else {3}" "type";
@@ -124,8 +124,8 @@ let basic_functionality_tests = [
   t "comp15" "false == true" "false";
   t "comp16" "false == false" "true";
 
-  t "not1" "not(true)" "false";
-  t "not2" "not(false)" "true";
+  t "not1" "!true" "false";
+  t "not2" "!false" "true";
 
   t "add1_1" "add1(2)" "3";
   t "add1_2" "add1(5)" "6";
@@ -560,8 +560,8 @@ let optimization_tests = [
   tfsound "test_counter_sound" "counter" "1\n2\n3\n3";
   te "test_dae_sound" "let x = 2 + false; 3" "type";
   te "test_const_fold_times_zero_sound" "let f = ((x) => {x * 0}); f(false)" "Number";
-  te "test_const_fold_or_sound" "let f = ((x) => {x or true}); f(1)" "Bool";
-  te "test_const_fold_and_sound" "let f = ((x) => {false and x}); f(1)" "Bool";
+  te "test_const_fold_or_sound" "let f = ((x) => {x || true}); f(1)" "Bool";
+  te "test_const_fold_and_sound" "let f = ((x) => {false && x}); f(1)" "Bool";
   te "test_const_fold_plus_sound" "let f = ((x) => {0 + x}); f(true)" "Number";
   te "test_const_fold_times_one_sound" "let f = ((x) => {x * 1}); f(true)" "Number";
 

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -150,6 +150,8 @@ let basic_functionality_tests = [
   te "if2" "let y = 0; if (y) {5} else {6}" "type";
   te "if3" "if (sub1(1)) {2} else {5}" "type";
 
+  t "if4" "if (false) 1 else if (false) 2 else {3}" "3";
+
   (* Non-compile-time overflows *)
   te "overflow1" "9999999 * 99999999" "overflow";
   te "overflow2" "-99999999 - 999999999" "overflow";

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -255,8 +255,8 @@ let record_tests = [
   t "record_destruct_deep" "data Rec = {foo: Number}; data Rec2 = {bar: Rec}; let { bar: { foo } } = {bar: {foo: 4}}; foo" "4";
   te "record_destruct_deep_alias" "data Rec = {foo: Number}; data Rec2 = {bar: Rec}; let { bar: { foo } } = {bar: {foo: 4}}; bar" "Unbound value bar";
 
-  t "record_match_1" "data Rec = {foo: Number, bar: String, baz: Bool}; match ({foo: 4, bar: 'boo', baz: true}) { | { foo, _ } => foo }" "4";
-  t "record_match_2" "data Rec = {foo: Number, bar: String, baz: Bool}; match ({foo: 4, bar: 'boo', baz: true}) { | { bar, _ } => bar }" "\"boo\"";
+  t "record_match_1" "data Rec = {foo: Number, bar: String, baz: Bool}; match ({foo: 4, bar: 'boo', baz: true}) { { foo, _ } => foo }" "4";
+  t "record_match_2" "data Rec = {foo: Number, bar: String, baz: Bool}; match ({foo: 4, bar: 'boo', baz: true}) { { bar, _ } => bar }" "\"boo\"";
   t "record_match_3" "data Rec = {foo: Number, bar: Number, baz: Number}; match ({foo: 4, bar: 5, baz: 6}) { | { foo, bar, _ } => foo + bar }" "9";
   t "record_match_4" "data Rec = {foo: Number, bar: Number, baz: Number}; match ({foo: 4, bar: 5, baz: 6}) { | { foo, bar, baz } => foo + bar + baz}" "15";
   t "record_match_deep" "data Rec = {foo: Number}; data Rec2 = {bar: Rec}; match ({bar: {foo: 4}}) { | { bar: { foo } } => foo }" "4";

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -184,6 +184,9 @@ let function_tests = [
   te "arity_2" "let foo = ((x) => {x + 5});\nfoo()" "type";
   te "arity_3" "let foo = ((x) => {x});\nfoo(1, 2, 3)" "type";
 
+  t "shorthand_1" "let foo = (x) => x; foo(1)" "1";
+  t "shorthand_2" "let foo = (x) => x + 3; foo(1)" "4";
+
   t "lambda_1" "print((x) => {x})" "<lambda>\n<lambda>";
   t "app_1" "((x) => {x})(1)" "1";
   t "letrec_1" "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -90,7 +90,7 @@ let basic_functionality_tests = [
       8
     }
     "  "3\n-3";
-  t "complex2" "print(2 + 3)" "5\n5";
+  t "complex2" "print(2 + 3)" "5\nvoid";
 
   t "binop1" "2 + 2" "4";
   t "binop2" "2 - 2" "0";
@@ -141,6 +141,8 @@ let basic_functionality_tests = [
   te "comp_bool3" "if (true >= 4) {3} else {4}" "type";
   te "comp_bool4" "let x = true; if (x < 4) {3} else {5}" "type";
 
+  t "void" "{'foo';}" "void";
+
   te "arith1" "2 + true" "type";
   te "arith2" "true + 4" "type";
   te "arith3" "false - 5" "type";
@@ -177,7 +179,7 @@ let function_tests = [
   tfile "sinister_tail_call" "sinister-tail-call" "true";
   tefile "fib_big" "too-much-fib" "overflow";
 
-  t "func_no_args" "let foo = (() => {print(5)});\nfoo()" "5\n5";
+  t "func_no_args" "let foo = (() => {print(5)});\nfoo()" "5\nvoid";
   t "multi_bind" "let rec x = 2, y = x + 1; y" "3";
   te "unbound_fun" "2 + foo()" "unbound";
   te "unbound_id_simple" "5 - x" "unbound";
@@ -193,7 +195,7 @@ let function_tests = [
   t "shorthand_3" "let foo = x => x; foo(1)" "1";
   t "shorthand_4" "let foo = x => x + 3; foo(1)" "4";
 
-  t "lambda_1" "print((x) => {x})" "<lambda>\n<lambda>";
+  t "lambda_1" "print((x) => {x})" "<lambda>\nvoid";
   t "app_1" "((x) => {x})(1)" "1";
   t "letrec_1" "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),
                         y = ((n) => {x(n + 1)});
@@ -221,8 +223,8 @@ let function_tests = [
 let mylist = "Cons(1, Cons(2, Cons(3, Empty)))"
 
 let tuple_tests = [
-  t "print_tup" "print((1, 2))" "(1, 2)\n(1, 2)";
-  t "big_tup" "print((1, 2, 3, 4))" "(1, 2, 3, 4)\n(1, 2, 3, 4)";
+  t "print_tup" "print((1, 2))" "(1, 2)\nvoid";
+  t "big_tup" "print((1, 2, 3, 4))" "(1, 2, 3, 4)\nvoid";
   t "big_tup_access" "let (a, b, c, d) = (1, 2, 3, 4); c" "3";
   t "nested_tup_1" "let (a, b) = ((1, 2), (3, 4)); a" "(1, 2)";
   t "nested_tup_2" "let (a, b) = ((1, 2), (3, 4)); let (c, d) = b; d" "4";
@@ -293,7 +295,6 @@ let stdlib_tests = [
     "Cons(2, Cons(3, Cons(4, Empty)))";
   tlib "map_2" ("import * from 'lists'; map(((x) => {x * 2}), " ^ mylist ^ ")")
     "Cons(2, Cons(4, Cons(6, Empty)))";
-  tlib "map_print" ("import * from 'lists'; map(print, " ^ mylist ^ ")") "1\n2\n3\nCons(1, Cons(2, Cons(3, Empty)))";
   tlib "fold_left_1" ("import * from 'lists'; fold_left(((acc, cur) => {acc - cur}), 0, " ^ mylist ^ ")")
     "-6";
   tlib "fold_right_1" ("import * from 'lists'; fold_right(((cur, acc) => {cur - acc}), 0, " ^ mylist ^ ")")
@@ -324,7 +325,7 @@ let box_tests = [
               unbox(b)
             }" "3";
   t "test_set_extra1" "box(1) := 2" "2";
-  tfile "counter" "counter" "1\n2\n3\n3";
+  tfile "counter" "counter" "1\n2\n3\nvoid";
   te "test_unbox_err" "unbox(5)" "Box";
 ]
 
@@ -469,9 +470,8 @@ let optimization_tests = [
     (AExp.comp (Comp.imm (Imm.const (Const_int 4))));
 
   tfinalanf "test_dead_branch_elimination_4" 
-    "{let x = if (true) {4; 4} else {5}; x}"
-    (AExp.seq (Comp.imm (Imm.const (Const_int 4)))
-      (AExp.comp (Comp.imm (Imm.const (Const_int 4)))));
+    "{let x = if (true) {4} else {5}; x}"
+      (AExp.comp (Comp.imm (Imm.const (Const_int 4))));
 
   t "test_dead_branch_elimination_5" "
       let x = box(1);
@@ -512,7 +512,7 @@ let optimization_tests = [
   {
     let y = x;
     x
-  };
+  }
   x + y}"
     (AExp.seq (Comp.imm (Imm.const (Const_int 5)))
       (AExp.comp (Comp.imm (Imm.const (Const_int 17)))));
@@ -559,7 +559,7 @@ let optimization_tests = [
      @@ AExp.let_ Nonrecursive [(app, Comp.app (Imm.id foo) [(Imm.const (Const_int 3))])]
      @@ AExp.comp @@ Comp.prim2 Plus (Imm.id app) (Imm.const (Const_int 5)));
 
-  tfsound "test_counter_sound" "counter" "1\n2\n3\n3";
+  tfsound "test_counter_sound" "counter" "1\n2\n3\nvoid";
   te "test_dae_sound" "let x = 2 + false; 3" "type";
   te "test_const_fold_times_zero_sound" "let f = ((x) => {x * 0}); f(false)" "Number";
   te "test_const_fold_or_sound" "let f = ((x) => {x || true}); f(1)" "Bool";

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -81,8 +81,8 @@ let basic_functionality_tests = [
   t "fals" "let x = false; x" "false";
   t "tru" "let x = true; x" "true";
   t "complex1" "
-    let x = 2, y = 3, z = if true { 4 } else { 5 };
-    if true {
+    let x = 2, y = 3, z = if (true) { 4 } else { 5 };
+    if (true) {
       print(y) - (z + x)
     } else {
       print(8)
@@ -105,17 +105,17 @@ let basic_functionality_tests = [
   t "or3" "false or true" "true";
   t "or4" "false or false" "false";
 
-  t "comp1" "if 2 < 3 {true} else {false}" "true";
-  te "comp1e" "if 2 < 3 {true} else {3}" "type";
-  t "comp2" "if 2 <= 3 {true} else {false}" "true";
-  te "comp2e" "if 2 <= 3 {true} else {3}" "type";
-  t "comp3" "if 2 >= 3 {4} else {5}" "5";
-  t "comp4" "if 2 > 3 {4} else {5}" "5";
-  t "comp5" "if 2 < 3 {4} else {5}" "4";
-  t "comp6" "if 2 == 3 {8} else {9}" "9";
-  t "comp7" "if 2 == 2 {8} else {9}" "8";
-  t "comp8" "if 2 <= 2 {10} else {11}" "10";
-  t "comp9" "if 2 >= 2 {10} else {11}" "10";
+  t "comp1" "if (2 < 3) {true} else {false}" "true";
+  te "comp1e" "if (2 < 3) {true} else {3}" "type";
+  t "comp2" "if (2 <= 3) {true} else {false}" "true";
+  te "comp2e" "if (2 <= 3) {true} else {3}" "type";
+  t "comp3" "if (2 >= 3) {4} else {5}" "5";
+  t "comp4" "if (2 > 3) {4} else {5}" "5";
+  t "comp5" "if (2 < 3) {4} else {5}" "4";
+  t "comp6" "if (2 == 3) {8} else {9}" "9";
+  t "comp7" "if (2 == 2) {8} else {9}" "8";
+  t "comp8" "if (2 <= 2) {10} else {11}" "10";
+  t "comp9" "if (2 >= 2) {10} else {11}" "10";
   t "comp10" "let x = 2, y = 4; (y - 2) == x" "true";
   t "comp11" "true == 2" "false";
   t "comp12" "2 == false" "false";
@@ -134,10 +134,10 @@ let basic_functionality_tests = [
   t "sub1_2" "sub1(5)" "4";
   t "sub1_3" "sub1(0)" "-1";
 
-  te "comp_bool1" "if 2 < true {3} else {4}" "type";
-  te "comp_bool2" "if 2 > true {3} else {4}" "type";
-  te "comp_bool3" "if true >= 4 {3} else {4}" "type";
-  te "comp_bool4" "let x = true; if x < 4 {3} else {5}" "type";
+  te "comp_bool1" "if (2 < true) {3} else {4}" "type";
+  te "comp_bool2" "if (2 > true) {3} else {4}" "type";
+  te "comp_bool3" "if (true >= 4) {3} else {4}" "type";
+  te "comp_bool4" "let x = true; if (x < 4) {3} else {5}" "type";
 
   te "arith1" "2 + true" "type";
   te "arith2" "true + 4" "type";
@@ -146,9 +146,9 @@ let basic_functionality_tests = [
   te "arith5" "let x = true; x * 4" "type";
   te "arith6" "let x = false; 4 * x" "type";
 
-  te "if1" "if 2 {5} else {6}" "type";
-  te "if2" "let y = 0; if y {5} else {6}" "type";
-  te "if3" "if sub1(1) {2} else {5}" "type";
+  te "if1" "if (2) {5} else {6}" "type";
+  te "if2" "let y = 0; if (y) {5} else {6}" "type";
+  te "if3" "if (sub1(1)) {2} else {5}" "type";
 
   (* Non-compile-time overflows *)
   te "overflow1" "9999999 * 99999999" "overflow";
@@ -186,18 +186,18 @@ let function_tests = [
 
   t "lambda_1" "print((x) => {x})" "<lambda>\n<lambda>";
   t "app_1" "((x) => {x})(1)" "1";
-  t "letrec_1" "let rec x = ((n) => {if n > 3 {n} else {x(n + 2)}}),
+  t "letrec_1" "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),
                         y = ((n) => {x(n + 1)});
                  y(2)" "5";
   (* Check that recursion is order-independent *)
   t "letrec_2" "let rec y = ((n) => {x(n + 1)}),
-                        x = ((n) => {if n > 3 {n} else {x(n + 2)}});
+                        x = ((n) => {if (n > 3) {n} else {x(n + 2)}});
                  y(2)" "5";
   t "let_1" "let rec x = ((n) => {n + 1}),
                      y = x(3),
                      z = ((n) => {x(n) + y});
                z(5)" "10";
-  te "let_norec_1" "let x = ((n) => {if n > 3 {n} else {x(n + 2)}}),
+  te "let_norec_1" "let x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),
                         y = ((n) => {x(n + 1)});
                  y(2)" "Unbound value x.";
   te "lambda_dup_args" "((x, y, x) => {5})" "Variable x is bound several times";


### PR DESCRIPTION
## New syntax 🎉
Semicolons are no longer required. If a statement is followed by a semicolon, its type is ignored in a manner similar to OCaml's `ignore` function.

Type annotations (constraints) may now be placed on any expression:
```grain
let add5 = (x) => {
  (x : Number) + 5
}
```

Curly braces may now be omitted for lambdas that only return one expression:
```grain
let add = (a, b) => a + b
```

Parens around the argument of a single-argument lambda may now be omitted:
```grain
let identity = x => x
```

Curly braces are no longer required around the `then` or `else` branches of an `if`:
```grain
if (bool) this else that
```

`if`/`else if` blocks are now supported.

Boolean `and`, `or`, and `not` have been renamed to `&&`, `||`, and `!`, respectively.

`print` now has type `a -> Void`.