### PR TITLE
Allow arbitrary toplevel expressions

### DIFF
--- a/src/codegen/transl_anf.ml
+++ b/src/codegen/transl_anf.ml
@@ -97,6 +97,7 @@ let compile_const (c : Asttypes.constant) =
   | Const_int64 i64 -> MConstI64 i64
   | Const_bool b when b = true -> const_true
   | Const_bool _ -> const_false
+  | Const_void -> const_void
 
 let compile_imm env (i : imm_expression) =
   match i.imm_desc with

--- a/src/parsing/ast_helper.ml
+++ b/src/parsing/ast_helper.ml
@@ -146,6 +146,7 @@ module Top = struct
   let foreign ?loc e d = mk ?loc (PTopForeign (e, d))
   let data ?loc e d = mk ?loc (PTopData (e, d))
   let let_ ?loc e r vb = mk ?loc (PTopLet(e, r, vb))
+  let expr ?loc e = mk ?loc (PTopExpr e)
   let export ?loc e = mk ?loc (PTopExport e)
   let export_all ?loc e = mk ?loc (PTopExportAll e)
 end

--- a/src/parsing/ast_helper.mli
+++ b/src/parsing/ast_helper.mli
@@ -104,6 +104,7 @@ module Top: sig
   val foreign: ?loc:loc -> export_flag -> value_description -> toplevel_stmt
   val data: ?loc:loc -> export_flag -> data_declaration -> toplevel_stmt
   val let_: ?loc:loc -> export_flag -> rec_flag -> value_binding list -> toplevel_stmt
+  val expr: ?loc:loc -> expression -> toplevel_stmt
   val export: ?loc:loc -> export_declaration list -> toplevel_stmt
   val export_all: ?loc:loc -> export_except list -> toplevel_stmt
 end

--- a/src/parsing/ast_iterator.ml
+++ b/src/parsing/ast_iterator.ml
@@ -167,6 +167,7 @@ module TL = struct
       | PTopForeign(e, vd) -> sub.value_description sub vd
       | PTopData(e, dd) -> sub.data sub dd
       | PTopLet(e, r, vb) -> List.iter (sub.value_binding sub) vb
+      | PTopExpr e -> sub.expr sub e
 end
 
 let default_iterator = {

--- a/src/parsing/ast_mapper.ml
+++ b/src/parsing/ast_mapper.ml
@@ -184,6 +184,7 @@ module TL = struct
       | PTopForeign(e, d) -> Top.foreign ~loc e (sub.value_description sub d)
       | PTopData(e, dd) -> Top.data ~loc e (sub.data sub dd)
       | PTopLet(e, r, vb) -> Top.let_ ~loc e r (List.map (sub.value_binding sub) vb)
+      | PTopExpr e -> Top.expr ~loc (sub.expr sub e)
       | PTopExport ex -> Top.export ~loc (sub.export sub ex)
       | PTopExportAll ex -> Top.export_all ~loc (sub.export_all sub ex)
 end

--- a/src/parsing/asttypes.ml
+++ b/src/parsing/asttypes.ml
@@ -26,6 +26,7 @@ type constant =
   | Const_int32 of int32
   | Const_int64 of int64
   | Const_bool of bool
+  | Const_void
 [@@deriving sexp]
 
 (** Marker for exported/nonexported let bindings *)

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -86,14 +86,13 @@ let fix_tyvar_mapper super =
     | _ -> super.typ mapper t in
   {super with typ}
 
-let fix_blocks ({statements; body} as prog) =
+let fix_blocks ({statements} as prog) =
   let open Ast_mapper in
   let mapper = default_mapper
     |> fix_block_mapper
     |> fix_tyvar_mapper in
   {prog with
-   statements=List.map (mapper.toplevel mapper) statements;
-   body=mapper.expr mapper body}
+   statements=List.map (mapper.toplevel mapper) statements}
 
 let no_record_block exprs =
   match exprs with
@@ -128,13 +127,13 @@ let mkid ns =
 
 let mkstr dyp s = mkloc s (symbol_rloc dyp)
 
-let make_program statements body =
+let make_program statements =
   let prog_loc = {
     loc_start=(!first_loc).loc_end;
     loc_end=(!last_loc).loc_end;
     loc_ghost=false;
   } in
-  fix_blocks {statements; body; prog_loc}
+  fix_blocks {statements; prog_loc}
 
 }
 
@@ -474,6 +473,7 @@ foreign_stmt :
 toplevel_stmt :
   | LET REC value_binds { Top.let_ Nonexported Recursive $3 }
   | LET value_binds { Top.let_ Nonexported Nonrecursive $2 }
+  | expr { Top.expr $1 }
   | import_stmt { Top.import $1 }
   | export_stmt { $1 }
   | foreign_stmt { Top.foreign ~loc:(symbol_rloc dyp) Nonexported $1 }
@@ -483,9 +483,7 @@ toplevel_stmts :
   | toplevel_stmt [eos toplevel_stmt {$2}]* { $1::$2 }
 
 program :
-  | EOL? toplevel_stmts eos? EOF { make_program $2 (Exp.null ~loc:dummy_loc ()) }
-  | EOL? toplevel_stmts eos expr eos? EOF { make_program $2 $4 }
-  | EOL? expr eos? EOF { prerr_string "\nprogram\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); make_program [] $2 }
+  | EOL? toplevel_stmts eos? EOF { make_program $2 }
 
 %%
 

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -197,6 +197,7 @@ type toplevel_stmt_desc =
   | PTopForeign of export_flag * value_description
   | PTopData of export_flag * data_declaration
   | PTopLet of export_flag * rec_flag * value_binding list
+  | PTopExpr of expression
   | PTopExport of export_declaration list
   | PTopExportAll of export_except list
 [@@deriving sexp]
@@ -209,7 +210,6 @@ type toplevel_stmt = {
 (** The type for parsed programs *)
 type parsed_program = {
   statements: toplevel_stmt list;
-  body: expression;
   prog_loc: Location.t [@sexp_drop_if fun _ -> not !Grain_utils.Config.sexp_locs_enabled];
 } [@@deriving sexp]
 

--- a/src/parsing/well_formedness.ml
+++ b/src/parsing/well_formedness.ml
@@ -211,9 +211,8 @@ let well_formedness_checker() =
     {errs=ref []; iterator=default_iterator}
     well_formedness_checks
 
-let check_well_formedness {statements; body} =
+let check_well_formedness {statements} =
   let checker = well_formedness_checker() in
   List.iter (checker.iterator.toplevel checker.iterator) statements;
-  checker.iterator.expr checker.iterator body;
   (* FIXME: We should be able to raise _all_ errors at once *)
   List.iter (fun e -> raise (Error e)) !(checker.errs)

--- a/src/typed/parmatch.ml
+++ b/src/typed/parmatch.ml
@@ -125,12 +125,14 @@ let all_coherent column =
         | Const_int64 _, Const_int64 _
         | Const_float _, Const_float _
         | Const_bool _, Const_bool _
+        | Const_void, Const_void
         | Const_string _, Const_string _ -> true
         | ( Const_int _
           | Const_int32 _
           | Const_int64 _
           | Const_float _
           | Const_bool _
+          | Const_void
           | Const_string _), _ -> false
       end
     | TPatTuple l1, TPatTuple l2 -> List.length l1 = List.length l2
@@ -231,6 +233,7 @@ let const_compare x y =
     | Const_string _
     | Const_float _
     | Const_bool _
+    | Const_void
     | Const_int32 _
     | Const_int64 _), _ -> Stdlib.compare x y
 
@@ -1719,7 +1722,7 @@ let inactive ~partial pat =
           true
         | TPatConstant c -> begin
             match c with
-            | Const_string _
+            | Const_string _ | Const_void
             | Const_int _ | Const_bool _ | Const_float _
             | Const_int32 _ | Const_int64 _ -> true
           end

--- a/src/typed/printpat.ml
+++ b/src/typed/printpat.ml
@@ -32,6 +32,7 @@ let pretty_const c = match c with
   | Const_int64 i -> Printf.sprintf "%LdL" i
   | Const_bool true -> "true"
   | Const_bool false -> "false"
+  | Const_void -> "void"
 
 let rec pretty_val ppf v =
   match v.pat_extra with

--- a/src/typed/typedtree.ml
+++ b/src/typed/typedtree.ml
@@ -198,6 +198,7 @@ type toplevel_stmt_desc =
   | TTopExport of export_declaration list
   | TTopData of data_declaration list
   | TTopLet of export_flag * rec_flag * value_binding list
+  | TTopExpr of expression
 [@@deriving sexp]
 
 type toplevel_stmt = {
@@ -208,7 +209,6 @@ type toplevel_stmt = {
 
 type typed_program = {
   statements: toplevel_stmt list;
-  body: expression;
   env: (Env.t [@sexp.opaque]);
   signature: Cmi_format.cmi_infos;
 } [@@deriving sexp]

--- a/src/typed/typedtree.mli
+++ b/src/typed/typedtree.mli
@@ -186,6 +186,7 @@ type toplevel_stmt_desc =
   | TTopExport of export_declaration list
   | TTopData of data_declaration list
   | TTopLet of export_flag * rec_flag * value_binding list
+  | TTopExpr of expression
 
 type toplevel_stmt = {
   ttop_desc: toplevel_stmt_desc;
@@ -195,7 +196,6 @@ type toplevel_stmt = {
 
 type typed_program = {
   statements: toplevel_stmt list;
-  body: expression;
   env: Env.t;
   signature: Cmi_format.cmi_infos;
 } [@@deriving sexp]

--- a/src/typed/typedtreeIter.ml
+++ b/src/typed/typedtreeIter.ml
@@ -55,10 +55,9 @@ end = struct
 
   let may_iter = Option.may
 
-  let rec iter_typed_program ({statements; body} as tp) =
+  let rec iter_typed_program ({statements} as tp) =
     Iter.enter_typed_program tp;
     iter_toplevel_stmts statements;
-    iter_expression body;
     Iter.leave_typed_program tp
 
   and iter_core_type ct =
@@ -125,6 +124,7 @@ end = struct
       | TTopForeign _
       | TTopImport _
       | TTopExport _ -> ()
+      | TTopExpr e -> iter_expression e
       | TTopLet (exportflag, recflag, binds) -> iter_bindings exportflag recflag binds
     end;
     Iter.leave_toplevel_stmt stmt
@@ -135,6 +135,7 @@ end = struct
         | TTopForeign _
         | TTopImport _ 
         | TTopExport _ 
+        | TTopExpr _
         | TTopLet _ -> iter_toplevel_stmt cur
         | TTopData _ -> 
           Iter.enter_data_declarations();

--- a/src/typed/typedtreeMap.ml
+++ b/src/typed/typedtreeMap.ml
@@ -46,8 +46,7 @@ end = struct
   let rec map_typed_program tp =
     let tp = Map.enter_typed_program tp in
     let statements = List.map map_toplevel_stmt tp.statements in
-    let body = map_expression tp.body in
-    Map.leave_typed_program {tp with statements=statements; body=body}
+    Map.leave_typed_program {tp with statements=statements}
 
   and map_core_type ct =
     let ct = Map.enter_core_type ct in
@@ -116,6 +115,7 @@ end = struct
       | TTopImport _
       | TTopExport _  -> stmt.ttop_desc
       | TTopLet (exportflag, recflag, binds) -> TTopLet(exportflag, recflag, map_bindings recflag binds)
+      | TTopExpr e -> TTopExpr(map_expression e)
     end in
     Map.leave_toplevel_stmt {stmt with ttop_desc}
 

--- a/test/input/toplevelStatements.gr
+++ b/test/input/toplevelStatements.gr
@@ -1,0 +1,14 @@
+let one = 1
+let two = 2
+print(one)
+print(two)
+
+let three = 3
+print(three)
+
+let four = 4
+let five = two + three
+print(four)
+print(five)
+
+'foo'


### PR DESCRIPTION
This PR allows any expression to appear at the top level, so multiple expression statements don't have to all appear in a block at the bottom of the file.

## New syntax 🙏 

Here's an example (valid) program:
```grain
let one = 1
let two = 2
print(one)
print(two)

let three = 3
print(three)

let four = 4
let five = two + three
print(four)
print(five)
```