### PR TITLE
Fix: Add missing yojson depends

### DIFF
--- a/grain_parsing.opam
+++ b/grain_parsing.opam
@@ -17,6 +17,8 @@ depends: [
   "ocamlbuild" {build & >= "0.12.0" }
   "dune" {build & >= "1.0" }
   "ppx_deriving"
+  "ppx_deriving_yojson"
+  "yojson"
   "ppx_sexp_conv"
   "sexplib"
   "grain_dypgen" { = "0.1" }


### PR DESCRIPTION
Building the project against itself failed because these depends were missing in for `grain_parsing`