### PR TITLE
Implement new Box utilities

### DIFF
--- a/src/parsing/lexer.mll
+++ b/src/parsing/lexer.mll
@@ -136,6 +136,7 @@ rule token = parse
   | "]" { RBRACK }
   | "<" { LCARET }
   | ">" { RCARET }
+  | "^" { CARET }
   | "+" { PLUS }
   | "-" { DASH }
   | "*" { STAR }

--- a/src/parsing/parser.dyp
+++ b/src/parsing/parser.dyp
@@ -151,6 +151,7 @@ let make_program statements =
 %token <string> TYPEID
 %token <string> STRING
 %token LBRACK RBRACK LPAREN LPARENNOSPACE RPAREN LBRACE RBRACE LCARET RCARET
+%token CARET
 %token COMMA SEMI AS
 %token THICKARROW ARROW PIPE
 %token EQEQ LESSEQ GREATEREQ
@@ -234,6 +235,10 @@ expr :
   | binop_expr
 
 binop_expr :
+  | binop_expr(<=pa) EOL? pluseq_op EOL?    binop_expr(<pa) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pa
+  | binop_expr(<=pa) EOL? dasheq_op EOL?    binop_expr(<pa) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pa
+  | binop_expr(<=pa) EOL? stareq_op EOL?    binop_expr(<pa) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pa
+  | binop_expr(<=pa) EOL? slasheq_op EOL?   binop_expr(<pa) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pa
   | binop_expr(<=pp) EOL? plus_op EOL?      binop_expr(<pp) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pp
   | binop_expr(<=pp) EOL? dash_op EOL?      binop_expr(<pp) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pp
   | binop_expr(<=pt) EOL? star_op EOL?      binop_expr(<pt) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$3]) [$1; $5] } pt
@@ -260,7 +265,7 @@ pattern :
   | UNDERSCORE { Pat.any ~loc:(symbol_rloc dyp) () }
   /* If the pattern uses an external ID, we know it's a constructor, not a variable */
   | ext_constructor { Pat.construct ~loc:(symbol_rloc dyp) $1 [] }
-  | ID { Pat.var ~loc:(symbol_rloc dyp) (mkstr dyp $1) }
+  | [ID | infix] { Pat.var ~loc:(symbol_rloc dyp) (mkstr dyp $1) }
   | lparen tuple_patterns rparen { Pat.tuple ~loc:(symbol_rloc dyp) $2 }
   | lparen pattern rparen { $2 }
   | lbrace record_patterns rbrace { Pat.record ~loc:(symbol_rloc dyp) $2 }
@@ -353,7 +358,8 @@ data_declaration :
   | DATA TYPEID [lcaret ID [comma ID {$2}]* rcaret {$2::$3}]? equal data_labels { Dat.record ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
 
 prim1_expr :
-  | NOT expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["!"]) [$2] }
+  | NOT non_assign_expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["!"]) [$2] }
+  | CARET non_assign_expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["^"]) [$2] }
 
 paren_expr :
   | lparen expr rparen { $2 }
@@ -393,6 +399,14 @@ ampamp_op :
   | AMPAMP { "&&" }
 pipepipe_op :  
   | PIPEPIPE { "||" }
+pluseq_op :  
+  | PLUS EQUAL { "+=" }
+dasheq_op :  
+  | DASH EQUAL { "-=" }
+stareq_op :  
+  | STAR EQUAL { "*=" }
+slasheq_op :  
+  | SLASH EQUAL { "/=" }
 
 infix_op :
   | plus_op
@@ -407,12 +421,17 @@ infix_op :
   | greatereq_op
   | ampamp_op
   | pipepipe_op
+  | pluseq_op
+  | dasheq_op
+  | stareq_op
+  | slasheq_op
 
 infix :
   | lparen infix_op rparen { $2 }
 
 prefix :
   | lparen NOT rparen { "!" }
+  | lparen CARET rparen { "^" }
 
 id :
   | [TYPEID dot {$1}]* [ID | TYPEID | infix | prefix] { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid (List.append $1 [$2])) (symbol_rloc dyp) }
@@ -482,7 +501,7 @@ stmt_expr :
   | FAIL expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["fail"]) [$2] }
 
 assign_expr :
-  | expr EOL? GETS EOL? expr { no_array_access $1; Exp.assign ~loc:(symbol_rloc dyp) $1 $5 }
+  | binop_expr(<pl) EOL? GETS EOL? expr { no_array_access $1; Exp.assign ~loc:(symbol_rloc dyp) $1 $5 }
   | array_set { $1 }
 
 non_assign_expr :

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -26,6 +26,11 @@ primitive (||) : (Bool, Bool) -> Bool = "@or"
 # Box operations
 primitive box : a -> Box<a> = "@box"
 primitive unbox : Box<a> -> a = "@unbox"
+primitive (^) : Box<a> -> a = "@unbox"
+let (+=) : (Box<Number>, Number) -> Number = (b, n) => b := ^b + n
+let (-=) : (Box<Number>, Number) -> Number = (b, n) => b := ^b - n
+let (*=) : (Box<Number>, Number) -> Number = (b, n) => b := ^b * n
+let (/=) : (Box<Number>, Number) -> Number = (b, n) => b := ^b / n
 
 # Other operations
 primitive ignore : a -> Void = "@ignore"

--- a/test/test_end_to_end.ml
+++ b/test/test_end_to_end.ml
@@ -339,6 +339,7 @@ let box_tests = [
             {
               unbox(unbox(b))
             }" "4";
+  t "box3_2" "let b = box(box(4)); ^^b" "4";
   t "box4" "let b = box(4);
             {
               b := 3;
@@ -353,7 +354,17 @@ let box_tests = [
   tfile "counter" "counter" "1\n2\n3\nvoid";
   te "test_unbox_err" "unbox(5)" "Box";
 
-  te "test_box_typing" "unbox(box(false)) + 4" "expression has type Bool but"
+  te "test_box_typing" "unbox(box(false)) + 4" "expression has type Bool but";
+
+  (* Operations on Box<Number> *)
+  t "box_addition1" "let b = box(4); b += 19" "23";
+  t "box_addition2" "let b = box(4); b += 19; ^b" "23";
+  t "box_subtraction1" "let b = box(4); b -= 19" "-15";
+  t "box_subtraction2" "let b = box(4); b -= 19; ^b" "-15";
+  t "box_multiplication1" "let b = box(4); b *= 19" "76";
+  t "box_multiplication2" "let b = box(4); b *= 19; ^b" "76";
+  t "box_division1" "let b = box(76); b /= 19" "4";
+  t "box_division2" "let b = box(76); b /= 19; ^b" "4";
 ]
 
 let loop_tests = [
@@ -692,7 +703,7 @@ let tests =
   array_tests @
   record_tests @
   stdlib_tests @
-  box_tests @ 
+  box_tests @
   loop_tests @
   (*oom @ gc @*) 
   match_tests @


### PR DESCRIPTION
This PR adds a shorthand syntax for unboxing: `^box`. It also adds four new utilities for `Box<Number>`:

```grain
box += 6
box -= 6
box *= 6
box /= 6
```

These should make working with the most common uses for boxes much nicer.