### PR TITLE
Update README and contributor docs; fix gotchas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,59 @@
 
 Thanks for your interest in contributing to Grain! There are all sorts of ways to contribute—there's core compiler work, implementing standard libraries, writing documentation, or even maintaining the website. No matter your interests or skill level, we're happy to have your help. Logistically, the best way to get involved is to chat with us on Discord. From there, we'll be able to direct you to various areas of the project.
 
+## Code of Conduct
+
+Please note that this project is released with a [contributor code of conduct](https://github.com/grain-lang/grain/blob/master/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
 ## Joining the Discord
 
 Shoot an email over to oscar[at]grain-lang.org and we'll send you an invitation to join.
 
 ## Getting up and running
 
-The instructions in the README should be fairly straightforward, but if you run into any issues please reach out to us on Discord.
+If it's your first time here, we suggest that you follow [the Grain setup guide](https://grain-lang.org/guide/getting_grain) to get up and running. We also have build instructions listed in the README. The instructions should be fairly straightforward, but if you run into any issues please reach out to us on Discord.
 
-## Code of Conduct
+## Typical development workflows
 
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
+### Compiler
+
+Once you have the compiler building, the typical flow for development is to make changes in the `compiler` directory, then run:
+
+```bash
+yarn compiler:build
+yarn compiler:test
+```
+
+It can sometimes be helpful to run small Grain programs directly to test some functionality without running the full test suite. If you change the compiler, you'll need to run `yarn compiler:install` to install the latest built version to see your compiler changes take effect when you run the `grain` CLI.
+
+### Runtime
+
+After making changes in the `runtime` directory, run:
+
+```bash
+yarn runtime:build
+yarn runtime:test
+```
+
+Once the runtime has been built, it's the only one active. Grain programs that you run from the command line or the tests will use that version.
+
+### Standard library
+
+If you're only changing `.gr` stdlib files, you don't need to do anything special. Running the tests will automatically recompile all of the standard library files. If you change any of the AssemblyScript files in the `stdlib-external` directory of `stdlib`, you'll need to run `yarn stdlib:build` to recompile them.
+
+It's usually easiest to create a small Grain program that imports your library to try it out, like so:
+
+```grain
+import Array from 'arrays'
+
+let appended = Array.append([> 1, 2, 3], [> 4, 5, 6])
+print(appended)
+```
+
+The tests for the standard library are located in `compiler/test/stdlib`. Since the standard library tests are written in Grain, rather than running the whole test suite, you can just run them directly:
+
+```bash
+grain compiler/test/stdlib/arrays.test.gr
+```
+
+If there's no error, you're all set.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![GitHub version](https://badge.fury.io/gh/grain-lang%2Fgrain.svg)](https://badge.fury.io/gh/grain-lang%2Fgrain)
+[![Build Status](https://travis-ci.org/grain-lang/grain.svg?branch=master)](https://travis-ci.org/grain-lang/grain)
 
 # The Grain Compiler
 
-Grain is a strongly-typed functional programming language built for the modern web by leveraging the brilliant work done by the [WebAssembly project](http://webassembly.org/).
+Grain is a new programming language that compiles to [WebAssembly](http://webassembly.org/). For more information about the language, check out [grain-lang.org](https://grain-lang.org/).
 
-This language is still a work in progress, but be sure to stay tuned, or even contribute!
+If it's your first time here, it's highly recommended that you follow [the Grain guide](https://grain-lang.org/guide) to get up and running!
 
-For more information about the language, visit [grain-lang.org](https://grain-lang.org/).
+## Contributing
+
+There are tons of ways to contribute to Grain. Check out our [contributing guide](https://github.com/grain-lang/grain/blob/master/CONTRIBUTING.md) for more info and instructions on how to join our community Discord. All contributors are held to our [contributor code of conduct](https://github.com/grain-lang/grain/blob/master/CODE_OF_CONDUCT.md).
 
 ## Building
 
@@ -33,6 +36,38 @@ To put the Grain compiler binaries on your path, run:
 yarn compiler:install
 ```
 
+If running tests is your kind of thing, run
+
+```bash
+yarn compiler:test
+```
+
+### Other Commands
+
+To build the standard library:
+
+```bash
+yarn stdlib:build
+```
+
+To build the runtime:
+
+```bash
+yarn runtime:build
+```
+
+To link the CLI:
+
+```bash
+yarn cli:link
+```
+
+To reset your compiler build:
+
+```bash
+yarn compiler:clean
+```
+
 ## Running Grain Programs
 
 You can run programs using the Grain CLI:
@@ -49,7 +84,3 @@ grainc hello.gr
 ```
 
 Copyright ©️ 2017-2020 Philip Blair and Oscar Spencer.
-
-[philip]: https://github.com/belph
-[oscar]: http://github.com/ospencer
-[wasm]: http://webassembly.org/

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf #{self.root}/_esy",
     "no-pnp": "rm -rf #{self.root}/_esy/default/bin",
     "install-compiler": "dune install",
-    "test": "dune runtest"
+    "test": "dune runtest --force"
   },
   "dependencies": {
     "@opam/grain": "*",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "compiler:build": "yarn workspace compiler run esy",
     "postcompiler:build": "yarn workspace compiler run esy no-pnp",
     "compiler:install": "yarn workspace compiler run esy install-compiler",
+    "postcompiler:install": "yarn stdlib:clean",
     "compiler:test": "yarn workspace compiler run esy test",
     "runtime:build": "yarn workspace @grain/runtime build",
     "stdlib:build": "yarn workspace @grain/stdlib build",
+    "stdlib:clean": "yarn workspace @grain/stdlib clean",
     "cli:link": "yarn workspace @grain/cli link",
     "setup": "yarn runtime:build && yarn stdlib:build && yarn cli:link"
   }

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "build": "for f in stdlib-external/*.ts; do asc $f -o stdlib-external/$(basename $f .ts).wasm -O3 --runtime none --importMemory; done"
+    "build": "for f in stdlib-external/*.ts; do asc $f -o stdlib-external/$(basename $f .ts).wasm -O3 --runtime none --importMemory; done",
+    "clean": "rm *.wasm"
   }
 }


### PR DESCRIPTION
When I was updating the contributor docs and was trying to outline gotchas, I felt that was kinda dumb instead of just fixing them, so I did.

Two new things happen now:
1. Post `yarn compiler:install` we now clean the stdlib, so the stdlib will get recompiled will with the new installed compiler.
2. The tests now run with `dune runtest --force`, which always runs the test binary, not just if the dependencies changed.