### PR TITLE
Add contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Shoot an email over to oscar[at]grain-lang.org and we'll send you an invitation 
 
 If it's your first time here, we suggest that you follow [the Grain setup guide](https://grain-lang.org/guide/getting_grain) to get up and running. We also have build instructions listed in the README. The instructions should be fairly straightforward, but if you run into any issues please reach out to us on Discord.
 
+## Contributor docs
+
+There are a set of contributor docs in [docs/contributor](https://github.com/grain-lang/grain/tree/master/docs/contributor). These documents go into technical details on how things work in Grain.
+
 ## Typical development workflows
 
 ### Compiler

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Grain Docs
+
+## For users
+
+If you're looking for language documentation, you can find it at grain-lang.org. Looking to contribute? The source can be found in the [Grain website repository](https://github.com/grain-lang/grain-lang.org).
+
+## For contributors
+
+The contributor docs are hosted here, in the `contributor` directory. These docs should be helpful as you implement features.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,0 +1,7 @@
+# Grain Contributor Docs
+
+These docs are meant to be helpful to contributors as they continue improving Grain. If there's a topic not covered here that you think would be helpful, let us know! Additionally, feel free to make any changes that you think would make this information more clear.
+
+If you're new to Grain and want to jump straight into core compiler development, or you're just curious about how things work under the hood, check out the [compiler walkthrough](https://github.com/grain-lang/grain/blob/master/docs/contributor/compiler_walkthrough.md).
+
+If you want to know more about how Grain data structures are stored in memory, check out the [data representations guide](https://github.com/grain-lang/grain/blob/master/docs/contributor/data_representations.md).

--- a/docs/contributor/compiler_walkthrough.md
+++ b/docs/contributor/compiler_walkthrough.md
@@ -1,0 +1,132 @@
+# A Walkthrough of the Grain Compiler
+
+This guide will take you through all of the phases of the compiler to give you a general sense of how we go from a `.gr` file to a `.wasm` file.
+
+We'll largely be following the `next_state` function in [compile.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/compile.ml).
+
+## Lexing
+
+Lexing is the process of breaking up a string input into tokens. A Grain program string is tokenized into things like:
+
+* keywords (`let`, `import`, `data`, `assert`, etc.)
+* constants (`17`, `'foobar'`, etc.)
+* delimiters (`{`, `}`, `[`, `]`, `,`, `;`, etc.)
+* operators (`*`, `+`, `==`, `&&`, etc.)
+* identifiers (`myVar`, `List`, etc.)
+* comments (`# this is a comment`, etc.)
+
+To make this happen, we use [ocamllex](https://caml.inria.fr/pub/docs/manual-ocaml/lexyacc.html). `ocamllex` is a tool that generates OCaml code to do this based on rules we've defined in [parsing/lexer.mll](https://github.com/grain-lang/grain/blob/master/compiler/src/parsing/lexer.mll).
+
+## Parsing
+
+Once we've got our tokens, we move on to parsing. The goal of parsing is to take our tokens and produce an abstract syntax tree, or AST. An AST is a representation of the program's structure in a format that's easier for us to work with than the tokens themselves. For example, think of the tokens `1` `+` `2` `+` `3`. In reality, the `+` operator only works on two operands at once, so after parsing, we end up with a tree that looks like this:
+
+```plaintext
+     add
+    /   \
+  add    3
+ /   \
+1     2
+```
+
+Writing a parser by hand would be annoying, so instead we use [dypgen](http://dypgen.free.fr/). `dypgen` is a dynamic parser generator that produces OCaml code for a parser based on some rules we've defined. We call these rules a "grammar" and you can find the grammar for the Grain language in [parsing/parser.dyp](https://github.com/grain-lang/grain/blob/master/compiler/src/parsing/parser.dyp). If you'd like to learn more about BNF grammars, check out [this resource](http://people.cs.ksu.edu/~schmidt/300s05/Lectures/GrammarNotes/bnf.html).
+
+The definition for the Grain AST (which we often refer to as the parsetree) can be found in [parsing/parsetree.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/parsing/parsetree.ml).
+
+## Well-formedness
+
+This is just a fancy term for asking the question "does this program—for the most part—make sense?" In Grain, type identifers must always start with a capital letter, so there's a well-formedness check that enforces this. In general, we like to be as lenient as possible while parsing and provide helpful error messages from well-formedness checks. If a user writes a program like `data foo = ...`, it's much better to say `Error: 'foo' should be capitalized` rather than `Syntax error`.
+
+You can find the Grain well-formedness checks in [parsing/well_formedness.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/parsing/well_formedness.ml).
+
+## Typechecking
+
+Grain implements a [Hindley-Milner type system](https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system). This is by far the most academically challenging step of the compilation process. As such, the Grain typechecker is largely borrowed from the [OCaml compiler](https://github.com/ocaml/ocaml) (yay open source 🎉). This is the process that infers the type of all Grain expressions, and makes sure they line up.
+
+The internals pretty much never need to be touched 🙏, though it's sometimes necessary to make changes to how we make calls to the typechecker in [typed/typemod.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/typed/typemod.ml) or [typed/typecore.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/typed/typecore.ml).
+
+After typechecking a module, we're left with a typedtree. You can find the definition in [typed/typedtree.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/typed/typedtree.ml).
+
+## Linearization
+
+In this step, we convert the typedtree into [A-normal Form](https://en.wikipedia.org/wiki/A-normal_form), or ANF. This purpose of this step is to create a linear set of expressions that could be performed in order from start to finish. For example, given the expression `foo(3 * 4, bar(5))`, we'd want to produce:
+
+```plaintext
+$arg1 := 3 * 4
+$arg2 := bar(5)
+foo($arg1, $arg2)
+```
+
+This gets us a step closer to actually starting to emit wasm instructions. The linearization step produces an anftree, and you can find the definition in [middle_end/anftree.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/middle_end/anftree.ml).
+
+## Optimization
+
+Who doesn't love fast programs? This step analyzes the program and alters it to run faster or use less memory. For example, three optimizations we do are constant propagation, constant folding, and dead assignment elimination. Constant propagation rewrites identifiers for constants into just the constant value, like so:
+
+```plaintext
+Before:
+
+let x = 5
+let y = x + 2
+
+After:
+
+let x = 5
+let y = 5 + 2
+```
+
+Constant folding precomputes operations on constants:
+
+```plaintext
+Before:
+
+let y = 5 + 2
+
+After:
+
+let y = 7
+```
+
+Dead assignment elimination gets rid of unused assignments:
+
+```plaintext
+Before:
+
+let x = 5
+let y = 5 + 2
+
+After:
+
+let y = 5 + 2
+```
+
+By default, we do a number of optimization passes which allows all of the optimizations to work together. Simple programs will optimize down to just their result:
+
+```plaintext
+Before:
+
+let a = 4 + 12
+let b = a * 2
+let c = (b / 4)
+c - 2
+
+After:
+
+6
+```
+
+You can find the entrypoints into optimization in [middle_end/optimize.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/middle_end/optimize.ml).
+
+## Mashing
+
+We couldn't think of a better name for this stage, but it's (mostly) the last representation before outputting the actual WebAssembly instructions. It's here that we decide what actually gets allocated in memory and how we retrieve and change things in memory. You can find the mashtree [here](https://github.com/grain-lang/grain/blob/master/compiler/src/codegen/mashtree.ml) and the conversion process from ANF in [codegen/transl_anf.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/codegen/transl_anf.ml).
+
+## Code generation
+
+The code generation (or codegen) step is where we generate the actual WebAssembly code for the program. By this point, we should have reduced the complexity of the original program down enough that there is a straightforward set of wasm instructions for each action that needs to happen. You can see what some of this looks like in [codegen/compcore.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/codegen/compcore.ml).
+
+You can check out the online version of the [wasm spec](https://webassembly.github.io/spec/core/index.html), but if you're looking for the OCaml types that Grain uses, you can check that out in [the Grain fork of the wasm-spec repository](https://github.com/grain-lang/wasm-spec).
+
+## Emission
+
+Lastly, we write the wasm to a file. And that's it! If you want an in-depth dive into any of the stages of the compiler, feel free to ask in the Discord and someone will be more than happy to walk you through it.

--- a/docs/contributor/data_representations.md
+++ b/docs/contributor/data_representations.md
@@ -1,0 +1,131 @@
+# Grain In-Memory Data Representations
+
+There are two places that Grain data can live—on the stack or on the heap. All values are either the literal value, or a pointer to a value that lives on the heap. Currently, all values on the stack are represented as either signed or unsigned 32-bit numbers. All values on the heap are 32-bit sequences, with an exception for strings.
+
+## Value tagging
+
+Values in Grain are tagged. This means that we reserve a number of bits to signal the type of the value. Normally, since Grain is a statically typed language, we wouldn't need to tag the values because the types are guaranteed at compile-time. However, since our values are tagged, at runtime we can determine the type of a value. This is what allows us to have a generic `print` function that works for any data type—even user defined types.
+
+You can find all of the tags in the code in [codegen/value_tags.ml](https://github.com/grain-lang/grain/blob/master/compiler/src/codegen/value_tags.ml), but they'll be broken down here.
+
+### Numbers
+
+The last bit of a value determines if that value is a number or something else. If it's 0, the value is a number. Conveniently, this means that every Grain number is stored as `n * 2`. This means that addition and subtraction don't require any additional instructions to compute, since `2a + 2b = 2(a + b)`. There are other tricks like this for the other operations that allow us to avoid unnecessary untagging.
+
+The downside of this tag for numbers is the loss of one bit of information. There are 2^31 possible values for signed numbers in Grain rather than 2^32.
+
+To tag a number, we perform a shift left by 1. To untag a number, we perform an arithmetic (signed) shift right by 1.
+
+### Other values
+
+For other values, we look at the last 3 bits to determine the type.
+
+```plaintext
+tuples*   0b001
+closures* 0b101
+generic*  0b011
+enums     0b111
+
+*pointer to a heap value
+```
+
+Untagging (and tagging) is done by XORing the value with the tag listed above (and there are utilities in the code to do this). After untagging a heap pointer, it's just a regular pointer that points at the location of the real value on the heap. For generic heap values, the first 32-bit value tells you what kind of heap value it is (string, record, array, ADT, etc.), and you can find these corresponding tags in `value_tags.ml` as well.
+
+## Structure of Heap Data
+
+### Tuples
+
+Tuples are the simplest Grain data structure.
+
+```plaintext
+╔══════╦════════╤═══════╤═══════╤═════╤═══════╗
+║ size ║ 32     │ 32    │ 32    │ 32  │ 32    ║
+╠══════╬════════╪═══════╪═══════╪═════╪═══════╣
+║ what ║ length │ elt_0 │ elt_1 │ ... │ elt_n ║
+╚══════╩════════╧═══════╧═══════╧═════╧═══════╝
+```
+
+The length is **untagged**, but all other elements are regular Grain values.
+
+### Arrays
+
+Please note that arrays and lists are different. If you're looking to see how lists are represented, view the section on ADTs.
+
+```plaintext
+╔══════╦═══════════╤════════╤═══════╤═══════╤═════╤═══════╗
+║ size ║ 32        │ 32     │ 32    │ 32    │ 32  │ 32    ║
+╠══════╬═══════════╪════════╪═══════╪═══════╪═════╪═══════╣
+║ what ║ value tag │ length │ elt_0 │ elt_1 │ ... │ elt_n ║
+╚══════╩═══════════╧════════╧═══════╧═══════╧═════╧═══════╝
+```
+
+The length is **untagged**, but all other elements are regular Grain values, even the array value tag.
+
+### Records
+
+Records store a little more information to enable printing.
+
+```plaintext
+╔══════╦═══════════╤════════════╤══════════╤════════╤═══════╤═════╤═══════╗
+║ size ║ 32        │ 32         │ 32       │ 32     │ 32    │ 32  │ 32    ║
+╠══════╬═══════════╪════════════╪══════════╪════════╪═══════╪═════╪═══════╣
+║ what ║ value tag │ module tag │ type tag │ length │ elt_0 │ ... │ elt_n ║
+╚══════╩═══════════╧════════════╧══════════╧════════╧═══════╧═════╧═══════╝
+```
+
+The module tag tells us which module the record type is defined in, and the type tag tells us which type in the module this record corresponds to.
+
+The length is **untagged**, but all other elements are regular Grain values, even the tags.
+
+### Algebraic Data Types (ADTs)
+
+ADTs also store a little more information to enable printing. All user-defined types and some built-in types are ADTs, including lists.
+
+```plaintext
+╔══════╦═══════════╤════════════╤══════════╤═════════════╤═══════╤═══════╤═════╤═══════╗
+║ size ║ 32        │ 32         │ 32       │ 32          │ 32    │ 32    │ 32  │ 32    ║
+╠══════╬═══════════╪════════════╪══════════╪═════════════╪═══════╪═══════╪═════╪═══════╣
+║ what ║ value tag │ module tag │ type tag │ variant tag │ arity │ elt_0 │ ... │ elt_n ║
+╚══════╩═══════════╧════════════╧══════════╧═════════════╧═══════╧═══════╧═════╧═══════╝
+```
+
+The module tag tells us which module this ADT is defined in, the type tag tells us which type in the module this ADT corresponds to, and the variant tag tells us which ADT variant is allocated here.
+
+The arity is **untagged**, but all other elements are regular Grain values, even the tags.
+
+### Closures (Lambdas)
+
+Closures contain all of the values closed over by a function, i.e. in the code:
+
+```grain
+let x = 5
+let foo = () => x
+```
+
+The value `x` gets "saved" so later when we call `foo`, we still have access to `x`. The heap layout looks like this:
+
+```plaintext
+╔══════╦═══════╤════════════╤══════╤═══════╤═════╤═══════╗
+║ size ║ 32    │ 32         │ 32   │ 32    │ 32  │ 32    ║
+╠══════╬═══════╪════════════╪══════╪═══════╪═════╪═══════╣
+║ what ║ arity │ *wasm func │ size │ val_0 │ ... │ val_n ║
+╚══════╩═══════╧════════════╧══════╧═══════╧═════╧═══════╝
+```
+
+The arity represents the number of arguments to the function. `*wasm func` is a pointer to where the assembled wasm fuction is located in the WebAssembly function table. `size` is the number of values stored in the closure.
+
+The arity, wasm function pointer, and size are all **untagged**. All other elements are regular Grain values.
+
+### Strings
+
+Strings are currently the only data type that stores data in 8-bit chunks rather than 32 bits.
+
+```plaintext
+╔══════╦═══════════╤══════╤════════╤════════╤═════╤════════╗
+║ size ║ 32        │ 32   │ 8      │ 8      │ 8   │ 8      ║
+╠══════╬═══════════╪══════╪════════╪════════╪═════╪════════╣
+║ what ║ value tag │ size │ byte_0 │ byte_1 │ ... │ byte_n ║
+╚══════╩═══════════╧══════╧════════╧════════╧═════╧════════╝
+```
+
+The size is **untagged**. Note that Grain strings are UTF-8 encoded, so one byte does not necessarily fully represent one character. As such, the size set here is the size of the string in bytes, rather than the actual number of characters. The size will always be greater than or equal to the number of characters in the string.


### PR DESCRIPTION
This sets up the `docs/contributor` folder, and adds a general compiler walkthrough and information on how data is represented in memory in Grain.