### PR TITLE
Fix ADT printing

### DIFF
--- a/compiler/src/middle_end/linearize.ml
+++ b/compiler/src/middle_end/linearize.ml
@@ -10,8 +10,8 @@ module MatchCompiler = Matchcomp.MatchTreeCompiler
 let compile_constructor_tag =
   let open Grain_typed.Types in
   function
-  | CstrConstant i -> i lsl 1
-  | CstrBlock i -> (i lsl 1) lor 1
+  | CstrConstant i -> i
+  | CstrBlock i -> i
   | CstrUnboxed -> failwith "compile_constructor_tag: cannot compile CstrUnboxed"
 
 let gensym = Ident.create

--- a/compiler/src/typed/datarepr.ml
+++ b/compiler/src/typed/datarepr.ml
@@ -69,39 +69,35 @@ let constructor_descrs ty_path decl cstrs =
        if cd_args = TConstrSingleton then incr num_consts else incr num_nonconsts;
        incr num_normal)
     cstrs;
-  let rec describe_constructors idx_const idx_nonconst = function
-      [] -> []
-    | {cd_id; cd_args; cd_res; cd_loc} :: rem ->
-      let ty_res =
-        match cd_res with
-        | Some ty_res' -> ty_res'
-        | None -> ty_res
-      in
-      let (tag, descr_rem) =
-        match cd_args with
-        | TConstrSingleton -> (CstrConstant idx_const,
-                               describe_constructors (idx_const+1) idx_nonconst rem)
-        | _  -> (CstrBlock idx_nonconst,
-                 describe_constructors idx_const (idx_nonconst+1) rem) in
-      let cstr_name = Ident.name cd_id in
-      let existentials, cstr_args, cstr_inlined =
-        constructor_args cd_args cd_res
-          (Path.PExternal (ty_path, cstr_name, Path.nopos))
-      in
-      let cstr =
-        { 
-          cstr_name;
-          cstr_res = ty_res;
-          cstr_existentials = existentials;
-          cstr_args;
-          cstr_arity = List.length cstr_args;
-          cstr_tag = tag;
-          cstr_consts = !num_consts;
-          cstr_nonconsts = !num_nonconsts;
-          cstr_loc = cd_loc;
-        } in
-      (cd_id, cstr) :: descr_rem in
-  describe_constructors 0 0 cstrs
+  let describe_constructor idx {cd_id; cd_args; cd_res; cd_loc} =
+    let ty_res =
+      match cd_res with
+      | Some ty_res' -> ty_res'
+      | None -> ty_res
+    in
+    let tag =
+      match cd_args with
+      | TConstrSingleton -> CstrConstant idx
+      | _  -> CstrBlock idx in
+    let cstr_name = Ident.name cd_id in
+    let existentials, cstr_args, cstr_inlined =
+      constructor_args cd_args cd_res
+        (Path.PExternal (ty_path, cstr_name, Path.nopos))
+    in
+    let cstr =
+      {
+        cstr_name;
+        cstr_res = ty_res;
+        cstr_existentials = existentials;
+        cstr_args;
+        cstr_arity = List.length cstr_args;
+        cstr_tag = tag;
+        cstr_consts = !num_consts;
+        cstr_nonconsts = !num_nonconsts;
+        cstr_loc = cd_loc;
+      } in
+    (cd_id, cstr) in
+  List.mapi describe_constructor cstrs
 
 let none = {desc = TTyTuple []; level = -1; id = -1}
                                         (* Clearly ill-formed type *)

--- a/compiler/test/input/adtprint.gr
+++ b/compiler/test/input/adtprint.gr
@@ -1,0 +1,14 @@
+export data Printable =
+  | Foo
+  | Bar
+  | Baz(String)
+  | Qux(Number, String, Bool)
+  | Quux
+  | Flip(String)
+
+print(Foo)
+print(Bar)
+print(Baz('baz'))
+print(Qux(5, 'qux', false))
+print(Quux)
+print(Flip('flip'))

--- a/compiler/test/test_end_to_end.ml
+++ b/compiler/test/test_end_to_end.ml
@@ -679,6 +679,7 @@ let string_tests =
 let data_tests =
   [
     tfile "basicdata" "basicdata" "(false, true, true)";
+    tfile "adtprint" "adtprint" "Foo\nBar\nBaz(\"baz\")\nQux(5, \"qux\", false)\nQuux\nFlip(\"flip\")\nvoid";
   ]
 
 let export_tests =


### PR DESCRIPTION
We were double-tagging constructor tags and specially tagging non-constant constructors, and our match/allocation implementations don't depend on that. We also didn't use separate numbers for constant/tuple constructors which caused printing to be dependent on the order in which the type variants were defined, i.e.
```grain
export data Option<a> = None | Some(a)

print(Some(9))
print(None)
```
correctly prints
```
Some(9)
None
```

but
```
export data Option<a> = Some(a) | None

print(Some(9))
print(None)
```
casually prints
```
None
Some(0)
```


Nothing is wrong with the data in memory (so pattern matching and whatnot still works properly) but the printing is busted. Also, if you define more than one tuple constructor or more than one constant constructor, that doesn't work at all 😬

But now it's fixed! 