### PR TITLE
Heap allocate should call malloc

### DIFF
--- a/runtime/src/core/heap.js
+++ b/runtime/src/core/heap.js
@@ -1,4 +1,4 @@
-import { memory } from '../runtime';
+import { memory, malloc } from '../runtime';
 import { GrainError } from '../errors/errors';
 
 export const heapController = {
@@ -19,8 +19,5 @@ export function grainCheckMemory(numBytes) {
 
 export function grainHeapAllocate(numWords) {
   // allocates the number of words
-  let curTop = heapController.heapAdjust(0);
-  let wordsToAllocate = 4 * (Math.ceil((numWords - 1) / 4) + 1);
-  heapController.heapAdjust(wordsToAllocate * 4);
-  return curTop;
+  return malloc(numWords * 4)
 }

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -21,6 +21,7 @@ export const encoder = new TextEncoder("utf-8");
 export const decoder = new TextDecoder("utf-8");
 
 const managedMemory = new ManagedMemory(memory);
+export const malloc = managedMemory.malloc.bind(managedMemory)
 
 const importObj = {
   env: {
@@ -36,7 +37,7 @@ const importObj = {
     tbl: table,
     throwError: throwGrainError,
     checkMemory: grainCheckMemory,
-    malloc: managedMemory.malloc.bind(managedMemory)
+    malloc: malloc
   },
   grainBuiltins: {
     ...libStrings,

--- a/runtime/src/utils/utils.js
+++ b/runtime/src/utils/utils.js
@@ -1,6 +1,5 @@
 import { memory, view, encoder, decoder } from '../runtime';
 import { grainHeapAllocate } from '../core/heap';
-import { GrainClosure } from '../core/closures';
 import { GrainError } from '../errors/errors';
 import { grainDOMRefs } from '../lib/DOM';
 


### PR DESCRIPTION
`toString`, `stringSlice`, and `stringAppend` haven't been working since we had real malloc. This actually calls malloc for those methods.