### PR TITLE
Fix postinstall error

### DIFF
--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -34,6 +34,6 @@
   "dependencies": {},
   "scripts": {
     "build": "for f in stdlib-external/*.ts; do asc $f -o stdlib-external/$(basename $f .ts).wasm -O3 --runtime none --importMemory; done",
-    "clean": "rm *.wasm"
+    "clean": "rm -f *.wasm"
   }
 }


### PR DESCRIPTION
Happens when the stdlib has already been cleaned.