### PR TITLE
Fix export scoping

### DIFF
--- a/compiler/src/codegen/compcore.ml
+++ b/compiler/src/codegen/compcore.ml
@@ -1496,6 +1496,7 @@ let compile_exports env {functions; imports; exports; num_globals} =
   let compiled_lambda_exports = List.mapi compile_lambda_export functions in
   let exports =
     let exported = Hashtbl.create 14 in
+    (* Exports are already reversed, so keeping the first of any name is the correct behavior. *)
     List.filter (fun {ex_name} ->
       if Hashtbl.mem exported (Ident.name ex_name) then false
       else (Hashtbl.add exported (Ident.name ex_name) (); true)

--- a/compiler/src/codegen/compcore.ml
+++ b/compiler/src/codegen/compcore.ml
@@ -1494,6 +1494,12 @@ let compile_exports env {functions; imports; exports; num_globals} =
   let heap_adjust_idx = add_dummy_loc @@ Int32.of_int heap_adjust_idx in
   let main_idx = add_dummy_loc @@ Int32.of_int main_idx in
   let compiled_lambda_exports = List.mapi compile_lambda_export functions in
+  let exports =
+    let exported = Hashtbl.create 14 in
+    List.filter (fun {ex_name} ->
+      if Hashtbl.mem exported (Ident.name ex_name) then false
+      else (Hashtbl.add exported (Ident.name ex_name) (); true)
+    ) exports in
   let compiled_exports = List.mapi compile_getter exports in
   (List.append
      compiled_lambda_exports

--- a/compiler/src/codegen/transl_anf.ml
+++ b/compiler/src/codegen/transl_anf.ml
@@ -63,8 +63,8 @@ let reset_global() =
 
 let next_global id =
   (* RIP Hygiene (this behavior works as expected until we have more metaprogramming constructs) *)
-  match Ident.find_name_opt (Ident.name id) (!global_table) with
-  | Some(_, (ret, ret_get)) -> Int32.to_int ret, Int32.to_int ret_get
+  match Ident.find_same_opt id (!global_table) with
+  | Some(ret, ret_get) -> Int32.to_int ret, Int32.to_int ret_get
   | None ->
     begin
       let ret = !global_index in

--- a/compiler/test/test-libs/sameExport.gr
+++ b/compiler/test/test-libs/sameExport.gr
@@ -1,0 +1,4 @@
+export *
+
+let foo = () => 5
+let foo = () => foo() + 1

--- a/compiler/test/test_end_to_end.ml
+++ b/compiler/test/test_end_to_end.ml
@@ -494,6 +494,8 @@ let import_tests = [
   t "import_all_constructor" "import * from 'tlists'; Cons(2, Empty)" "Cons(2, Empty)";
   t "import_all_except_constructor" "import * except {Cons} from 'tlists'; Empty" "Empty";
   t "import_all_except_multiple_constructor" "import * except {Cons, append} from 'tlists'; sum(Empty)" "0";
+  
+  t "import_with_export_multiple" "import * from 'sameExport'; foo()" "6";
 
   (* import * errors *)
   te "import_all_except_error" "import * except {y} from 'exportStar'; {print(x); print(y); z}" "Unbound value y";

--- a/stdlib/sys.gr
+++ b/stdlib/sys.gr
@@ -317,12 +317,12 @@ import foreign wasm fdDatasync : (FileDescriptor) -> Void from 'stdlib-external/
 # @param fd: FileDescriptor The file descriptor to synchronize
 import foreign wasm fdSync : (FileDescriptor) -> Void from 'stdlib-external/sys'
 
-import foreign wasm fdStats : (FileDescriptor) -> (Number, Int64, Int64, Int64) as fdStatsRaw from 'stdlib-external/sys'
+import foreign wasm fdStats : (FileDescriptor) -> (Number, Int64, Int64, Int64) from 'stdlib-external/sys'
 # Retrieve information about a file descriptor
 # @param fd: FileDescriptor The file descriptor of which to retrieve information
 # @returns Stats A record containing the filetype, flags, rights, and inheriting rights associated with the file descriptor
 let fdStats = (fd) => {
-  let (filetype, fdflags, rights, rightsInheriting) = fdStatsRaw(fd)
+  let (filetype, fdflags, rights, rightsInheriting) = fdStats(fd)
 
   let orderedFdflags = [
     Append,
@@ -402,12 +402,12 @@ import foreign wasm fdSetFlags : (FileDescriptor, List<FdFlag>) -> Void from 'st
 # @param rightsInheriting: List<Rights> Inheriting rights to apply to the file descriptor
 import foreign wasm fdSetRights : (FileDescriptor, List<Rights>, List<Rights>) -> Void from 'stdlib-external/sys'
 
-import foreign wasm fdFilestats : (FileDescriptor) -> (Int64, Int64, Number, Int64, Int64, Int64, Int64, Int64) as fdFilestatsRaw from 'stdlib-external/sys'
+import foreign wasm fdFilestats : (FileDescriptor) -> (Int64, Int64, Number, Int64, Int64, Int64, Int64, Int64) from 'stdlib-external/sys'
 # Retrieve information about a file
 # @param fd: FileDescriptor The file descriptor of the file to retrieve information
 # @returns Filestats A record containing the information about the file
 let fdFilestats = (fd) => {
-  let (device, inode, filetype, linkcount, size, accessed, modified, changed) = fdFilestatsRaw(fd)
+  let (device, inode, filetype, linkcount, size, accessed, modified, changed) = fdFilestats(fd)
 
   let filetype = filetypeFromNumber(filetype)
   


### PR DESCRIPTION
We had a bug when exporting multiple values with the same name.

In this example:
```grain
export *
let foo = () => true
let foo = () => foo()
foo()
```

calling `foo` results in an infinite loop. Fortunately, there was no typechecking issue, just a codegen issue.