### PR TITLE
Fix tail-call analysis for branches

### DIFF
--- a/compiler/test/input/oneBranchTail.gr
+++ b/compiler/test/input/oneBranchTail.gr
@@ -1,0 +1,8 @@
+let rec filter = (f, l) => {
+  match (l) {
+    | [hd, ...tl] => if (f(hd)) [hd, ...filter(f, tl)] else filter(f, tl)
+    | [] => []
+  }
+};
+
+filter((x) => x == 2, [1, 2, 3])

--- a/compiler/test/test_end_to_end.ml
+++ b/compiler/test/test_end_to_end.ml
@@ -205,6 +205,9 @@ let function_tests = [
   (* NOTE: This file also will test that we're doing tail calls
      and mutual recursion properly (should stack overflow otherwise) *)
 
+  (* Tests tail calls on only on one branch *)
+  tfile "one_branch_tail_call" "oneBranchTail" "[2]";
+
   tfile "forward_decl" "forward-decl" "true";
   (* This will test that we are doing tail calls for arbitrary-arity
      functions correctly *)


### PR DESCRIPTION
Basically, if a function was tail-callable and contained a branch with a tail position recursive call and another branch with a non-tail position recursive call, the non-tail position call would still be transformed as though it were in tail position.

The bug is a bit more obvious to see by the unconditional call to `push_tail_call`.

The fix is to only mark tail calls if they're in tail position. For sequences, only the last item is marked. A binding is never in tail position, but we do mark bindings to recursive functions as in tail position to properly analyze nested definitions.

Writing a test for the optimized AST would be a little brittle, so I just added a test with the code where we found the bug.