### PR TITLE
Make compiler subpackage linkable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           yarn setup
       - name: esy install
         run: |
-          yarn workspace compiler run esy install
+          yarn workspace @grain/compiler run esy install
       - name: Restore esy cache
         id: restore-cache
         uses: actions/cache@v1
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-esy-
       - name: Import esy cache
         run: |
-          yarn workspace compiler run esy import-dependencies _export
+          yarn workspace @grain/compiler run esy import-dependencies _export
           rm -rf compiler/_export
       - name: Build compiler
         run: |
@@ -36,7 +36,7 @@ jobs:
       # Re-export dependencies if anything has changed or if it is the first time
       - name: Build esy cache 
         run: |
-          yarn workspace compiler run esy export-dependencies
+          yarn workspace @grain/compiler run esy export-dependencies
         if: steps.restore-cache.outputs.cache-hit != 'true'
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ yarn compiler:build
 
 This will set up the Grain runtime, standard library, and CLI.
 
-To put the Grain compiler binaries on your path, run:
-
-```bash
-yarn compiler:install
-```
-
 If running tests is your kind of thing, run
 
 ```bash

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "compiler",
+  "name": "@grain/compiler",
   "private": true,
   "version": "0.0.1",
+  "bin": {
+    "grainc": "_esy/default/build/install/default/bin/grainc"
+  },
   "engines": {
     "node": ">=14"
   },

--- a/package.json
+++ b/package.json
@@ -13,15 +13,16 @@
     "node": ">=14"
   },
   "scripts": {
-    "compiler:clean": "yarn workspace compiler run esy clean",
-    "compiler:build": "yarn workspace compiler run esy",
-    "compiler:install": "yarn workspace compiler run esy install-compiler",
-    "postcompiler:install": "yarn stdlib:clean",
-    "compiler:test": "yarn workspace compiler run esy test",
+    "compiler:clean": "yarn workspace @grain/compiler run esy clean",
+    "compiler:build": "yarn workspace @grain/compiler run esy",
+    "postcompiler:build": "yarn stdlib:clean",
+    "compiler:test": "yarn workspace @grain/compiler run esy test",
+    "test": "yarn compiler:test",
     "runtime:build": "yarn workspace @grain/runtime build",
     "stdlib:build": "yarn workspace @grain/stdlib build",
     "stdlib:clean": "yarn workspace @grain/stdlib clean",
     "cli:link": "yarn workspace @grain/cli link",
-    "setup": "yarn runtime:build && yarn stdlib:build && yarn cli:link"
+    "compiler:link": "yarn workspace @grain/compiler link",
+    "setup": "yarn runtime:build && yarn stdlib:build && yarn cli:link && yarn compiler:link"
   }
 }


### PR DESCRIPTION
This makes the development `grainc` available via `yarn workspace @grain/compiler link`, which I think is a good solution until we decide if we want to bundle the compiler with the CLI.