### PR TITLE
Copy the grainc binary to the CLI directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ script/public/javascripts/grain-runtime.js
 script/public/javascripts/grain-runtime-browser.js
 /*.gr
 _esy/
+
+# The grainc.exe binary is copied to the CLI directory during build
+cli/bin/grainc.exe

--- a/cli/bin/compile.js
+++ b/cli/bin/compile.js
@@ -1,8 +1,11 @@
+const path = require('path');
 const { execSync } = require('child_process');
+
+const grainc = path.join(__dirname, 'grainc.exe');
 
 module.exports = (file, options) => {
   try {
-    execSync(`grainc --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} ${file}`);
+    execSync(`${grainc} --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} ${file}`);
     return file.replace(/\.gr$/, '.wasm')
   } catch (e) {
     console.log(e.stdout.toString());

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -23,7 +23,9 @@ function num(val) {
 }
 
 function graincVersion() {
-  return execSync(`grainc --version`).toString().trim();
+  const grainc = path.join(__dirname, 'grainc.exe');
+
+  return execSync(`${grainc} --version`).toString().trim();
 }
 
 program

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -4,13 +4,15 @@
   "esy": {
     "buildEnv": {
       "DUNE_BUILD_DIR": "#{self.target_dir}",
-      "GRAIN_STDLIB": "#{self.root}/../stdlib"
+      "GRAIN_STDLIB": "#{self.root / '..' / 'stdlib'}",
+      "GRAINC_BIN_PATH": "#{self.target_dir / 'default' / 'grainc' / 'grainc.exe'}",
+      "CLI_BIN_DIR": "#{self.root / '..' / 'cli' / 'bin'}"
     }
   },
   "scripts": {
-    "compile": "dune build @all @install",
+    "compile": "dune build",
+    "copy-compiler": "cp #{$GRAINC_BIN_PATH} #{$CLI_BIN_DIR}",
     "clean": "rm -rf #{self.root}/_esy",
-    "install-compiler": "dune install",
     "test": "dune runtest --force"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "compiler:clean": "yarn workspace @grain/compiler run esy clean",
-    "compiler:build": "yarn workspace @grain/compiler run esy install && yarn workspace @grain/compiler run esy compile",
+    "compiler:build": "yarn workspace @grain/compiler run esy install && yarn workspace @grain/compiler run esy compile && yarn workspace @grain/compiler run esy copy-compiler",
     "postcompiler:build": "yarn stdlib:clean",
     "compiler:test": "yarn workspace @grain/compiler run esy test",
     "test": "yarn compiler:test",


### PR DESCRIPTION
This adds another step to the "compiler:build" command that copies the generated binary of `grainc.exe` into the `cli/bin` directory and then the execSync calls use the absolute path to that binary.

This should avoid people having to install the grainc binary. There might be a possible issue with that absolute path on Windows, but we'll need to get something in CI to check it.

This is also phase 1 in getting a publishable CLI that people can just use.