### PR TITLE
Adds a build script to run assemblyscript

### DIFF
--- a/stdlib/build.mjs
+++ b/stdlib/build.mjs
@@ -13,7 +13,7 @@ const asc = require('assemblyscript/cli/asc');
 
 const compileFile = promisify(asc.main);
 
-// Binaryen is ready
+// AssemblyScript compiler is ready
 await asc.ready;
 
 const filenames = await globby('stdlib-external/**/*.ts');

--- a/stdlib/build.mjs
+++ b/stdlib/build.mjs
@@ -1,0 +1,29 @@
+#!/bin/sh
+// 2>/dev/null; exec /usr/bin/env node --harmony-top-level-await "$0"
+
+import { promisify } from 'util';
+import { createRequire } from 'module';
+
+import globby from 'globby';
+import replaceExt from 'replace-ext';
+
+// Making asc interop with ESM
+const require = createRequire(import.meta.url);
+const asc = require('assemblyscript/cli/asc');
+
+const compileFile = promisify(asc.main);
+
+// Binaryen is ready
+await asc.ready;
+
+const filenames = await globby('stdlib-external/**/*.ts');
+
+const files = filenames.map((filename) => compileFile([
+  filename,
+  '-o', replaceExt(filename, '.wasm'),
+  '-O3',
+  '--runtime', 'none',
+  '--importMemory',
+]));
+
+await Promise.all(files);

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -33,11 +33,13 @@
   "homepage": "https://grain-lang.org",
   "devDependencies": {
     "assemblyscript": "^0.9.4",
-    "del-cli": "^3.0.1"
+    "del-cli": "^3.0.1",
+    "globby": "^11.0.1",
+    "replace-ext": "^2.0.0"
   },
   "dependencies": {},
   "scripts": {
-    "build": "for f in stdlib-external/*.ts; do asc $f -o stdlib-external/$(basename $f .ts).wasm -O3 --runtime none --importMemory; done",
-    "clean": "del '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/*.wasm'"
+    "build": "./build.mjs",
+    "clean": "del '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/**'"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,7 +1306,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-glob@^3.0.3:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
@@ -1562,6 +1562,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
+globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
@@ -1680,7 +1692,7 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -2844,6 +2856,11 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-2.0.0.tgz#9471c213d22e1bcc26717cd6e50881d88f812b06"
+  integrity sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This adds a cross-platform build script that generates all wasm files based on assemblyscript files in `stdlib-external`.

I also fixed a globbing issue with my clean script.