### PR TITLE
Utilize dune-build-info for grainc version

### DIFF
--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.0)
 (name grain)
-(version 0.0.1)
+(version 0.1.0)

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@opam/grain": "*",
+    "@opam/grainc": "*",
     "@opam/grain_utils": "*",
     "@opam/grain_parsing": "*",
     "@opam/grain_typed": "*",
@@ -26,6 +27,7 @@
   },
   "resolutions": {
     "@opam/grain": "link:./grain.opam",
+    "@opam/grainc": "link:./grainc.opam",
     "@opam/grain_utils": "link:./grain_utils.opam",
     "@opam/grain_parsing": "link:./grain_parsing.opam",
     "@opam/grain_typed": "link:./grain_typed.opam",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "76bac30b5b3e9fb6186007160c390c60",
+  "checksum": "e72edc55509e6e27c2ecd22b64801db5",
   "root": "compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.8.1000@d41d8cd9": {
@@ -23,7 +23,7 @@
       "source": { "type": "link-dev", "path": ".", "manifest": "esy.json" },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/grainc@link:./grainc.opam",
         "@opam/grain_utils@link:./grain_utils.opam",
         "@opam/grain_typed@link:./grain_typed.opam",
         "@opam/grain_parsing@link:./grain_parsing.opam",
@@ -1805,6 +1805,46 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
+    "@opam/grainc@link:./grainc.opam": {
+      "id": "@opam/grainc@link:./grainc.opam",
+      "name": "@opam/grainc",
+      "version": "link:./grainc.opam",
+      "source": { "type": "link", "path": ".", "manifest": "grainc.opam" },
+      "overrides": [],
+      "dependencies": [
+        "@opam/stdint@opam:0.6.0@d1e22c8e",
+        "@opam/sexplib@opam:v0.14.0@f67f18de",
+        "@opam/ppx_sexp_conv@opam:v0.14.0@a2eef025",
+        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ounit@opam:2.2.2@e13ca575",
+        "@opam/ocamlgraph@opam:1.8.8@2767ad0b",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/grain_wasm_spec@opam:0.1@d07a2c3e",
+        "@opam/grain_dypgen@opam:0.1@0b95a143",
+        "@opam/grain@link:./grain.opam", "@opam/extlib@opam:1.7.7@750728e7",
+        "@opam/dune-build-info@opam:2.5.1@921e5578",
+        "@opam/dune@opam:2.5.0@aef1678b", "@opam/core@opam:v0.14.0@d187027a",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/batteries@opam:3.0.0@8b2b498b",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/stdint@opam:0.6.0@d1e22c8e",
+        "@opam/sexplib@opam:v0.14.0@f67f18de",
+        "@opam/ppx_sexp_conv@opam:v0.14.0@a2eef025",
+        "@opam/ppx_deriving@opam:4.5@bb81afdc",
+        "@opam/ounit@opam:2.2.2@e13ca575",
+        "@opam/ocamlgraph@opam:1.8.8@2767ad0b",
+        "@opam/grain_wasm_spec@opam:0.1@d07a2c3e",
+        "@opam/grain_dypgen@opam:0.1@0b95a143",
+        "@opam/grain@link:./grain.opam", "@opam/extlib@opam:1.7.7@750728e7",
+        "@opam/dune-build-info@opam:2.5.1@921e5578",
+        "@opam/core@opam:v0.14.0@d187027a",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@opam/batteries@opam:3.0.0@8b2b498b"
+      ]
+    },
     "@opam/grain_wasm_spec@opam:0.1@d07a2c3e": {
       "id": "@opam/grain_wasm_spec@opam:0.1@d07a2c3e",
       "name": "@opam/grain_wasm_spec",
@@ -2258,6 +2298,28 @@
         "@opam/dune-private-libs@opam:2.5.1@60c1661f",
         "@opam/dune@opam:2.5.0@aef1678b"
       ]
+    },
+    "@opam/dune-build-info@opam:2.5.1@921e5578": {
+      "id": "@opam/dune-build-info@opam:2.5.1@921e5578",
+      "name": "@opam/dune-build-info",
+      "version": "opam:2.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/8f/8f77d3a87f208e0d7cccaa1c48c4bb1bb87d62d07c3f25e9b8ba298e028ce52b#sha256:8f77d3a87f208e0d7cccaa1c48c4bb1bb87d62d07c3f25e9b8ba298e028ce52b",
+          "archive:https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz#sha256:8f77d3a87f208e0d7cccaa1c48c4bb1bb87d62d07c3f25e9b8ba298e028ce52b"
+        ],
+        "opam": {
+          "name": "dune-build-info",
+          "version": "2.5.1",
+          "path": "esy.lock/opam/dune-build-info.2.5.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:2.5.0@aef1678b" ]
     },
     "@opam/dune@opam:2.5.0@aef1678b": {
       "id": "@opam/dune@opam:2.5.0@aef1678b",

--- a/compiler/esy.lock/opam/dune-build-info.2.5.1/opam
+++ b/compiler/esy.lock/opam/dune-build-info.2.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "2.3"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz"
+  checksum: [
+    "sha256=8f77d3a87f208e0d7cccaa1c48c4bb1bb87d62d07c3f25e9b8ba298e028ce52b"
+    "sha512=f209f12ced10c1abf8782bdb0143f4cec77795f7174d2cc75130afb1e01550b01f2f77b9e3ec4888efdad83d2f9878d179b39126f824f4e522f3ef4da34bf27e"
+  ]
+}

--- a/compiler/grainc.opam
+++ b/compiler/grainc.opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlfind" {build & >= "1.7.3" }
   "ocamlbuild" {build & >= "0.12.0" }
   "dune" {build & >= "2.0" }
+  "dune-build-info"
   "ppx_deriving"
   "ppx_sexp_conv"
   "sexplib"

--- a/compiler/grainc/dune
+++ b/compiler/grainc/dune
@@ -3,4 +3,4 @@
  (public_name grainc)
  (package grain)
  (modules grainc)
- (libraries grain))
+ (libraries grain dune-build-info))

--- a/compiler/grainc/grainc.ml
+++ b/compiler/grainc/grainc.ml
@@ -86,8 +86,11 @@ let help_cmd =
 
 let cmd =
   let doc = sprintf "Compile Grain programs" in
+  let version = (match Build_info.V1.version () with
+   | None -> "unknown"
+   | Some v -> Build_info.V1.Version.to_string v) in
   Term.(ret (Grain_utils.Config.with_cli_options compile_file $ input_filename $ output_filename)),
-  Term.info (Sys.argv.(0)) ~version:"0.1.0" ~doc
+  Term.info (Sys.argv.(0)) ~version ~doc
 
 let () =
   match Term.eval cmd with


### PR DESCRIPTION
This uses `dune-build-info` to inline the version number into the grainc binary.

More information on dune-build-info at https://dune.readthedocs.io/en/stable/dune-libs.html?highlight=build-info#build-info

While making these changes, I noticed we didn't have grainc in the esy.json, which I think was just an oversight. Also, the grain compiler version number didn't match the rest of the project 😉 