### PR TITLE
Proxy the root scripts to packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
           yarn
           yarn setup
 
-      - name: Esy install
+      - name: Esy setup
         run: |
-          yarn compiler install
+          yarn compiler setup
 
       - name: Esy cache
         id: esy-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Esy install
         run: |
-          yarn workspace @grain/compiler run esy install
+          yarn compiler install
 
       - name: Esy cache
         id: esy-cache
@@ -47,22 +47,22 @@ jobs:
       - name: Import esy cache
         if: steps.esy-cache.outputs.cache-hit == 'true'
         run: |
-          yarn workspace @grain/compiler run esy import-dependencies _export
+          yarn compiler import-dependencies
           shx rm -rf compiler/_export
 
       - name: Build compiler
         run: |
-          yarn compiler:build
+          yarn compiler build
 
       # Re-export dependencies if anything has changed or if it is the first time
       - name: Build esy cache
         if: steps.esy-cache.outputs.cache-hit != 'true'
         run: |
-          yarn workspace @grain/compiler run esy export-dependencies
+          yarn compiler export-dependencies
 
       - name: Run tests
         run: |
-          yarn compiler:test
+          yarn compiler test
 
       # This is to test the CLI is working
       - name: Log Grain version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,26 +25,26 @@ There are a set of contributor docs in [docs/contributor](https://github.com/gra
 Once you have the compiler building, the typical flow for development is to make changes in the `compiler` directory, then run:
 
 ```bash
-yarn compiler:build
-yarn compiler:test
+yarn compiler build
+yarn compiler test
 ```
 
-It can sometimes be helpful to run small Grain programs directly to test some functionality without running the full test suite. If you change the compiler, you'll need to run `yarn compiler:install` to install the latest built version to see your compiler changes take effect when you run the `grain` CLI.
+It can sometimes be helpful to run small Grain programs directly to test some functionality without running the full test suite.
 
 ### Runtime
 
 After making changes in the `runtime` directory, run:
 
 ```bash
-yarn runtime:build
-yarn runtime:test
+yarn runtime build
+yarn runtime test
 ```
 
 Once the runtime has been built, it's the only one active. Grain programs that you run from the command line or the tests will use that version.
 
 ### Standard library
 
-If you're only changing `.gr` stdlib files, you don't need to do anything special. Running the tests will automatically recompile all of the standard library files. If you change any of the AssemblyScript files in the `stdlib-external` directory of `stdlib`, you'll need to run `yarn stdlib:build` to recompile them.
+If you're only changing `.gr` stdlib files, you don't need to do anything special. Running the tests will automatically recompile all of the standard library files. If you change any of the AssemblyScript files in the `stdlib-external` directory of `stdlib`, you'll need to run `yarn stdlib build` to recompile them.
 
 It's usually easiest to create a small Grain program that imports your library to try it out, like so:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn runtime build
 To link the CLI:
 
 ```bash
-yarn link @grain/cli
+yarn cli link
 ```
 
 To reset your compiler build:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build Grain, you'll need `yarn` and Node.js version 10 or higher. To get ever
 ```bash
 yarn
 yarn setup
-yarn compiler:build
+yarn compiler build
 ```
 
 This will set up the Grain runtime, standard library, and CLI.
@@ -33,7 +33,7 @@ This will set up the Grain runtime, standard library, and CLI.
 If running tests is your kind of thing, run
 
 ```bash
-yarn compiler:test
+yarn compiler test
 ```
 
 ### Other Commands
@@ -41,26 +41,34 @@ yarn compiler:test
 To build the standard library:
 
 ```bash
-yarn stdlib:build
+yarn stdlib build
 ```
 
 To build the runtime:
 
 ```bash
-yarn runtime:build
+yarn runtime build
 ```
 
 To link the CLI:
 
 ```bash
-yarn cli:link
+yarn link @grain/cli
 ```
 
 To reset your compiler build:
 
 ```bash
-yarn compiler:clean
+yarn compiler clean
 ```
+
+To navigate tasks available in the system:
+
+```bash
+yarn run
+```
+
+This will display an interactive session where you can select the project and command you want.
 
 ## Running Grain Programs
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
     "node": ">=14"
   },
   "scripts": {
+    "link": "yarn link",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -10,5 +10,12 @@
   },
   "devDependencies": {
     "esy": "0.6.6"
+  },
+  "scripts": {
+    "clean": "esy clean",
+    "build": "esy install && esy compile && esy copy-compiler",
+    "test": "esy test",
+    "import-dependencies": "esy import-dependencies _export",
+    "export-dependencies": "esy export-dependencies"
   }
 }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "link": "yarn link",
     "clean": "esy clean",
+    "setup": "esy install",
     "build": "esy install && esy compile && esy copy-compiler",
     "test": "esy test",
     "import-dependencies": "esy import-dependencies _export",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -12,6 +12,7 @@
     "esy": "0.6.6"
   },
   "scripts": {
+    "link": "yarn link",
     "clean": "esy clean",
     "build": "esy install && esy compile && esy copy-compiler",
     "test": "esy test",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "setup": "yarn runtime build && yarn stdlib build && yarn link @grain/cli && yarn link @grain/compiler",
+    "setup": "yarn runtime build && yarn stdlib build && yarn cli link && yarn compiler link",
     "test": "yarn compiler test",
     "cli": "yarn workspace @grain/cli run",
     "runtime": "yarn workspace @grain/runtime run",

--- a/package.json
+++ b/package.json
@@ -13,17 +13,12 @@
     "node": ">=14"
   },
   "scripts": {
-    "compiler:clean": "yarn workspace @grain/compiler run esy clean",
-    "compiler:build": "yarn workspace @grain/compiler run esy install && yarn workspace @grain/compiler run esy compile && yarn workspace @grain/compiler run esy copy-compiler",
-    "postcompiler:build": "yarn stdlib:clean",
-    "compiler:test": "yarn workspace @grain/compiler run esy test",
-    "test": "yarn compiler:test",
-    "runtime:build": "yarn workspace @grain/runtime build",
-    "runtime:build:dev": "yarn workspace @grain/runtime build:dev",
-    "stdlib:build": "yarn workspace @grain/stdlib build",
-    "stdlib:clean": "yarn workspace @grain/stdlib clean",
-    "cli:link": "yarn workspace @grain/cli link",
-    "compiler:link": "yarn workspace @grain/compiler link",
-    "setup": "yarn runtime:build && yarn stdlib:build && yarn cli:link && yarn compiler:link"
+    "setup": "yarn runtime build && yarn stdlib build && yarn link @grain/cli && yarn link @grain/compiler",
+    "test": "yarn compiler test",
+    "cli": "yarn workspace @grain/cli run",
+    "runtime": "yarn workspace @grain/runtime run",
+    "compiler": "yarn workspace @grain/compiler run",
+    "stdlib": "yarn workspace @grain/stdlib run",
+    "postcompiler": "yarn stdlib clean"
   }
 }


### PR DESCRIPTION
This changes the scripts from all being defined as `package:command` to being proxied through `yarn workspace` into the package that defines the build script. It also moves the `esy` commands into the package.json of the compiler so we can utilize them from the CI.

A really neat trick is that you can use `yarn run` to navigate into packages and select a command because they all spawn `yarn run` commands. Here's an example of me navigating from the root into the compiler package where I can select a new command:
<img width="571" alt="Screen Shot 2020-06-30 at 5 27 58 PM" src="https://user-images.githubusercontent.com/992373/86189785-64db3f00-baf7-11ea-9fda-9dd4716caabd.png">
