### PR TITLE
Add OCaml LSP w/ setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ _esy/
 
 # The grainc.exe binary is copied to the CLI directory during build
 cli/bin/grainc.exe
+
+# Local settings.json for vscode should not be checked in
+# But the directory contains a build script for setting up OCaml LSP
+.vscode/settings.json

--- a/.vscode/setup-ocaml-lsp.js
+++ b/.vscode/setup-ocaml-lsp.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const settingsPath = path.join(__dirname, 'settings.json');
+
+const compilerPath = path.join(__dirname, '../compiler');
+
+const output = `{
+  "ocaml.sandbox": {
+    "root": "${compilerPath}",
+    "kind": "esy"
+  }
+}`;
+
+fs.writeFileSync(settingsPath, output);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ If running tests is your kind of thing, run
 yarn compiler test
 ```
 
+If you are using `vscode` as your editor, we recommend you run:
+
+```bash
+yarn vscode
+```
+
+This will create local settings that point OCaml LSP to our `compiler` directory. Then, you should be able to use the [OCaml Platform](https://github.com/ocamllabs/vscode-ocaml-platform) extension!
+
 ### Other Commands
 
 To build the standard library:

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -27,7 +27,8 @@
     "ocaml": "~4.8.1000"
   },
   "devDependencies": {
-    "@opam/reason": "*"
+    "@opam/reason": "*",
+    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam"
   },
   "resolutions": {
     "@opam/grain": "link:./grain.opam",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "529f5986f14ad23a1ddacae733a6bc7a",
+  "checksum": "cf5fece145744e4e6e78b814fe85b893",
   "root": "compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.8.1000@d41d8cd9": {
@@ -31,7 +31,10 @@
         "@opam/grain_codegen@link:./grain_codegen.opam",
         "@opam/grain@link:./grain.opam"
       ],
-      "devDependencies": [ "@opam/reason@opam:3.6.0@2da53ff9" ],
+      "devDependencies": [
+        "@opam/reason@opam:3.6.0@2da53ff9",
+        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c6d632185e61e474d4e663540ab542352123a1b6@d41d8cd9"
+      ],
       "installConfig": { "pnp": false }
     },
     "@opam/yojson@opam:1.7.0@7056d985": {
@@ -309,6 +312,32 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6": {
+      "id": "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
+      "name": "@opam/ppx_yojson_conv_lib",
+      "version": "opam:v0.14.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e2/e23c5593a7211ad4fb09e26e9a74698a#md5:e23c5593a7211ad4fb09e26e9a74698a",
+          "archive:https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_yojson_conv_lib-v0.14.0.tar.gz#md5:e23c5593a7211ad4fb09e26e9a74698a"
+        ],
+        "opam": {
+          "name": "ppx_yojson_conv_lib",
+          "version": "v0.14.0",
+          "path": "esy.lock/opam/ppx_yojson_conv_lib.v0.14.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },
@@ -643,6 +672,38 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
+        "@opam/dune@opam:2.5.0@aef1678b"
+      ]
+    },
+    "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c6d632185e61e474d4e663540ab542352123a1b6@d41d8cd9": {
+      "id":
+        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c6d632185e61e474d4e663540ab542352123a1b6@d41d8cd9",
+      "name": "@opam/ocaml-lsp-server",
+      "version":
+        "github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c6d632185e61e474d4e663540ab542352123a1b6",
+      "source": {
+        "type": "install",
+        "source": [
+          "github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c6d632185e61e474d4e663540ab542352123a1b6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/dune-build-info@opam:2.5.1@921e5578",
+        "@opam/dune@opam:2.5.0@aef1678b", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/menhir@opam:20200624@8629ff13",
+        "@opam/dune-build-info@opam:2.5.1@921e5578",
         "@opam/dune@opam:2.5.0@aef1678b"
       ]
     },

--- a/compiler/esy.lock/opam/ppx_yojson_conv_lib.v0.14.0/opam
+++ b/compiler/esy.lock/opam/ppx_yojson_conv_lib.v0.14.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_yojson_conv_lib"
+bug-reports: "https://github.com/janestreet/ppx_yojson_conv_lib/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv_lib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_yojson_conv_lib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "4.02.3"}
+  "dune"   {>= "2.0.0"}
+  "yojson" {>= "1.7.0"}
+]
+synopsis: "Runtime lib for ppx_yojson_conv"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_yojson_conv_lib-v0.14.0.tar.gz"
+  checksum: "md5=e23c5593a7211ad4fb09e26e9a74698a"
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=14"
   },
   "scripts": {
+    "vscode": "node .vscode/setup-ocaml-lsp.js && yarn compiler setup",
     "setup": "yarn runtime build && yarn stdlib build && yarn cli link && yarn compiler link",
     "test": "yarn compiler test",
     "cli": "yarn workspace @grain/cli run",


### PR DESCRIPTION
We have all sorts of issues with the reason-vscode extension and development on the OCaml Platform extension seems to be moving quickly, so I added some quick-and-dirty scripts to get contributors set up with using it.