### PR TITLE
Implement a Map module for stdlib

### DIFF
--- a/compiler/test/stdlib/map.test.gr
+++ b/compiler/test/stdlib/map.test.gr
@@ -1,0 +1,59 @@
+import Map from 'map'
+
+# With Number keys
+let nums = Map.make();
+
+assert Map.set(1, "🌾", nums) == void;
+assert Map.set(2, "🐑", nums) == void;
+assert Map.set(3, "🧱", nums) == void;
+
+assert Map.get(1, nums) == Some("🌾");
+assert Map.get(2, nums) == Some("🐑");
+assert Map.get(3, nums) == Some("🧱");
+assert Map.get(4, nums) == None;
+
+# With String keys
+let strs = Map.make();
+
+assert Map.set("🌾", 1, strs) == void;
+assert Map.set("🐑", 2, strs) == void;
+assert Map.set("🧱", 3, strs) == void;
+
+assert Map.get("🌾", strs) == Some(1);
+assert Map.get("🐑", strs) == Some(2);
+assert Map.get("🧱", strs) == Some(3);
+assert Map.get("🌳", strs) == None;
+
+# With variant keys
+data Resource = Grain | Sheep | Brick | Wood;
+
+let vars = Map.make();
+
+assert Map.set(Grain, "🌾", vars) == void;
+assert Map.set(Sheep, "🐑", vars) == void;
+assert Map.set(Brick, "🧱", vars) == void;
+
+assert Map.get(Grain, vars) == Some("🌾");
+assert Map.get(Sheep, vars) == Some("🐑");
+assert Map.get(Brick, vars) == Some("🧱");
+assert Map.get(Wood, vars) == None;
+
+# With record keys
+data ResourceData = { name: String, emoji: String }
+
+let recs = Map.make();
+
+assert Map.set({ name: "Grain", emoji: "🌾" }, 1, recs) == void;
+assert Map.set({ name: "Sheep", emoji: "🐑" }, 2, recs) == void;
+assert Map.set({ name: "Brick", emoji: "🧱" }, 3, recs) == void;
+
+assert Map.get({ name: "Grain", emoji: "🌾" }, recs) == Some(1);
+assert Map.get({ name: "Sheep", emoji: "🐑" }, recs) == Some(2);
+assert Map.get({ name: "Brick", emoji: "🧱" }, recs) == Some(3);
+assert Map.get({ name: "Wood", emoji: "🌳" }, recs) == None;
+
+# Overwriting data
+assert Map.set(1, "🐑", nums) == void;
+assert Map.set(1, "🌾", nums) == void;
+
+assert Map.get(1, nums) == Some("🌾");

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -561,6 +561,7 @@ let stdlib_tests = [
   tlib("int64.test"),
   tlib("strings.test"),
   tlib("sys.file.test"),
+  tlib("map.test"),
   tlib(~returns="", ~code=5, "sys.process.test"),
 ];
 

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -1,0 +1,86 @@
+# Standard library for Map (aka HashMap) functionality
+
+import Array from 'arrays'
+import { hash } from 'hash'
+
+data Container<a> = {
+  size: Box<Number>,
+  buckets: Box<Array<Option<a>>>
+}
+
+data Bucket<k, v> = {
+  key: Box<k>,
+  value: Box<v>,
+  next: Option<Bucket<k, v>>
+}
+
+# TODO: This could take an `eq` function to custom comparisons
+export let makeSized = (size) => {
+  let buckets = Array.make(size, None);
+  {
+    size: box(size),
+    buckets: box(buckets)
+  }
+}
+
+export let make = () => {
+  makeSized(16)
+}
+
+let getBucketIndex = (key, buckets) => {
+  let bucketsLength = Array.length(buckets);
+  let hashedKey = hash(key);
+  hashedKey % bucketsLength
+}
+
+let rec replaceInBucket = (key, value, cell) => {
+  if (key == unbox(cell.key)) {
+    cell.value := value;
+    false
+  } else {
+    match (cell.next) {
+      | None => true
+      | Some(next) => replaceInBucket(key, value, next)
+    }
+  }
+}
+
+export let set = (key, value, map) => {
+  let buckets = unbox(map.buckets);
+  let idx = getBucketIndex(key, buckets)
+  let bucket = buckets[idx];
+  match (bucket) {
+    | None => {
+      buckets[idx] := Some({ key: box(key), value: box(value), next: None });
+      map.size += 1;
+    }
+    | Some(cell) => {
+      if (replaceInBucket(key, value, cell)) {
+        buckets[idx] := Some({ key: box(key), value: box(value), next: bucket });
+        map.size += 1;
+      };
+    }
+  };
+  # TODO: Need to check and possibly resize the buckets array
+}
+
+let rec valueFromBucket = (key, cell) => {
+  if (key == unbox(cell.key)) {
+    Some(unbox(cell.value))
+  } else {
+    match (cell.next) {
+      | None => None
+      | Some(next) => valueFromBucket(key, next)
+    }
+  }
+}
+
+export let get = (key, map) => {
+  let buckets = unbox(map.buckets);
+  let idx = getBucketIndex(key, buckets);
+  let bucket = buckets[idx];
+  match (bucket) {
+    | None => None
+    | Some(cell) => valueFromBucket(key, cell)
+  }
+}

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -1,4 +1,4 @@
-# Standard library for list functionality
+# Standard library for Option functionality
 
 export *
 


### PR DESCRIPTION
This is a base implementation of Map (aka HashMap) for the stdlib. It was heavily influenced by [BuckleScript's Belt.HashMap](https://github.com/BuckleScript/bucklescript/blob/3b317c4784e5e4b4bbe47893241aed8a873a9a76/jscomp/others/belt_HashMap.ml).

There's still a ton of work to do but I wanted an initial review because I've never implemented something like this before. 🙏 