### PR TITLE
stdlib: Add Map.isEmpty & fix size bug

### DIFF
--- a/compiler/test/stdlib/map.test.gr
+++ b/compiler/test/stdlib/map.test.gr
@@ -1,5 +1,13 @@
 import Map from 'map'
 
+# Map.isEmpty()
+
+let e = Map.make();
+
+assert Map.isEmpty(e) == true;
+assert Map.set("🌾", "🌾", e) == void;
+assert Map.isEmpty(e) == false;
+
 # With Number keys
 let nums = Map.make();
 

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -18,7 +18,7 @@ data Bucket<k, v> = {
 export let makeSized = (size) => {
   let buckets = Array.make(size, None);
   {
-    size: box(size),
+    size: box(0),
     buckets: box(buckets)
   }
 }
@@ -83,4 +83,8 @@ export let get = (key, map) => {
     | None => None
     | Some(cell) => valueFromBucket(key, cell)
   }
+}
+
+export let isEmpty = (map) => {
+  unbox(map.size) == 0
 }


### PR DESCRIPTION
I went to implement `Map.isEmpty` and I found a bug with the size starting out at the initial buckets size, but it is supposed to represent how many elements are in the Map.