### PR TITLE
stdlib: Add more methods to Map

### DIFF
--- a/compiler/test/stdlib/map.test.gr
+++ b/compiler/test/stdlib/map.test.gr
@@ -1,12 +1,57 @@
-import Map from 'map'
+import Map from 'map';
+import List from 'lists';
+import Array from 'arrays';
 
-# Map.isEmpty()
+# Data types used in multiple tests
+data Resource = Grain | Sheep | Brick | Wood;
+data ResourceData = { name: String, emoji: String }
+
+### Map.isEmpty()
 
 let e = Map.make();
 
 assert Map.isEmpty(e) == true;
-assert Map.set("🌾", "🌾", e) == void;
+Map.set("🌾", "🌾", e);
 assert Map.isEmpty(e) == false;
+
+### Map.size()
+
+let s = Map.make();
+
+Map.set("🌾", 1, s);
+Map.set("🐑", 2, s);
+Map.set("🧱", 3, s);
+
+assert Map.size(s) == 3;
+
+### Map.clear()
+
+let c = Map.make();
+
+Map.set("🌾", 1, c);
+Map.set("🐑", 2, c);
+Map.set("🧱", 3, c);
+
+assert Map.isEmpty(c) == false;
+
+assert Map.clear(c) == void;
+
+assert Map.isEmpty(c) == true;
+
+### Map.contains()
+
+let h = Map.make();
+
+Map.set("🌾", 1, h);
+Map.set("🐑", 2, h);
+Map.set("🧱", 3, h);
+
+assert Map.contains("🌾", h) == true;
+assert Map.contains("🐑", h) == true;
+assert Map.contains("🧱", h) == true;
+assert Map.contains("🌳", h) == false;
+
+### Map.set() & Map.get()
 
 # With Number keys
 let nums = Map.make();
@@ -33,8 +78,6 @@ assert Map.get("🧱", strs) == Some(3);
 assert Map.get("🌳", strs) == None;
 
 # With variant keys
-data Resource = Grain | Sheep | Brick | Wood;
-
 let vars = Map.make();
 
 assert Map.set(Grain, "🌾", vars) == void;
@@ -47,8 +90,6 @@ assert Map.get(Brick, vars) == Some("🧱");
 assert Map.get(Wood, vars) == None;
 
 # With record keys
-data ResourceData = { name: String, emoji: String }
-
 let recs = Map.make();
 
 assert Map.set({ name: "Grain", emoji: "🌾" }, 1, recs) == void;
@@ -61,7 +102,180 @@ assert Map.get({ name: "Brick", emoji: "🧱" }, recs) == Some(3);
 assert Map.get({ name: "Wood", emoji: "🌳" }, recs) == None;
 
 # Overwriting data
-assert Map.set(1, "🐑", nums) == void;
-assert Map.set(1, "🌾", nums) == void;
+let o = Map.make();
 
-assert Map.get(1, nums) == Some("🌾");
+assert Map.set(1, "🐑", o) == void;
+assert Map.set(1, "🌾", o) == void;
+
+assert Map.get(1, o) == Some("🌾");
+
+### Map.remove()
+
+let r = Map.make();
+
+Map.set("🌾", 1, r);
+Map.set("🐑", 2, r);
+Map.set("🧱", 3, r);
+
+assert Map.size(r) == 3;
+
+assert Map.remove("🐑", r) == void;
+
+assert Map.size(r) == 2;
+assert Map.get("🐑", r) == None;
+
+assert Map.remove("🌳", r) == void;
+
+assert Map.size(r) == 2;
+
+assert Map.remove("🌾", r) == void;
+assert Map.get("🌾", r) == None;
+
+assert Map.remove("🧱", r) == void;
+assert Map.get("🧱", r) == None;
+
+assert Map.isEmpty(r);
+
+### Map.forEach()
+
+let fe = Map.make();
+
+Map.set(Grain, "🌾", fe);
+Map.set(Sheep, "🐑", fe);
+Map.set(Brick, "🧱", fe);
+
+let called = box(0);
+
+Map.forEach((key, value) => {
+  called += 1;
+  match (key) {
+    | Grain => assert value == "🌾"
+    | Sheep => assert value == "🐑"
+    | Brick => assert value == "🧱"
+    | _ => fail "Map.forEach() should not contain this value."
+  }
+}, fe);
+
+assert ^called == 3;
+
+### Map.reduce()
+
+let r = Map.make();
+
+Map.set(Grain, 1, r);
+Map.set(Sheep, 2, r);
+Map.set(Brick, 3, r);
+
+let called = box(0);
+
+let result = Map.reduce((acc, key, value) => {
+  called += 1;
+  match (key) {
+    | Grain => assert value == 1
+    | Sheep => assert value == 2
+    | Brick => assert value == 3
+    | _ => fail "Map.reduce() should not contain this value."
+  };
+  acc + value
+}, 0, r);
+
+assert ^called == 3;
+assert result == 6;
+
+### Map.keys() & Map.values();
+
+let kvs = Map.make();
+
+Map.set(Grain, "🌾", kvs);
+Map.set(Sheep, "🐑", kvs);
+Map.set(Brick, "🧱", kvs);
+
+let keys = Map.keys(kvs);
+
+# No order is guaranteed
+assert List.contains(Grain, keys);
+assert List.contains(Sheep, keys);
+assert List.contains(Brick, keys);
+assert List.contains(Wood, keys) == false;
+
+let vals = Map.values(kvs);
+
+# No order is guaranteed
+assert List.contains("🌾", vals);
+assert List.contains("🐑", vals);
+assert List.contains("🧱", vals);
+assert List.contains("🌳", vals) == false;
+
+### Map.toList()
+
+let tl = Map.make();
+
+Map.set(Grain, "🌾", tl);
+Map.set(Sheep, "🐑", tl);
+Map.set(Brick, "🧱", tl);
+
+let lis = Map.toList(tl);
+
+# No order is guaranteed
+assert List.contains((Grain, "🌾"), lis);
+assert List.contains((Sheep, "🐑"), lis);
+assert List.contains((Brick, "🧱"), lis);
+assert List.contains((Wood, "🌳"), lis) == false;
+
+### Map.fromList()
+
+let fl = Map.fromList([
+  (Grain, "🌾"),
+  (Sheep, "🐑"),
+  (Brick, "🧱")
+]);
+
+assert Map.contains(Grain, fl);
+assert Map.contains(Sheep, fl);
+assert Map.contains(Brick, fl);
+assert Map.contains(Wood, fl) == false;
+
+### Map.toArray()
+
+let ta = Map.make();
+
+Map.set(Grain, "🌾", ta);
+Map.set(Sheep, "🐑", ta);
+Map.set(Brick, "🧱", ta);
+
+let arr = Map.toArray(ta);
+
+# No order is guaranteed
+assert Array.contains((Grain, "🌾"), arr);
+assert Array.contains((Sheep, "🐑"), arr);
+assert Array.contains((Brick, "🧱"), arr);
+assert Array.contains((Wood, "🌳"), arr) == false;
+
+### Map.fromArray()
+
+let fa = Map.fromArray([> (Grain, "🌾"), (Sheep, "🐑"), (Brick, "🧱")]);
+
+assert Map.contains(Grain, fa);
+assert Map.contains(Sheep, fa);
+assert Map.contains(Brick, fa);
+assert Map.contains(Wood, fa) == false;
+
+### Resizes the map when it grows
+# TODO: Don't use these internals, as they need to change
+# after https://github.com/grain-lang/grain/issues/190 is fixed
+
+let resize = Map.makeSized(1);
+
+# (nodeCount, bucketLength)
+assert Map.getInternalStats(resize) == (0, 1);
+
+Map.set("🌾", 1, resize);
+Map.set("🐑", 1, resize);
+
+# (nodeCount, bucketLength)
+assert Map.getInternalStats(resize) == (2, 1);
+
+Map.set("🧱", 1, resize);
+
+# (nodeCount, bucketLength)
+assert Map.getInternalStats(resize) == (3, 2);

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -1,5 +1,6 @@
 # Standard library for Map (aka HashMap) functionality
 
+import List from 'lists'
 import Array from 'arrays'
 import { hash } from 'hash'
 
@@ -8,10 +9,11 @@ data Container<a> = {
   buckets: Box<Array<Option<a>>>
 }
 
+# TODO: Consider implementing this as List<(Box<k>, Box<v>)>
 data Bucket<k, v> = {
   key: Box<k>,
   value: Box<v>,
-  next: Option<Bucket<k, v>>
+  next: Box<Option<Bucket<k, v>>>
 }
 
 # TODO: This could take an `eq` function to custom comparisons
@@ -33,12 +35,60 @@ let getBucketIndex = (key, buckets) => {
   hashedKey % bucketsLength
 }
 
-let rec replaceInBucket = (key, value, cell) => {
-  if (key == unbox(cell.key)) {
-    cell.value := value;
+let rec copyNodeWithNewHash = (oldNode, next, tail) => {
+  match (oldNode) {
+    | None => void
+    | Some(node) => {
+      let idx = getBucketIndex(unbox(node.key), next);
+      let newNode = Some(node);
+      match (tail[idx]) {
+        | None => {
+          next[idx] := newNode;
+        }
+        | Some(tailNode) => {
+          # If there's already a tail node, we add this to the end
+          tailNode.next := newNode;
+        }
+      }
+      # Always place this node as the new tail
+      tail[idx] := newNode;
+      # Recurse with the next node
+      copyNodeWithNewHash(unbox(node.next), next, tail);
+    }
+  }
+}
+
+let resize = (map) => {
+  let currentBuckets = unbox(map.buckets);
+  let currentSize = Array.length(currentBuckets);
+  let nextSize = currentSize * 2;
+  if (nextSize >= currentSize) {
+    let nextBuckets = Array.make(nextSize, None);
+    # This tracks the tail nodes so we can set their `next` to None
+    let tailNodes = Array.make(nextSize, None);
+    map.buckets := nextBuckets;
+    Array.forEach(currentBuckets, (old) => {
+      copyNodeWithNewHash(old, nextBuckets, tailNodes);
+    });
+    Array.forEach(tailNodes, (tail) => {
+      match (tail) {
+        | None => void
+        | Some(node) => {
+          node.next := None;
+        }
+      }
+    });
+  } else {
+    void
+  }
+}
+
+let rec replaceInBucket = (key, value, node) => {
+  if (key == unbox(node.key)) {
+    node.value := value;
     false
   } else {
-    match (cell.next) {
+    match (unbox(node.next)) {
       | None => true
       | Some(next) => replaceInBucket(key, value, next)
     }
@@ -51,24 +101,29 @@ export let set = (key, value, map) => {
   let bucket = buckets[idx];
   match (bucket) {
     | None => {
-      buckets[idx] := Some({ key: box(key), value: box(value), next: None });
+      buckets[idx] := Some({ key: box(key), value: box(value), next: box(None) });
       map.size += 1;
     }
-    | Some(cell) => {
-      if (replaceInBucket(key, value, cell)) {
-        buckets[idx] := Some({ key: box(key), value: box(value), next: bucket });
+    | Some(node) => {
+      if (replaceInBucket(key, value, node)) {
+        buckets[idx] := Some({ key: box(key), value: box(value), next: box(bucket) });
         map.size += 1;
       };
     }
-  };
-  # TODO: Need to check and possibly resize the buckets array
+  }
+  # Resize if there are more than 2x the amount of nodes as buckets
+  if (unbox(map.size) > (Array.length(buckets) * 2)) {
+    resize(map);
+  } else {
+    void
+  }
 }
 
-let rec valueFromBucket = (key, cell) => {
-  if (key == unbox(cell.key)) {
-    Some(unbox(cell.value))
+let rec valueFromBucket = (key, node) => {
+  if (key == unbox(node.key)) {
+    Some(unbox(node.value))
   } else {
-    match (cell.next) {
+    match (unbox(node.next)) {
       | None => None
       | Some(next) => valueFromBucket(key, next)
     }
@@ -81,10 +136,160 @@ export let get = (key, map) => {
   let bucket = buckets[idx];
   match (bucket) {
     | None => None
-    | Some(cell) => valueFromBucket(key, cell)
+    | Some(node) => valueFromBucket(key, node)
   }
 }
 
+let rec nodeInBucket = (key, node) => {
+  if (key == unbox(node.key)) {
+    true
+  } else {
+    match (unbox(node.next)) {
+      | None => false
+      | Some(next) => nodeInBucket(key, next)
+    }
+  }
+}
+
+export let contains = (key, map) => {
+  let buckets = unbox(map.buckets);
+  let idx = getBucketIndex(key, buckets);
+  let bucket = buckets[idx];
+  match (bucket) {
+    | None => false
+    | Some(node) => nodeInBucket(key, node)
+  }
+}
+
+let rec removeInBucket = (key, node) => {
+  match (unbox(node.next)) {
+    | None => false
+    | Some(next) => {
+      if (key == unbox(next.key)) {
+        node.next := unbox(next.next);
+        true
+      } else {
+        removeInBucket(key, next)
+      }
+    }
+  }
+}
+
+export let remove = (key, map) => {
+  let buckets = unbox(map.buckets);
+  let idx = getBucketIndex(key, buckets);
+  let bucket = buckets[idx];
+  match (bucket) {
+    | None => void
+    | Some(node) => {
+      # If it is a top-level node, just replace with next node
+      if (key == unbox(node.key)) {
+        map.size -= 1;
+        buckets[idx] := unbox(node.next);
+      } else {
+        if (removeInBucket(key, node)) {
+          map.size -= 1;
+        }
+      }
+    }
+  }
+}
+
+export let size = (map) => {
+  unbox(map.size)
+}
+
 export let isEmpty = (map) => {
-  unbox(map.size) == 0
+  size(map) == 0
+}
+
+export let clear = (map) => {
+  map.size := 0;
+  let buckets = unbox(map.buckets);
+  Array.forEachi(buckets, (bucket, idx) => {
+    buckets[idx] := None;
+  });
+}
+
+let rec forEachBucket = (fn, node) => {
+  match (node) {
+    | None => void
+    | Some({ key, value, next }) => {
+      fn(^key, ^value);
+      forEachBucket(fn, ^next);
+    }
+  }
+}
+
+export let forEach = (fn, map) => {
+  let buckets = unbox(map.buckets);
+  Array.forEach(buckets, (bucket) => {
+    forEachBucket(fn, bucket)
+  });
+}
+
+# TODO: fold?
+export let reduce = (fn, init, map) => {
+  let buckets = unbox(map.buckets);
+  let acc = box(init);
+  forEach((key, value) => {
+    acc := fn(^acc, key, value);
+  }, map);
+  ^acc
+}
+
+export let keys = (map) => {
+  reduce((lis, key, _value) => {
+    match (lis) {
+      | [] => [key]
+      | [...rest] => [key, ...rest]
+    }
+  }, [], map)
+}
+
+export let values = (map) => {
+  reduce((lis, _key, value) => {
+    match (lis) {
+      | [] => [value]
+      | [...rest] => [value, ...rest]
+    }
+  }, [], map)
+}
+
+export let toList = (map) => {
+  reduce((lis, key, value) => {
+    match (lis) {
+      | [] => [(key, value)]
+      | [...rest] => [(key, value), ...rest]
+    }
+  }, [], map)
+}
+
+export let fromList = (list) => {
+  let map = make();
+  List.forEach((pair) => {
+    let (key, value) = pair;
+    set(key, value, map);
+  }, list);
+  map
+}
+
+export let toArray = (map) => {
+  Array.fromList(toList(map))
+}
+
+export let fromArray = (array) => {
+  let map = make();
+  # TODO: Fix this when Array.forEach is collection-last
+  Array.forEach(array, (pair) => {
+    let (key, value) = pair;
+    set(key, value, map);
+  });
+  map
+}
+
+# TODO: Should return a Record type instead of a Tuple
+# Waiting on https://github.com/grain-lang/grain/issues/190
+export let getInternalStats = (map) => {
+  (unbox(map.size), Array.length(unbox(map.buckets)))
 }

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -280,7 +280,6 @@ export let toArray = (map) => {
 
 export let fromArray = (array) => {
   let map = make();
-  # TODO: Fix this when Array.forEach is collection-last
   Array.forEach(array, (pair) => {
     let (key, value) = pair;
     set(key, value, map);


### PR DESCRIPTION
This adds a bunch of methods to the Map stdlib, and also improves the original implementation by resizing it once the amount of nodes exceeds double the size of the buckets.

There are still improvements to be made but I will open issues for some right now!