### PR TITLE
script: del is already a Windows command

### DIFF
--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -40,6 +40,6 @@
   "dependencies": {},
   "scripts": {
     "build": "./build.mjs",
-    "clean": "del '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/**'"
+    "clean": "del-cli '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/**'"
   }
 }


### PR DESCRIPTION
Re: conversation in Discord. I missed this in the `del` README when I added it here.

fyi @JohnnyRidout