### PR TITLE
lang: Support trailing commas in records

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -364,7 +364,7 @@ data_label :
   | simple_id colon typ { LDecl.mk ~loc:(symbol_rloc dyp) $1 $3 }
 
 data_labels :
-  | lbrace data_label [comma data_label {$2}]* rbrace { $2::$3 }
+  | lbrace data_label [comma data_label {$2}]* comma? rbrace { $2::$3 }
 
 data_declaration :
   | DATA TYPEID [lcaret ID [comma ID {$2}]* rcaret {$2::$3}]? equal data_constructors { Dat.variant ~loc:(symbol_rloc dyp) (mkstr dyp $2) (List.map Typ.var (Option.default [] $3)) $5 }
@@ -565,7 +565,7 @@ record_pun :
   | ID { mkid [$1] (symbol_rloc dyp), Exp.ident ~loc:(symbol_rloc dyp) (mkid [$1] (symbol_rloc dyp)) }
 
 record_exprs :
-  | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* {$1::$2}
+  | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* comma? {$1::$2}
 
 block_body :
   | block_body_stmt* block_body_expr SEMI { $1 @ [Exp.ignore $2] }

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -483,6 +483,57 @@ let record_tests = [
     "data Rec = {foo: Number}; data Rec2 = {bar: Rec}; let { bar: { foo } } = {bar: {foo: 4}}; bar",
     "Unbound value bar",
   ),
+  // Record trailing commas
+  t(
+    "record_definition_trailing",
+    "export data Rec = {foo: Number,}; {foo: 4}",
+    "{\n  foo: 4\n}",
+  ),
+  t(
+    "record_value_trailing",
+    "export data Rec = {foo: Number}; {foo: 4,}",
+    "{\n  foo: 4\n}",
+  ),
+  t(
+    "record_both_trailing",
+    "export data Rec = {foo: Number,}; {foo: 4,}",
+    "{\n  foo: 4\n}",
+  ),
+  t(
+    "record_multiple_fields_definition_trailing",
+    "export data Rec = {foo: Number, bar: String, baz: Bool,}; {foo: 4, bar: 'boo', baz: true}",
+    "{\n  foo: 4,\n  bar: \"boo\",\n  baz: true\n}",
+  ),
+  t(
+    "record_multiple_fields_value_trailing",
+    "export data Rec = {foo: Number, bar: String, baz: Bool}; {foo: 4, bar: 'boo', baz: true,}",
+    "{\n  foo: 4,\n  bar: \"boo\",\n  baz: true\n}",
+  ),
+  t(
+    "record_multiple_fields_both_trailing",
+    "export data Rec = {foo: Number, bar: String, baz: Bool,}; {foo: 4, bar: 'boo', baz: true,}",
+    "{\n  foo: 4,\n  bar: \"boo\",\n  baz: true\n}",
+  ),
+  t(
+    "record_pun_trailing",
+    "export data Rec = {foo: Number}; let foo = 4; {foo,}",
+    "{\n  foo: 4\n}",
+  ),
+  t(
+    "record_pun_multiple_trailing",
+    "export data Rec = {foo: Number, bar: Bool}; let foo = 4; let bar = false; {foo, bar,}",
+    "{\n  foo: 4,\n  bar: false\n}",
+  ),
+  t(
+    "record_pun_mixed_trailing",
+    "export data Rec = {foo: Number, bar: Bool}; let foo = 4; {foo, bar: false,}",
+    "{\n  foo: 4,\n  bar: false\n}",
+  ),
+  t(
+    "record_pun_mixed_2_trailing",
+    "export data Rec = {foo: Number, bar: Bool}; let bar = false; {foo: 4, bar,}",
+    "{\n  foo: 4,\n  bar: false\n}",
+  ),
 ];
 
 let stdlib_tests = [


### PR DESCRIPTION
Ref #182

I only implemented the Record syntax because it is a pain-point for me, but this should also give guidance on how someone could add it to the other balanced-syntax data structures mentioned there.