### PR TITLE
Stdlib consistency

### DIFF
--- a/compiler/test/stdlib/arrays.test.gr
+++ b/compiler/test/stdlib/arrays.test.gr
@@ -4,18 +4,18 @@ let arr = [> 1, 2, 3]
 
 # Array.get
 
-assert Array.get(arr, 1) == 2
-assert Array.get(arr, -1) == 3
-assert Array.get(arr, -2) == 2
-assert Array.get(arr, 0) == 1
+assert Array.get(1, arr) == 2
+assert Array.get(-1, arr) == 3
+assert Array.get(-2, arr) == 2
+assert Array.get(0, arr) == 1
 
 # Array.set
 
 let arr = [> 1, 2]
 
-Array.set(arr, 0, 5)
+Array.set(0, 5, arr)
 assert arr[0] == 5
-Array.set(arr, -1, 5)
+Array.set(-1, 5, arr)
 assert arr[1] == 5
 
 # Array.append
@@ -61,7 +61,7 @@ let sentinel = (_n) => {
   sum := 42
 }
 
-Array.forEach([>], sentinel)
+Array.forEach(sentinel, [>])
 
 assert unbox(sum) == 0
 
@@ -69,7 +69,7 @@ let addToSum = (n) => {
   sum := unbox(sum) + n
 }
 
-Array.forEach(arr1, addToSum)
+Array.forEach(addToSum, arr1)
 
 assert unbox(sum) == 6
 
@@ -82,7 +82,7 @@ let sentinel = (_n, _i) => {
   sum := 42
 }
 
-Array.forEachi([>], sentinel)
+Array.forEachi(sentinel, [>])
 
 assert unbox(sum) == 0
 
@@ -90,7 +90,7 @@ let addToSum = (n, i) => {
   sum := unbox(sum) + (n * i)
 }
 
-Array.forEachi(arr1, addToSum)
+Array.forEachi(addToSum, arr1)
 
 assert unbox(sum) == 8
 
@@ -106,8 +106,8 @@ assert Array.fromList([1, 2, 3]) == [> 1, 2, 3]
 
 # Array.map
 
-assert Array.map([>], incr) == [>]
-assert Array.map([> 2, 3, 4], incr) == [> 3, 4, 5]
+assert Array.map(incr, [>]) == [>]
+assert Array.map(incr, [> 2, 3, 4]) == [> 3, 4, 5]
 
 # Array.mapi
 

--- a/compiler/test/stdlib/hash.test.gr
+++ b/compiler/test/stdlib/hash.test.gr
@@ -6,7 +6,7 @@ import List from 'lists'
 let uniq = (list) => {
   let itemsSeen = box([])
 
-  List.foldLeft((acc, item) => {
+  List.reduce((acc, item) => {
     let seen = List.contains(item, ^itemsSeen)
     itemsSeen := [item, ...^itemsSeen]
     acc && !seen

--- a/compiler/test/stdlib/lists.test.gr
+++ b/compiler/test/stdlib/lists.test.gr
@@ -41,15 +41,15 @@ let multiply = (n, i) => n * i
 assert mapi(multiply, numbers) == [0, 3, 8]
 assert mapi(multiply, []) == []
 
-# List.foldLeft
+# List.reduce
 
-assert foldLeft((acc, cur) => acc - cur, 0, list) == -6
-assert foldLeft((acc, cur) => acc - cur, 0, []) == 0
+assert reduce((acc, cur) => acc - cur, 0, list) == -6
+assert reduce((acc, cur) => acc - cur, 0, []) == 0
 
-# List.foldRight
+# List.reduceRight
 
-assert foldRight((acc, cur) => acc - cur, 0, list) == 2
-assert foldRight((acc, cur) => acc - cur, 0, []) == 0
+assert reduceRight((acc, cur) => acc - cur, 0, list) == 2
+assert reduceRight((acc, cur) => acc - cur, 0, []) == 0
 
 # List.every
 
@@ -75,15 +75,15 @@ assert reject(x => x > 0, list) == []
 assert reject(x => x > 3, list) == list
 assert reject(x => x == 3, list) == [1, 2]
 
-# List.hd
+# List.head
 
-assert hd(list) == 1
-assert hd([2]) == 2
+assert head(list) == 1
+assert head([2]) == 2
 
-# List.tl
+# List.tail
 
-assert tl(list) == [2, 3]
-assert tl([1]) == []
+assert tail(list) == [2, 3]
+assert tail([1]) == []
 
 # List.nth
 
@@ -124,6 +124,6 @@ assert rotate(-2, list) == [2, 3, 1]
 
 # List.uniq
 
-assert uniq([]) == []
-assert uniq(list) == list
-assert uniq([1, 1, 1, 1]) == [1]
+assert unique([]) == []
+assert unique(list) == list
+assert unique([1, 1, 1, 1]) == [1]

--- a/compiler/test/stdlib/lists.test.gr
+++ b/compiler/test/stdlib/lists.test.gr
@@ -122,7 +122,7 @@ assert rotate(1, list) == [2, 3, 1]
 assert rotate(2, list) == [3, 1, 2]
 assert rotate(-2, list) == [2, 3, 1]
 
-# List.uniq
+# List.unique
 
 assert unique([]) == []
 assert unique(list) == list

--- a/stdlib/arrays.gr
+++ b/stdlib/arrays.gr
@@ -2,28 +2,28 @@ export primitive length : Array<a> -> Number = "@array.length"
 export primitive make : (Number, a) -> Array<a> = "@array.make"
 export primitive init : (Number, Number -> a) -> Array<a> = "@array.init"
 
-export let get = (array, index) => {
+export let get = (index, array) => {
   array[index]
 }
 
-export let set = (array, index, value) => {
+export let set = (index, value, array) => {
   array[index] := value
 }
 
-export let append = (a1, a2) => {
-  let len1 = length(a1)
-  let len2 = length(a2)
+export let append = (array1, array2) => {
+  let len1 = length(array1)
+  let len2 = length(array2)
 
   init(len1 + len2, n => {
     if (n < len1) {
-      a1[n]
+      array1[n]
     } else {
-      a2[n - len1]
+      array2[n - len1]
     }
   })
 }
 
-export let concat = (arrs) => {
+export let concat = (arrays) => {
   # This function is slightly verbose to avoid depending on the List stdlib.
 
   let rec findLength = (arrays, acc) => {
@@ -34,33 +34,33 @@ export let concat = (arrs) => {
   }
 
   let offset = box(0)
-  let arrays = box(arrs)
+  let arrs = box(arrays)
 
-  let rec next = (n) => {
-    let arr = match (unbox(arrays)) {
+  let rec next = (index) => {
+    let array = match (unbox(arrs)) {
       | [fst, ..._] => fst
       | [] => fail "end of arrays list"
     }
-    if (n - unbox(offset) == length(arr)) {
-      offset := unbox(offset) + length(arr)
-      arrays := match (unbox(arrays)) {
+    if (index - unbox(offset) == length(array)) {
+      offset := unbox(offset) + length(array)
+      arrs := match (unbox(arrs)) {
         | [_, ...rest] => rest
         | [] => fail "end of arrays list"
       }
-      next(n)
+      next(index)
     } else {
-      arr[n - unbox(offset)]
+      array[index - unbox(offset)]
     }
   }
 
-  init(findLength(arrs, 0), next)
+  init(findLength(arrays, 0), next)
 }
 
 export let copy = (array) => {
   init(length(array), n => array[n])
 }
 
-export let forEach = (array, fn) => {
+export let forEach = (fn, array) => {
   let length = length(array)
   let count = box(0)
   while (unbox(count) < length) {
@@ -69,7 +69,7 @@ export let forEach = (array, fn) => {
   }
 }
 
-export let forEachi = (array, fn) => {
+export let forEachi = (fn, array) => {
   let length = length(array)
   let count = box(0)
   while (unbox(count) < length) {
@@ -78,7 +78,7 @@ export let forEachi = (array, fn) => {
   }
 }
 
-export let map = (array, fn) => {
+export let map = (fn, array) => {
   let length = length(array)
   init(length, (i) => {
     fn(array[i])
@@ -93,12 +93,12 @@ export let mapi = (fn, array) => {
 }
 
 export let toList = (array) => {
-  let rec buildList = (acc, n) => {
-    let n = n - 1
-    if (n < 0) {
+  let rec buildList = (acc, index) => {
+    let index = index - 1
+    if (index < 0) {
       acc
     } else {
-      buildList([array[n], ...acc], n)
+      buildList([array[index], ...acc], index)
     }
   }
   buildList([], length(array))
@@ -113,13 +113,13 @@ export let fromList = (list) => {
   }
 
   let list = box(list)
-  let rec next = (n) => {
+  let rec next = (index) => {
     match (unbox(list)) {
       | [fst, ...rest] => {
         list := rest
         fst
       }
-      | [] => next(n)
+      | [] => next(index)
     }
   }
   init(listLength(unbox(list), 0), next)
@@ -128,11 +128,11 @@ export let fromList = (list) => {
 # TODO: This should use recursion when we can pattern match arrays
 export let contains = (search, array) => {
   let len = length(array);
-  let idx = box(0);
+  let index = box(0);
   let found = box(false);
-  while ((^found == false) && (^idx < len)) {
-    found := (array[^idx] == search);
-    idx += 1;
+  while ((^found == false) && (^index < len)) {
+    found := (array[^index] == search);
+    index += 1;
   }
   ^found
 }

--- a/stdlib/lists.gr
+++ b/stdlib/lists.gr
@@ -118,25 +118,25 @@ let rec reject = (fn, list) => {
 
 let head = (list) => {
   match (list) {
-    | [] => fail 'Cannot get the first element of an empty List'
+    | [] => fail 'head cannot get the first element of an empty List'
     | [first, ..._] => first
   }
 }
 
 let tail = (list) => {
   match (list) {
-    | [] => fail 'Cannot get any elements from an empty List'
+    | [] => fail 'tail cannot get any elements from an empty List'
     | [_, ...rest] => rest
   }
 }
 
-let rec nth = (count, list) => {
-  if (count < 0) {
-    fail 'Cannot be a negative number'
+let rec nth = (index, list) => {
+  if (index < 0) {
+    fail 'nth index cannot be a negative number'
   } else {
     match (list) {
-      | [] => fail 'Cannot get any elements from an empty List'
-      | [first, ...rest] => if (count == 0) first else nth(count - 1, rest)
+      | [] => fail 'nth index is out-of-bounds'
+      | [first, ...rest] => if (index == 0) first else nth(index - 1, rest)
     }
   }
 }
@@ -150,10 +150,10 @@ let rec flatten = (list) => {
 
 let rec insert = (value, index, list) => {
   if (index < 0) {
-    fail 'Cannot be a negative number'
+    fail 'insert index cannot be a negative number'
   } else {
     match(list) {
-      | [] => if (index == 0) [value] else fail 'Can only insert at index 0 in an empty list'
+      | [] => if (index == 0) [value] else fail 'insert index is out-of-bounds'
       | [first, ...rest] => if (index == 0) [value, ...list] else [first, ...insert(value, index - 1, rest)]
     }
   }
@@ -168,11 +168,11 @@ let rec count = (fn, list) => {
 
 let part = (count, list) => {
   if (count < 0) {
-    fail 'Cannot be a negative number'
+    fail 'part count cannot be a negative number'
   } else {
     let rec iter = (list1, list2, count) => {
       match (list2) {
-        | [] => if (count > 0) fail 'Can only part an empty list by 0' else (list1, list2)
+        | [] => if (count > 0) fail 'part count is out-of-bounds' else (list1, list2)
         | [first, ...rest] => if (count > 0) iter([first, ...list1], rest, count - 1) else (list1, list2)
       }
     }

--- a/stdlib/lists.gr
+++ b/stdlib/lists.gr
@@ -2,185 +2,196 @@
 
 export *
 
-let rec length = (lst) => {
-  match (lst) {
+let rec length = (list) => {
+  match (list) {
     | [] => 0
-    | [hd, ...tl] => 1 + length(tl)
+    | [_, ...rest] => 1 + length(rest)
   }
 }
 
-let rec sum = (lst) => {
-  match (lst) {
+let rec sum = (list) => {
+  match (list) {
     | [] => 0
-    | [hd, ...tl] => hd + sum(tl)
+    | [first, ...rest] => first + sum(rest)
   }
 }
 
-let reverse = (lst) => {
-  let rec help = (l, acc) => {
-    match (l) {
+let reverse = (list) => {
+  let rec iter = (list, acc) => {
+    match (list) {
       | [] => acc
-      | [hd, ...tl] => help(tl, [hd, ...acc])
+      | [first, ...rest] => iter(rest, [first, ...acc])
     }
   }
-  help(lst, [])
+  iter(list, [])
 }
 
-let rec append = (l1, l2) => {
-  match (l1) {
-    | [] => l2
-    | [hd, ...tl] => [hd, ...append(tl, l2)]
+let rec append = (list1, list2) => {
+  match (list1) {
+    | [] => list2
+    | [first, ...rest] => [first, ...append(rest, list2)]
   }
 }
 
-let rec contains = (e, l) => {
-  match (l) {
+let rec contains = (value, list) => {
+  match (list) {
     | [] => false
-    | [hd, ...tl] => (hd == e) || contains(e, tl)
+    | [first, ...rest] => (first == value) || contains(value, rest)
   }
 }
 
-let rec foldLeft = (f, b, l) => {
-  match (l) {
-    | [] => b
-    | [hd, ...tl] => foldLeft(f, f(b, hd), tl)
+let rec reduce = (fn, acc, list) => {
+  match (list) {
+    | [] => acc
+    | [first, ...rest] => reduce(fn, fn(acc, first), rest)
   }
 }
 
-let rec foldRight = (f, b, l) => {
-  match (l) {
-    | [] => b
-    | [hd, ...tl] => f(hd, foldRight(f, b, tl))
+let rec reduceRight = (fn, acc, list) => {
+  match (list) {
+    | [] => acc
+    | [first, ...rest] => fn(first, reduceRight(fn, acc, rest))
   }
 }
 
-let rec map = (f, l) => {
-  match (l) {
+let rec map = (fn, list) => {
+  match (list) {
     | [] => []
-    | [hd, ...tl] => [f(hd), ...map(f, tl)]
+    | [first, ...rest] => [fn(first), ...map(fn, rest)]
   }
 }
 
 let mapi = (fn, list) => {
-  let rec help = (fn, list, index) => {
+  let rec iter = (fn, list, index) => {
     match (list) {
       | [] => []
-      | [hd, ...tl] => [fn(hd, index), ...help(fn, tl, index + 1)]
+      | [first, ...rest] => [fn(first, index), ...iter(fn, rest, index + 1)]
     }
   }
-  help(fn, list, 0)
+  iter(fn, list, 0)
 }
 
-let every = (f, l) => {
-  foldLeft((acc, item) => { acc && f(item) }, true, l)
+let every = (fn, list) => {
+  reduce((acc, value) => { acc && fn(value) }, true, list)
 }
 
-let some = (f, l) => {
-  foldLeft((acc, item) => { acc || f(item) }, false, l)
+let some = (fn, list) => {
+  reduce((acc, value) => { acc || fn(value) }, false, list)
 }
 
-let rec forEach = (f, l) => {
-  match (l) {
+let rec forEach = (fn, list) => {
+  match (list) {
     | [] => void
-    | [hd, ...tl] => {
-      f(hd)
-      forEach(f, tl)
+    | [first, ...rest] => {
+      fn(first)
+      forEach(fn, rest)
     }
   }
 }
 
-let forEachi = (f, l) => {
-  let rec help = (f, l, c) => {
-    match (l) {
+let forEachi = (fn, list) => {
+  let rec iter = (fn, list, index) => {
+    match (list) {
       | [] => void
-      | [hd, ...tl] => {
-        f(hd, c)
-        help(f, tl, c + 1)
+      | [first, ...rest] => {
+        fn(first, index)
+        iter(fn, rest, index + 1)
       }
     }
   }
-  help(f, l, 0)
+  iter(fn, list, 0)
 }
 
-let rec filter = (f, l) => {
-  match (l) {
+let rec filter = (fn, list) => {
+  match (list) {
     | [] => []
-    | [hd, ...tl] => if (f(hd)) [hd, ...filter(f, tl)] else filter(f, tl)
+    | [first, ...rest] => if (fn(first)) [first, ...filter(fn, rest)] else filter(fn, rest)
   }
 }
 
-let rec reject = (f, l) => {
-  match (l) {
+let rec reject = (fn, list) => {
+  match (list) {
     | [] => []
-    | [hd, ...tl] => if (!f(hd)) [hd, ...reject(f, tl)] else reject(f, tl)
+    | [first, ...rest] => if (!fn(first)) [first, ...reject(fn, rest)] else reject(fn, rest)
   }
 }
 
-let hd = (l) => {
-  match (l) {
-    | [] => fail 'hd'
-    | [hd, ..._] => hd
+let head = (list) => {
+  match (list) {
+    | [] => fail 'Cannot get the first element of an empty List'
+    | [first, ..._] => first
   }
 }
 
-let tl = (l) => {
-  match (l) {
-    | [] => fail 'tl'
-    | [_, ...tl] => tl
+let tail = (list) => {
+  match (list) {
+    | [] => fail 'Cannot get any elements from an empty List'
+    | [_, ...rest] => rest
   }
 }
 
-let rec nth = (n, l) => {
-  match (l) {
-    | [] => fail 'nth'
-    | [hd, ...tl] => if (n < 0) fail 'nth' else if (n == 0) hd else nth(n - 1, tl)
-  }
-}
-
-let rec flatten = (l) => {
-  match (l) {
-    | [] => []
-    | [hd, ...tl] => append(hd, flatten(tl))
-  }
-}
-
-let rec insert = (x, i, l) => {
-  match(l) {
-    | [] => if (i == 0) [x] else fail 'insert'
-    | [hd, ...tl] => if (i < 0) fail 'insert' else if (i == 0) [x, ...l] else [hd, ...insert(x, i - 1, tl)]
-  }
-}
-
-let rec count = (f, l) => {
-  match (l) {
-    | [] => 0
-    | [hd, ...tl] => if (f(hd)) 1 + count(f, tl) else count(f, tl)
-  }
-}
-
-let part = (n, l) => {
-  if (n < 0) fail 'part'
-  let rec help = (l1, l2, n) => {
-    match (l2) {
-      | [] => if (n > 0) fail 'part' else (l1, l2)
-      | [hd, ...tl] => if (n > 0) help([hd, ...l1], tl, n - 1) else (l1, l2)
+let rec nth = (count, list) => {
+  if (count < 0) {
+    fail 'Cannot be a negative number'
+  } else {
+    match (list) {
+      | [] => fail 'Cannot get any elements from an empty List'
+      | [first, ...rest] => if (count == 0) first else nth(count - 1, rest)
     }
   }
-  let (pt1, pt2) = help([], l, n)
-  (reverse(pt1), pt2)
 }
 
-let rotate = (n, l) => {
-  let (beginning, end) = if (n >= 0) part(n, l) else part(length(l) + n, l)
+let rec flatten = (list) => {
+  match (list) {
+    | [] => []
+    | [first, ...rest] => append(first, flatten(rest))
+  }
+}
+
+let rec insert = (value, index, list) => {
+  if (index < 0) {
+    fail 'Cannot be a negative number'
+  } else {
+    match(list) {
+      | [] => if (index == 0) [value] else fail 'Can only insert at index 0 in an empty list'
+      | [first, ...rest] => if (index == 0) [value, ...list] else [first, ...insert(value, index - 1, rest)]
+    }
+  }
+}
+
+let rec count = (fn, list) => {
+  match (list) {
+    | [] => 0
+    | [first, ...rest] => if (fn(first)) 1 + count(fn, rest) else count(fn, rest)
+  }
+}
+
+let part = (count, list) => {
+  if (count < 0) {
+    fail 'Cannot be a negative number'
+  } else {
+    let rec iter = (list1, list2, count) => {
+      match (list2) {
+        | [] => if (count > 0) fail 'Can only part an empty list by 0' else (list1, list2)
+        | [first, ...rest] => if (count > 0) iter([first, ...list1], rest, count - 1) else (list1, list2)
+      }
+    }
+    let (pt1, pt2) = iter([], list, count)
+    (reverse(pt1), pt2)
+  }
+}
+
+let rotate = (count, list) => {
+  let (beginning, end) = if (count >= 0) part(count, list) else part(length(list) + count, list)
   append(end, beginning)
 }
 
-let uniq = (l) => {
-  let rec help = (l, acc) => {
-    match (l) {
+let unique = (list) => {
+  let rec iter = (list, acc) => {
+    match (list) {
       | [] => reverse(acc)
-      | [hd, ...tl] => if (contains(hd, acc)) help(tl, acc) else help(tl, [hd, ...acc])
+      | [first, ...rest] => if (contains(first, acc)) iter(rest, acc) else iter(rest, [first, ...acc])
     }
   }
-  help(l, [])
+  iter(list, [])
 }

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -67,17 +67,17 @@ let resize = (map) => {
     # This tracks the tail nodes so we can set their `next` to None
     let tailNodes = Array.make(nextSize, None);
     map.buckets := nextBuckets;
-    Array.forEach(currentBuckets, (old) => {
+    Array.forEach((old) => {
       copyNodeWithNewHash(old, nextBuckets, tailNodes);
-    });
-    Array.forEach(tailNodes, (tail) => {
+    }, currentBuckets);
+    Array.forEach((tail) => {
       match (tail) {
         | None => void
         | Some(node) => {
           node.next := None;
         }
       }
-    });
+    }, tailNodes);
   } else {
     void
   }
@@ -206,9 +206,9 @@ export let isEmpty = (map) => {
 export let clear = (map) => {
   map.size := 0;
   let buckets = unbox(map.buckets);
-  Array.forEachi(buckets, (bucket, idx) => {
+  Array.forEachi((bucket, idx) => {
     buckets[idx] := None;
-  });
+  }, buckets);
 }
 
 let rec forEachBucket = (fn, node) => {
@@ -223,12 +223,11 @@ let rec forEachBucket = (fn, node) => {
 
 export let forEach = (fn, map) => {
   let buckets = unbox(map.buckets);
-  Array.forEach(buckets, (bucket) => {
+  Array.forEach((bucket) => {
     forEachBucket(fn, bucket)
-  });
+  }, buckets);
 }
 
-# TODO: fold?
 export let reduce = (fn, init, map) => {
   let buckets = unbox(map.buckets);
   let acc = box(init);
@@ -280,10 +279,10 @@ export let toArray = (map) => {
 
 export let fromArray = (array) => {
   let map = make();
-  Array.forEach(array, (pair) => {
+  Array.forEach((pair) => {
     let (key, value) = pair;
     set(key, value, map);
-  });
+  }, array);
   map
 }
 

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -1,69 +1,69 @@
-# Standard library for Option functionality
+# Standard library for optionion functionality
 
 export *
 
-let isSome = (opt) => {
-  match (opt) {
+let isSome = (option) => {
+  match (option) {
     | Some(_) => true
     | None => false
   }
 }
 
-let isNone = (opt) => {
-  match (opt) {
+let isNone = (option) => {
+  match (option) {
     | None => true
     | Some(_) => false
   }
 }
 
-let contains = (val, opt) => {
-  match (opt) {
+let contains = (val, option) => {
+  match (option) {
     | Some(x) => x == val
     | None => false
   }
 }
 
-let expect = (msg, opt) => {
-  match (opt) {
+let expect = (msg, option) => {
+  match (option) {
     | Some(x) => x
     | None => fail msg
   }
 }
 
-let unwrap = (opt) => {
-  expect('Could not unwrap None value', opt)
+let unwrap = (option) => {
+  expect('Could not unwrap None value', option)
 }
 
-let unwrapWithDefault = (default, opt) => {
-  match (opt) {
+let unwrapWithDefault = (default, option) => {
+  match (option) {
     | Some(x) => x
     | None => default
   }
 }
 
-let map = (fn, opt) => {
-  match (opt) {
+let map = (fn, option) => {
+  match (option) {
     | Some(x) => Some(fn(x))
     | None => None
   }
 }
 
-let mapWithDefault = (default, fn, opt) => {
-  match (opt) {
+let mapWithDefault = (default, fn, option) => {
+  match (option) {
     | Some(x) => fn(x)
     | None => default
   }
 }
 
-let flatMap = (fn, opt) => {
-  match (opt) {
+let flatMap = (fn, option) => {
+  match (option) {
     | Some(x) => fn(x)
     | None => None
   }
 }
 
-let filter = (pred, opt) => {
-  match (opt) {
+let filter = (pred, option) => {
+  match (option) {
     | Some(x) =>
       if (pred(x)) {
         Some(x)
@@ -74,49 +74,49 @@ let filter = (pred, opt) => {
   }
 }
 
-let zip = (optA, optB) => {
-  match ((optA, optB)) {
+let zip = (optionA, optionB) => {
+  match ((optionA, optionB)) {
     | (Some(a), Some(b)) => Some((a, b))
     | _ => None
   }
 }
 
-let zipWith = (fn, optA, optB) => {
-  match ((optA, optB)) {
+let zipWith = (fn, optionA, optionB) => {
+  match ((optionA, optionB)) {
     | (Some(a), Some(b)) => Some(fn(a, b))
     | _ => None
   }
 }
 
-let flatten = (opt) => {
-  match (opt) {
+let flatten = (option) => {
+  match (option) {
     | Some(Some(x)) => Some(x)
     | _ => None
   }
 }
 
-let toList = (opt) => {
-  match (opt) {
+let toList = (option) => {
+  match (option) {
     | Some(x) => [x]
     | None => []
   }
 }
 
-let toArray = (opt) => {
-  match (opt) {
+let toArray = (option) => {
+  match (option) {
     | Some(x) => [> x]
     | None => [>]
   }
 }
 
-let sideEffect = (fn, opt) => {
-  match (opt) {
+let sideEffect = (fn, option) => {
+  match (option) {
     | Some(x) => fn(x)
     | None => void
   }
 }
 
-let peek = (fn, opt) => {
-  sideEffect(fn, opt)
-  opt
+let peek = (fn, option) => {
+  sideEffect(fn, option)
+  option
 }

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -1,4 +1,4 @@
-# Standard library for optionion functionality
+# Standard library for option functionality
 
 export *
 

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -356,11 +356,11 @@ import foreign wasm fdReaddir : (FileDescriptor) -> Array<(Int64, String, Number
 # @returns Array<DirectoryEntry> An array of records containing information about each entry in the directory
 let fdReaddir = (fd) => {
   let dirents = fdReaddirRaw(fd)
-  Array.map(dirents, (dirent) => {
+  Array.map((dirent) => {
     let (inode, path, filetype) = dirent
     let filetype = filetypeFromNumber(filetype)
     { inode, path, filetype }
-  })
+  }, dirents)
 }
 
 # Atomically replace a file descriptor by renumbering another file descriptor


### PR DESCRIPTION
These are some breaking changes to the stdlib that:
* Renames some methods to make things more clear (`foldLeft` -> `reduce`, `hd` -> `head`, etc)
* Updates some methods that didn't adhere to the collection-last style
* Prefers longer variable names to make the stdlib easier for non-FP people to contribute

After this is approved, I will get all the docs changed on the website before merging.