### PR TITLE
cli: Add compile & run subcommands (closes #223)

### DIFF
--- a/cli/bin/compile.js
+++ b/cli/bin/compile.js
@@ -12,7 +12,7 @@ module.exports = (file, options) => {
     if (options.graceful) {
       process.exit()
     } else {
-      process.exit(-1)
+      process.exit(1)
     }
   }
 }

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -34,7 +34,6 @@ program
     process.exit(0)
   })
   .description('Compile and run Grain programs. 🌾')
-  .option('-w, --wasm', 'run a wasm file')
   .option('-p, --print-output', 'print the output of the program')
   .option('-g, --graceful', 'return a 0 exit code if the program errors')
   .option('-I, --include-dirs <dirs>', 'include directories the runtime should find wasm modules', list, [])
@@ -44,25 +43,13 @@ program
   // The root command that compiles & runs
   .arguments('<file>')
   .action(function (file) {
-    let wasmFile;
-    if (program.wasm) {
-      wasmFile = file;
-    } else {
-      wasmFile = compile(file, program);
-    }
-
-    run(wasmFile, program);
+    run(compile(file, program), program);
   })
 
 program
   .command('compile <file>')
   .description('compile a grain program into wasm')
   .action(function (file) {
-    if (program.wasm) {
-      console.error('--wasm is invalid for the compile command');
-      process.exit(1);
-    }
-
     compile(file, program);
   });
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "@grain/runtime": "*",
     "@grain/stdlib": "*",
-    "commander": "^2.14.1"
+    "commander": "^5.1.0"
   }
 }

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -127,7 +127,7 @@ let run_output = (~code=0, ~heap_size=?, cstate, test_ctxt) => {
     ~use_stderr=true,
     ~ctxt=test_ctxt,
     "grain",
-    ["-wpg", "-S", stdlib, "-I", testlibs] @ heap_args @ [file],
+    ["-pg", "-S", stdlib, "-I", testlibs] @ heap_args @ ["run", file],
   );
   result^;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,10 +885,15 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-commander@^2.14.1, commander@^2.20.0:
+commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Adds some subcommands to make things easier to do with just the `grain` CLI

By moving people to use one CLI, any underlying changes we make to structure shouldn't affect the majority of users, like when I started copying `grainc.exe` into the CLI directory.