### PR TITLE
cleanup: Remove workaround for old ppx_sexp_conv bug

### DIFF
--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -124,44 +124,12 @@ and constructor_description = {
 and value_unbound_reason =
   | ValUnboundGhostRecursive;
 
-[@deriving sexp]
+[@deriving (sexp, yojson)]
 type value_kind =
   | TValReg
   | TValPrim(string)
   | TValUnbound(value_unbound_reason)
   | TValConstructor(constructor_description);
-
-/* See: https://github.com/janestreet/ppx_sexp_conv/issues/26 */
-let rec value_kind_to_yojson =
-  fun
-  | TValReg => `String("TValReg")
-  | TValPrim(n) => `List([`String("TValPrim"), `String(n)])
-  | TValUnbound(r) =>
-    `List([`String("TValUnbound"), value_unbound_reason_to_yojson(r)])
-  | TValConstructor(d) =>
-    `List([
-      `String("TValConstructor"),
-      constructor_description_to_yojson(d),
-    ])
-
-and value_kind_of_yojson = {
-  let res_map = f =>
-    fun
-    | Result.Ok(v) => Result.Ok(f(v))
-    | Result.Error(e) => Result.Error(e);
-
-  fun
-  | `String("TValReg") => Result.Ok(TValReg)
-  | `List([`String("TValPrim"), `String(n)]) => Result.Ok(TValPrim(n))
-  | `List([`String("TValUnbound"), r]) =>
-    res_map(r => TValUnbound(r), value_unbound_reason_of_yojson(r))
-  | `List([`String("TValConstructor"), d]) =>
-    res_map(d => TValConstructor(d), constructor_description_of_yojson(d))
-  | other =>
-    Result.Error(
-      "value_kind_of_yojson: Invalid JSON: " ++ Yojson.Safe.to_string(other),
-    );
-};
 
 [@deriving (sexp, yojson)]
 type value_description = {


### PR DESCRIPTION
I was doing some general cleanup (and getting to know the compiler internals better) and I ran across an old issue by @belph to ppx_sexp_conv linked from a workaround in the code. 

I believe ppx_sexp_conv both fixed the opaque bug, and refactored a bunch of the code since that issue was filed. I didn't see any place where opaque was used or needed, so I added yojson to the deriving and was able to remove the workaround code.

@belph Maybe you can let me know if `[@sexp.opaque]` needs to be added anywhere.