### PR TITLE
cleanup: Remove output_enabled config since not used

### DIFF
--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -137,11 +137,9 @@ let next_state = ({cstate_desc, cstate_filename} as cs) => {
     | Mashed(mashed) =>
       Compiled(Compmod.compile_wasm_module(~name=?cstate_filename, mashed))
     | Compiled(compiled) =>
-      if (Grain_utils.Config.output_enabled^) {
-        switch (cs.cstate_outfile) {
-        | Some(outfile) => Emitmod.emit_module(compiled, outfile)
-        | None => ()
-        };
+      switch (cs.cstate_outfile) {
+      | Some(outfile) => Emitmod.emit_module(compiled, outfile)
+      | None => ()
       };
       Binaryen.Module.dispose(compiled.asm);
       Assembled;

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -286,8 +286,6 @@ let option_conv = ((prsr, prntr)) => (
     | Some(x) => prntr(ppf, x),
 );
 
-let output_enabled = internal_opt(true);
-
 let optimizations_enabled =
   toggle_flag(~doc="Disable optimizations.", ~names=["O0"], true);
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -64,10 +64,6 @@ let unsound_optimizations: ref(bool);
 
 let safe_string: ref(bool);
 
-/** Whether to enable file writes. This is useful for testing. */
-
-let output_enabled: ref(bool);
-
 /*** Configuration Saving/Restoring */
 
 /** Abstract type representing a saved set of configuration options */


### PR DESCRIPTION
While poking around for JSOO stuff, I noticed that `output_enabled` was a config option but @ospencer said that it isn't actually used.

I think it would be an awesome feature to have in the future, but it is confusing to exist right now because disabling it breaks a bunch of assumptions the compiler makes.

When merged, I'll open a feature request to make the compiler work without filesystem access.