### PR TITLE
cleanup: Refactor sexp_locs_enabled access & adjust comments

### DIFF
--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -65,14 +65,14 @@ let (prim2_of_sexp, sexp_of_prim2) = (
   Parsetree.prim2_of_sexp,
   Parsetree.sexp_of_prim2,
 );
-let locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
+let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
 
 /** Immediate expressions (requiring no computation) */
 
 [@deriving sexp]
 type imm_expression = {
   imm_desc: imm_expression_desc,
-  [@sexp_drop_if locs_disabled]
+  [@sexp_drop_if sexp_locs_disabled]
   imm_loc: Location.t,
   imm_env: [@sexp.opaque] Env.t,
   imm_analyses: [@sexp.opaque] ref(list(analysis)),
@@ -88,7 +88,7 @@ and imm_expression_desc =
 [@deriving sexp]
 type comp_expression = {
   comp_desc: comp_expression_desc,
-  [@sexp_drop_if locs_disabled]
+  [@sexp_drop_if sexp_locs_disabled]
   comp_loc: Location.t,
   comp_env: [@sexp.opaque] Env.t,
   comp_analyses: [@sexp.opaque] ref(list(analysis)),
@@ -129,7 +129,7 @@ and comp_expression_desc =
 [@deriving sexp]
 and anf_expression = {
   anf_desc: anf_expression_desc,
-  [@sexp_drop_if locs_disabled]
+  [@sexp_drop_if sexp_locs_disabled]
   anf_loc: Location.t,
   anf_env: [@sexp.opaque] Env.t,
   anf_analyses: [@sexp.opaque] ref(list(analysis)),

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -15,6 +15,8 @@
 /**************************************************************************/
 open Sexplib.Conv;
 
+let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
+
 /** Auxiliary AST types used by parsetree and typedtree. */;
 
 /* These are taken from OCaml. While not all fully supported,
@@ -63,6 +65,6 @@ type closed_flag =
 type loc('a) =
   Location.loc('a) = {
     txt: 'a,
-    [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+    [@sexp_drop_if sexp_locs_disabled]
     loc: Location.t,
   };

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -5,6 +5,8 @@
 open Sexplib.Conv;
 open Asttypes;
 
+let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
+
 type loc('a) =
   Asttypes.loc('a) = {
     txt: 'a,
@@ -28,7 +30,7 @@ type parsed_type_desc =
 
 and parsed_type = {
   ptyp_desc: parsed_type_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   ptyp_loc: Location.t,
 };
 
@@ -45,7 +47,7 @@ type constructor_arguments =
 type constructor_declaration = {
   pcd_name: loc(string),
   pcd_args: constructor_arguments,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pcd_loc: Location.t,
 };
 
@@ -56,7 +58,7 @@ type label_declaration = {
   pld_name: loc(Identifier.t),
   pld_type: parsed_type,
   pld_mutable: mut_flag,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pld_loc: Location.t,
 };
 
@@ -74,7 +76,7 @@ type data_declaration = {
   pdata_name: loc(string),
   pdata_params: list(parsed_type),
   pdata_kind: data_kind,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pdata_loc: Location.t,
 };
 
@@ -106,7 +108,7 @@ type pattern_desc =
 [@deriving sexp]
 and pattern = {
   ppat_desc: pattern_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   ppat_loc: Location.t,
 };
 
@@ -161,7 +163,7 @@ type prim2 =
 [@deriving sexp]
 type expression = {
   pexp_desc: expression_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pexp_loc: Location.t,
 }
 
@@ -197,7 +199,7 @@ and expression_desc =
 and value_binding = {
   pvb_pat: pattern,
   pvb_expr: expression,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pvb_loc: Location.t,
 }
 
@@ -205,7 +207,7 @@ and value_binding = {
 and match_branch = {
   pmb_pat: pattern,
   pmb_body: expression,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pmb_loc: Location.t,
 };
 
@@ -222,7 +224,7 @@ type import_declaration = {
   pimp_mod_alias: option(loc(Identifier.t)),
   pimp_path: loc(string),
   pimp_val: import_value,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pimp_loc: Location.t,
 };
 
@@ -233,7 +235,7 @@ type value_description = {
   pval_name_alias: option(loc(string)),
   pval_type: parsed_type,
   pval_prim: list(string),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pval_loc: Location.t,
 };
 
@@ -241,7 +243,7 @@ type value_description = {
 type export_declaration_desc = {
   pex_name: loc(string),
   pex_alias: option(loc(string)),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pex_loc: Location.t,
 }
 
@@ -271,7 +273,7 @@ type toplevel_stmt_desc =
 [@deriving sexp]
 type toplevel_stmt = {
   ptop_desc: toplevel_stmt_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   ptop_loc: Location.t,
 };
 
@@ -280,6 +282,6 @@ type toplevel_stmt = {
 [@deriving sexp]
 type parsed_program = {
   statements: list(toplevel_stmt),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   prog_loc: Location.t,
 };

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -18,6 +18,8 @@ open Sexplib.Conv;
 open Grain_parsing;
 open Types;
 
+let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
+
 type loc('a) = Location.loc('a);
 [@deriving sexp]
 type partial =
@@ -84,7 +86,7 @@ type core_type = {
   ctyp_desc: core_type_desc,
   ctyp_type: type_expr,
   ctyp_env: [@sexp.opaque] Env.t,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   ctyp_loc: Location.t,
 }
 
@@ -109,7 +111,7 @@ type constructor_declaration = {
   cd_name: loc(string),
   cd_args: constructor_arguments,
   cd_res: option(core_type),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   cd_loc: Location.t,
 };
 
@@ -118,7 +120,7 @@ type record_field = {
   rf_name: Ident.t,
   rf_type: core_type,
   rf_mutable: bool,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   rf_loc: Location.t,
 };
 
@@ -134,14 +136,14 @@ type data_declaration = {
   data_params: list(core_type),
   data_type: Types.type_declaration,
   data_kind,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   data_loc: Location.t,
 };
 
 [@deriving sexp]
 type pattern = {
   pat_desc: pattern_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   pat_loc: Location.t,
   [@default []] [@sexp_drop_default (==)]
   pat_extra: list((pat_extra, Location.t)),
@@ -170,7 +172,7 @@ and pattern_desc =
 [@deriving sexp]
 type expression = {
   exp_desc: expression_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   exp_loc: Location.t,
   [@default []] [@sexp_drop_default (==)]
   exp_extra: list((exp_extra, Location.t)),
@@ -224,7 +226,7 @@ and record_label_definition =
 and value_binding = {
   vb_pat: pattern,
   vb_expr: expression,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   vb_loc: Location.t,
 }
 
@@ -232,21 +234,21 @@ and value_binding = {
 and match_branch = {
   mb_pat: pattern,
   mb_body: expression,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   mb_loc: Location.t,
 };
 
 [@deriving sexp]
 type import_declaration = {
   timp_path: Path.t,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   timp_loc: Location.t,
 };
 
 [@deriving sexp]
 type export_declaration = {
   tex_path: Path.t,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   tex_loc: Location.t,
 };
 
@@ -258,7 +260,7 @@ type value_description = {
   tvd_desc: core_type,
   tvd_val: Types.value_description,
   tvd_prim: list(string),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   tvd_loc: Location.t,
 };
 
@@ -274,7 +276,7 @@ type toplevel_stmt_desc =
 [@deriving sexp]
 type toplevel_stmt = {
   ttop_desc: toplevel_stmt_desc,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   ttop_loc: Location.t,
   ttop_env: [@sexp.opaque] Env.t,
 };

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -19,6 +19,8 @@
 open Grain_parsing;
 open Types;
 
+let sexp_locs_disabled: 'a => bool;
+
 type loc('a) = Location.loc('a);
 type partial =
   | Partial
@@ -103,7 +105,7 @@ type record_field = {
   rf_name: Ident.t,
   rf_type: core_type,
   rf_mutable: bool,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   rf_loc: Location.t,
 };
 
@@ -216,7 +218,7 @@ type import_declaration = {
 [@deriving sexp]
 type export_declaration = {
   tex_path: Path.t,
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   tex_loc: Location.t,
 };
 
@@ -228,7 +230,7 @@ type value_description = {
   tvd_desc: core_type,
   tvd_val: Types.value_description,
   tvd_prim: list(string),
-  [@sexp_drop_if _ => ! Grain_utils.Config.sexp_locs_enabled^]
+  [@sexp_drop_if sexp_locs_disabled]
   tvd_loc: Location.t,
 };
 


### PR DESCRIPTION
This is just some cleanup I had lying around related to some config work I'm hoping to tackle.

I also noticed that `refmt` handled the OCaml comments really weird, so I did some spelunking and re-aligned them correctly. I plan to do this whenever something seems off during refactoring.