### PR TITLE
lang: Support trailing comma in list literals

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -412,15 +412,15 @@ ampamp_op :
   | AMPAMP { "&&" }
 pipepipe_op :
   | PIPEPIPE { "||" }
-pluseq_op :  
+pluseq_op :
   | PLUS EQUAL { "+" }
-dasheq_op :  
+dasheq_op :
   | DASH EQUAL { "-" }
-stareq_op :  
+stareq_op :
   | STAR EQUAL { "*" }
-slasheq_op :  
+slasheq_op :
   | SLASH EQUAL { "/" }
-percenteq_op :  
+percenteq_op :
   | PERCENT EQUAL { "%" }
 
 infix_op :
@@ -520,12 +520,12 @@ stmt_expr :
   | FAIL expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["fail"]) [$2] }
 
 assign_binop_op :
-  | pluseq_op 
-  | dasheq_op 
-  | stareq_op 
+  | pluseq_op
+  | dasheq_op
+  | stareq_op
   | slasheq_op
   | percenteq_op
-  
+
 assign_expr :
   | binop_expr(<pl) eols? GETS eols? expr { no_array_access $1; Exp.box_assign ~loc:(symbol_rloc dyp) $1 $5 }
   | id_expr equal expr { Exp.assign ~loc:(symbol_rloc dyp) $1 $3 }

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -509,7 +509,7 @@ match_expr :
 
 list_expr :
   | lbrack rbrack { Exp.list ~loc:(symbol_rloc dyp) [] None }
-  | lbrack expr [comma expr {$2}]* [comma ELLIPSIS expr {$3}]? rbrack { Exp.list ~loc:(symbol_rloc dyp) ($2::$3) $4 }
+  | lbrack expr [comma expr {$2}]* comma? [ELLIPSIS expr {$2}]? rbrack { Exp.list ~loc:(symbol_rloc dyp) ($2::$3) $5 }
 
 array_expr :
   | lbrack rcaret rbrack { Exp.array ~loc:(symbol_rloc dyp) [] }

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -507,9 +507,13 @@ match_branches :
 match_expr :
   | MATCH lparen expr rparen lbrace match_branches rbrace { Exp.match_ ~loc:(symbol_rloc dyp) $3 $6 }
 
+list_expr_ending :
+  | comma? { None }
+  | comma ELLIPSIS expr { Some $3 }
+
 list_expr :
   | lbrack rbrack { Exp.list ~loc:(symbol_rloc dyp) [] None }
-  | lbrack expr [comma expr {$2}]* comma? [ELLIPSIS expr {$2}]? rbrack { Exp.list ~loc:(symbol_rloc dyp) ($2::$3) $5 }
+  | lbrack expr [comma expr {$2}]* list_expr_ending rbrack { Exp.list ~loc:(symbol_rloc dyp) ($2::$3) $4 }
 
 array_expr :
   | lbrack rcaret rbrack { Exp.array ~loc:(symbol_rloc dyp) [] }

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -337,6 +337,22 @@ let tuple_tests = [
   t("no_singleton_tup", "(1)", "1"),
 ];
 
+let list_tests = [
+  t("list1", "[1, 2, 3]", "[1, 2, 3]"),
+  t("list2", "[]", "[]"),
+  t("list_heterogeneous", "[1, false, 2]", "[1, false, 2]"),
+  t("list_spread", "let a = [3, 4]; [1, 2, ...a]", "[1, 2, 3, 4]"),
+  // trailing commas
+  t("list1_trailing", "[1, 2, 3,]", "[1, 2, 3]"),
+  t("list1_trailing_space", "[1, 2, 3, ]", "[1, 2, 3]"),
+  te("invalid_empty_trailing", "[,]", "Error: Syntax error"),
+  te(
+    "invalid_list_spread_trailing",
+    "let a = [3, 4]; [1, 2, ...a,]",
+    "Error: Syntax error",
+  ),
+];
+
 let array_tests = [
   t("array1", "[> 1, 2, 3]", "[> 1, 2, 3]"),
   t("array2", "[>]", "[> ]"),
@@ -1371,6 +1387,7 @@ let tests =
   >::: basic_functionality_tests
   @ function_tests
   @ tuple_tests
+  @ list_tests
   @ array_tests
   @ record_tests
   @ stdlib_tests

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -340,8 +340,14 @@ let tuple_tests = [
 let list_tests = [
   t("list1", "[1, 2, 3]", "[1, 2, 3]"),
   t("list2", "[]", "[]"),
-  t("list_heterogeneous", "[1, false, 2]", "[1, false, 2]"),
+  // TODO: This should fail with typechecker error
+  // t("list_heterogeneous", "[1, false, 2]", "[1, false, 2]"),
   t("list_spread", "let a = [3, 4]; [1, 2, ...a]", "[1, 2, 3, 4]"),
+  te(
+    "invalid_list_no_comma_before_spread",
+    "let a = [3, 4]; [1, 2 ...a]",
+    "Error: Syntax error",
+  ),
   // trailing commas
   t("list1_trailing", "[1, 2, 3,]", "[1, 2, 3]"),
   t("list1_trailing_space", "[1, 2, 3, ]", "[1, 2, 3]"),


### PR DESCRIPTION
This adds support for parsing list literals with a trailing comma, given they aren't empty and don't end with a spread.

I also added tests for the list syntax because they didn't seem to exist. I also discovered that lists are heterogeneous?!!?

There is an additional commit here that cleans up trailing whitespace in the parser file because I'm sick of dodging it in my PRs 🤣 

Ref #182 