### PR TITLE
Allow wildcard pattern for lambda function argument

### DIFF
--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1091,6 +1091,7 @@ and type_function =
       arity([{...mb, pmb_pat: p}])
     | [{pmb_pat: {ppat_desc: PPatTuple(args)}, _}] => List.length(args)
     | [{pmb_pat: {ppat_desc: PPatVar(_)}, _}] => 1
+    | [{pmb_pat: {ppat_desc: PPatAny}, _}] => 1
     /* FIXME: Less hard-coding, please */
     | [
         {

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -323,6 +323,7 @@ let function_tests = [
     "let rec may only be used with recursive function definitions",
   ),
   te("nonfunction_1", "let x = 5; x(3)", "type"),
+  t("lambda_pat_any", "let x = (_) => 5; x('foo')", "5"),
 ];
 
 let mylist = "[1, 2, 3]";


### PR DESCRIPTION
Closes #260 