### PR TITLE
Source Map Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ _build/
 notes.org
 node_modules/
 *.wasm
+*.wasm.map
 *.wasm.wast
 *.wasm.modsig
 .tern-port

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -17,8 +17,21 @@ let emit_module = ({asm, signature}, outfile) => {
     output_string(oc, sig_string);
     close_out(oc);
   };
-  let (encoded, _) = Binaryen.Module.write(asm, None);
+  let source_map_name =
+    if (Config.source_map^) {
+      Some(Filename.basename(outfile) ++ ".map");
+    } else {
+      None;
+    };
+  let (encoded, map) = Binaryen.Module.write(asm, source_map_name);
   let oc = open_out_bin(outfile);
   output_bytes(oc, encoded);
   close_out(oc);
+  switch (map) {
+  | Some(map) =>
+    let oc = open_out_bin(outfile ++ ".map");
+    output_string(oc, map);
+    close_out(oc);
+  | None => ()
+  };
 };

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -71,6 +71,8 @@ let prim_map =
   );
 
 let transl_prim = (env, desc) => {
+  let loc = desc.tvd_loc;
+
   let prim =
     try(PrimMap.find(prim_map, List.hd(desc.tvd_prim))) {
     | Not_found => failwith("This primitive does not exist.")
@@ -78,18 +80,19 @@ let transl_prim = (env, desc) => {
 
   let value =
     switch (prim) {
-    | Primitive1(p) => Exp.lambda([pat_a], Exp.prim1(p, id_a))
-    | Primitive2(p) => Exp.lambda([pat_a, pat_b], Exp.prim2(p, id_a, id_b))
+    | Primitive1(p) => Exp.lambda(~loc, [pat_a], Exp.prim1(~loc, p, id_a))
+    | Primitive2(p) =>
+      Exp.lambda(~loc, [pat_a, pat_b], Exp.prim2(~loc, p, id_a, id_b))
     };
 
   let binds = [
     {
       pvb_pat: {
         ppat_desc: PPatVar(desc.tvd_name),
-        ppat_loc: desc.tvd_loc,
+        ppat_loc: loc,
       },
       pvb_expr: value,
-      pvb_loc: desc.tvd_loc,
+      pvb_loc: loc,
     },
   ];
   let mut_flag = desc.tvd_val.val_mutable ? Mutable : Immutable;

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -371,6 +371,9 @@ let unsound_optimizations =
     false,
   );
 
+let source_map =
+  toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
+
 /* To be filled in by grainc */
 let base_path = internal_opt("");
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -58,6 +58,10 @@ let debug: ref(bool);
 
 let unsound_optimizations: ref(bool);
 
+/** Whether or not to generate source maps. */
+
+let source_map: ref(bool);
+
 /*** Internal options (no command line flags) */
 
 /** Whether to use safe string representations (always true for now) */


### PR DESCRIPTION
Source map support is here! 🎉 

Wasm source maps are currently supported in Chrome and Firefox. I'm going to look for some options for Node until there's support, like using `node --inspect`, but that's not important for this initial pass.

Here's what it looks like:

![image](https://user-images.githubusercontent.com/7244034/91251378-4ecdb180-e729-11ea-8c1d-ce1e28d4033a.png)

(The example program does `assert 1 == 2` on line 5 in `hello.gr`, and `assert` is defined in `pervasives.gr` on line 30.)

We can do some things to make it nicer, like using the original source names in the wasm output—but this is a great start.

Made #273 to track the above ☝️ 