### PR TITLE
Support pattern matching with guards

### DIFF
--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -173,3 +173,9 @@ type anf_program = {
   signature: Cmi_format.cmi_infos,
   analyses: [@sexp.opaque] ref(list(analysis)),
 };
+
+type anf_bind =
+  | BSeq(comp_expression)
+  | BLet(Ident.t, comp_expression)
+  | BLetRec(list((Ident.t, comp_expression)))
+  | BLetExport(rec_flag, list((Ident.t, comp_expression)));

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -161,3 +161,9 @@ type anf_program = {
   signature: Cmi_format.cmi_infos,
   analyses: ref(list(analysis)),
 };
+
+type anf_bind =
+  | BSeq(comp_expression)
+  | BLet(Ident.t, comp_expression)
+  | BLetRec(list((Ident.t, comp_expression)))
+  | BLetExport(rec_flag, list((Ident.t, comp_expression)));

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -531,10 +531,7 @@ let rec transl_imm =
         transl_imm,
         exp_ans,
       );
-    (
-      Imm.id(~loc, ~env, tmp),
-      (exp_setup @ setup) @ [BLet(tmp, ans)],
-    );
+    (Imm.id(~loc, ~env, tmp), (exp_setup @ setup) @ [BLet(tmp, ans)]);
   | TExpConstruct(_) => failwith("NYI: transl_imm: Construct")
   }
 

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -78,21 +78,17 @@ let convert_binds = anf_binds => {
   let ans =
     switch (last_bind) {
     | BSeq(exp) => AExp.comp(exp)
-    | [@implicit_arity] BLet(name, exp) =>
-      AExp.let_(Nonrecursive, [(name, exp)], void)
+    | BLet(name, exp) => AExp.let_(Nonrecursive, [(name, exp)], void)
     | BLetRec(names) => AExp.let_(Recursive, names, void)
-    | [@implicit_arity] BLetExport(rf, binds) =>
-      AExp.let_(~glob=Global, rf, binds, void)
+    | BLetExport(rf, binds) => AExp.let_(~glob=Global, rf, binds, void)
     };
   List.fold_left(
     (body, bind) =>
       switch (bind) {
       | BSeq(exp) => AExp.seq(exp, body)
-      | [@implicit_arity] BLet(name, exp) =>
-        AExp.let_(Nonrecursive, [(name, exp)], body)
+      | BLet(name, exp) => AExp.let_(Nonrecursive, [(name, exp)], body)
       | BLetRec(names) => AExp.let_(Recursive, names, body)
-      | [@implicit_arity] BLetExport(rf, binds) =>
-        AExp.let_(~glob=Global, rf, binds, body)
+      | BLetExport(rf, binds) => AExp.let_(~glob=Global, rf, binds, body)
       },
     ans,
     top_binds,
@@ -537,7 +533,7 @@ let rec transl_imm =
       );
     (
       Imm.id(~loc, ~env, tmp),
-      (exp_setup @ setup) @ [[@implicit_arity] BLet(tmp, ans)],
+      (exp_setup @ setup) @ [BLet(tmp, ans)],
     );
   | TExpConstruct(_) => failwith("NYI: transl_imm: Construct")
   }

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -273,13 +273,13 @@ module Vb = {
 };
 
 module Mb = {
-  let mk = (~loc=?, p, e) => {
+  let mk = (~loc=?, p, e, g) => {
     let loc =
       switch (loc) {
       | None => default_loc_src^()
       | Some(l) => l
       };
-    {pmb_pat: p, pmb_body: e, pmb_loc: loc};
+    {pmb_pat: p, pmb_body: e, pmb_guard: g, pmb_loc: loc};
   };
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -151,7 +151,10 @@ module Val: {
 
 module Vb: {let mk: (~loc: loc=?, pattern, expression) => value_binding;};
 
-module Mb: {let mk: (~loc: loc=?, pattern, expression) => match_branch;};
+module Mb: {
+  let mk:
+    (~loc: loc=?, pattern, expression, option(expression)) => match_branch;
+};
 
 module Imp: {
   let mk:

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -194,9 +194,11 @@ module V = {
 };
 
 module MB = {
-  let map = (sub, {pmb_pat: pat, pmb_body: expr, pmb_loc: loc}) => {
+  let map =
+      (sub, {pmb_pat: pat, pmb_body: expr, pmb_guard: guard, pmb_loc: loc}) => {
     pmb_pat: sub.pat(sub, pat),
     pmb_body: sub.expr(sub, expr),
+    pmb_guard: Option.map(sub.expr(sub), guard),
     pmb_loc: sub.location(sub, loc),
   };
 };

--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -132,6 +132,7 @@ rule token = parse
   | "wasm" { WASM }
   | "while" { WHILE }
   | "if" { IF }
+  | "when" { WHEN }
   | "else" { ELSE }
   | "true" { TRUE }
   | "false" { FALSE }

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -171,7 +171,7 @@ let make_program statements =
 %token PLUS DASH STAR SLASH PERCENT
 %token TRUE FALSE VOID
 
-%token LET MUT REC IF ELSE MATCH WHILE
+%token LET MUT REC IF WHEN ELSE MATCH WHILE
 %token AMPAMP PIPEPIPE NOT
 
 %token DATA IMPORT EXPORT FOREIGN WASM PRIMITIVE
@@ -503,7 +503,7 @@ while_expr :
   | WHILE lparen expr rparen block { Exp.while_ ~loc:(symbol_rloc dyp) $3 $5 }
 
 match_branch :
-  | pattern thickarrow expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $3 }
+  | pattern [WHEN expr {$2}]? thickarrow expr { Mb.mk ~loc:(symbol_rloc dyp) $1 $4 $2 }
 
 match_branches :
   | pipe? match_branch [eols? pipe match_branch {$3}]* { $2::$3 }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -207,6 +207,7 @@ and value_binding = {
 and match_branch = {
   pmb_pat: pattern,
   pmb_body: expression,
+  pmb_guard: option(expression),
   [@sexp_drop_if sexp_locs_disabled]
   pmb_loc: Location.t,
 };

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -217,9 +217,10 @@ let all_idents_cases = el => {
 
   let iterator = {...default_iterator, expr: f_expr};
   List.iter(
-    cp =>
-      /*may (iterator.expr iterator) cp.pc_guard;*/
-      iterator.expr(iterator, cp.pmb_body),
+    cp => {
+      Option.iter(iterator.expr(iterator), cp.pmb_guard);
+      iterator.expr(iterator, cp.pmb_body);
+    },
     el,
   );
   Hashtbl.fold((x, (), rest) => [x, ...rest], idents, []);
@@ -1441,12 +1442,6 @@ and type_cases =
   let pat_env_list =
     List.map(
       ({pmb_pat, pmb_body}) => {
-        /*let loc = pmb_body.pexp_loc
-            (*let open Location in
-            match pc_guard with
-            | None -> pc_rhs.pexp_loc
-            | Some g -> {pc_rhs.pexp_loc with loc_start=g.pexp_loc.loc_start}*)
-          in*/
         if (Grain_utils.Config.principal^) {
           begin_def();
         }; /* propagation of pattern */

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -234,6 +234,7 @@ and value_binding = {
 and match_branch = {
   mb_pat: pattern,
   mb_body: expression,
+  mb_guard: option(expression),
   [@sexp_drop_if sexp_locs_disabled]
   mb_loc: Location.t,
 };

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -206,6 +206,7 @@ and value_binding = {
 and match_branch = {
   mb_pat: pattern,
   mb_body: expression,
+  mb_guard: option(expression),
   mb_loc: Location.t,
 };
 

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -962,6 +962,86 @@ let match_tests = [
     "data Rec = {foo: Number}; match ([{foo: 5}]) { | [] => 999 | [{foo}, ..._] => foo }",
     "5",
   ),
+  t(
+    "guarded_match_1",
+    "match ((1, 2, 3)) { | (a, b, c) when a == 1 => 42 | _ => 99 }",
+    "42",
+  ),
+  t(
+    "guarded_match_2",
+    "match ((2, 2, 3)) { | (a, b, c) when a == 1 => 42 | _ => 99 }",
+    "99",
+  ),
+  t(
+    "guarded_match_3",
+    "match ((2, 2, 3)) { | (a, b, c) when (a == 2) && (c == 3) => 42 | _ => 99 }",
+    "42",
+  ),
+  t(
+    "guarded_match_4",
+    "match ((8, 2, 3)) { | (a, b, c) when (a == 2) && (c == 3) => 42 | _ => 99 }",
+    "99",
+  ),
+  t(
+    "guarded_match_5",
+    "data ADT = Foo((String, Number)) | Bar
+     match (Foo(('abcd', 4))) {
+       | Foo((s, n)) when (s == 'abcd') && (n == 4) => 42
+       | Foo((s, n)) when (s == 'wxyz') && (n == 4) => 99
+       | Foo(_) when false => 90
+       | Foo(_) => 89
+       | Bar => 79
+     }",
+    "42",
+  ),
+  t(
+    "guarded_match_6",
+    "data ADT = Foo((String, Number)) | Bar
+     match (Foo(('abcd', 3))) {
+       | Foo((s, n)) when (s == 'abcd') && (n == 4) => 42
+       | Foo((s, n)) when (s == 'wxyz') && (n == 4) => 99
+       | Foo(_) when false => 90
+       | Foo(_) => 89
+       | Bar => 79
+     }",
+    "89",
+  ),
+  t(
+    "guarded_match_7",
+    "data ADT = Foo((String, Number)) | Bar
+     match (Foo(('wxyz', 4))) {
+       | Foo((s, n)) when (s == 'abcd') && (n == 4) => 42
+       | Foo((s, n)) when (s == 'wxyz') && (n == 4) => 99
+       | Foo(_) when false => 90
+       | Foo(_) => 89
+       | Bar => 79
+     }",
+    "99",
+  ),
+  t(
+    "guarded_match_8",
+    "data ADT = Foo((String, Number)) | Bar
+     match (Foo(('wxyz', 15))) {
+       | Foo((s, n)) when (s == 'abcd') && (n == 4) => 42
+       | Foo((s, n)) when (s == 'wxyz') && (n == 4) => 99
+       | Foo(_) when false => 90
+       | Foo(_) => 89
+       | Bar => 79
+     }",
+    "89",
+  ),
+  t(
+    "guarded_match_9",
+    "data ADT = Foo((String, Number)) | Bar
+     match (Bar) {
+       | Foo((s, n)) when (s == 'abcd') && (n == 4) => 42
+       | Foo((s, n)) when (s == 'wxyz') && (n == 4) => 99
+       | Foo(_) when false => 90
+       | Foo(_) => 89
+       | Bar => 79
+     }",
+    "79",
+  ),
   tfile("mixed_matching", "mixedPatternMatching", "true"),
 ];
 


### PR DESCRIPTION
Closes #283.

This PR adds the ability to "guard" a match pattern with a condition, like so:

```grain
data Example = Foo(Number) | Bar

match (Foo(6)) {
  | Foo(n) when n == 2 => print('it was two')
  | Foo(n) when n == 6 => print('it was six')
  | Foo(_) => print('it was not two or six')
  | Bar => print('it was bar')
}
```