### PR TITLE
Fix printing of constructors for exhaustiveness checking

### DIFF
--- a/compiler/src/typed/printpat.re
+++ b/compiler/src/typed/printpat.re
@@ -70,14 +70,12 @@ let rec pretty_val = (ppf, v) =>
         fprintf(ppf, "@[{%a%t}@]", pretty_lvals, filtered_lvs, elision_mark);
       };
     | TPatConstant(c) => fprintf(ppf, "%s", pretty_const(c))
-    | [@implicit_arity] TPatConstruct({txt: id}, _, args) =>
-      fprintf(
-        ppf,
-        "@[%s(%a)@]",
-        Identifier.string_of_ident(id),
-        pretty_vals(","),
-        args,
-      )
+    | [@implicit_arity] TPatConstruct(_, cstr, args) =>
+      if (List.length(args) > 0) {
+        fprintf(ppf, "@[%s(%a)@]", cstr.cstr_name, pretty_vals(","), args);
+      } else {
+        fprintf(ppf, "@[%s@]", cstr.cstr_name);
+      }
     | [@implicit_arity] TPatAlias(v, x, _) =>
       fprintf(ppf, "@[(%a@ as %a)@]", pretty_val, v, Ident.print, x)
     | [@implicit_arity] TPatOr(v, w) =>


### PR DESCRIPTION
Funny enough, I tried to show examples of this working, but there's another bug that I fixed in #286 that's preventing me from doing so in all cases, but once that's merged everything should be all set. Based on the code though, I'm sure you can probably see how this fixes the issue we were having. 😛 

Closes #291.