### PR TITLE
Literal rational literals

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -2107,6 +2107,10 @@ let allocate_int64 = (wasm_mod, env, i) => {
   call_new_int64(wasm_mod, env, [i]);
 };
 
+let allocate_rational = (wasm_mod, env, n, d) => {
+  call_new_rational(wasm_mod, env, [n, d]);
+};
+
 /* Store an int64 */
 let allocate_int64_imm = (wasm_mod, env, i) => {
   let get_swap64 = () => get_swap(~ty=Type.int64, wasm_mod, env, 0);
@@ -2900,6 +2904,13 @@ let compile_allocation = (wasm_mod, env, alloc_type) =>
       wasm_mod,
       env,
       Expression.const(wasm_mod, Literal.float64(i)),
+    )
+  | MRational(n, d) =>
+    allocate_rational(
+      wasm_mod,
+      env,
+      Expression.const(wasm_mod, Literal.int32(n)),
+      Expression.const(wasm_mod, Literal.int32(d)),
     )
   };
 

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -118,7 +118,8 @@ type allocation_type =
   | MInt32(int32)
   | MInt64(int64)
   | MFloat32(float)
-  | MFloat64(float);
+  | MFloat64(float)
+  | MRational(int32, int32);
 
 [@deriving sexp]
 type tag_op =

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -590,8 +590,7 @@ let rec compile_comp = (env, c) => {
       MAllocate(MInt32(Int64.to_int32(n)))
     | CNumber(Const_number_int(n)) => MAllocate(MInt64(n))
     | CNumber(Const_number_float(f)) => MAllocate(MFloat64(f))
-    | CNumber(Const_number_rational(n, d)) =>
-      failwith("NYI: compile_comp Const_number_rational")
+    | CNumber(Const_number_rational(n, d)) => MAllocate(MRational(n, d))
     | CInt32(i) => MAllocate(MInt32(i))
     | CInt64(i) => MAllocate(MInt64(i))
     | CFloat32(f) => MAllocate(MFloat32(f))

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -34,7 +34,7 @@ type constant =
 and number_type =
   | Const_number_int(int64)
   | Const_number_float(float)
-  | Const_number_rational(int64, int64);
+  | Const_number_rational(int32, int32);
 
 /** Marker for exported/nonexported let bindings */
 

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -122,6 +122,11 @@ let no_array_access expr =
   | PExpArrayGet _ -> raise Dyp.Giveup
   | _ -> ()
 
+let no_rational_literal expr1 expr2 =
+  match expr1.pexp_desc, expr2.pexp_desc with
+  | PExpConstant(PConstNumber (PConstNumberInt _)), PExpConstant(PConstNumber (PConstNumberInt _)) -> raise Dyp.Giveup
+  | _ -> ()
+
 
 let mkid ns =
   let help ns =
@@ -246,6 +251,7 @@ equal :
 const :
   | dash_op? NUMBER_INT { Const.number (PConstNumberInt (if Option.is_some $1 then "-" ^ $2 else $2)) }
   | dash_op? NUMBER_FLOAT { Const.number (PConstNumberFloat (if Option.is_some $1 then "-" ^ $2 else $2)) }
+  | dash_op? NUMBER_INT SLASH eols? dash_op? NUMBER_INT { Const.number (PConstNumberRational ((if Option.is_some $1 then "-" ^ $2 else $2), (if Option.is_some $5 then "-" ^ $6 else $6))) }
   | dash_op? INT32 { Const.int32 (if Option.is_some $1 then "-" ^ $2 else $2) }
   | dash_op? INT64 { Const.int64 (if Option.is_some $1 then "-" ^ $2 else $2) }
   | dash_op? FLOAT32 { Const.float32 (if Option.is_some $1 then "-" ^ $2 else $2) }
@@ -263,7 +269,7 @@ binop_expr :
   | binop_expr(<=p110) plus_op eols?      binop_expr(<p110) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p110
   | binop_expr(<=p110) dash_op eols?      binop_expr(<p110) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p110
   | binop_expr(<=p120) star_op eols?      binop_expr(<p120) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p120
-  | binop_expr(<=p120) slash_op eols?     binop_expr(<p120) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p120
+  | binop_expr(<=p120) slash_op eols?     binop_expr(<p120) { no_rational_literal $1 $4; Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p120
   | binop_expr(<=p120) percent_op eols?   binop_expr(<p120) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p120
   | binop_expr(<=p80) is_op eols?        binop_expr(<p80) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p80
   | binop_expr(<=p80) eqeq_op eols?      binop_expr(<p80) { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp [$2]) [$1; $4] } p80

--- a/compiler/src/typed/checkertypes.re
+++ b/compiler/src/typed/checkertypes.re
@@ -100,8 +100,23 @@ let constant:
           ),
         )
       }
-    | PConstNumber(PConstNumberRational(_)) =>
-      failwith("NYI: checkertypes constant PConstNumberRational")
+    | PConstNumber(PConstNumberRational(n, d)) =>
+      switch (Literals.conv_number_rational(n, d)) {
+      | Some((n, d)) when d == 1l =>
+        Ok(Const_number(Const_number_int(Int64.of_int32(n))))
+      | Some((n, d)) when d == (-1l) =>
+        Ok(Const_number(Const_number_int(Int64.of_int32(Int32.neg(n)))))
+      | Some((n, d)) => Ok(Const_number(Const_number_rational(n, d)))
+      | None =>
+        Error(
+          Location.errorf(
+            ~loc,
+            "Number literal %s/%s is outside of the rational number range of the Number type.",
+            n,
+            d,
+          ),
+        )
+      }
     | PConstInt32(n) =>
       switch (Literals.conv_int32(n)) {
       | Some(n) => Ok(Const_int32(n))

--- a/compiler/src/typed/checkertypes.re
+++ b/compiler/src/typed/checkertypes.re
@@ -104,8 +104,6 @@ let constant:
       switch (Literals.conv_number_rational(n, d)) {
       | Some((n, d)) when d == 1l =>
         Ok(Const_number(Const_number_int(Int64.of_int32(n))))
-      | Some((n, d)) when d == (-1l) =>
-        Ok(Const_number(Const_number_int(Int64.of_int32(Int32.neg(n)))))
       | Some((n, d)) => Ok(Const_number(Const_number_rational(n, d)))
       | None =>
         Error(

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1757,8 +1757,8 @@ let untype_constant =
   | Const_number(Const_number_rational(n, d)) =>
     Parsetree.PConstNumber(
       Parsetree.PConstNumberRational(
-        Int64.to_string(n),
-        Int64.to_string(d),
+        Int32.to_string(n),
+        Int32.to_string(d),
       ),
     )
   | Const_string(s) => Parsetree.PConstString(s)

--- a/compiler/src/typed/printpat.re
+++ b/compiler/src/typed/printpat.re
@@ -30,7 +30,7 @@ let pretty_const = c =>
   | Const_number(Const_number_int(i)) => Printf.sprintf("%Ld", i)
   | Const_number(Const_number_float(f)) => Printf.sprintf("%f", f)
   | Const_number(Const_number_rational(n, d)) =>
-    Printf.sprintf("%Ld/%Ld", n, d)
+    Printf.sprintf("%ld/%ld", n, d)
   | Const_string(s) => Printf.sprintf("%S", s)
   | Const_float64(f)
   | Const_float32(f) => Printf.sprintf("%f", f)

--- a/compiler/src/utils/literals.re
+++ b/compiler/src/utils/literals.re
@@ -10,6 +10,52 @@ let conv_number_float = s => {
   Float.of_string_opt(s);
 };
 
+let conv_number_rational = (n, d) => {
+  open Int32;
+  // https://en.wikipedia.org/wiki/Binary_GCD_algorithm
+  let rec gcd_help = (x, y) => {
+    switch (x, y) {
+    | (x, y) when x == y => y
+    | (x, y) when x == 0l => y
+    | (x, y) when y == 0l => x
+    | (x, y) when logand(lognot(x), 1l) != 0l =>
+      // x is even
+      if (logand(y, 1l) != 0l) {
+        // y is odd
+        gcd_help(shift_right(x, 1), y);
+      } else {
+        shift_left(gcd_help(shift_right(x, 1), shift_right(y, 1)), 1);
+      }
+    | (x, y) when logand(lognot(y), 1l) != 0l =>
+      // y is even and x is odd
+      gcd_help(x, shift_right(y, 1))
+    | (x, y) when x > y => gcd_help(sub(x, y), y)
+    | _ => gcd_help(sub(y, x), x)
+    };
+  };
+  // Algorithm above breaks on negatives, so
+  // we make sure that they are positive at the beginning
+  let gcd = (x, y) => gcd_help(abs(x), abs(y));
+
+  let numerator = Int32.of_string_opt(n);
+  let denominator = Int32.of_string_opt(d);
+  switch (numerator, denominator) {
+  | (Some(n), Some(d)) =>
+    // Division by zero handled by well-formedness
+    let factor = gcd(n, d);
+    if (n < 0l && d < 0l) {
+      // Never do negative/negative
+      Some((
+        div(neg(n), factor),
+        div(neg(d), factor),
+      ));
+    } else {
+      Some((div(n, factor), div(d, factor)));
+    };
+  | _ => None
+  };
+};
+
 let conv_int32 = s => {
   Int32.of_string_opt(s);
 };

--- a/compiler/src/utils/literals.re
+++ b/compiler/src/utils/literals.re
@@ -43,8 +43,8 @@ let conv_number_rational = (n, d) => {
   | (Some(n), Some(d)) =>
     // Division by zero handled by well-formedness
     let factor = gcd(n, d);
-    if (n < 0l && d < 0l) {
-      // Never do negative/negative
+    if (d < 0l) {
+      // Never do negative/negative or negative denominator
       Some((
         div(neg(n), factor),
         div(neg(d), factor),

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -1622,7 +1622,10 @@ let number_tests = [
   t("numbers7", "(1 / 3) + (1 / 6)", "1/2"),
   t("numbers8", "(1 / 3) * (1 / 3)", "1/9"),
   t("numbers9", "(1 / 3) / (1 / 3)", "1"),
-  te("numbers10", "9 / 0", "denominator of zero"),
+  t("numbers10", "-2 / 4", "-1/2"),
+  t("numbers11", "2 / -4", "-1/2"),
+  t("numbers12", "-2 / -4", "1/2"),
+  te("numbers13", "9 / 0", "denominator of zero"),
   // basic syntax tests
   t("number_syntax1", "1.2", "1.2"),
   t("number_syntax2", "1.2d", "1.2"),

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -172,7 +172,7 @@ let basic_functionality_tests = [
   t("binop4", "2 * 3", "6"),
   t("binop5", "10 / 5", "2"),
   t("binop6", "9 % 5", "4"),
-  te("division_by_zero", "9 / 0", "division by zero"),
+  te("division_by_zero", "let nine = 9; nine / 0", "division by zero"),
   te("modulo_by_zero", "9 % 0", "modulo by zero"),
   t("division1", "5 / 2", "5/2"),
   t("modulo1", "-17 % 4", "3"),
@@ -1622,6 +1622,7 @@ let number_tests = [
   t("numbers7", "(1 / 3) + (1 / 6)", "1/2"),
   t("numbers8", "(1 / 3) * (1 / 3)", "1/9"),
   t("numbers9", "(1 / 3) / (1 / 3)", "1"),
+  te("numbers10", "9 / 0", "denominator of zero"),
   // basic syntax tests
   t("number_syntax1", "1.2", "1.2"),
   t("number_syntax2", "1.2d", "1.2"),

--- a/stdlib/stdlib-external/numbers.ts
+++ b/stdlib/stdlib-external/numbers.ts
@@ -140,8 +140,9 @@ function gcd32(x: i32, y: i32): i32 {
 
 
 function reducedFraction(x: i32, y: i32): u32 {
-  if (x < 0 && y < 0) {
+  if (y < 0) {
     // Normalization 1: Never do negative/negative
+    // Normalization 2: Never allow a negative denominator
     x = -x
     y = -y
   }
@@ -158,7 +159,9 @@ function reducedFraction(x: i32, y: i32): u32 {
 }
 
 function reducedFraction64(x: i64, y: i64): u32 {
-  if (x < 0 && y < 0) {
+  if (y < 0) {
+    // Normalization 1: Never do negative/negative
+    // Normalization 2: Never allow a negative denominator
     x = -x
     y = -y
   }


### PR DESCRIPTION
This PR bakes in support for rational literals instead of only creating them via division. This will make it possible to do pattern matching on rational constants (as well as be slightly more performant than having to perform the division/factoring at runtime).

Requires #326. 