### PR TITLE
Add an extra install call to update checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN yarn workspace @grain/compiler esy build-dependencies
 
 COPY . /grain
 RUN yarn setup
+
+# Copying the files into the image after we already tell esy to build results in
+# an incorrect SHA, so we need to re-run install once to update it
+RUN yarn workspace @grain/compiler esy install
 RUN yarn workspace @grain/compiler esy compile
 RUN yarn workspace @grain/compiler esy copy-compiler
 


### PR DESCRIPTION
The way we are currently building the dockerfile fails if you don't have a previous cache because the checksum/SHA changes between building the dependencies and building the project. Calling `esy install` one time before we compile the project regenerates the checksum so we don't get the "needs an esy install" error.

Note: this won't be an issue anymore when we can use the `esy` command directly, which is the recommended way to use the project these days.