### PR TITLE
Implement pattern matching on constants

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -53,6 +53,7 @@ type prim2 =
     | Greater
     | LessEq
     | GreaterEq
+    | Is
     | Eq
     | And
     | Or

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -44,6 +44,7 @@ type prim2 =
     | Greater
     | LessEq
     | GreaterEq
+    | Is
     | Eq
     | And
     | Or

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -45,6 +45,7 @@ type prim2 =
     | Greater
     | LessEq
     | GreaterEq
+    | Is
     | Eq
     | And
     | Or

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -730,8 +730,8 @@ let prepare_match_branches = branches => {
       };
     };
     let add_constant_guard = (id, c, loc) => {
-      let vd = make_vd(id, type_constant(c));
       let ty = type_constant(c);
+      let vd = make_vd(id, ty);
       let expr = env => {
         let ident =
           TExpIdent(

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -700,6 +700,9 @@ let rec compile_matrix = mtx =>
     Swap(i, result);
   };
 
+/* Currently, this only desugars constant patterns into guard expressions,
+ * but could be extended to do any other necessary preprocessing.
+ */
 let prepare_match_branches = branches => {
   let map_branch = branch => {
     let guard = ref(branch.mb_guard);

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -289,6 +289,7 @@ binop_expr :
 pattern :
   | pattern colon typ { Pat.constraint_ ~loc:(symbol_rloc dyp) $1 $3 }
   | UNDERSCORE { Pat.any ~loc:(symbol_rloc dyp) () }
+  | const { Pat.constant ~loc:(symbol_rloc dyp) $1 }
   /* If the pattern uses an external ID, we know it's a constructor, not a variable */
   | ext_constructor { Pat.construct ~loc:(symbol_rloc dyp) $1 [] }
   | [ID | infix] { Pat.var ~loc:(symbol_rloc dyp) (mkstr dyp $1) }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -179,6 +179,7 @@ type prim2 =
   | Greater
   | LessEq
   | GreaterEq
+  | Is
   | Eq
   | And
   | Or

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1761,9 +1761,13 @@ let untype_constant =
         Int32.to_string(d),
       ),
     )
+  | Const_int32(i) => Parsetree.PConstInt32(Int32.to_string(i))
+  | Const_int64(i) => Parsetree.PConstInt64(Int64.to_string(i))
+  | Const_float32(f) => Parsetree.PConstFloat32(Float.to_string(f))
+  | Const_float64(f) => Parsetree.PConstFloat64(Float.to_string(f))
   | Const_string(s) => Parsetree.PConstString(s)
   | Const_bool(b) => Parsetree.PConstBool(b)
-  | _ => failwith("NYI untype_constant");
+  | Const_void => Parsetree.PConstVoid;
 
 /* conversion from Typedtree.pattern to Parsetree.pattern list */
 module Conv = {

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -48,6 +48,7 @@ let prim_map =
       ("@greater", Primitive2(Greater)),
       ("@lesseq", Primitive2(LessEq)),
       ("@greatereq", Primitive2(GreaterEq)),
+      ("@is", Primitive2(Is)),
       ("@eq", Primitive2(Eq)),
       ("@and", Primitive2(And)),
       ("@or", Primitive2(Or)),

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -145,6 +145,7 @@ let prim2_type =
       Builtin_types.type_bool,
       Builtin_types.type_bool,
     )
+  | Is
   | Eq => {
       let v1 = newvar(~name="equal", ())
       and v2 = newvar(~name="equal", ());

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -59,6 +59,7 @@ type prim2 =
     | Greater
     | LessEq
     | GreaterEq
+    | Is
     | Eq
     | And
     | Or

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -58,6 +58,7 @@ type prim2 =
     | Greater
     | LessEq
     | GreaterEq
+    | Is
     | Eq
     | And
     | Or

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -973,6 +973,7 @@ let match_tests = [
     "data Rec = {foo: Number}; match ([{foo: 5}]) { | [] => 999 | [{foo}, ..._] => foo }",
     "5",
   ),
+  // Guarded branches
   t(
     "guarded_match_1",
     "match ((1, 2, 3)) { | (a, b, c) when a == 1 => 42 | _ => 99 }",
@@ -1052,6 +1053,17 @@ let match_tests = [
        | Bar => 79
      }",
     "79",
+  ),
+  // Constant patterns
+  t(
+    "constant_match_1",
+    "match (1/3) { | 5 => false | 2/6 => true | _ => false }",
+    "true",
+  ),
+  t(
+    "constant_match_2",
+    "match (('foo', 5, false)) { | ('bar', 5, false) => false | ('foo', _, true) => false | ('foo', _, false) => true | _ => false }",
+    "true",
   ),
   tfile("mixed_matching", "mixedPatternMatching", "true"),
 ];

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -1065,6 +1065,16 @@ let match_tests = [
     "match (('foo', 5, false)) { | ('bar', 5, false) => false | ('foo', _, true) => false | ('foo', _, false) => true | _ => false }",
     "true",
   ),
+  t(
+    "constant_match_3",
+    "match ('foo') { | 'foo' when false => false | 'foo' when true => true | _ => false }",
+    "true",
+  ),
+  t(
+    "constant_match_4",
+    "match (('foo', 5)) { | ('foo', n) when n == 7 => false | ('foo', 9) when true => false | ('foo', n) when n == 5 => true | _ => false }",
+    "true",
+  ),
   tfile("mixed_matching", "mixedPatternMatching", "true"),
 ];
 

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -58,7 +58,7 @@ import foreign wasm print : a -> Void from 'grainBuiltins'
 import foreign wasm equal : (a, a) -> Bool as (==) from 'stdlib-external/runtime'
 let (!=) : (a, a) -> Bool = (x, y) => !(x == y)
 # Checks the given items for physical equality.
-primitive (is) : (a, a) -> Bool = "@eq"
+primitive (is) : (a, a) -> Bool = "@is"
 
 # Converts the given value to a string
 import foreign wasm toString : a -> String from 'grainBuiltins'


### PR DESCRIPTION
This PR adds the ability to do pattern matching on constant patterns:
```grain
match (('foo', 5, true)) {
  | ('bar', _, false) => false
  | ('foo', 5, _) => true
  | _ => false
}
```

Ended up going with the desugaring into guards (after typechecking) approach since I believe it is more performant than checking constants on the fly (though this seems to only be true for matches with many cases with constant patterns—I believe it's faster to check them on the fly if there are few cases with constant patterns).

Tests are light since they're just exercising already-tested guarded branches.

Closes #284.