### PR TITLE
Update docker working directory and default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ RUN yarn workspace @grain/compiler esy compile
 RUN yarn workspace @grain/compiler esy copy-compiler
 
 # Set up container environment
-WORKDIR /grain
+WORKDIR /
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,5 @@ RUN yarn workspace @grain/compiler esy compile
 RUN yarn workspace @grain/compiler esy copy-compiler
 
 # Set up container environment
-WORKDIR /
+WORKDIR /grain
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This makes it so if you `docker run` without any command, you're in a shell where `grain` works rather than the node repl. It also sets the default directory to the Grain repo rather than just `/`.