### PR TITLE
Fix generated module names

### DIFF
--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -840,7 +840,7 @@ let type_module = (~toplevel=false, funct_body, anchor, env, sstr /*scope*/) => 
 let type_module = type_module(false, None);
 
 let implicit_modules: ref(list((string, string))) = (
-  ref([("pervasives", "pervasives")]): ref(list((string, string)))
+  ref([("Pervasives", "pervasives")]): ref(list((string, string)))
 );
 
 let open_implicit_module = (m, env) => {

--- a/compiler/src/utils/files.re
+++ b/compiler/src/utils/files.re
@@ -17,15 +17,17 @@ let filename_to_module_name = fname => {
       | Relative(path) => Fp.baseName(path)
       }
     );
-  switch (baseName) {
-  | Some(baseName) => remove_extension(baseName)
-  | None =>
-    raise(
-      Invalid_argument(
-        Printf.sprintf("Invalid filepath (fname: '%s')", fname),
-      ),
-    )
-  };
+  let name =
+    switch (baseName) {
+    | Some(baseName) => remove_extension(baseName)
+    | None =>
+      raise(
+        Invalid_argument(
+          Printf.sprintf("Invalid filepath (fname: '%s')", fname),
+        ),
+      )
+    };
+  String.capitalize_ascii(name);
 };
 
 let ensure_parent_directory_exists = fname => {


### PR DESCRIPTION
Fixes #329.

With program
```grain
import * from './test2'

Foo(5) + 5
```

You now get error
```
Error: This expression has type Test2.Foo
       but an expression was expected of type Number
```