### PR TITLE
Update Map type

### DIFF
--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -4,16 +4,16 @@ import List from 'list'
 import Array from 'array'
 import { hash } from 'hash'
 
-data Container<a> = {
-  mut size: Number,
-  mut buckets: Array<Option<a>>
-}
-
 # TODO: Consider implementing this as List<(Box<k>, Box<v>)>
 data Bucket<k, v> = {
   mut key: k,
   mut value: v,
   mut next: Option<Bucket<k, v>>
+}
+
+data Map<k, v> = {
+  mut size: Number,
+  mut buckets: Array<Option<Bucket<k, v>>>
 }
 
 # TODO: This could take an `eq` function to custom comparisons


### PR DESCRIPTION
This makes the Map type referenceable as `Map.Map<k, v>` (tbd on if it should be `Map.T`) instead of `Map.Container<Map.Bucket<k, v>>`.

Side note: I would love syntax for optional types, like `Array<Bucket<k, v>?>` or `Array<?Bucket<k, v>>` (and also shorthands for list and maybe array types)!