### PR TITLE
Slightly better node source map support

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -47,6 +47,7 @@
     "@wasmer/wasi": "^0.11.2",
     "@wasmer/wasmfs": "^0.11.2",
     "fast-text-encoding": "^1.0.0",
-    "treeify": "^1.1.0"
+    "treeify": "^1.1.0",
+    "wasm-sourcemap": "^1.0.0"
   }
 }

--- a/stdlib/build.mjs
+++ b/stdlib/build.mjs
@@ -19,7 +19,7 @@ await asc.ready;
 const filenames = await globby('stdlib-external/**/*.ts');
 
 const files = filenames.map((filename) =>
-  compileFile([filename, "-o", replaceExt(filename, ".gr.wasm")])
+  compileFile([filename, "--sourceMap", "-o", replaceExt(filename, ".gr.wasm")])
 );
 
 await Promise.all(files);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,6 +3574,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+wasm-sourcemap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wasm-sourcemap/-/wasm-sourcemap-1.0.0.tgz#c9aa3a2105eb2f15b838687b5aebeac4e0c9a07c"
+  integrity sha512-IiOoUHnsI6bVVbs8Q+JO6cj7KtxwGiiS5nJGDbZXfj6srbIDzjjbZk9WMAusvynTzzlPlMgJhb/4SGz92ZgXsA==
+
 watchpack@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.1.tgz#280da0a8718592174010c078c7585a74cd8cd0e2"


### PR DESCRIPTION
This makes it so if you run Grain via `node --inspect`, you can see a properly source-mapped call stack in the Chrome Node Debugger:

![image](https://user-images.githubusercontent.com/7244034/94994944-dc8e8f00-0568-11eb-95f2-e0b4f50f3ca5.png)

You can even set breakpoints and they work:

![image](https://user-images.githubusercontent.com/7244034/94994961-fb8d2100-0568-11eb-9113-5796d0ae1d85.png)

This doesn't fix the issue with the mappings not showing in the actual stack trace, though, since those are generated by Node and not the Chrome debugger. 😞 

The mappings still work properly if you're running directly in Chrome, though.