### PR TITLE
Add `List.find`, `List.findIndex`

### DIFF
--- a/compiler/test/stdlib/list.test.gr
+++ b/compiler/test/stdlib/list.test.gr
@@ -143,3 +143,12 @@ assert dropWhile(x => false, list) == list
 assert dropWhile(x => x < 3, list) == [3]
 assert dropWhile(x => x < 5, list) == []
 assert dropWhile(x => x > 5, list) == list
+
+# List.find
+
+assert find(x => x == 2, list) == 2
+
+# List.findIndex
+
+assert findIndex(x => x == 1, list) == 0
+assert findIndex(x => x == 2, list) == 1

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -224,5 +224,19 @@ let rec dropWhile = (fn, list) => {
   }
 }
 
+let rec find = (fn, list) => {
+  match (list) {
+    | [] => fail 'could not find a match'
+    | [first, ...rest] => if (fn(first)) first else find(fn, rest)
+  }
+}
 
-
+let findIndex = (fn, list) => {
+  let rec findItemIndex = (l, index) => {
+    match (l) {
+      | [] => fail 'could not find a match'
+      | [first, ...rest] => if (fn(first)) index else findItemIndex(rest, index + 1)
+    }
+  }
+  findItemIndex(list, 0)
+}


### PR DESCRIPTION
Note I'm not familiar with how to catch exceptions, so I don't know how to test the failure cases.