### PR TITLE
add support for trailing commas in arrays

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -540,9 +540,13 @@ list_expr :
   | lbrack rbrack { Exp.list ~loc:(symbol_rloc dyp) [] None }
   | lbrack expr [comma expr {$2}]* list_expr_ending rbrack { Exp.list ~loc:(symbol_rloc dyp) ($2::$3) $4 }
 
+array_expr_ending :
+  | comma? { None }
+  | comma ELLIPSIS expr { Some $3 }
+
 array_expr :
   | lbrack rcaret rbrack { Exp.array ~loc:(symbol_rloc dyp) [] }
-  | lbrack rcaret expr [comma expr {$2}]* rbrack { Exp.array ~loc:(symbol_rloc dyp) ($3::$4) }
+  | lbrack rcaret expr [comma expr {$2}]* array_expr_ending rbrack { Exp.array ~loc:(symbol_rloc dyp) ($3::$4) }
 
 stmt_expr :
   | ASSERT expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["assert"]) [$2] }
@@ -646,7 +650,7 @@ primitive_stmt :
 exception_stmt :
   | EXCEPTION type_id_str { Except.singleton ~loc:(symbol_rloc dyp) $2 }
   | EXCEPTION type_id_str lparen typs rparen { Except.tuple ~loc:(symbol_rloc dyp) $2 $4 }
-  
+
 toplevel_stmt :
   | LET REC value_binds { Top.let_ Nonexported Recursive Immutable $3 }
   | LET value_binds { Top.let_ Nonexported Nonrecursive Immutable $2 }

--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -1,6 +1,6 @@
 import Array from 'array'
 
-let arr = [> 1, 2, 3]
+let arr = [> 1, 2, 3,]
 
 # Array.get
 

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -461,6 +461,10 @@ let array_tests = [
     "let x = [> true, false, false]; (x[1] := true) + 3",
     "has type Bool but",
   ),
+  // trailing commas
+  t("array1_trailing", "[> 1, 2, 3,]", "[> 1, 2, 3]"),
+  t("array1_trailing_space", "[> 1, 2, 3, ]", "[> 1, 2, 3]"),
+  te("invalid_empty_trailing", "[> ,]", "Error: Syntax error"),
 ];
 
 let record_tests = [


### PR DESCRIPTION
Partially addresses https://github.com/grain-lang/grain/issues/182