### PR TITLE
add support for trailing commas in tuples

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -586,7 +586,7 @@ block_body_stmt :
 
 tuple_exprs :
   | expr comma { [$1] }
-  | expr [comma expr {$2}]+ { $1::$2 }
+  | expr [comma expr {$2}]+ comma? { $1::$2 }
 
 array_get :
   | non_assign_expr lbrack expr rbrack { Exp.array_get ~loc:(symbol_rloc dyp) $1 $3 }

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -381,6 +381,10 @@ let tuple_tests = [
   t("nested_tup_2", "let (a, b) = ((1, 2), (3, 4)); let (c, d) = b; d", "4"),
   t("nested_tup_3", "let (x, y) = ((1, 2), (3, 4)); let (a, b) = y; a", "3"),
   t("no_singleton_tup", "(1)", "1"),
+  // trailing commas
+  t("tup1_trailing", "(1, 2, 3,)", "(1, 2, 3)"),
+  t("tup1_trailing_space", "(1, 2, 3, )", "(1, 2, 3)"),
+  te("invalid_empty_trailing", "(,)", "Error: Syntax error"),
 ];
 
 let list_tests = [


### PR DESCRIPTION
Partially addresses #182