### PR TITLE
Fix imported ADT typechecking

### DIFF
--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -393,8 +393,7 @@ let tuple_tests = [
 let list_tests = [
   t("list1", "[1, 2, 3]", "[1, 2, 3]"),
   t("list2", "[]", "[]"),
-  // TODO: This should fail with typechecker error
-  // t("list_heterogeneous", "[1, false, 2]", "[1, false, 2]"),
+  te("list_heterogeneous", "[1, false, 2]", "type"),
   t("list_spread", "let a = [3, 4]; [1, 2, ...a]", "[1, 2, 3, 4]"),
   te(
     "invalid_list_no_comma_before_spread",

--- a/stdlib/result.gr
+++ b/stdlib/result.gr
@@ -17,28 +17,28 @@ export let toOption = (v) => {
 export let flatMap = (fn, v) => {
     match (v) {
         | Ok(x)  => fn(x)
-        | _      => v
+        | Err(e) => Err(e)
     }
 }
 
 export let flatMapErr = (fn, v) => {
     match (v) {
         | Err(e) => fn(e)
-        | _      => v
+        | Ok(x)  => Ok(x)
     }
 }
 
 export let map = (fn, v) => {
     match (v) {
-        | Ok(x) => Ok(fn(x))
-        | _     => v
+        | Ok(x)  => Ok(fn(x))
+        | Err(e) => Err(e)
     }
 }
 
 export let mapErr = (fn, v) => {
     match (v) {
-        | Err(x) => Err(fn(x))
-        | _      => v
+        | Err(e) => Err(fn(e))
+        | Ok(x)  => Ok(x)
     }
 }
 


### PR DESCRIPTION
Fixes #315.

In addition to linking type variables for imported values, we now also do it for imported types (which includes variants and records).

Fixing this made some of the Result tests fail, and after reviewing the code it made perfect sense. I updated the implementations to have the behavior the tests expected. 😄 