### PR TITLE
Added an LSP mode for use with vscode lsp implementation.

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -8,6 +8,7 @@ const path = require('path');
 let program = require('commander');
 let compile = require('./compile.js');
 let run = require('./run.js');
+let lsp = require('./lsp.js');
 
 let pervasivesPath = require.resolve('@grain/stdlib');
 let stdlibPath = path.dirname(pervasivesPath);
@@ -51,6 +52,13 @@ program
   .description('compile a grain program into wasm')
   .action(function (file) {
     compile(file, program);
+  });
+
+program
+  .command('lsp <file>')
+  .description('check a grain file for LSP')
+  .action(function (file) {
+    lsp(file, program);
   });
 
 program

--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -9,7 +9,7 @@ const grainc = path.join(__dirname, 'grainc.exe');
 
 module.exports = (file, options) => {
   try {
-    execSync(`${grainc} --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} --lsp ${file}`, { stdio: 'inherit' });
+    execSync(`${grainc} --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} -g --lsp ${file}`, { stdio: 'inherit' });
     process.exit()
   } catch (e) {
     //  console.log(e); //.stdout.toString());

--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -12,7 +12,6 @@ module.exports = (file, options) => {
     execSync(`${grainc} --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} -g --lsp ${file}`, { stdio: 'inherit' });
     process.exit()
   } catch (e) {
-    //  console.log(e); //.stdout.toString());
     console.log(e);
     if (options.graceful) {
       process.exit()

--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const { execSync } = require('child_process');
+
+const grainc = path.join(__dirname, 'grainc.exe');
+
+// call the compiler, passing stdio through so the compiler gets the source code on stdin
+// and we get the compiler output in stdout
+// we still take the file name so we have it available
+
+module.exports = (file, options) => {
+  try {
+    execSync(`${grainc} --stdlib=${options.stdlib} ${options.cflags ? options.cflags : ''} --lsp ${file}`, { stdio: 'inherit' });
+    process.exit()
+  } catch (e) {
+    //  console.log(e); //.stdout.toString());
+    console.log(e);
+    if (options.graceful) {
+      process.exit()
+    } else {
+      process.exit(1)
+    }
+  }
+}

--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -42,38 +42,32 @@ let default_assembly_filename = name =>
 let default_mashtree_filename = name =>
   safe_remove_extension(name) ++ ".mashtree";
 
-
-
 /* LSP mode - read the file to compile from stdin and return nothing or compile errors on stdout */
 
-let compile_string = (name) => {
+let compile_string = name => {
+  let program_str = ref("");
+  /* read from stdin until we get end of buffer */
+  try(
+    while (true) {
+      program_str := program_str^ ++ read_line() ++ "\n";
+    }
+  ) {
+  | exn => ()
+  };
 
-   let program_str = ref("");
-   /* read from stdin until we get end of buffer */
-   try({
-     while(true) {
-       program_str :=  program_str^ ++ read_line() ++ "\n";
-     }
-   }) {
-     | exn  => ()
-   }
+  try(
+    ignore(
+      Compile.compile_string(~hook=stop_after_typed, ~name, program_str^),
+    )
+  ) {
+  | exn =>
+    let err_rep = Grain_parsing.Location.print_exception(exn);
+    print_string(err_rep);
+  };
 
-   try({
-     ignore(Compile.compile_string(
-       ~hook=stop_after_typed,
-       ~name,
-       program_str^,
-     ))
-   }) {
-   | exn =>
-     let err_rep = Grain_parsing.Location.print_exception(exn);
-     print_string(err_rep);
-   };
-
-   /* as the compiler throws an exception on an error, we always just return OK */
-   `Ok();
- };
- 
+  /* as the compiler throws an exception on an error, we always just return OK */
+  `Ok();
+};
 
 let compile_file = (name, outfile_arg) => {
   Grain_utils.Config.base_path := dirname(name);
@@ -111,13 +105,12 @@ let compile_file = (name, outfile_arg) => {
 
 /* add a wrapper so we can switch to LSP mode based on cli config */
 
-let compile_wrapper = (name, outfile_arg) => {
+let compile_wrapper = (name, outfile_arg) =>
   if (Grain_utils.Config.lsp_mode^) {
     compile_string(name);
-   } else {
-    compile_file(name,outfile_arg);
-   }
-};
+  } else {
+    compile_file(name, outfile_arg);
+  };
 
 /** Converter which checks that the given output filename is valid */
 

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -544,15 +544,14 @@ let rec report_exception = (ppf, exn) => {
 };
 
 /* output error in a format friendly for LSP processing */
-let error_to_string = ({loc, msg, sub, if_highlight}) =>  {
+let error_to_string = ({loc, msg, sub, if_highlight}) => {
   let (file, line, startchar) = get_pos_info(loc.loc_start);
   let (_, endline, endchar) = get_pos_info(loc.loc_end);
   sprintf("%d %d %d %d\n%s\n", line, startchar, endline, endchar, msg);
-  
-}
+};
 
 /* lsp - print error to stdout */
-let rec print_exception = (exn) => {
+let rec print_exception = exn => {
   let rec loop = (n, exn) =>
     switch (error_of_exn(exn)) {
     | None => reraise(exn)

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -543,6 +543,26 @@ let rec report_exception = (ppf, exn) => {
   loop(10, exn);
 };
 
+/* output error in a format friendly for LSP processing */
+let error_to_string = ({loc, msg, sub, if_highlight}) =>  {
+  let (file, line, startchar) = get_pos_info(loc.loc_start);
+  let (_, endline, endchar) = get_pos_info(loc.loc_end);
+  sprintf("%d %d %d %d\n%s\n", line, startchar, endline, endchar, msg);
+  
+}
+
+/* lsp - print error to stdout */
+let rec print_exception = (exn) => {
+  let rec loop = (n, exn) =>
+    switch (error_of_exn(exn)) {
+    | None => reraise(exn)
+    | Some(`Already_displayed) => ""
+    | Some(`Ok(err)) => error_to_string(err)
+    | exception exn when n > 0 => loop(n - 1, exn)
+    };
+  loop(10, exn);
+};
+
 exception Error(error);
 
 let () =

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -543,11 +543,43 @@ let rec report_exception = (ppf, exn) => {
   loop(10, exn);
 };
 
+type lsp_error = {
+  file: string,
+  line: int,
+  startchar: int,
+  endline: int,
+  endchar: int,
+  lsp_message: string,
+};
+
+let lsp_error_to_yojson = (e: lsp_error): Yojson.t =>
+  `Assoc([
+    ("file", `String(e.file)),
+    ("line", `Int(e.line)),
+    ("startchar", `Int(e.startchar)),
+    ("endline", `Int(e.endline)),
+    ("endchar", `Int(e.endchar)),
+    ("lsp_message", `String(e.lsp_message)),
+  ]);
+
 /* output error in a format friendly for LSP processing */
-let error_to_string = ({loc, msg, sub, if_highlight}) => {
+let error_to_json = ({loc, msg, sub, if_highlight}) => {
   let (file, line, startchar) = get_pos_info(loc.loc_start);
   let (_, endline, endchar) = get_pos_info(loc.loc_end);
-  sprintf("%d %d %d %d\n%s\n", line, startchar, endline, endchar, msg);
+
+  let error_json: lsp_error = {
+    file,
+    line,
+    startchar,
+    endline,
+    endchar,
+    lsp_message: msg,
+  };
+
+  let json_string = Yojson.to_string(lsp_error_to_yojson(error_json));
+
+  json_string;
+  /* sprintf("%d %d %d %d\n%s\n", line, startchar, endline, endchar, msg); */
 };
 
 /* lsp - print error to stdout */
@@ -556,7 +588,7 @@ let rec print_exception = exn => {
     switch (error_of_exn(exn)) {
     | None => reraise(exn)
     | Some(`Already_displayed) => ""
-    | Some(`Ok(err)) => error_to_string(err)
+    | Some(`Ok(err)) => error_to_json(err)
     | exception exn when n > 0 => loop(n - 1, exn)
     };
   loop(10, exn);

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -576,10 +576,7 @@ let error_to_json = ({loc, msg, sub, if_highlight}) => {
     lsp_message: msg,
   };
 
-  let json_string = Yojson.to_string(lsp_error_to_yojson(error_json));
-
-  json_string;
-  /* sprintf("%d %d %d %d\n%s\n", line, startchar, endline, endchar, msg); */
+  Yojson.to_string(lsp_error_to_yojson(error_json));
 };
 
 /* lsp - print error to stdout */

--- a/compiler/src/parsing/location.rei
+++ b/compiler/src/parsing/location.rei
@@ -155,3 +155,7 @@ let default_error_reporter: (formatter, error) => unit;
 /** Reraise the exception if it is unknown. */
 
 let report_exception: (formatter, exn) => unit;
+
+/* print the error to stdout in LSP friendly form */
+
+let print_exception: (exn) => string;

--- a/compiler/src/parsing/location.rei
+++ b/compiler/src/parsing/location.rei
@@ -158,4 +158,4 @@ let report_exception: (formatter, exn) => unit;
 
 /* print the error to stdout in LSP friendly form */
 
-let print_exception: (exn) => string;
+let print_exception: exn => string;

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -368,6 +368,9 @@ let unsound_optimizations =
 let source_map =
   toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
 
+let lsp_mode =
+  toggle_flag(~names=["lsp"], ~doc="Generate lsp errors and warnings only", false);
+
 /* To be filled in by grainc */
 let base_path = internal_opt("");
 

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -369,7 +369,11 @@ let source_map =
   toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
 
 let lsp_mode =
-  toggle_flag(~names=["lsp"], ~doc="Generate lsp errors and warnings only", false);
+  toggle_flag(
+    ~names=["lsp"],
+    ~doc="Generate lsp errors and warnings only",
+    false,
+  );
 
 /* To be filled in by grainc */
 let base_path = internal_opt("");

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -68,6 +68,10 @@ let source_map: ref(bool);
 
 let safe_string: ref(bool);
 
+/** Just output errors and warnings for LSP mode. */
+
+let lsp_mode: ref(bool);
+
 /*** Configuration Saving/Restoring */
 
 /** Abstract type representing a saved set of configuration options */


### PR DESCRIPTION
(works with https://github.com/ng-marcus/lsp-grain which isn't a published extension yet so you need to run it in debug mode)

I've modified the cli and compiler to support an lsp mode where the cli passes through stdin as the content to compile,  and reports back the errors (it any) on stdout in a form of

startline startchat endline endchar
Error message 
over multiple lines

The assumption is the compiler stops after the first error so there's only one to report.

I'm not really sure what's happening in location.re (report exception) so I just copied it and sprintfed the result, I assume it's to do with nested exceptions.   It works for now, but I'm not confident in the code.

Your feedback on approach (modifying the compiler in this way, method of reporting back) would be appreciated.
