### PR TITLE
add support for trailing commas in ADT constructors and function arg lists

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -348,7 +348,7 @@ typ :
   | data_typ
 
 typs :
-  | [typ [comma typ {$2}]* {$1::$2}]? { Option.value ~default:[] $1 }
+  | [typ [comma typ {$2}]* {$1::$2}]? comma? { Option.value ~default:[] $1 }
 
 tuple_typs :
   | typ comma { [$1] }
@@ -412,9 +412,9 @@ app_arg_exprs :
   | [expr [comma expr {$2}]* { $1::$2 }]? { Option.value ~default:[] $1 }
 
 app_expr :
-  | id_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
-  | paren_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
-  | app_expr lparen app_arg_exprs rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | id_expr lparen app_arg_exprs comma? rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | paren_expr lparen app_arg_exprs comma? rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
+  | app_expr lparen app_arg_exprs comma? rparen { prerr_string "\napp_expr\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); Exp.apply ~loc:(symbol_rloc dyp) $1 $3 }
 
 ext_constructor :
   | TYPEID [dot TYPEID {$2}]+ { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid ($1::$2)) (symbol_rloc dyp) }
@@ -523,7 +523,7 @@ lam_args :
   | patterns? { Option.value ~default:[] $1 }
 
 lam_expr :
-  | lparen lam_args rparen thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen lam_args comma? rparen thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
   | ID thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 let_expr :

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -523,7 +523,7 @@ lam_args :
   | patterns? { Option.value ~default:[] $1 }
 
 lam_expr :
-  | lparen lam_args comma? rparen thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) $2 $5 }
+  | lparen lam_args comma? rparen thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) $2 $6 }
   | ID thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 let_expr :

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -303,6 +303,18 @@ let function_tests = [
   t("shorthand_2", "let foo = (x) => x + 3; foo(1)", "4"),
   t("shorthand_3", "let foo = x => x; foo(1)", "1"),
   t("shorthand_4", "let foo = x => x + 3; foo(1)", "4"),
+  // Trailing commas
+  t("fn_trailing_comma", "let testFn = (x, y,) => x + y; testFn(2, 3,)", "5"),
+  t(
+    "adt_trailing_comma",
+    "data Topping = Cheese | Pepperoni | Peppers | Pineapple
+     data Dough = WholeWheat | GlutenFree
+     data Menu = Pizza(Topping,Dough,) | Calzone(Topping,Dough,)
+     let item = Calzone(Peppers, WholeWheat,)
+     item
+    ",
+    "<adt value>"
+  ),
   t("lam_destructure_1", "((_) => 5)('foo')", "5"),
   t("lam_destructure_2", "let foo = (_) => 5; foo('foo')", "5"),
   t("lam_destructure_3", "(((a, b, c)) => a + b + c)((1, 2, 3))", "6"),
@@ -1633,6 +1645,7 @@ let data_tests = [
     "Foo\nBar\nBaz(\"baz\")\nQux(5, \"qux\", false)\nQuux\nFlip(\"flip\")\nvoid",
   ),
   t("adtprint_nonexported", "data Foo = Foo; Foo", "<adt value>"),
+  t("adt_trailing", "data Topping = Cheese(Bool,) | Pepperoni; Pepperoni", "<adt value>")
 ];
 
 let export_tests = [

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -313,7 +313,7 @@ let function_tests = [
      let item = Calzone(Peppers, WholeWheat,)
      item
     ",
-    "<adt value>"
+    "<adt value>",
   ),
   t("lam_destructure_1", "((_) => 5)('foo')", "5"),
   t("lam_destructure_2", "let foo = (_) => 5; foo('foo')", "5"),
@@ -1645,7 +1645,11 @@ let data_tests = [
     "Foo\nBar\nBaz(\"baz\")\nQux(5, \"qux\", false)\nQuux\nFlip(\"flip\")\nvoid",
   ),
   t("adtprint_nonexported", "data Foo = Foo; Foo", "<adt value>"),
-  t("adt_trailing", "data Topping = Cheese(Bool,) | Pepperoni; Pepperoni", "<adt value>")
+  t(
+    "adt_trailing",
+    "data Topping = Cheese(Bool,) | Pepperoni; Pepperoni",
+    "<adt value>",
+  ),
 ];
 
 let export_tests = [


### PR DESCRIPTION
Addresses remainder of #182