### PR TITLE
Use proper unlimited memory instead of max_int

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3597,7 +3597,8 @@ let compile_wasm_module = (~env=?, ~name=?, prog) => {
     );
   };
   let _ = Module.set_features(wasm_mod, [Features.mvp, Features.multivalue]);
-  let _ = Memory.set_memory(wasm_mod, 0, max_int, "memory", [], false);
+  let _ =
+    Memory.set_memory(wasm_mod, 0, Memory.unlimited, "memory", [], false);
   let () = ignore @@ compile_functions(wasm_mod, env, prog);
   let () = ignore @@ compile_imports(wasm_mod, env, prog);
   let () = ignore @@ compile_exports(wasm_mod, env, prog);


### PR DESCRIPTION
In Binaryen.ml v0.3.0, we added the `Memory.unlimited` constant which is the value `-1` which seems to be the way Binaryen expects you to specify unlimited memory (hooray C code).

This switches our OCaml `max_int` to that constant.