### PR TITLE
Bump Grain version to 0.2.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grain/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A command line tool for the Grain language.",
   "main": "index.js",
   "engines": {

--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,6 +1,6 @@
 (lang dune 2.0)
 (name grain)
-(version 0.1.0)
+(version 0.2.0)
 
 ; Flip this to `true` when we want to generate opam files again
 (generate_opam_files false)

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -1,6 +1,6 @@
 {
   "name": "@grain/compiler",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "esy": {
     "build": [
       "dune build --no-buffer"

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grain/compiler",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "bin": {
     "grainc": "_esy/default/build/install/default/bin/grainc"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grain",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "The Grain monorepo.",
   "workspaces": [
     "cli",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grain/runtime",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "The JavaScript runtime for the Grain language.",
   "main": "src/index.js",
   "scripts": {

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grain/stdlib",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "The standard library for the Grain language.",
   "main": "pervasives.gr",
   "engines": {


### PR DESCRIPTION
I believe we are at a point where we should bump the language's version again. We've introduced a lot of features (`let mut`, number system) and breaking changes (`enum`, `record`, comment syntax).

Bumping the version will indicate to anyone coming back from a break that things have changed and their code might not compile.

@ospencer can you merge this and tag a release? I think we might want to editorialize some release notes with the highlights too.