### PR TITLE
Remove unnecessary wasm exports

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3328,14 +3328,8 @@ let compile_exports =
     export;
   };
 
-  let compile_lambda_export = (i, _) => {
-    let internal_name = "func_" ++ string_of_int(i + env.func_offset);
-    let external_name = "GRAIN$LAM_" ++ string_of_int(i);
-    Export.add_function_export(wasm_mod, internal_name, external_name);
-  };
   let main_idx = env.func_offset + List.length(functions);
   let cleanup_globals_idx = main_idx + 1;
-  ignore @@ List.mapi(compile_lambda_export, functions);
   let exports = {
     let exported = Hashtbl.create(14);
     /* Exports are already reversed, so keeping the first of any name is the correct behavior. */

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -88,8 +88,8 @@ module AExp = {
     anf_env: or_default_env(env),
     anf_analyses: ref([]),
   };
-  let let_ = (~loc=?, ~env=?, ~glob=Nonglobal, rec_flag, binds, body) =>
-    mk(~loc?, ~env?, AELet(glob, rec_flag, binds, body));
+  let let_ = (~loc=?, ~env=?, ~global=Nonglobal, rec_flag, binds, body) =>
+    mk(~loc?, ~env?, AELet(global, rec_flag, binds, body));
   let seq = (~loc=?, ~env=?, hd, tl) => mk(~loc?, ~env?, AESeq(hd, tl));
   let comp = (~loc=?, ~env=?, e) => mk(~loc?, ~env?, AEComp(e));
 };
@@ -102,10 +102,10 @@ module Imp = {
     imp_exported: e,
     imp_analyses: ref([]),
   };
-  let grain_value = (~glob=Nonglobal, a, md, name, s) =>
-    mk(a, GrainValue(md, name), s, glob);
-  let wasm_func = (~glob=Nonglobal, a, md, name, s) =>
-    mk(a, WasmFunction(md, name), s, glob);
-  let js_func = (~glob=Nonglobal, a, md, name, s) =>
-    mk(a, JSFunction(md, name), s, glob);
+  let grain_value = (~global=Nonglobal, a, md, name, s) =>
+    mk(a, GrainValue(md, name), s, global);
+  let wasm_func = (~global=Nonglobal, a, md, name, s) =>
+    mk(a, WasmFunction(md, name), s, global);
+  let js_func = (~global=Nonglobal, a, md, name, s) =>
+    mk(a, JSFunction(md, name), s, global);
 };

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -95,13 +95,17 @@ module AExp = {
 };
 
 module Imp = {
-  let mk = (use_id, d, s) => {
+  let mk = (use_id, d, s, e) => {
     imp_use_id: use_id,
     imp_desc: d,
     imp_shape: s,
+    imp_exported: e,
     imp_analyses: ref([]),
   };
-  let grain_value = (a, md, name, s) => mk(a, GrainValue(md, name), s);
-  let wasm_func = (a, md, name, s) => mk(a, WasmFunction(md, name), s);
-  let js_func = (a, md, name, s) => mk(a, JSFunction(md, name), s);
+  let grain_value = (~glob=Nonglobal, a, md, name, s) =>
+    mk(a, GrainValue(md, name), s, glob);
+  let wasm_func = (~glob=Nonglobal, a, md, name, s) =>
+    mk(a, WasmFunction(md, name), s, glob);
+  let js_func = (~glob=Nonglobal, a, md, name, s) =>
+    mk(a, JSFunction(md, name), s, glob);
 };

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -131,8 +131,11 @@ module AExp: {
 };
 
 module Imp: {
-  let mk: (ident, import_desc, import_shape) => import_spec;
-  let grain_value: (ident, string, string, import_shape) => import_spec;
-  let wasm_func: (ident, string, string, import_shape) => import_spec;
-  let js_func: (ident, string, string, import_shape) => import_spec;
+  let mk: (ident, import_desc, import_shape, global_flag) => import_spec;
+  let grain_value:
+    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
+  let wasm_func:
+    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
+  let js_func:
+    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
 };

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -133,9 +133,12 @@ module AExp: {
 module Imp: {
   let mk: (ident, import_desc, import_shape, global_flag) => import_spec;
   let grain_value:
-    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) =>
+    import_spec;
   let wasm_func:
-    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) =>
+    import_spec;
   let js_func:
-    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) =>
+    import_spec;
 };

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -118,7 +118,7 @@ module AExp: {
     (
       ~loc: loc=?,
       ~env: env=?,
-      ~glob: global_flag=?,
+      ~global: global_flag=?,
       rec_flag,
       list((ident, comp_expression)),
       anf_expression
@@ -133,9 +133,9 @@ module AExp: {
 module Imp: {
   let mk: (ident, import_desc, import_shape, global_flag) => import_spec;
   let grain_value:
-    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
   let wasm_func:
-    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
   let js_func:
-    (~glob: global_flag=?, ident, string, string, import_shape) => import_spec;
+    (~global: global_flag=?, ident, string, string, import_shape) => import_spec;
 };

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -169,6 +169,7 @@ type import_spec = {
   imp_use_id: Ident.t, /* <- internal references to the name will use this */
   imp_desc: import_desc,
   imp_shape: import_shape,
+  imp_exported: global_flag,
   imp_analyses: [@sexp.opaque] ref(list(analysis)),
 };
 

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -157,6 +157,7 @@ type import_spec = {
   imp_use_id: Ident.t, /* <- internal references to the name will use this */
   imp_desc: import_desc,
   imp_shape: import_shape,
+  imp_exported: global_flag,
   imp_analyses: ref(list(analysis)),
 };
 

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -81,7 +81,7 @@ let convert_binds = anf_binds => {
     | BSeq(exp) => AExp.comp(exp)
     | BLet(name, exp) => AExp.let_(Nonrecursive, [(name, exp)], void)
     | BLetRec(names) => AExp.let_(Recursive, names, void)
-    | BLetExport(rf, binds) => AExp.let_(~glob=Global, rf, binds, void)
+    | BLetExport(rf, binds) => AExp.let_(~global=Global, rf, binds, void)
     };
   List.fold_left(
     (body, bind) =>
@@ -89,7 +89,7 @@ let convert_binds = anf_binds => {
       | BSeq(exp) => AExp.seq(exp, body)
       | BLet(name, exp) => AExp.let_(Nonrecursive, [(name, exp)], body)
       | BLetRec(names) => AExp.let_(Recursive, names, body)
-      | BLetExport(rf, binds) => AExp.let_(~glob=Global, rf, binds, body)
+      | BLetExport(rf, binds) => AExp.let_(~global=Global, rf, binds, body)
       },
     ans,
     top_binds,
@@ -1018,7 +1018,7 @@ let rec transl_anf_statement =
   | TTopException(_, ext) => (Some(linearize_exception(env, ext)), [])
   | TTopForeign(exported, desc) =>
     let arity = Ctype.arity(desc.tvd_desc.ctyp_type);
-    let glob =
+    let global =
       switch (exported) {
       | Exported => Global
       | Nonexported => Nonglobal
@@ -1027,7 +1027,7 @@ let rec transl_anf_statement =
       None,
       [
         Imp.wasm_func(
-          ~glob,
+          ~global,
           desc.tvd_id,
           desc.tvd_mod.txt,
           desc.tvd_name.txt,

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -1016,12 +1016,18 @@ let rec transl_anf_statement =
       (None, []);
     };
   | TTopException(_, ext) => (Some(linearize_exception(env, ext)), [])
-  | TTopForeign(desc) =>
+  | TTopForeign(exported, desc) =>
     let arity = Ctype.arity(desc.tvd_desc.ctyp_type);
+    let glob =
+      switch (exported) {
+      | Exported => Global
+      | Nonexported => Nonglobal
+      };
     (
       None,
       [
         Imp.wasm_func(
+          ~glob,
           desc.tvd_id,
           desc.tvd_mod.txt,
           desc.tvd_name.txt,

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -300,7 +300,7 @@ type value_description = {
 
 [@deriving sexp]
 type toplevel_stmt_desc =
-  | TTopForeign(value_description)
+  | TTopForeign(export_flag, value_description)
   | TTopImport(import_declaration)
   | TTopExport(list(export_declaration))
   | TTopData(list(data_declaration))

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -269,7 +269,7 @@ type value_description = {
 };
 
 type toplevel_stmt_desc =
-  | TTopForeign(value_description)
+  | TTopForeign(export_flag, value_description)
   | TTopImport(import_declaration)
   | TTopExport(list(export_declaration))
   | TTopData(list(data_declaration))

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -400,7 +400,7 @@ let type_module = (~toplevel=false, funct_body, anchor, env, sstr /*scope*/) => 
       | Nonexported => None
       };
     let foreign = {
-      ttop_desc: TTopForeign(desc),
+      ttop_desc: TTopForeign(e, desc),
       ttop_loc: loc,
       ttop_env: env,
     };


### PR DESCRIPTION
We were exporting everything that was global in a module rather than just things that are explicitly exported. This wasn't a huge deal, since the compiler won't let you import them, but this is the first step to some wasm cleanup.