### PR TITLE
Add support for loading Grain modules directly from an ArrayBuffer

### DIFF
--- a/runtime/src/core/grain-module.js
+++ b/runtime/src/core/grain-module.js
@@ -233,3 +233,8 @@ export async function readURL(url) {
   let module = await WebAssembly.compileStreaming(response);
   return new GrainModule(module, modname);
 }
+
+export async function readBuffer(buffer, modname) {
+  let module = await WebAssembly.compile(buffer);
+  return new GrainModule(module, modname);
+}

--- a/runtime/src/core/runner.js
+++ b/runtime/src/core/runner.js
@@ -1,5 +1,5 @@
 import { GrainError } from '../errors/errors';
-import { wasi, readFile, readURL } from './grain-module';
+import { wasi, readFile, readURL, readBuffer } from './grain-module';
 import { makePrint } from '../lib/print';
 import { makeToString } from '../lib/to-string';
 import { grainToString } from '../utils/utils';
@@ -129,6 +129,21 @@ export class GrainRunner {
 
   async runURLUnboxed(path) {
     let module = await this.loadURL(path);
+    return module.runUnboxed();
+  }
+
+  async loadBuffer(buffer) {
+    let module = await readBuffer(buffer);
+    return this.load(module.name, module);
+  }
+
+  async runBuffer(buffer) {
+    let module = await this.loadBuffer(buffer);
+    return module.start();
+  }
+
+  async runBufferUnboxed(buffer) {
+    let module = await this.loadBuffer(buffer);
     return module.runUnboxed();
   }
 }


### PR DESCRIPTION
This allows Grain's browser runtime to be executed with an `ArrayBuffer`
of compiled Web Assembly code, which is extremely useful for bundling Grain apps (e.g. Webpack) rather than depending
on the WASM being hosted somewhere for `readURL`.