### PR TITLE
Remove some unused cmdliner stuff in grainc

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -146,16 +146,6 @@ let output_filename = {
   );
 };
 
-let help_flag = {
-  let doc = "Show this help message";
-  Arg.(value & flag & info(["h"], ~doc));
-};
-
-let help_cmd = (
-  Term.(ret(const(_ => `Help((`Pager, None))) $ help_flag)),
-  Term.info("help"),
-);
-
 let cmd = {
   let doc = sprintf("Compile Grain programs");
   let version =


### PR DESCRIPTION
While working on the base structure for `graindoc`, I noticed some cmdliner config in grainc that isn't used. This removes it.