### PR TITLE
Switch the setup command to prepare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Set up runtime and CLI
         run: |
           yarn
-          yarn setup
 
       - name: Esy setup
         run: |
-          yarn compiler setup
+          yarn compiler prepare
 
       - name: Esy cache
         id: esy-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY ./yarn.lock /grain/
 
 WORKDIR /grain
 RUN yarn install --pure-lockfile
-RUN yarn compiler setup
+RUN yarn compiler prepare
 # Slow!
 RUN yarn compiler build-dependencies
 
@@ -26,7 +26,7 @@ RUN yarn compiler build-dependencies
 # (probably won't be cached from this point on)
 
 COPY . /grain
-RUN yarn setup
+RUN yarn prepare
 RUN yarn compiler build
 
 # Set up container environment

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ To build Grain, you'll need [Node.js](https://nodejs.org/en/download/current/) v
 
 ```bash
 yarn
-yarn setup
 yarn compiler build
 ```
 

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "link": "yarn link",
     "clean": "esy clean",
-    "setup": "esy install",
+    "prepare": "esy install",
     "build": "esy",
     "postbuild": "esy copy-compiler",
     "test": "esy test",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "node": ">=14"
   },
   "scripts": {
-    "vscode": "node .vscode/setup-ocaml-lsp.js && yarn compiler setup",
-    "setup": "yarn runtime build && yarn stdlib build && yarn cli link",
+    "vscode": "node .vscode/setup-ocaml-lsp.js && yarn compiler prepare",
+    "prepare": "yarn runtime build && yarn stdlib build && yarn cli link",
     "test": "yarn compiler test",
     "cli": "yarn workspace @grain/cli run",
     "runtime": "yarn workspace @grain/runtime run",


### PR DESCRIPTION
Yarn supports the [`prepare` script](https://classic.yarnpkg.com/en/docs/package-json#toc-scripts), which is a lifecycle script that is run after `yarn` or `yarn install` is run.

By renaming our `setup` to `prepare`, it will reduce the initial setup to 2 commands, instead of 3.