### PR TITLE
fix: ensure Dockerfile works with `yarn prepare` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,28 +5,11 @@ LABEL description="Grain CLI and Runtime"
 LABEL vcs-url="https://github.com/grain-lang/grain"
 LABEL maintainer="philip@grain-lang.org"
 
-# We want to cache the heavy stuff, so we first just copy in the dependencies
-# and install them with yarn/esy:
-COPY ./package.json /grain/
-COPY ./compiler/package.json /grain/compiler/
-COPY ./runtime/package.json /grain/runtime/
-COPY ./cli/package.json /grain/cli/
-COPY ./stdlib/package.json /grain/stdlib/
-COPY ./compiler/esy.json /grain/compiler
-COPY ./compiler/esy.lock /grain/compiler
-COPY ./yarn.lock /grain/
+COPY . /grain
 
 WORKDIR /grain
-RUN yarn install --pure-lockfile
-RUN yarn compiler prepare
-# Slow!
-RUN yarn compiler build-dependencies
 
-# Now that we've done the heavy lifting, we can pull in the rest of the files
-# (probably won't be cached from this point on)
-
-COPY . /grain
-RUN yarn prepare
+RUN yarn --pure-lockfile
 RUN yarn compiler build
 
 # Set up container environment


### PR DESCRIPTION
When switching our setup command to `yarn prepare`, I broke the docker container creation. This was due to the caching strategy we were trying to employ, which didn't allow for the stdlib or runtime scripts to be executed immediately after `yarn install` (which is when `yarn prepare` is guaranteed to run).

Since this container is mostly consumed from container registries, I've just reduced the dockerfile to have no caching. We should consider a better strategy for our lifecycle scripts going forward, but I think that will require some changes to the compiler itself.