### PR TITLE
docs: add message about not building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ There are tons of ways to contribute to Grain. Check out our [contributing guide
 
 ## Building
 
+Grain currently only works on Mac and Linux. We are hard at work trying to integrate Binaryen and OCaml on Windows, but this is uncharted territory! Please let us know if you have this low-level expertise. :bow:
+
 To build Grain, you'll need [Node.js](https://nodejs.org/en/download/current/) v14 and [Yarn](https://yarnpkg.com/getting-started/install). To get everything set up, run:
 
 ```bash


### PR DESCRIPTION
We've fielded some of these questions in discord, but we should have a proper note in the readme.