### PR TITLE
feat: add update method to map stdlib

### DIFF
--- a/compiler/test/stdlib/map.test.gr
+++ b/compiler/test/stdlib/map.test.gr
@@ -345,3 +345,28 @@ let rejectTestMap = makeFilterTestMap();
 Map.reject((key, value) => false, rejectTestMap);
 
 assert Map.size(rejectTestMap) == 3;
+
+// Map.update()
+
+let toUpdate = Map.fromList([("a", 1), ("b", 2), ("c", 3)]);
+
+Map.update("b", (old) => {
+  assert old == Some(2)
+  Some(4)
+}, toUpdate);
+
+assert Map.get("b", toUpdate) == Some(4);
+
+Map.update("d", (old) => {
+  assert old == None
+  Some(10)
+}, toUpdate);
+
+assert Map.get("d", toUpdate) == Some(10);
+
+Map.update("c", (old) => {
+  assert old == Some(3)
+  None
+}, toUpdate);
+
+assert Map.contains("c", toUpdate) == false;

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -195,6 +195,14 @@ export let remove = (key, map) => {
   }
 }
 
+export let update = (key, fn, map) => {
+  let val = get(key, map);
+  match (fn(val)) {
+    Some(next) => set(key, next, map),
+    None => remove(key, map)
+  }
+}
+
 export let size = (map) => {
   map.size
 }
@@ -280,7 +288,7 @@ export let fromArray = (array) => {
 }
 
 export let filter = (predicate, map) => {
-  let keysToRemove = reduce((list, key, value) => 
+  let keysToRemove = reduce((list, key, value) =>
     if (!predicate(key, value)) {
       [key, ...list]
     } else {


### PR DESCRIPTION
Closes #192 

This implements the `Map.update` method that sets, updates, or removes the value at a given key in a Map data structure. The updater function receives an `Option` of the existing (or not) value and must return an `Option` indicating whether to set or remove the value.