### PR TITLE
chore: add ocamllex highlight to our dyp file in our workspace

### DIFF
--- a/.vscode/setup-ocaml-lsp.js
+++ b/.vscode/setup-ocaml-lsp.js
@@ -9,6 +9,9 @@ const output = `{
   "ocaml.sandbox": {
     "root": "${compilerPath}",
     "kind": "esy"
+  },
+  "files.associations": {
+    "*.dyp": "ocaml.ocamllex"
   }
 }`;
 


### PR DESCRIPTION
This updates our "setup vscode" script to assign the `.dyp` extension to ocamllex syntax highlighting within our workspace. I got sick of manually setting this each time I needed to work on the file, lol.