### PR TITLE
Add source code formatting support

### DIFF
--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -30,6 +30,7 @@
     (grain_typed (>= 0))
     (grain_middle_end (>= 0))
     (grain_diagnostics (>= 0))
+    (grain_format (>= 0))
     (grain_codegen (>= 0))))
 
 (package
@@ -127,3 +128,11 @@
   (yojson (>= 1.7.0))
   (grain_utils (>= 0))
   (grain_parsing (>= 0))))
+
+(package
+  (name grain_format)
+  (synopsis "The Grain formatter")
+  (depends
+    (reason (>= 3.6.0))
+    (grain_utils (>= 0))
+    (grain_parsing (>= 0))))

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -38,7 +38,7 @@
     "ocaml": "4.11.0"
   },
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "1.1.0",
+    "@opam/ocaml-lsp-server": "1.3.0",
     "@opam/ounit": ">= 2.0.0"
   },
   "resolutions": {

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c8b520dea4c617e46751e37275545792",
+  "checksum": "dfc5fc5b52b51b63c7fddd2eebf0ba4a",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -1049,20 +1049,20 @@
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
-    "@opam/ocaml-lsp-server@opam:1.1.0@1478aa3c": {
-      "id": "@opam/ocaml-lsp-server@opam:1.1.0@1478aa3c",
+    "@opam/ocaml-lsp-server@opam:1.3.0@aba8691f": {
+      "id": "@opam/ocaml-lsp-server@opam:1.3.0@aba8691f",
       "name": "@opam/ocaml-lsp-server",
-      "version": "opam:1.1.0",
+      "version": "opam:1.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/fa/fa0ca1d3c5c3377f798c221381228a65e8f49fece42715d279ebe91f2f4f74c8#sha256:fa0ca1d3c5c3377f798c221381228a65e8f49fece42715d279ebe91f2f4f74c8",
-          "archive:https://github.com/ocaml/ocaml-lsp/releases/download/1.1.0/ocaml-lsp-server-1.1.0.tbz#sha256:fa0ca1d3c5c3377f798c221381228a65e8f49fece42715d279ebe91f2f4f74c8"
+          "archive:https://opam.ocaml.org/cache/sha256/59/598e27258e4749b6e2511e2c5efe00d16f0965806296e808d202cd614d655fba#sha256:598e27258e4749b6e2511e2c5efe00d16f0965806296e808d202cd614d655fba",
+          "archive:https://github.com/ocaml/ocaml-lsp/releases/download/1.3.0/jsonrpc-1.3.0.tbz#sha256:598e27258e4749b6e2511e2c5efe00d16f0965806296e808d202cd614d655fba"
         ],
         "opam": {
           "name": "ocaml-lsp-server",
-          "version": "1.1.0",
-          "path": "esy.lock/opam/ocaml-lsp-server.1.1.0"
+          "version": "1.3.0",
+          "path": "esy.lock/opam/ocaml-lsp-server.1.3.0"
         }
       },
       "overrides": [],
@@ -1072,10 +1072,10 @@
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/dune-build-info@opam:2.7.1@da03d61d",
-        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/csexp@opam:1.3.2@5cea14af",
-        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.7.1@f5f493bc",
+        "@opam/dot-merlin-reader@opam:3.4.2@55baebb0",
+        "@opam/csexp@opam:1.3.2@5cea14af", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
@@ -1083,9 +1083,10 @@
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/dune-build-info@opam:2.7.1@da03d61d",
-        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/csexp@opam:1.3.2@5cea14af"
+        "@opam/dune@opam:2.7.1@f5f493bc",
+        "@opam/dot-merlin-reader@opam:3.4.2@55baebb0",
+        "@opam/csexp@opam:1.3.2@5cea14af"
       ]
     },
     "@opam/ocaml-compiler-libs@opam:v0.12.3@f0f069bd": {
@@ -1596,6 +1597,37 @@
         "@opam/base-threads@opam:base@36803084"
       ]
     },
+    "@opam/dot-merlin-reader@opam:3.4.2@55baebb0": {
+      "id": "@opam/dot-merlin-reader@opam:3.4.2@55baebb0",
+      "name": "@opam/dot-merlin-reader",
+      "version": "opam:3.4.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/e1/e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81#sha256:e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81",
+          "archive:https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz#sha256:e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81"
+        ],
+        "opam": {
+          "name": "dot-merlin-reader",
+          "version": "3.4.2",
+          "path": "esy.lock/opam/dot-merlin-reader.3.4.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/csexp@opam:1.3.2@5cea14af",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/result@opam:1.5@6b753c82",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/csexp@opam:1.3.2@5cea14af"
+      ]
+    },
     "@opam/csexp@opam:1.3.2@5cea14af": {
       "id": "@opam/csexp@opam:1.3.2@5cea14af",
       "name": "@opam/csexp",
@@ -1831,7 +1863,7 @@
       ],
       "devDependencies": [
         "@opam/ounit@opam:2.2.3@840861c4",
-        "@opam/ocaml-lsp-server@opam:1.1.0@1478aa3c"
+        "@opam/ocaml-lsp-server@opam:1.3.0@aba8691f"
       ],
       "installConfig": { "pnp": false }
     },

--- a/compiler/esy.lock/opam/dot-merlin-reader.3.4.2/opam
+++ b/compiler/esy.lock/opam/dot-merlin-reader.3.4.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+]
+x-commit-hash: "c9761a552380838e9f530b5c47c0ea3c47c33565"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz"
+  checksum: [
+    "sha256=e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81"
+    "sha512=7c39c70fc923971c4eca9432061077941498574c0b804efc20af244c1c9ab34c9178d7eb50ab750feaac30696e7ff911a0ccd5fb86341b68485bedae472aa15f"
+  ]
+}

--- a/compiler/esy.lock/opam/ocaml-lsp-server.1.3.0/opam
+++ b/compiler/esy.lock/opam/ocaml-lsp-server.1.3.0/opam
@@ -15,22 +15,21 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
+  "dune" {>= "2.5"}
   "yojson"
   "stdlib-shims"
-  "menhir"
   "ppx_yojson_conv_lib"
   "dune-build-info"
+  "dot-merlin-reader"
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}
   "ocamlformat" {with-test}
-  "reason" {with-test}
   "ocamlfind" {>= "1.5.2"}
   "ocaml" {>= "4.06" & < "4.12"}
-  "dune" {>= "2.5.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -40,12 +39,12 @@ build: [
     "--release"
   ]
 ]
-x-commit-hash: "fee074471b2c345f7e42c6ed3482363279d4f32c"
+x-commit-hash: "47d01696d197f0980b6a43d92549a917357b835f"
 url {
   src:
-    "https://github.com/ocaml/ocaml-lsp/releases/download/1.1.0/ocaml-lsp-server-1.1.0.tbz"
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.3.0/jsonrpc-1.3.0.tbz"
   checksum: [
-    "sha256=fa0ca1d3c5c3377f798c221381228a65e8f49fece42715d279ebe91f2f4f74c8"
-    "sha512=c00ad47478a4ddfebe3798895700d2bececa29a610c7757619f47a5b90ede921afa56efc776df3a1c4a8b2f082898423a5806d00c041dae137da1b57ee487a9b"
+    "sha256=598e27258e4749b6e2511e2c5efe00d16f0965806296e808d202cd614d655fba"
+    "sha512=febe80f8a88fac7683cafbd045dceee4869beda1f250b78a1d94d3ad19e746388d24869e805abcb2f33f93687508d65db19a38424c1059670915c050b4f6dbb9"
   ]
 }

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -3,7 +3,7 @@
  (public_name grain)
  ;; Note: 'dyp' is provided by the 'dypgen' OPAM package
  (libraries cmdliner compiler-libs.common grain_codegen grain_middle_end
-   grain_parsing grain_typed grain_utils grain_diagnostics oUnit
+   grain_parsing grain_typed grain_utils grain_diagnostics grain_format oUnit
    ppx_sexp_conv.runtime-lib sexplib)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/compiler/src/format/document.re
+++ b/compiler/src/format/document.re
@@ -1,3 +1,7 @@
+type break_mode =
+  | Break
+  | Flat;
+
 type line_style =
   | Medium
   | Soft
@@ -52,3 +56,68 @@ let join = (~sep, docs) =>
   |> List.rev
   |> List.tl
   |> concat;
+
+let to_string = (~width, ~indent, doc) => {
+  let buffer = Buffer.create(1000);
+  let rec process = (~pos, lineSuffices, stack) =>
+    switch (stack) {
+    | [(ind, mode, doc) as cmd, ...rest] =>
+      switch (doc) {
+      | Nil
+      | BreakParent => process(~pos, lineSuffices, rest)
+      | Text(s) =>
+        Buffer.add_string(buffer, s);
+        process(~pos=String.length(s) + pos, lineSuffices, rest);
+      | Concat(ds) =>
+        let ops = List.map(d => (ind, mode, d), ds);
+        process(~pos, lineSuffices, List.append(ops, rest));
+      | Group(b, d) =>
+        if (b) {
+          process(~pos, lineSuffices, [(ind, Break, d), ...rest]);
+        } else {
+          process(~pos, lineSuffices, [(ind, Flat, d), ...rest]);
+        }
+      | IfBreak(y, n) =>
+        if (mode == Break) {
+          process(~pos, lineSuffices, [(ind, mode, y), ...rest]);
+        } else {
+          process(~pos, lineSuffices, [(ind, mode, n), ...rest]);
+        }
+      | LineBreak(ls) =>
+        if (mode == Break) {
+          switch (lineSuffices) {
+          | [] =>
+            Buffer.add_char(buffer, '\n'); // TODO
+            Buffer.add_string(buffer, String.make(ind, ' '));
+            process(~pos=ind, [], rest);
+          | _ =>
+            process(
+              ~pos=ind,
+              [],
+              List.append(List.rev(lineSuffices), [cmd, ...rest]),
+            )
+          };
+        } else {
+          let pos =
+            switch (ls) {
+            | Medium =>
+              Buffer.add_string(buffer, " ");
+              pos + 1;
+            | Soft => pos
+            | Hard =>
+              Buffer.add_char(buffer, '\n'); // TODO
+              0;
+            };
+          process(~pos, lineSuffices, rest);
+        }
+      | LineSuffix(d) =>
+        process(~pos, [(ind, mode, d), ...lineSuffices], rest)
+      | CustomLayout(_) => () // TODO
+      | Indent(d) =>
+        process(~pos, lineSuffices, [(ind + indent, mode, d), ...rest])
+      }
+    | [] => ()
+    };
+  process(~pos=0, [], [(0, Flat, doc)]);
+  Buffer.contents(buffer);
+};

--- a/compiler/src/format/document.re
+++ b/compiler/src/format/document.re
@@ -1,0 +1,54 @@
+type line_style =
+  | Medium
+  | Soft
+  | Hard;
+
+type t =
+  | Nil
+  | Text(string)
+  | Concat(list(t))
+  | Group(bool, t)
+  | IfBreak(t, t)
+  | BreakParent
+  | LineBreak(line_style)
+  | LineSuffix(t)
+  | CustomLayout(list(t))
+  | Indent(t);
+
+let nil = Nil;
+let text = s => Text(s);
+let concat = t => Concat(t);
+let group = t => Group(false, t);
+let break_group = (~should_break, t) => Group(should_break, t);
+let if_break = (y, n) => IfBreak(y, n);
+let break_parent = BreakParent;
+let line = LineBreak(Medium);
+let softline = LineBreak(Soft);
+let hardline = LineBreak(Hard);
+let line_suffix = t => LineSuffix(t);
+let custom_layout = t => CustomLayout(t);
+let indent = t => Indent(t);
+
+let space = Text(" ");
+let comma = Text(",");
+let dot = Text(".");
+let elipsis = Text("...");
+let less_than = Text("<");
+let greater_than = Text(">");
+let lbrace = Text("{");
+let rbrace = Text("}");
+let lparen = Text("(");
+let rparen = Text(")");
+let lbracket = Text("[");
+let rbracket = Text("]");
+let colon = Text(":");
+let equal = Text("=");
+let trailing_comma = IfBreak(comma, nil);
+let single_quote = Text("'");
+let double_quote = Text("\"");
+
+let join = (~sep, docs) =>
+  List.fold_left((acc, curr) => [curr, sep, ...acc], [], docs)
+  |> List.rev
+  |> List.tl
+  |> concat;

--- a/compiler/src/format/document.rei
+++ b/compiler/src/format/document.rei
@@ -33,3 +33,5 @@ let single_quote: t;
 let double_quote: t;
 
 let join: (~sep: t, list(t)) => t;
+
+let to_string: (~width: int, ~indent: int, t) => string;

--- a/compiler/src/format/document.rei
+++ b/compiler/src/format/document.rei
@@ -1,0 +1,35 @@
+type t;
+
+let nil: t;
+let text: string => t;
+let concat: list(t) => t;
+let group: t => t;
+let break_group: (~should_break: bool, t) => t;
+let if_break: (t, t) => t;
+let break_parent: t;
+let line: t;
+let softline: t;
+let hardline: t;
+let line_suffix: t => t;
+let custom_layout: list(t) => t;
+let indent: t => t;
+
+let space: t;
+let comma: t;
+let dot: t;
+let elipsis: t;
+let less_than: t;
+let greater_than: t;
+let lbrace: t;
+let rbrace: t;
+let lparen: t;
+let rparen: t;
+let lbracket: t;
+let rbracket: t;
+let colon: t;
+let equal: t;
+let trailing_comma: t;
+let single_quote: t;
+let double_quote: t;
+
+let join: (~sep: t, list(t)) => t;

--- a/compiler/src/format/dune
+++ b/compiler/src/format/dune
@@ -1,0 +1,5 @@
+(library
+ (name grain_format)
+ (public_name grain_format)
+ (synopsis "Source code formatter for Grain")
+ (libraries grain_parsing grain_utils))


### PR DESCRIPTION
WARNING: WIP & not usable yet.

This is my first iteration for `grainc format` command.
Based on and heavily inspired by [Phil Wadler's paper](http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf), Prettier, and ReasonML/ReScript's refmt.