### PR TITLE
fix!: remove ^ as unbox operator (fixes #183)

### DIFF
--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -193,6 +193,7 @@ rule token = parse
   | "]" { RBRACK }
   | "<" { LCARET }
   | ">" { RCARET }
+  | "^" { CARET }
   | "++" { PLUSPLUS }
   | "+" { PLUS }
   | "-" { DASH }

--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -193,7 +193,6 @@ rule token = parse
   | "]" { RBRACK }
   | "<" { LCARET }
   | ">" { RCARET }
-  | "^" { CARET }
   | "++" { PLUSPLUS }
   | "+" { PLUS }
   | "-" { DASH }

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -243,7 +243,6 @@ data_declaration :
 
 prim1_expr :
   | NOT non_assign_expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["!"]) [$2] }
-  | CARET non_assign_expr { Exp.apply ~loc:(symbol_rloc dyp) (mkid_expr dyp ["^"]) [$2] }
 
 paren_expr :
   | lparen expr rparen { $2 }
@@ -329,7 +328,6 @@ infix :
 
 prefix :
   | lparen NOT rparen { "!" }
-  | lparen CARET rparen { "^" }
 
 id :
   | [TYPEID dot {$1}]* [ID | TYPEID | infix | prefix] { prerr_string "\nid\n"; when_debug ~n:1 (fun () -> dyp.print_state stderr); (mkid (List.append $1 [$2])) (symbol_rloc dyp) }

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -743,7 +743,6 @@ let box_tests = [
     "let b = box(box(4));\n            {\n              unbox(unbox(b))\n            }",
     "4",
   ),
-  t("box3_2", "let b = box(box(4)); ^^b", "4"),
   t(
     "box4",
     "let b = box(4);\n            {\n              b := 3;\n              unbox(b)\n            }",
@@ -764,20 +763,27 @@ let box_tests = [
   ),
   /* Operations on Box<Number> */
   t("box_addition1", "let b = box(4); b := unbox(b) + 19", "23"),
-  t("box_addition2", "let b = box(4); b := unbox(b) + 19; ^b", "23"),
+  t("box_addition2", "let b = box(4); b := unbox(b) + 19; unbox(b)", "23"),
   t("box_subtraction1", "let b = box(4); b := unbox(b) - 19", "-15"),
-  t("box_subtraction2", "let b = box(4); b := unbox(b) - 19; ^b", "-15"),
+  t(
+    "box_subtraction2",
+    "let b = box(4); b := unbox(b) - 19; unbox(b)",
+    "-15",
+  ),
   t("box_multiplication1", "let b = box(4); b := unbox(b) * 19", "76"),
-  t("box_multiplication2", "let b = box(4); b := unbox(b) * 19; ^b", "76"),
+  t(
+    "box_multiplication2",
+    "let b = box(4); b := unbox(b) * 19; unbox(b)",
+    "76",
+  ),
   t("box_division1", "let b = box(76); b := unbox(b) / 19", "4"),
-  t("box_division2", "let b = box(76); b := unbox(b) / 19; ^b", "4"),
+  t("box_division2", "let b = box(76); b := unbox(b) / 19; unbox(b)", "4"),
 ];
 
 let let_mut_tests = [
   t("let-mut1", "let mut b = 4;b", "4"),
   t("let-mut2", "let mut b = (4, (5, 6));b", "(4, (5, 6))"),
   t("let-mut3", "let mut b = box(4);unbox(b)", "4"),
-  t("let-mut3_2", "let mut b = box(4); ^b", "4"),
   t("let-mut4", "let mut b = 4;b = 3;b", "3"),
   t("let-mut5", "let mut b = 4;b = b - 1;b", "3"),
   tfile("counter-mut", "counter-mut", "1\n2\n3\nvoid"),

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -44,7 +44,6 @@ import foreign wasm concat : (String, String) -> String as (++) from 'stdlib-ext
 // Box operations
 primitive box : a -> Box<a> = "@box"
 primitive unbox : Box<a> -> a = "@unbox"
-primitive (^) : Box<a> -> a = "@unbox"
 
 // Other operations
 primitive ignore : a -> Void = "@ignore"


### PR DESCRIPTION
We've had a few scenarios where the `^` being used for unboxing has caused problems, specifically around ambiguity (see #183 & #425) in the parsetree.

In this PR, I remove the `^` operator as the unbox operator but left the token in the lexer/parser for use as a bitwise operator in #425. I also removed the operator from Pervasives and cleaned up the tests.