### PR TITLE
fix: replace shebang trick with flagged-respawn to support Windows

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -1,5 +1,4 @@
-#!/bin/sh
-// 2>/dev/null; exec /usr/bin/env node --experimental-wasm-bigint "$0" "$@"
+#!/usr/bin/env node --experimental-wasm-bigint
 // https://github.com/grain-lang/grain/issues/114
 
 const { execSync } = require('child_process');

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -1,70 +1,91 @@
-#!/usr/bin/env node --experimental-wasm-bigint
-// https://github.com/grain-lang/grain/issues/114
+#!/usr/bin/env node
 
-const { execSync } = require('child_process');
-const path = require('path');
+const v8flags = require('v8flags');
+const flaggedRespawn = require('flagged-respawn');
 
-let program = require('commander');
-let compile = require('./compile.js');
-let run = require('./run.js');
-let lsp = require('./lsp.js');
+v8flags(onFlags);
 
-let pervasivesPath = require.resolve('@grain/stdlib');
-let stdlibPath = path.dirname(pervasivesPath);
+function onFlags(err, flags) {
+  if (err) {
+    console.error('Encountered error when retrieving v8 flags: ', err);
+    process.exit(1);
+  }
 
-function list(val) {
-  return val.split(',');
+  // https://github.com/grain-lang/grain/issues/114
+  flaggedRespawn(flags, process.argv, ['--experimental-wasm-bigint'], onRespawn);
 }
 
-function num(val) {
-  return Number.parseInt(val, 10);
+function onRespawn(ready, proc, argv) {
+  if (!ready) {
+    // Respawning
+    return;
+  }
+
+  const { execSync } = require('child_process');
+  const path = require('path');
+
+  let program = require('commander');
+  let compile = require('./compile.js');
+  let run = require('./run.js');
+  let lsp = require('./lsp.js');
+
+  let pervasivesPath = require.resolve('@grain/stdlib');
+  let stdlibPath = path.dirname(pervasivesPath);
+
+  function list(val) {
+    return val.split(',');
+  }
+
+  function num(val) {
+    return Number.parseInt(val, 10);
+  }
+
+  function graincVersion() {
+    const grainc = path.join(__dirname, 'grainc.exe');
+
+    return execSync(`${grainc} --version`).toString().trim();
+  }
+
+  program
+    .option('-v, --version', 'output CLI and compiler versions')
+    .on('option:version', () => {
+      console.log(`Grain cli ${require('../package.json').version}`)
+      console.log(`Grain compiler ${graincVersion()}`)
+      process.exit(0)
+    })
+    .description('Compile and run Grain programs. 🌾')
+    .option('-p, --print-output', 'print the output of the program')
+    .option('-g, --graceful', 'return a 0 exit code if the program errors')
+    .option('-I, --include-dirs <dirs>', 'include directories the runtime should find wasm modules', list, [])
+    .option('-f, --cflags <cflags>', 'pass flags to the Grain compiler')
+    .option('-S, --stdlib <path>', 'override the standard libary with your own', stdlibPath)
+    .option('--limitMemory <size>', 'maximum allowed heap size', num, -1)
+    // The root command that compiles & runs
+    .arguments('<file>')
+    .action(function (file) {
+      run(compile(file, program), program);
+    })
+
+  program
+    .command('compile <file>')
+    .description('compile a grain program into wasm')
+    .action(function (file) {
+      compile(file, program);
+    });
+
+  program
+    .command('lsp <file>')
+    .description('check a grain file for LSP')
+    .action(function (file) {
+      lsp(file, program);
+    });
+
+  program
+    .command('run <file>')
+    .description('run a wasm file with the grain runtime')
+    .action(function (wasmFile) {
+      run(wasmFile, program);
+    });
+
+  program.parse(argv);
 }
-
-function graincVersion() {
-  const grainc = path.join(__dirname, 'grainc.exe');
-
-  return execSync(`${grainc} --version`).toString().trim();
-}
-
-program
-  .option('-v, --version', 'output CLI and compiler versions')
-  .on('option:version', () => {
-    console.log(`Grain cli ${require('../package.json').version}`)
-    console.log(`Grain compiler ${graincVersion()}`)
-    process.exit(0)
-  })
-  .description('Compile and run Grain programs. 🌾')
-  .option('-p, --print-output', 'print the output of the program')
-  .option('-g, --graceful', 'return a 0 exit code if the program errors')
-  .option('-I, --include-dirs <dirs>', 'include directories the runtime should find wasm modules', list, [])
-  .option('-f, --cflags <cflags>', 'pass flags to the Grain compiler')
-  .option('-S, --stdlib <path>', 'override the standard libary with your own', stdlibPath)
-  .option('--limitMemory <size>', 'maximum allowed heap size', num, -1)
-  // The root command that compiles & runs
-  .arguments('<file>')
-  .action(function (file) {
-    run(compile(file, program), program);
-  })
-
-program
-  .command('compile <file>')
-  .description('compile a grain program into wasm')
-  .action(function (file) {
-    compile(file, program);
-  });
-
-program
-  .command('lsp <file>')
-  .description('check a grain file for LSP')
-  .action(function (file) {
-    lsp(file, program);
-  });
-
-program
-  .command('run <file>')
-  .description('run a wasm file with the grain runtime')
-  .action(function (wasmFile) {
-    run(wasmFile, program);
-  });
-
-program.parse(process.argv);

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@grain/runtime": "*",
     "@grain/stdlib": "*",
-    "commander": "^5.1.0"
+    "commander": "^5.1.0",
+    "flagged-respawn": "^1.0.1",
+    "v8flags": "^3.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,11 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flagged-respawn@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
+  integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -3560,6 +3565,13 @@ v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+
+v8flags@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
+  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
+  dependencies:
+    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
The hashbang as it is currently written doesn't work on Windows, because npm creates wrappers that are informed by the hashhang. When it sees `/usr/bin/env node`, it just replaces the call with something like `%PATH%\node.exe` but if you try to specify `/bin/sh` it tries to do `%PATH%\sh.exe` which crashes.

@ospencer I know you put this in place, so do you believe this simplification will work?