### PR TITLE
fix: use direct node call instead of executable file

### DIFF
--- a/stdlib/build.mjs
+++ b/stdlib/build.mjs
@@ -1,6 +1,3 @@
-#!/bin/sh
-// 2>/dev/null; exec /usr/bin/env node --harmony-top-level-await "$0"
-
 import { promisify } from 'util';
 import { createRequire } from 'module';
 

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "build": "./build.mjs",
+    "build": "node --harmony-top-level-await ./build.mjs",
     "clean": "del-cli '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/**'"
   }
 }


### PR DESCRIPTION
Windows doesn't know what to do with an executable `.mjs` file, so I just switched the build script to be exec'd with node directly.