### PR TITLE
fix: normalize filesystem paths to always be / character

### DIFF
--- a/compiler/src/utils/dune
+++ b/compiler/src/utils/dune
@@ -3,7 +3,7 @@
  (public_name grain_utils)
  (synopsis "Utilities for the Grain compiler")
  (libraries fp fs.lib cmdliner compiler-libs.common ppx_sexp_conv.runtime-lib
-   sexplib)
+   sexplib str)
  (inline_tests)
  (preprocess
   (pps ppx_sexp_conv ppx_expect)))


### PR DESCRIPTION
Until https://github.com/facebookexperimental/reason-native/pull/251 lands, we need to convert any `\` in a Windows path to `/` to use with reason-native's Fp library.