### PR TITLE
fix: temporarily disable inline tests for Windows

### DIFF
--- a/compiler/src/utils/dune
+++ b/compiler/src/utils/dune
@@ -4,6 +4,7 @@
  (synopsis "Utilities for the Grain compiler")
  (libraries fp fs.lib cmdliner compiler-libs.common ppx_sexp_conv.runtime-lib
    sexplib)
- (inline_tests)
+ ;Temporarily disabled due to https://github.com/janestreet/ppx_inline_test/issues/23
+ ;(inline_tests)
  (preprocess
   (pps ppx_sexp_conv ppx_expect)))


### PR DESCRIPTION
Inline tests are currently broken on Windows until https://github.com/janestreet/ppx_inline_test/issues/23 is fixed (hopefully in 0.15 🤞)

I couldn't come up with a good way to enable them on other platforms, so let's just turn them off temporarily.