### PR TITLE
feat: statically include MinGW libraries on Windows

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -24,6 +24,7 @@
     "@opam/cmdliner": ">= 1.0.2",
     "@opam/dune-build-info": ">= 2.0.0",
     "@opam/dune": ">= 2.0.0",
+    "@opam/dune-configurator": ">= 2.0.0",
     "@opam/fp": "0.0.1",
     "@opam/fs": "0.0.2",
     "@opam/grain_dypgen": "0.2",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "700ed4d0077a73bcc21c457188ad3e9d",
+  "checksum": "c8b520dea4c617e46751e37275545792",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -1823,6 +1823,7 @@
         "@opam/grain_dypgen@opam:0.2@ef01d3b4",
         "@opam/fs@github:facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
         "@opam/fp@github:facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/dune-configurator@opam:2.7.1@96307faa",
         "@opam/dune-build-info@opam:2.7.1@da03d61d",
         "@opam/dune@opam:2.7.1@f5f493bc",
         "@opam/cmdliner@opam:1.0.4@93208aac",

--- a/compiler/grainc/config/dune
+++ b/compiler/grainc/config/dune
@@ -1,0 +1,8 @@
+(executable
+ (name flags)
+ (libraries dune.configurator))
+
+(rule
+ (targets flags.sexp)
+ (action
+  (run ./flags.exe)))

--- a/compiler/grainc/config/flags.re
+++ b/compiler/grainc/config/flags.re
@@ -1,0 +1,20 @@
+module C = Configurator.V1;
+
+let () = {
+  C.main(~name="grainc_flags", c => {
+    let default = [];
+
+    let flags =
+      switch (C.ocaml_config_var(c, "system")) {
+      | Some("mingw64") =>
+        // MinGW needs the -static flag passed directly to the linker,
+        // to avoid needing MinGW locations in the path
+        // Ref https://github.com/grain-lang/binaryen.ml#static-linking
+        ["-ccopt", "--", "-ccopt", "-static"]
+      | Some(_) => default
+      | None => default
+      };
+
+    C.Flags.write_sexp("flags.sexp", flags);
+  });
+};

--- a/compiler/grainc/dune
+++ b/compiler/grainc/dune
@@ -3,4 +3,7 @@
  (public_name grainc)
  (package grain)
  (modules grainc)
+ (flags
+  (:standard
+   (:include ./config/flags.sexp)))
  (libraries grain grain_diagnostics binaryen.native dune-build-info))


### PR DESCRIPTION
This adds dune-configurator to provide linker flags to grainc on Windows that will allow it to statically include the MinGW libraries (libstdc++ and winthreads) into the binary so it doesn't need esy's MinGW location in the users' PATH.

I had to use configurator because it seems that on Mac, those flags cause Clang to fail for some reason.

Additionally, with this PR, the Grain compiler should build and run on Windows. The tests still fail, which needs to be looked into before we can add it to CI though.

If you want to try it out in Powershell, you need to add the results of running `yarn global bin` to the path using the `$env:PATH` variable (otherwise it's pretty similar to linux)