### PR TITLE
chore: update Reason to use published 3.6.2

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -31,7 +31,7 @@
     "@opam/ppx_deriving_yojson": ">= 3.5.2",
     "@opam/ppx_expect": ">= 0.14.0",
     "@opam/ppx_sexp_conv": ">= 0.14.0",
-    "@opam/reason": ">= 3.6.0",
+    "@opam/reason": ">= 3.6.2",
     "@opam/sexplib": ">= 0.14.0",
     "@opam/utf8": "0.1.0",
     "@opam/yojson": ">= 1.7.0",
@@ -44,7 +44,6 @@
   "resolutions": {
     "@opam/fp": "facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87",
     "@opam/fs": "facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87",
-    "@opam/reason": "facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4",
     "@opam/utf8": "facebookexperimental/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87"
   },
   "installConfig": {

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c8b520dea4c617e46751e37275545792",
+  "checksum": "fe828d000fe24d98e8df3add35054eaf",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -74,13 +74,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
@@ -125,7 +123,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppx_optcomp@opam:v0.14.1@181fd1a0",
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
@@ -133,7 +131,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppx_optcomp@opam:v0.14.1@181fd1a0",
         "@opam/ppx_base@opam:v0.14.0@b4702ed9",
         "@opam/jst-config@opam:v0.14.0@d0d7469e",
         "@opam/jane-street-headers@opam:v0.14.0@59432b6a",
@@ -289,23 +287,27 @@
         "ocaml@4.11.0@d41d8cd9", "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
-    "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9": {
-      "id":
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+    "@opam/reason@opam:3.6.2@1a34f8a4": {
+      "id": "@opam/reason@opam:3.6.2@1a34f8a4",
       "name": "@opam/reason",
-      "version":
-        "github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4",
+      "version": "opam:3.6.2",
       "source": {
         "type": "install",
         "source": [
-          "github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4"
-        ]
+          "archive:https://opam.ocaml.org/cache/md5/d6/d6de40f280f1c229f9cb26eb4015f1c5#md5:d6de40f280f1c229f9cb26eb4015f1c5",
+          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.6.2.tgz#md5:d6de40f280f1c229f9cb26eb4015f1c5"
+        ],
+        "opam": {
+          "name": "reason",
+          "version": "3.6.2",
+          "path": "esy.lock/opam/reason.3.6.2"
+        }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
         "@opam/merlin-extend@opam:0.6@404f814c",
         "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/fix@opam:20201120@5c318621", "@opam/dune@opam:2.7.1@f5f493bc",
@@ -313,7 +315,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/merlin-extend@opam:0.6@404f814c",
         "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/fix@opam:20201120@5c318621", "@opam/dune@opam:2.7.1@f5f493bc"
@@ -345,20 +347,20 @@
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
-    "@opam/ppxlib@opam:0.15.0@6a9d8126": {
-      "id": "@opam/ppxlib@opam:0.15.0@6a9d8126",
+    "@opam/ppxlib@opam:0.20.0@72354e44": {
+      "id": "@opam/ppxlib@opam:0.20.0@72354e44",
       "name": "@opam/ppxlib",
-      "version": "opam:0.15.0",
+      "version": "opam:0.20.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/0b/0b630d7f8d74a899a55cc27188b5ce03e735a93f07ea0c2de56532d8fd93b330#sha256:0b630d7f8d74a899a55cc27188b5ce03e735a93f07ea0c2de56532d8fd93b330",
-          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.15.0/ppxlib-0.15.0.tbz#sha256:0b630d7f8d74a899a55cc27188b5ce03e735a93f07ea0c2de56532d8fd93b330"
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1cb5903ef257de9c93e154cbb53df5979d4ad0f041d01967ea5984dd6d2cad37#sha256:1cb5903ef257de9c93e154cbb53df5979d4ad0f041d01967ea5984dd6d2cad37",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.20.0/ppxlib-0.20.0.tbz#sha256:1cb5903ef257de9c93e154cbb53df5979d4ad0f041d01967ea5984dd6d2cad37"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.15.0",
-          "path": "esy.lock/opam/ppxlib.0.15.0"
+          "version": "0.20.0",
+          "path": "esy.lock/opam/ppxlib.0.20.0"
         }
       },
       "overrides": [],
@@ -366,7 +368,7 @@
         "ocaml@4.11.0@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@148f22ac",
         "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
+        "@opam/ocaml-migrate-parsetree@opam:2.1.0@a3b6747d",
         "@opam/ocaml-compiler-libs@opam:v0.12.3@f0f069bd",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -374,7 +376,7 @@
         "ocaml@4.11.0@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@148f22ac",
         "@opam/sexplib0@opam:v0.14.0@ddeb6438",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
+        "@opam/ocaml-migrate-parsetree@opam:2.1.0@a3b6747d",
         "@opam/ocaml-compiler-libs@opam:v0.12.3@f0f069bd",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
@@ -405,61 +407,61 @@
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
-    "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c": {
-      "id": "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+    "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3": {
+      "id": "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
       "name": "@opam/ppx_sexp_conv",
+      "version": "opam:v0.14.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/61/6123bc2c8d1214afbe6dc2c86d6b1395#md5:6123bc2c8d1214afbe6dc2c86d6b1395",
+          "archive:https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.2.tar.gz#md5:6123bc2c8d1214afbe6dc2c86d6b1395"
+        ],
+        "opam": {
+          "name": "ppx_sexp_conv",
+          "version": "v0.14.2",
+          "path": "esy.lock/opam/ppx_sexp_conv.v0.14.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
+      ]
+    },
+    "@opam/ppx_optcomp@opam:v0.14.1@181fd1a0": {
+      "id": "@opam/ppx_optcomp@opam:v0.14.1@181fd1a0",
+      "name": "@opam/ppx_optcomp",
       "version": "opam:v0.14.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/43/438d8ccbbeedb5a9517ed55a8b9a768e#md5:438d8ccbbeedb5a9517ed55a8b9a768e",
-          "archive:https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.1.tar.gz#md5:438d8ccbbeedb5a9517ed55a8b9a768e"
-        ],
-        "opam": {
-          "name": "ppx_sexp_conv",
-          "version": "v0.14.1",
-          "path": "esy.lock/opam/ppx_sexp_conv.v0.14.1"
-        }
-      },
-      "overrides": [],
-      "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
-        "@esy-ocaml/substs@0.0.1@d41d8cd9"
-      ],
-      "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
-      ]
-    },
-    "@opam/ppx_optcomp@opam:v0.14.0@47cec200": {
-      "id": "@opam/ppx_optcomp@opam:v0.14.0@47cec200",
-      "name": "@opam/ppx_optcomp",
-      "version": "opam:v0.14.0",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://opam.ocaml.org/cache/md5/71/715fbb000594d50fb3689da29c6b0ab0#md5:715fbb000594d50fb3689da29c6b0ab0",
-          "archive:https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_optcomp-v0.14.0.tar.gz#md5:715fbb000594d50fb3689da29c6b0ab0"
+          "archive:https://opam.ocaml.org/cache/md5/4b/4ba24037b097bfedbbeb5a5c577694e1#md5:4ba24037b097bfedbbeb5a5c577694e1",
+          "archive:https://github.com/janestreet/ppx_optcomp/archive/v0.14.1.tar.gz#md5:4ba24037b097bfedbbeb5a5c577694e1"
         ],
         "opam": {
           "name": "ppx_optcomp",
-          "version": "v0.14.0",
-          "path": "esy.lock/opam/ppx_optcomp.v0.14.0"
+          "version": "v0.14.1",
+          "path": "esy.lock/opam/ppx_optcomp.v0.14.1"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -481,13 +483,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/octavius@opam:1.2.2@b328d1f1",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/octavius@opam:1.2.2@b328d1f1",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
@@ -511,13 +513,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -539,12 +541,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -566,39 +568,39 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
-    "@opam/ppx_expect@opam:v0.14.0@6aca553a": {
-      "id": "@opam/ppx_expect@opam:v0.14.0@6aca553a",
+    "@opam/ppx_expect@opam:v0.14.1@cee36131": {
+      "id": "@opam/ppx_expect@opam:v0.14.1@cee36131",
       "name": "@opam/ppx_expect",
-      "version": "opam:v0.14.0",
+      "version": "opam:v0.14.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/25/2570e8a8ea1e4c16258cafdc0313de96#md5:2570e8a8ea1e4c16258cafdc0313de96",
-          "archive:https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_expect-v0.14.0.tar.gz#md5:2570e8a8ea1e4c16258cafdc0313de96"
+          "archive:https://opam.ocaml.org/cache/md5/9c/9cc03dcabb00c72e17f7f5b0e4d28603#md5:9cc03dcabb00c72e17f7f5b0e4d28603",
+          "archive:https://github.com/janestreet/ppx_expect/archive/v0.14.1.tar.gz#md5:9cc03dcabb00c72e17f7f5b0e4d28603"
         ],
         "opam": {
           "name": "ppx_expect",
-          "version": "v0.14.0",
-          "path": "esy.lock/opam/ppx_expect.v0.14.0"
+          "version": "v0.14.1",
+          "path": "esy.lock/opam/ppx_expect.v0.14.1"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
@@ -606,7 +608,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
@@ -630,12 +632,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -659,50 +661,48 @@
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_deriving@opam:5.1@3037236f",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_deriving@opam:5.2@f72dce6d",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_deriving@opam:5.1@3037236f",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_deriving@opam:5.2@f72dce6d",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
-    "@opam/ppx_deriving@opam:5.1@3037236f": {
-      "id": "@opam/ppx_deriving@opam:5.1@3037236f",
+    "@opam/ppx_deriving@opam:5.2@f72dce6d": {
+      "id": "@opam/ppx_deriving@opam:5.2@f72dce6d",
       "name": "@opam/ppx_deriving",
-      "version": "opam:5.1",
+      "version": "opam:5.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/b0/b04f3b22b754e65af50812730695863192ae410e802e074b55ebbb8c4f73c4c4#sha256:b04f3b22b754e65af50812730695863192ae410e802e074b55ebbb8c4f73c4c4",
-          "archive:https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.1/ppx_deriving-v5.1.tbz#sha256:b04f3b22b754e65af50812730695863192ae410e802e074b55ebbb8c4f73c4c4"
+          "archive:https://opam.ocaml.org/cache/sha256/1c/1c2d2626824ca350c365bf6c8bc3a23c8045c3995c170f2bc500e53baeda2ee6#sha256:1c2d2626824ca350c365bf6c8bc3a23c8045c3995c170f2bc500e53baeda2ee6",
+          "archive:https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.2/ppx_deriving-v5.2.tbz#sha256:1c2d2626824ca350c365bf6c8bc3a23c8045c3995c170f2bc500e53baeda2ee6"
         ],
         "opam": {
           "name": "ppx_deriving",
-          "version": "5.1",
-          "path": "esy.lock/opam/ppx_deriving.5.1"
+          "version": "5.2",
+          "path": "esy.lock/opam/ppx_deriving.5.2"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
@@ -749,12 +749,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -776,12 +776,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/dune@opam:2.7.1@f5f493bc", "@opam/base@opam:v0.14.0@8bc55fce"
       ]
     },
@@ -803,8 +803,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
         "@opam/ppx_enumerate@opam:v0.14.0@63db8245",
@@ -813,8 +813,8 @@
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
         "@opam/ppx_enumerate@opam:v0.14.0@63db8245",
@@ -841,8 +841,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
@@ -850,8 +850,8 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/ppx_cold@opam:v0.14.0@345dec7c",
@@ -1021,32 +1021,29 @@
       ],
       "devDependencies": [ "ocaml@4.11.0@d41d8cd9" ]
     },
-    "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173": {
-      "id": "@opam/ocaml-migrate-parsetree@opam:1.8.0@305b6173",
+    "@opam/ocaml-migrate-parsetree@opam:2.1.0@a3b6747d": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:2.1.0@a3b6747d",
       "name": "@opam/ocaml-migrate-parsetree",
-      "version": "opam:1.8.0",
+      "version": "opam:2.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/b1/b1c2d176ff1444041f2775786ba605be796e46dfd2acb06c96f35d2bb88b8fb5#sha256:b1c2d176ff1444041f2775786ba605be796e46dfd2acb06c96f35d2bb88b8fb5",
-          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.8.0/ocaml-migrate-parsetree-v1.8.0.tbz#sha256:b1c2d176ff1444041f2775786ba605be796e46dfd2acb06c96f35d2bb88b8fb5"
+          "archive:https://opam.ocaml.org/cache/sha256/38/387b788ee4c0537f1fe02c25e05f0335af424828fc6fe940acc0db5948a5a71f#sha256:387b788ee4c0537f1fe02c25e05f0335af424828fc6fe940acc0db5948a5a71f",
+          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.1.0/ocaml-migrate-parsetree-v2.1.0.tbz#sha256:387b788ee4c0537f1fe02c25e05f0335af424828fc6fe940acc0db5948a5a71f"
         ],
         "opam": {
           "name": "ocaml-migrate-parsetree",
-          "version": "1.8.0",
-          "path": "esy.lock/opam/ocaml-migrate-parsetree.1.8.0"
+          "version": "2.1.0",
+          "path": "esy.lock/opam/ocaml-migrate-parsetree.2.1.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "ocaml@4.11.0@d41d8cd9", "@opam/dune@opam:2.7.1@f5f493bc",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.7.1@f5f493bc"
+        "ocaml@4.11.0@d41d8cd9", "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
     "@opam/ocaml-lsp-server@opam:1.1.0@1478aa3c": {
@@ -1293,12 +1290,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/js_of_ocaml@opam:3.8.0@c897ffea",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/js_of_ocaml@opam:3.8.0@c897ffea",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
@@ -1322,7 +1319,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/dune@opam:2.7.1@f5f493bc",
@@ -1331,7 +1328,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/menhir@opam:20201122@35e9e3ea",
         "@opam/dune@opam:2.7.1@f5f493bc",
         "@opam/cmdliner@opam:1.0.4@93208aac"
@@ -1356,13 +1353,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/js_of_ocaml-compiler@opam:3.8.0@0b5efb6b",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppxlib@opam:0.15.0@6a9d8126",
+        "@opam/ppxlib@opam:0.20.0@72354e44",
         "@opam/js_of_ocaml-compiler@opam:3.8.0@0b5efb6b",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
@@ -1429,14 +1426,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/fp@github:facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/fp@github:facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
@@ -1455,13 +1450,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/dune@opam:2.7.1@f5f493bc", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
+        "ocaml@4.11.0@d41d8cd9", "@opam/reason@opam:3.6.2@1a34f8a4",
         "@opam/dune@opam:2.7.1@f5f493bc"
       ]
     },
@@ -1816,9 +1809,9 @@
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/utf8@github:facebookexperimental/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
         "@opam/sexplib@opam:v0.14.0@f67f18de",
-        "@opam/reason@github:facebook/reason:reason.opam#d7dca24d89ab5035c3a76e23e701bd2d7c1211b4@d41d8cd9",
-        "@opam/ppx_sexp_conv@opam:v0.14.1@5fc4da3c",
-        "@opam/ppx_expect@opam:v0.14.0@6aca553a",
+        "@opam/reason@opam:3.6.2@1a34f8a4",
+        "@opam/ppx_sexp_conv@opam:v0.14.2@97bad0e3",
+        "@opam/ppx_expect@opam:v0.14.1@cee36131",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
         "@opam/grain_dypgen@opam:0.2@ef01d3b4",
         "@opam/fs@github:facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",

--- a/compiler/esy.lock/opam/ocaml-migrate-parsetree.2.1.0/opam
+++ b/compiler/esy.lock/opam/ocaml-migrate-parsetree.2.1.0/opam
@@ -14,10 +14,8 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "result"
-  "ppx_derivers"
-  "dune" {>= "1.9.0"}
-  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02.3" & < "4.13"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
@@ -27,12 +25,12 @@ This library converts parsetrees, outcometree and ast mappers between
 different OCaml versions.  High-level functions help making PPX
 rewriters independent of a compiler version.
 """
-x-commit-hash: "1d72648812bb235d1576f483cacdf546e25c03d8"
+x-commit-hash: "4a05cf7a00d84e5f827cc9ae9c75e5dc85126085"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.8.0/ocaml-migrate-parsetree-v1.8.0.tbz"
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.1.0/ocaml-migrate-parsetree-v2.1.0.tbz"
   checksum: [
-    "sha256=b1c2d176ff1444041f2775786ba605be796e46dfd2acb06c96f35d2bb88b8fb5"
-    "sha512=c14ffacbba9fda34243b3e8310ce49414415b530bbd982eaa6c1891517c5a9a6a35887afa7d6f15f7f94e225a7f15cc25417fd3337e685d4a7d6ee160e50e66e"
+    "sha256=387b788ee4c0537f1fe02c25e05f0335af424828fc6fe940acc0db5948a5a71f"
+    "sha512=6ac80face6b77531c8d89a77d7a246bd5d43da435c355f62c03c8b8e360e1d7e339c904709fd3dbc9aa340c86ada9a69d5ebcf97cbdb7bd51bec97f831741b99"
   ]
 }

--- a/compiler/esy.lock/opam/ppx_deriving.5.2/opam
+++ b/compiler/esy.lock/opam/ppx_deriving.5.2/opam
@@ -14,15 +14,14 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.07.0" & < "4.12"}
+  "ocaml" {>= "4.07.0"} # TODO: change back to OCaml >= 4.05 when stdlib-shims 0.2.0 is released (same for ppx_deriving 5.0 and 5.1)
   "dune" {>= "1.6.3"}
   "cppo" {build}
   "ocamlfind"
-  "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_derivers"
-  "ppxlib" {>= "0.14.0" & < "0.16.0"}
+  "ppxlib" {>= "0.20.0"}
   "result"
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 synopsis: "Type-driven code generation for OCaml"
 description: """
@@ -32,10 +31,10 @@ for common tasks.
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.1/ppx_deriving-v5.1.tbz"
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.2/ppx_deriving-v5.2.tbz"
   checksum: [
-    "sha256=b04f3b22b754e65af50812730695863192ae410e802e074b55ebbb8c4f73c4c4"
-    "sha512=abcccda4878a82b0d0eedcc23127da6ae5c10bface59335a226a714752a46b987bff01f48fbe432910b26bfc7b332b301d191da71a9da0db593d86335bc83cd9"
+    "sha256=1c2d2626824ca350c365bf6c8bc3a23c8045c3995c170f2bc500e53baeda2ee6"
+    "sha512=03ce8b3a0d8ed56b6c078212ac54862d99e4296c0e31cc982f9e632bae973a955207cfa968dbcd9d88aa444addda557556f549ef926ae7196534f9b7c007cf10"
   ]
 }
-x-commit-hash: "b29509ff51f79f0f47dd85d60ab837ded5d2c6e4"
+x-commit-hash: "b5c1c30692819393b3a6f9f5ffccf16b59594b4a"

--- a/compiler/esy.lock/opam/ppx_expect.v0.14.1/opam
+++ b/compiler/esy.lock/opam/ppx_expect.v0.14.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_inline_test" {>= "v0.14" & < "v0.15"}
   "stdio"           {>= "v0.14" & < "v0.15"}
   "dune"            {>= "2.0.0"}
-  "ppxlib"          {>= "0.11.0" & < "0.18.0"}
+  "ppxlib"          {>= "0.18.0"}
   "re"              {>= "1.8.0"}
 ]
 synopsis: "Cram like framework for OCaml"
@@ -24,6 +24,6 @@ description: "
 Part of the Jane Street's PPX rewriters collection.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_expect-v0.14.0.tar.gz"
-  checksum: "md5=2570e8a8ea1e4c16258cafdc0313de96"
+  src: "https://github.com/janestreet/ppx_expect/archive/v0.14.1.tar.gz"
+  checksum: "md5=9cc03dcabb00c72e17f7f5b0e4d28603"
 }

--- a/compiler/esy.lock/opam/ppx_optcomp.v0.14.1/opam
+++ b/compiler/esy.lock/opam/ppx_optcomp.v0.14.1/opam
@@ -14,13 +14,13 @@ depends: [
   "base"   {>= "v0.14" & < "v0.15"}
   "stdio"  {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.11.0" & < "0.18.0"}
+  "ppxlib" {>= "0.18.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.
 "
 url {
-  src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_optcomp-v0.14.0.tar.gz"
-  checksum: "md5=715fbb000594d50fb3689da29c6b0ab0"
+  src: "https://github.com/janestreet/ppx_optcomp/archive/v0.14.1.tar.gz"
+  checksum: "md5=4ba24037b097bfedbbeb5a5c577694e1"
 }

--- a/compiler/esy.lock/opam/ppx_sexp_conv.v0.14.2/opam
+++ b/compiler/esy.lock/opam/ppx_sexp_conv.v0.14.2/opam
@@ -14,13 +14,13 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.15.0" & < "0.18.0"}
+  "ppxlib"   {>= "0.18.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "
 Part of the Jane Street's PPX rewriters collection.
 "
 url {
-  src: "https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.1.tar.gz"
-  checksum: "md5=438d8ccbbeedb5a9517ed55a8b9a768e"
+  src: "https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.2.tar.gz"
+  checksum: "md5=6123bc2c8d1214afbe6dc2c86d6b1395"
 }

--- a/compiler/esy.lock/opam/ppxlib.0.20.0/opam
+++ b/compiler/esy.lock/opam/ppxlib.0.20.0/opam
@@ -14,10 +14,10 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.13"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers"            {>= "1.0"}
   "sexplib0"
   "stdlib-shims"
@@ -39,12 +39,12 @@ OCaml syntax directly and `ppxlib.traverse` which provides various
 ways of automatically traversing values of a given type, in particular
 allowing to inject a complex structured value into generated code.
 """
-x-commit-hash: "20cacbfc311f1baef6454051e0edd7b1628cb721"
+x-commit-hash: "51b6f0bd59692712ef2af73a4f378dccc7fabac8"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.15.0/ppxlib-0.15.0.tbz"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.20.0/ppxlib-0.20.0.tbz"
   checksum: [
-    "sha256=0b630d7f8d74a899a55cc27188b5ce03e735a93f07ea0c2de56532d8fd93b330"
-    "sha512=ecf0fff77ff6f1b356f018b6861b9e40bb8513092a7a486a3aa6024d12f5c15135899b77a188a44abc1c2ca84ebccb8bf9a78241e0383e023663fd7f86fbca72"
+    "sha256=1cb5903ef257de9c93e154cbb53df5979d4ad0f041d01967ea5984dd6d2cad37"
+    "sha512=fa4179e821a88b70cf874488f2f8fcc7d0d52a2df50069dd8822d57c61a88c92c40e782267dbca0a8efc2f35976eaed73f85fcbec4299585dcf7b748ccd1c19f"
   ]
 }

--- a/compiler/esy.lock/opam/reason.3.6.2/opam
+++ b/compiler/esy.lock/opam/reason.3.6.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/facebook/reason"
+doc: "http://reasonml.github.io/"
+bug-reports: "https://github.com/facebook/reason/issues"
+dev-repo: "git://github.com/facebook/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"         {>= "4.03" & < "4.12"}
+  "dune"          {>= "1.4"}
+  "ocamlfind"     {build}
+  "menhir"        {>= "20170418"}
+  "merlin-extend" {>= "0.6"}
+  "ppx_derivers" {< "2.0"}
+  "fix"
+  "result"
+]
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+url {
+  src: "https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.6.2.tgz"
+  checksum: "md5=d6de40f280f1c229f9cb26eb4015f1c5"
+}


### PR DESCRIPTION
Reason v3.6.2 was finally published to opam, so we no longer need a resolution! This was the release that had ocaml 4.11.0 support.