### PR TITLE
fix: set test sharding to 1 in attempt to avoid test race condition

### DIFF
--- a/compiler/test/dune
+++ b/compiler/test/dune
@@ -11,4 +11,4 @@
   (source_tree test-libs)
   (source_tree test-data))
  (action
-  (run %{<})))
+  (run %{<} -shards 1)))


### PR DESCRIPTION
I was poking around oUnit2 and I found it does parallel tests by default, so I added the `-help` flag to our test binary and it output this:
```
  -shards i                       Number of shards to use as worker (threads or processes). (default: 2)
```

I believe this means that oUnit is running our tests in parallel in 2 processes and that **might** be causing an issue where 1 process is trying to create a stdlib wasm file, like `pervasives.gr.wasm`, at the same time another process is trying to open that file, which would result in the input channel being closed immediately and `End_of_file` being surfaced which fails the test with `Cmi_format.Error`. It also _kind of_ explains why only 1 tests fails with that error because no other test going forward would be recreating that file, so they all could just read from it. Thoughts?

I haven't had a chance to run this change over and over on my system yet, but hoping to find time tomorrow.