### PR TITLE
chore: cleanup more generated files in stdlib

### DIFF
--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -40,6 +40,6 @@
   "dependencies": {},
   "scripts": {
     "build": "node --harmony-top-level-await ./build.mjs",
-    "clean": "del-cli '**/*.wasm' '**/*.wasm.modsig' '**/*.wasm.wast' '!stdlib-external/**'"
+    "clean": "del-cli '**/*.wasm' '**/*.wasm.*' '**/*.gr.mashtree' '!stdlib-external/**'"
   }
 }


### PR DESCRIPTION
During debugging, I noticed some other files hanging around that weren't being cleaned, so I adjusted the script to clean those up.