### PR TITLE
feat: allow setting the initial memory via CLI option

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -26,7 +26,7 @@ function onRespawn(ready, proc, argv) {
 
   let program = require('commander');
   // Workaround to defer loading of the grain runtime until the memory settings have been parsed
-  let imports = {
+  let actions = {
     get compile() {
       return require('./compile.js');
     },
@@ -77,28 +77,28 @@ function onRespawn(ready, proc, argv) {
     // The root command that compiles & runs
     .arguments('<file>')
     .action(function (file) {
-      imports.run(imports.compile(file, program), program);
+      actions.run(actions.compile(file, program), program);
     })
 
   program
     .command('compile <file>')
     .description('compile a grain program into wasm')
     .action(function (file) {
-      imports.compile(file, program);
+      actions.compile(file, program);
     });
 
   program
     .command('lsp <file>')
     .description('check a grain file for LSP')
     .action(function (file) {
-      imports.lsp(file, program);
+      actions.lsp(file, program);
     });
 
   program
     .command('run <file>')
     .description('run a wasm file with the grain runtime')
     .action(function (wasmFile) {
-      imports.run(wasmFile, program);
+      actions.run(wasmFile, program);
     });
 
   program.parse(argv);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -25,9 +25,18 @@ function onRespawn(ready, proc, argv) {
   const path = require('path');
 
   let program = require('commander');
-  let compile = require('./compile.js');
-  let run = require('./run.js');
-  let lsp = require('./lsp.js');
+  // Workaround to defer loading of the grain runtime until the memory settings have been parsed
+  let imports = {
+    get compile() {
+      return require('./compile.js');
+    },
+    get run() {
+      return require('./run.js');
+    },
+    get lsp() {
+      return require('./lsp.js');
+    }
+  }
 
   let pervasivesPath = require.resolve('@grain/stdlib');
   let stdlibPath = path.dirname(pervasivesPath);
@@ -60,31 +69,36 @@ function onRespawn(ready, proc, argv) {
     .option('-f, --cflags <cflags>', 'pass flags to the Grain compiler')
     .option('-S, --stdlib <path>', 'override the standard libary with your own', stdlibPath)
     .option('--limitMemory <size>', 'maximum allowed heap size', num, -1)
+    .option('--init-memory-pages <size>', 'number of pages used to initialize the grain runtime')
+    .on('option:init-memory-pages', (pages) => {
+      // Workaround for the runtime's memory being initialized statically on module load
+      process.env.GRAIN_INIT_MEMORY_PAGES = parseInt(pages, 10);
+    })
     // The root command that compiles & runs
     .arguments('<file>')
     .action(function (file) {
-      run(compile(file, program), program);
+      imports.run(imports.compile(file, program), program);
     })
 
   program
     .command('compile <file>')
     .description('compile a grain program into wasm')
     .action(function (file) {
-      compile(file, program);
+      imports.compile(file, program);
     });
 
   program
     .command('lsp <file>')
     .description('check a grain file for LSP')
     .action(function (file) {
-      lsp(file, program);
+      imports.lsp(file, program);
     });
 
   program
     .command('run <file>')
     .description('run a wasm file with the grain runtime')
     .action(function (wasmFile) {
-      run(wasmFile, program);
+      imports.run(wasmFile, program);
     });
 
   program.parse(argv);

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -12,7 +12,8 @@ import * as libDOM from './lib/DOM';
 
 export let grainModule;
 
-export const memory = new WebAssembly.Memory({initial: 16});
+// Workaround for this memory being initialized statically on module load
+export const memory = new WebAssembly.Memory({initial: process.env.GRAIN_INIT_MEMORY_PAGES || 16});
 export const table = new WebAssembly.Table({element: 'anyfunc', initial: 1024});
 export const view = new Int32Array(memory.buffer);
 export const uview = new Uint32Array(memory.buffer);


### PR DESCRIPTION
This allows setting the initial amount of memory page via a command line option. It actually required a handful of workarounds due to the static initialization (and dependents upon it), which we should consider when taking a deeper look at the runtime in the future.

Using this CLI option, I am able to compile my Advent of Code solutions.