### PR TITLE
fix: Lock module reading/writing to prevent race conditions

### DIFF
--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -26,7 +26,8 @@ let emit_module = ({asm, signature}, outfile) => {
   let (encoded, map) = Binaryen.Module.write(asm, source_map_name);
   let oc = open_out_bin(outfile);
   let fd = Unix.descr_of_out_channel(oc);
-  Unix.lockf(fd, Unix.F_LOCK, 0);
+  // Create a lock on the file for the full length we plan to write
+  Unix.lockf(fd, Unix.F_LOCK, Bytes.length(encoded));
   output_bytes(oc, encoded);
   Unix.lockf(fd, Unix.F_ULOCK, 0);
   close_out(oc);

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -25,7 +25,10 @@ let emit_module = ({asm, signature}, outfile) => {
     };
   let (encoded, map) = Binaryen.Module.write(asm, source_map_name);
   let oc = open_out_bin(outfile);
+  let fd = Unix.descr_of_out_channel(oc);
+  Unix.lockf(fd, Unix.F_LOCK, 0);
   output_bytes(oc, encoded);
+  Unix.lockf(fd, Unix.F_ULOCK, 0);
   close_out(oc);
   switch (map) {
   | Some(map) =>

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -29,7 +29,6 @@ let emit_module = ({asm, signature}, outfile) => {
   // Create a lock on the file for the full length we plan to write
   Unix.lockf(fd, Unix.F_LOCK, Bytes.length(encoded));
   output_bytes(oc, encoded);
-  Unix.lockf(fd, Unix.F_ULOCK, 0);
   close_out(oc);
   switch (map) {
   | Some(map) =>

--- a/compiler/src/typed/cmi_format.re
+++ b/compiler/src/typed/cmi_format.re
@@ -102,9 +102,12 @@ module CmiBinarySection =
 
 let read_cmi = filename => {
   let ic = open_in_bin(filename);
+  let fd = Unix.descr_of_in_channel(ic);
+  Unix.lockf(fd, Unix.F_RLOCK, 0);
   try(
     switch (CmiBinarySection.load(ic)) {
     | Some(cmi) =>
+      Unix.lockf(fd, Unix.F_ULOCK, 0);
       close_in(ic);
       cmi;
     | None => raise(End_of_file)
@@ -112,9 +115,11 @@ let read_cmi = filename => {
   ) {
   | End_of_file
   | Failure(_) =>
+    Unix.lockf(fd, Unix.F_ULOCK, 0);
     close_in(ic);
     raise(Error(Corrupted_interface(filename)));
   | Error(e) =>
+    Unix.lockf(fd, Unix.F_ULOCK, 0);
     close_in(ic);
     raise(Error(e));
   };

--- a/compiler/src/typed/cmi_format.re
+++ b/compiler/src/typed/cmi_format.re
@@ -107,7 +107,6 @@ let read_cmi = filename => {
   try(
     switch (CmiBinarySection.load(ic)) {
     | Some(cmi) =>
-      Unix.lockf(fd, Unix.F_ULOCK, 0);
       close_in(ic);
       cmi;
     | None => raise(End_of_file)
@@ -115,11 +114,9 @@ let read_cmi = filename => {
   ) {
   | End_of_file
   | Failure(_) =>
-    Unix.lockf(fd, Unix.F_ULOCK, 0);
     close_in(ic);
     raise(Error(Corrupted_interface(filename)));
   | Error(e) =>
-    Unix.lockf(fd, Unix.F_ULOCK, 0);
     close_in(ic);
     raise(Error(e));
   };

--- a/compiler/test/dune
+++ b/compiler/test/dune
@@ -11,4 +11,4 @@
   (source_tree test-libs)
   (source_tree test-data))
  (action
-  (run %{<})))
+  (run %{<} -shards 4)))


### PR DESCRIPTION
Still need to run it through the paces, but I believe this should fix the issues we've been experiencing.