### PR TITLE
feat!: change return type of Array.find/findIndex to Option

### DIFF
--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -126,12 +126,16 @@ assert !Array.contains(4, arr)
 
 // Array.find
 
-assert Array.find(x => x == 2, arr) == 2
+assert Array.find(x => x == 2, arr) == Some(2)
+assert Array.find(x => fail "Shoulnd't be called", [>]) == None
+assert Array.find(x => false, arr) == None
 
 // Array.findIndex
 
-assert Array.findIndex(x => x == 1, arr) == 0
-assert Array.findIndex(x => x == 2, arr) == 1
+assert Array.findIndex(x => x == 1, arr) == Some(0)
+assert Array.findIndex(x => x == 2, arr) == Some(1)
+assert Array.findIndex(x => fail "Shouldn't be called", [>]) == None
+assert Array.findIndex(x => false, arr) == None
 
 // Array.fill
 

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -186,7 +186,7 @@ export let contains = (search, array) => {
 export let find = (fn, array) => {
   let length = length(array)
   if(length == 0){
-    fail 'empty array provided'
+    None
   } else {
     let mut count = 0
     let mut matching = false
@@ -201,31 +201,35 @@ export let find = (fn, array) => {
       }
     }
     if(!matching) {
-      fail 'could not find a match'
+      None
     } else {
-      matchedItem
+      Some(matchedItem)
     }
   }
 }
 
 export let findIndex = (fn, array) => {
   let length = length(array)
-  let mut count = 0
-  let mut matching = false
-  let mut matchedIndex = 0
-  while (count < length) {
-    if(fn(array[count])) {
-      matching = true
-      matchedIndex = count
-      count = length
-    } else {
-      count = incr(count)
-    }
-  }
-  if(!matching) {
-    fail 'could not find a match'
+  if(length == 0){
+    None
   } else {
-    matchedIndex
+    let mut count = 0
+    let mut matching = false
+    let mut matchedIndex = 0
+    while (count < length) {
+      if(fn(array[count])) {
+        matching = true
+        matchedIndex = count
+        count = length
+      } else {
+        count = incr(count)
+      }
+    }
+    if(!matching) {
+      None
+    } else {
+      Some(matchedIndex)
+    }
   }
 }
 


### PR DESCRIPTION
In #159, it seemed that most people were on-board with fallible stdlib methods to return Option.  During AoC, I actually found a use case for Array.find to return an Option (when I wrote my naive parseInt function), so I thought I'd get that started with this PR.

Just wanted to get the 👍 before I go through and convert the rest.