### PR TITLE
feat: add Set stdlib module

### DIFF
--- a/compiler/test/stdlib/set.test.gr
+++ b/compiler/test/stdlib/set.test.gr
@@ -1,0 +1,223 @@
+import Set from "set"
+import List from "list"
+import Array from "array"
+
+// Data types used in multiple tests
+enum Resource { Grain, Sheep, Brick, Wood }
+record ResourceData { name: String, emoji: String }
+
+// Set.isEmpty
+
+let e = Set.make()
+
+assert Set.isEmpty(e)
+Set.add("🌾", e)
+assert !Set.isEmpty(e)
+
+// Set.size
+
+let s = Set.fromList(["🌾", "🐑", "🧱"])
+
+assert Set.size(s) == 3
+
+// Set.clear
+
+let c = Set.fromList(["🌾", "🐑", "🧱"])
+
+assert !Set.isEmpty(c)
+assert Set.clear(c) == void
+assert Set.isEmpty(c)
+
+// Set.contains
+
+let h = Set.fromList(["🌾", "🐑", "🧱"])
+
+assert Set.contains("🌾", h)
+assert Set.contains("🐑", h)
+assert Set.contains("🧱", h)
+assert !Set.contains("🌳", h)
+
+// Set.add
+
+let vars = Set.make()
+
+assert Set.add(Grain, vars) == void
+assert Set.add(Sheep, vars) == void
+assert Set.add(Grain, vars) == void
+
+assert Set.size(vars) == 2
+
+let recs = Set.make()
+
+assert Set.add({ name: "Grain", emoji: "🌾" }, recs) == void
+assert Set.add({ name: "Sheep", emoji: "🐑" }, recs) == void
+assert Set.add({ name: "Brick", emoji: "🧱" }, recs) == void
+assert Set.add({ name: "Grain", emoji: "🌾" }, recs) == void
+assert Set.add({ name: "Sheep", emoji: "🐑" }, recs) == void
+assert Set.add({ name: "Brick", emoji: "🧱" }, recs) == void
+
+assert Set.size(recs) == 3
+
+// Set.remove
+
+let r = Set.fromList(["🌾", "🐑", "🧱"])
+
+assert Set.size(r) == 3
+
+assert Set.remove("🌾", r) == void
+
+assert Set.size(r) == 2
+assert !Set.contains("🌾", r)
+
+assert Set.remove("🐑", r) == void
+assert Set.remove("🧱", r) == void
+
+assert Set.isEmpty(r)
+
+// Set.filter
+
+let makeTestSet = () => Set.fromList([Grain, Sheep, Brick])
+
+let emptySet = Set.make()
+
+let filterTestSet = makeTestSet()
+
+Set.filter((key) => fail "Shouldn't be called", emptySet)
+Set.filter((key) => key == Sheep, filterTestSet)
+
+assert !Set.contains(Grain, filterTestSet)
+assert Set.contains(Sheep, filterTestSet)
+assert !Set.contains(Brick, filterTestSet)
+
+// Set.reject
+
+let rejectTestSet = makeTestSet()
+
+Set.reject((key) => fail "Shouldn't be called", emptySet)
+Set.reject((key) => key == Sheep, rejectTestSet)
+
+assert Set.contains(Grain, rejectTestSet)
+assert !Set.contains(Sheep, rejectTestSet)
+assert Set.contains(Brick, rejectTestSet)
+
+// Set.reduce
+
+let reduceTestSet = makeTestSet()
+
+let result = Set.reduce((acc, key) => fail "Shouldn't be called", 0, emptySet)
+
+assert result == 0
+
+let mut called = 0
+
+let result = Set.reduce((acc, key) => {
+  called += 1
+  match (key) {
+    Grain => void,
+    Sheep => void,
+    Brick => void,
+    _ => fail "Set.reduce() should not contain this value."
+  }
+  [key, ...acc]
+}, [], reduceTestSet)
+
+assert called == 3
+assert List.contains(Grain, result)
+assert List.contains(Sheep, result)
+assert List.contains(Brick, result)
+
+// Set.forEach
+
+let forEachTestSet = makeTestSet()
+
+Set.forEach((key) => fail "Shouldn't be called", emptySet)
+
+let mut called = 0
+
+Set.forEach((key) => {
+  called += 1
+  match (key) {
+    Grain => void,
+    Sheep => void,
+    Brick => void,
+    _ => fail "Set.forEach() should not contain this value."
+  }
+}, forEachTestSet)
+
+assert called == 3
+
+// Set.diff
+
+let d = Set.fromList([0, 1, 2, 3])
+let e = Set.fromList([1, 2, 3, 4])
+
+let diffSet = Set.diff(d, e)
+
+assert Set.size(diffSet) == 2
+assert Set.contains(0, diffSet)
+assert !Set.contains(1, diffSet)
+assert !Set.contains(2, diffSet)
+assert !Set.contains(3, diffSet)
+assert Set.contains(4, diffSet)
+
+// Set.union
+
+let unionSet = Set.union(d, e)
+
+assert Set.size(unionSet) == 5
+assert Set.contains(0, unionSet)
+assert Set.contains(1, unionSet)
+assert Set.contains(2, unionSet)
+assert Set.contains(3, unionSet)
+assert Set.contains(4, unionSet)
+
+// Set.intersect
+
+let intersectSet = Set.intersect(d, e)
+
+assert Set.size(intersectSet) == 3
+assert !Set.contains(0, intersectSet)
+assert Set.contains(1, intersectSet)
+assert Set.contains(2, intersectSet)
+assert Set.contains(3, intersectSet)
+assert !Set.contains(4, intersectSet)
+
+// Set.fromList
+
+let k = Set.fromList([1, 1, 1])
+
+assert Set.size(k) == 1
+assert Set.contains(1, k)
+
+// Set.toList
+
+let o = Set.fromList([0, 1, 2, 3, 4])
+
+let l = Set.toList(o)
+
+assert List.length(l) == 5
+assert List.contains(0, l)
+assert List.contains(1, l)
+assert List.contains(2, l)
+assert List.contains(3, l)
+assert List.contains(4, l)
+
+// Set.fromArray
+
+let q = Set.fromArray([> 0, 0, 0])
+
+assert Set.size(q) == 1
+assert Set.contains(0, q)
+
+// Set.toArray
+
+let p = Set.fromArray([> 0, 1, 2, 3, 4, 3, 2, 1, 0])
+
+let r = Set.toArray(p)
+
+assert Array.length(r) == 5
+assert Array.contains(0, r)
+assert Array.contains(1, r)
+assert Array.contains(2, r)
+assert Array.contains(3, r)
+assert Array.contains(4, r)

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -752,6 +752,7 @@ let stdlib_tests = [
   tlib("string.test"),
   tlib("sys.file.test"),
   tlib("map.test"),
+  tlib("set.test"),
   tlib("result.test"),
   tlib("queue.test"),
   tlib(~returns="", ~code=5, "sys.process.test"),

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -1,0 +1,292 @@
+// Standard library for Set functionality
+
+import List from "list"
+import Array from "array"
+import { hash } from "hash"
+
+record Bucket<t> {
+  mut key: t,
+  mut next: Option<Bucket<t>>
+}
+
+record Set<k> {
+  mut size: Number,
+  mut buckets: Array<Option<Bucket<k>>>
+}
+
+// TODO: This could take an `eq` function to custom comparisons
+export let makeSized = (size) => {
+  let buckets = Array.make(size, None);
+  {
+    size: 0,
+    buckets
+  }
+}
+
+export let make = () => {
+  makeSized(16)
+}
+
+let getBucketIndex = (key, buckets) => {
+  let bucketsLength = Array.length(buckets);
+  let hashedKey = hash(key);
+  hashedKey % bucketsLength
+}
+
+let rec copyNodeWithNewHash = (oldNode, next, tail) => {
+  match (oldNode) {
+    None => void,
+    Some(node) => {
+      let idx = getBucketIndex(node.key, next);
+      let newNode = Some(node);
+      match (tail[idx]) {
+        None => {
+          next[idx] := newNode;
+        },
+        Some(tailNode) => {
+          // If there's already a tail node, we add this to the end
+          tailNode.next = newNode;
+        }
+      }
+      // Always place this node as the new tail
+      tail[idx] := newNode;
+      // Recurse with the next node
+      copyNodeWithNewHash(node.next, next, tail);
+    }
+  }
+}
+
+let resize = (set) => {
+  let currentBuckets = set.buckets;
+  let currentSize = Array.length(currentBuckets);
+  let nextSize = currentSize * 2;
+  if (nextSize >= currentSize) {
+    let nextBuckets = Array.make(nextSize, None);
+    // This tracks the tail nodes so we can set their `next` to None
+    let tailNodes = Array.make(nextSize, None);
+    set.buckets = nextBuckets;
+    Array.forEach((old) => {
+      copyNodeWithNewHash(old, nextBuckets, tailNodes);
+    }, currentBuckets);
+    Array.forEach((tail) => {
+      match (tail) {
+        None => void,
+        Some(node) => {
+          node.next = None;
+        }
+      }
+    }, tailNodes);
+  } else {
+    void
+  }
+}
+
+let rec nodeInBucket = (key, node) => {
+  if (key == node.key) {
+    true
+  } else {
+    match (node.next) {
+      None => false,
+      Some(next) => nodeInBucket(key, next)
+    }
+  }
+}
+
+export let add = (key, set) => {
+  let buckets = set.buckets;
+  let idx = getBucketIndex(key, buckets)
+  let bucket = buckets[idx];
+  match (bucket) {
+    None => {
+      buckets[idx] := Some({ key, next: None });
+      set.size = incr(set.size);
+    },
+    Some(node) => {
+      if (!nodeInBucket(key, node)) {
+        buckets[idx] := Some({ key, next: bucket });
+        set.size = incr(set.size);
+      };
+    }
+  }
+  // Resize if there are more than 2x the amount of nodes as buckets
+  if (set.size > (Array.length(buckets) * 2)) {
+    resize(set);
+  } else {
+    void
+  }
+}
+
+export let contains = (key, set) => {
+  let buckets = set.buckets;
+  let idx = getBucketIndex(key, buckets);
+  let bucket = buckets[idx];
+  match (bucket) {
+    None => false,
+    Some(node) => nodeInBucket(key, node)
+  }
+}
+
+let rec removeInBucket = (key, node) => {
+  match (node.next) {
+    None => false,
+    Some(next) => {
+      if (key == next.key) {
+        node.next = next.next;
+        true
+      } else {
+        removeInBucket(key, next)
+      }
+    }
+  }
+}
+
+export let remove = (key, set) => {
+  let buckets = set.buckets;
+  let idx = getBucketIndex(key, buckets);
+  let bucket = buckets[idx];
+  match (bucket) {
+    None => void,
+    Some(node) => {
+      // If it is a top-level node, just replace with next node
+      if (key == node.key) {
+        set.size = decr(set.size);
+        buckets[idx] := node.next;
+      } else {
+        if (removeInBucket(key, node)) {
+          set.size = decr(set.size);
+        }
+      }
+    }
+  }
+}
+
+export let size = (set) => {
+  set.size
+}
+
+export let isEmpty = (set) => {
+  size(set) == 0
+}
+
+export let clear = (set) => {
+  set.size = 0;
+  let buckets = set.buckets;
+  Array.forEachi((bucket, idx) => {
+    buckets[idx] := None;
+  }, buckets);
+}
+
+let rec forEachBucket = (fn, node) => {
+  match (node) {
+    None => void,
+    Some({ key, next }) => {
+      fn(key);
+      forEachBucket(fn, next);
+    }
+  }
+}
+
+export let forEach = (fn, set) => {
+  let buckets = set.buckets;
+  Array.forEach((bucket) => {
+    forEachBucket(fn, bucket)
+  }, buckets);
+}
+
+let rec reduceEachBucket = (fn, node, acc) => {
+  match (node) {
+    None => acc,
+    Some({ key, next }) =>
+      reduceEachBucket(fn, next, fn(acc, key))
+  }
+}
+
+export let reduce = (fn, init, set) => {
+  let buckets = set.buckets;
+  let mut acc = init;
+  Array.forEach((bucket) => {
+    acc = reduceEachBucket(fn, bucket, acc)
+  }, buckets);
+  acc
+}
+
+export let filter = (predicate, set) => {
+  let keysToRemove = reduce((list, key) =>
+    if (!predicate(key)) {
+      [key, ...list]
+    } else {
+      list
+    }, [], set);
+  List.forEach((key) => {
+    remove(key, set);
+  }, keysToRemove);
+}
+
+export let reject = (predicate, set) => {
+  filter((key) => !predicate(key), set)
+}
+
+export let toList = (set) => {
+  reduce((list, key) => [key, ...list], [], set)
+}
+
+export let fromList = (list) => {
+  let set = make();
+  List.forEach((key) => {
+    add(key, set);
+  }, list);
+  set
+}
+
+export let toArray = (set) => {
+  Array.fromList(toList(set))
+}
+
+export let fromArray = (array) => {
+  let set = make();
+  Array.forEach((key) => {
+    add(key, set);
+  }, array);
+  set
+}
+
+export let union = (set1, set2) => {
+  let set = make();
+  forEach((key) => {
+    add(key, set);
+  }, set1)
+  forEach((key) => {
+    add(key, set);
+  }, set2);
+  set
+}
+
+export let diff = (set1, set2) => {
+  let set = make();
+  forEach((key) => {
+    if (!contains(key, set2)) {
+      add(key, set);
+    }
+  }, set1)
+  forEach((key) => {
+    if (!contains(key, set1)) {
+      add(key, set);
+    }
+  }, set2);
+  set
+}
+
+export let intersect = (set1, set2) => {
+  let set = make();
+  forEach((key) => {
+    if (contains(key, set2)) {
+      add(key, set);
+    }
+  }, set1)
+  forEach((key) => {
+    if (contains(key, set1)) {
+      add(key, set);
+    }
+  }, set2);
+  set
+}


### PR DESCRIPTION
Add initial implementation of Set module using ~~List as the~~ the same underlying data structure as Map.
It reuses many modified helper functions from the Map module.
Maybe we could unify those functions?

@ospencer, what is the convention for `init` and `make` family of functions?