### PR TITLE
Remove use of memory.data

### DIFF
--- a/stdlib/stdlib-external/sys/env.ts
+++ b/stdlib/stdlib-external/sys/env.ts
@@ -15,11 +15,12 @@ import {
 } from "bindings/wasi";
 
 export function argv(): u32 {
-  let argcPtr = memory.data(8);
+  let argcPtr = malloc(8);
   let argvBufSizePtr = argcPtr + 4;
 
   let err = args_sizes_get(argcPtr, argvBufSizePtr);
   if (err !== errno.SUCCESS) {
+    free(argcPtr);
     throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
   }
 
@@ -31,6 +32,7 @@ export function argv(): u32 {
 
   err = args_get(argvPtr, argvBufPtr);
   if (err !== errno.SUCCESS) {
+    free(argcPtr);
     free(argvPtr);
     free(argvBufPtr);
     throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
@@ -52,6 +54,7 @@ export function argv(): u32 {
     store<u32>(arr + i, grainStrPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4);
   }
 
+  free(argcPtr);
   free(argvPtr);
   free(argvBufPtr);
 
@@ -59,11 +62,12 @@ export function argv(): u32 {
 }
 
 export function env(): u32 {
-  let envcPtr = memory.data(8);
+  let envcPtr = malloc(8);
   let envvBufSizePtr = envcPtr + 4;
 
   let err = environ_sizes_get(envcPtr, envvBufSizePtr);
   if (err !== errno.SUCCESS) {
+    free(envcPtr);
     throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
   }
 
@@ -75,6 +79,7 @@ export function env(): u32 {
 
   err = environ_get(envvPtr, envvBufPtr);
   if (err !== errno.SUCCESS) {
+    free(envcPtr);
     free(envvPtr);
     free(envvBufPtr);
     throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
@@ -96,6 +101,7 @@ export function env(): u32 {
     store<u32>(arr + i, grainStrPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4);
   }
 
+  free(envcPtr);
   free(envvPtr);
   free(envvBufPtr);
 

--- a/stdlib/stdlib-external/sys/random.ts
+++ b/stdlib/stdlib-external/sys/random.ts
@@ -1,17 +1,19 @@
-import { throwError } from "../ascutils/grainRuntime"
+import { throwError, malloc, free } from "../ascutils/grainRuntime"
 
 import { GRAIN_ERR_SYSTEM } from "../ascutils/errors"
 
 import { errno, random_get } from "bindings/wasi"
 
 export function random(): u32 {
-  let buf = memory.data(4)
+  let buf = malloc(4)
 
   let err = random_get(buf, 4)
   if (err !== errno.SUCCESS) {
+    free(buf)
     throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
   }
 
   let rand = load<u32>(buf)
+  free(buf)
   return rand << 1
 }


### PR DESCRIPTION
Per the research I did for #472, we can't use `memory.data` in AS. This updates our code to not use it anymore.

Could maybe optimize the env one to not need to call malloc an extra time, but this is much cleaner.