### PR TITLE
fix: Multiline char locs

### DIFF
--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -234,7 +234,7 @@ and read_char buf =
   | "\\'" { CHAR "'" }
   | "\\\\'" { CHAR "\\" }
   | (num_esc as esc) ''' { add_code_point buf esc (lexbuf_loc lexbuf); CHAR (Buffer.contents buf) }
-  | ([^ '\'' '\\']+ as _match) '\'' { Buffer.add_string buf _match; CHAR (Buffer.contents buf) }
+  | ([^ '\'' '\\']+ as _match) '\'' { process_newlines lexbuf; Buffer.add_string buf _match; CHAR (Buffer.contents buf) }
   | _ { raise (Error(lexbuf_loc lexbuf, IllegalStringCharacter(lexeme lexbuf))) }
 
 and read_block_comment =


### PR DESCRIPTION
I realized that because 
```
'
'
```
is a valid character (newline), we also need to account for it.