### PR TITLE
feat(stdlib): add Stack module

### DIFF
--- a/compiler/test/stdlib/stack.test.gr
+++ b/compiler/test/stdlib/stack.test.gr
@@ -1,0 +1,28 @@
+import Stack from "stack"
+
+let empty = Stack.make()
+// 1 <- 2 <- 3
+let sampleStack = Stack.push(3, Stack.push(2, Stack.push(1, empty)))
+
+// Stack.isEmpty
+
+assert Stack.isEmpty(empty)
+assert !Stack.isEmpty(sampleStack)
+
+// Stack.head
+
+assert Stack.head(empty) == None
+assert Stack.head(sampleStack) == Some(3)
+
+// Stack.push
+
+assert Stack.head(Stack.push(1, empty)) == Some(1)
+assert Stack.head(Stack.push(4, sampleStack)) == Some(4)
+
+// Stack.pop
+
+assert Stack.isEmpty(Stack.pop(empty))
+assert Stack.isEmpty(Stack.pop(Stack.push(1, empty)))
+assert Stack.isEmpty(Stack.pop(Stack.pop(Stack.pop(sampleStack))))
+assert Stack.head(Stack.pop(sampleStack)) == Some(2)
+assert Stack.head(Stack.pop(Stack.push(4, Stack.pop(sampleStack)))) == Some(2)

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -755,6 +755,7 @@ let stdlib_tests = [
   tlib("set.test"),
   tlib("result.test"),
   tlib("queue.test"),
+  tlib("stack.test"),
   tlib(~returns="", ~code=5, "sys.process.test"),
 ];
 

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -1,0 +1,37 @@
+import List from "list"
+
+record Stack<a> {
+    data: List<a>
+}
+
+export let make = () => {
+    { data: [] }
+}
+
+export let isEmpty = (stack) => {
+    match (stack) {
+        { data: [] } => true,
+        _ => false
+    }
+}
+
+export let head = (stack) => {
+    match (stack) {
+        { data: [] } => None,
+        { data } => List.head(data)
+    }
+}
+
+export let push = (value, stack) => {
+    match (stack) {
+        { data: [] } => { data: [value] },
+        { data } => { data: [value, ...data] }
+    }
+}
+
+export let pop = (stack) => {
+    match (stack) {
+        { data: [] } => stack,
+        { data: [head, ...tail] } => { data: tail, }
+    }
+}


### PR DESCRIPTION
I realized we don't have a Stack module in the standard library.
Even though it's just a wrapper around List, it mirrors the Queue module.