### PR TITLE
Regression tests for 497

### DIFF
--- a/compiler/test/stdlib/map.test.gr
+++ b/compiler/test/stdlib/map.test.gr
@@ -280,6 +280,13 @@ Map.set("🧱", 1, resize);
 // (nodeCount, bucketLength)
 assert Map.getInternalStats(resize) == (3, 2);
 
+// Regression tests for https://github.com/grain-lang/grain/issues/497
+
+let largeMap = Map.fromArray(Array.init(128, i => (i, i)))
+
+// (nodeCount, bucketLength)
+assert Map.getInternalStats(largeMap) == (128, 64);
+
 // Map.filter()
 
 let makeFilterTestMap = () => Map.fromList([

--- a/compiler/test/stdlib/set.test.gr
+++ b/compiler/test/stdlib/set.test.gr
@@ -221,3 +221,30 @@ assert Array.contains(1, r)
 assert Array.contains(2, r)
 assert Array.contains(3, r)
 assert Array.contains(4, r)
+
+// Resizes the map when it grows
+// TODO: Don't use these internals, as they need to change
+// after https://github.com/grain-lang/grain/issues/190 is fixed
+
+let resize = Set.makeSized(1);
+
+// (nodeCount, bucketLength)
+assert Set.getInternalStats(resize) == (0, 1);
+
+Set.add("🌾", resize);
+Set.add("🐑", resize);
+
+// (nodeCount, bucketLength)
+assert Set.getInternalStats(resize) == (2, 1);
+
+Set.add("🧱", resize);
+
+// (nodeCount, bucketLength)
+assert Set.getInternalStats(resize) == (3, 2);
+
+// Regression tests for https://github.com/grain-lang/grain/issues/497
+
+let largeSet = Set.fromArray(Array.init(128, i => i))
+
+// (nodeCount, bucketLength)
+assert Set.getInternalStats(largeSet) == (128, 64);

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -290,3 +290,9 @@ export let intersect = (set1, set2) => {
   }, set2);
   set
 }
+
+// TODO: Should return a Record type instead of a Tuple
+// Waiting on https://github.com/grain-lang/grain/issues/190
+export let getInternalStats = (set) => {
+  (set.size, Array.length(set.buckets))
+}


### PR DESCRIPTION
This adds regression tests for Map & Set related to #497 - I needed to add a `getInternalStats` to Set and I copied the Map tests.

Closes #497 