### PR TITLE
Better lenses and hover for LSP

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -62,10 +62,10 @@ let compile_string = name => {
 
         switch (compile_state.cstate_desc) {
         | TypeChecked(typed_program) =>
-          let lenses: list(Grain_diagnostics.Lenses.lens_t) =
-            Grain_diagnostics.Lenses.output_lenses(typed_program);
+          let values: list(Grain_diagnostics.Lenses.lens_t) =
+            Grain_diagnostics.Lenses.get_lenses_values(typed_program);
           let json =
-            Grain_diagnostics.Output.result_to_json(~errors=[], ~lenses);
+            Grain_diagnostics.Output.result_to_json(~errors=[], ~values);
           print_endline(json);
         | _ => ()
         };
@@ -80,7 +80,7 @@ let compile_string = name => {
       | Some(err) => [err]
       };
 
-    let json = Grain_diagnostics.Output.result_to_json(~errors, ~lenses=[]);
+    let json = Grain_diagnostics.Output.result_to_json(~errors, ~values=[]);
     print_endline(json);
   };
 

--- a/compiler/src/diagnostics/lenses.re
+++ b/compiler/src/diagnostics/lenses.re
@@ -1,6 +1,6 @@
 open Grain_typed;
 
-// Left as a string not a variant as this is opaque to the 
+// Left as a string not a variant as this is opaque to the
 // work done here and gets parsed into a string immediately anyway
 
 // t:
@@ -11,14 +11,14 @@ open Grain_typed;
 
 [@deriving yojson]
 type lens_t = {
-  sl: int,  // start line
-  sc: int,  // start character
-  sb: int,  // start BOL
-  el: int,  // end line
-  ec: int,  // end character
-  eb: int,  // end BOL
+  sl: int, // start line
+  sc: int, // start character
+  sb: int, // start BOL
+  el: int, // end line
+  ec: int, // end character
+  eb: int, // end BOL
   s: string, // type signature
-  t: string,  // lens stype
+  t: string // lens stype
 };
 
 let get_raw_pos_info = (pos: Lexing.position) => (
@@ -142,7 +142,6 @@ let print_tree = (stmts: list(Grain_typed.Typedtree.toplevel_stmt)) => {
 
       lenses := List.append(lenses^, [lens]);
       Iterator.iter_toplevel_stmt(cur);
-      
     },
     stmts,
   );

--- a/compiler/src/diagnostics/lenses.re
+++ b/compiler/src/diagnostics/lenses.re
@@ -69,16 +69,18 @@ let create_record_signature = (labels: list(Types.record_field)) => {
         let ppf = Format.formatter_of_buffer(buf);
         Printtyp.type_expr(ppf, field.rf_type);
         Format.pp_print_flush(ppf, ());
-        acc
-        ++ comma
-        ++ Ident.name(field.rf_name)
-        ++ " : "
-        ++ Buffer.contents(buf);
+        Printf.sprintf(
+          "%s%s%s: %s",
+          acc,
+          comma,
+          Ident.name(field.rf_name),
+          Buffer.contents(buf),
+        );
       },
       "",
       labels,
     );
-  "{" ++ recSig ++ " }";
+  Printf.sprintf("{%s }", recSig);
 };
 
 let data_hover_val =

--- a/compiler/src/diagnostics/lenses.re
+++ b/compiler/src/diagnostics/lenses.re
@@ -4,22 +4,33 @@ open Grain_typed;
 type lens_t = {
   sl: int,
   sc: int,
+  sb: int,
   el: int,
   ec: int,
+  eb: int,
   s: string,
   t: string,
 };
 
+let get_raw_pos_info = (pos: Lexing.position) => (
+  pos.pos_fname,
+  pos.pos_lnum,
+  pos.pos_cnum - pos.pos_bol,
+  pos.pos_bol,
+);
+
 let make_value =
     (~location: Grain_parsing.Location.t, ~sigStr: string, ~valType: string) => {
-  let (file, startline, startchar) =
-    Location.get_pos_info(location.loc_start);
-  let (_, endline, endchar) = Location.get_pos_info(location.loc_end);
+  let (file, startline, startchar, sbol) =
+    get_raw_pos_info(location.loc_start);
+  let (_, endline, endchar, ebol) = get_raw_pos_info(location.loc_end);
   let lens: lens_t = {
     sl: startline,
     sc: startchar,
+    sb: sbol,
     el: endline,
     ec: endchar,
+    eb: ebol,
     s: sigStr,
     t: valType,
   };
@@ -105,15 +116,17 @@ let print_tree = (stmts: list(Grain_typed.Typedtree.toplevel_stmt)) => {
 
   List.iter(
     (cur: Grain_typed__Typedtree.toplevel_stmt) => {
-      let (file, startline, startchar) =
-        Location.get_pos_info(cur.ttop_loc.loc_start);
-      let (_, endline, endchar) =
-        Location.get_pos_info(cur.ttop_loc.loc_end);
+      let (file, startline, startchar, sbol) =
+        get_raw_pos_info(cur.ttop_loc.loc_start);
+      let (_, endline, endchar, ebol) =
+        get_raw_pos_info(cur.ttop_loc.loc_end);
       let lens: lens_t = {
         sl: startline,
         sc: startchar,
+        sb: sbol,
         el: endline,
         ec: endchar,
+        eb: ebol,
         s: "",
         t: "S",
       };

--- a/compiler/src/diagnostics/lenses.re
+++ b/compiler/src/diagnostics/lenses.re
@@ -2,76 +2,112 @@ open Grain_typed;
 
 [@deriving yojson]
 type lens_t = {
-  line: int,
-  signature: string,
+  sl: int,
+  sc: int,
+  el: int,
+  ec: int,
+  s: string,
+  t: string,
 };
 
-[@deriving yojson]
-type lens_list_t = {lenses: list(lens_t)};
-
-let lenses_to_json_string = (lenses: list(lens_t)): string => {
-  let lensList: lens_list_t = {lenses: lenses};
-  let json_list = lens_list_t_to_yojson(lensList);
-  Yojson.Basic.pretty_to_string(Yojson.Safe.to_basic(json_list));
+let make_value =
+    (~location: Grain_parsing.Location.t, ~sigStr: string, ~valType: string) => {
+  let (file, startline, startchar) =
+    Location.get_pos_info(location.loc_start);
+  let (_, endline, endchar) = Location.get_pos_info(location.loc_end);
+  let lens: lens_t = {
+    sl: startline,
+    sc: startchar,
+    el: endline,
+    ec: endchar,
+    s: sigStr,
+    t: valType,
+  };
+  lens;
 };
 
-let output_lenses = (program: Typedtree.typed_program): list(lens_t) => {
-  let lenses =
-    List.map(
-      (statement: Typedtree.toplevel_stmt) => {
-        let d = statement.ttop_desc;
-        switch (d) {
-        | TTopExpr(expr) =>
-          let buf = Buffer.create(64);
-          let ppf = Format.formatter_of_buffer(buf);
-          let t: Types.type_expr = expr.exp_type;
-          Printtyp.type_expr(ppf, t);
-          Format.pp_print_flush(ppf, ());
-          let signt = Buffer.contents(buf);
-          let lens: lens_t = {
-            line: statement.ttop_loc.loc_start.pos_lnum,
-            signature: signt,
-          };
-          Some(lens);
-        | TTopLet(_, _, _, valueBindings) =>
-          let signatures =
-            List.map(
-              (vb: Typedtree.value_binding) => {
-                let expr = vb.vb_expr;
+let hover_val =
+    (
+      ~location: Grain_parsing.Location.t,
+      ~t: Types.type_expr,
+      ~valType: string,
+    ) => {
+  let buf = Buffer.create(64);
+  let ppf = Format.formatter_of_buffer(buf);
+  Printtyp.type_expr(ppf, t);
+  Format.pp_print_flush(ppf, ());
+  let sigStr = Buffer.contents(buf);
+  make_value(~location, ~valType, ~sigStr);
+};
 
-                let t: Types.type_expr = expr.exp_type;
-                let buf = Buffer.create(64);
-                let ppf = Format.formatter_of_buffer(buf);
-                Printtyp.type_expr(ppf, t);
-                Format.pp_print_flush(ppf, ());
-                Buffer.contents(buf);
-              },
-              valueBindings,
-            );
-          if (List.length(signatures) > 0) {
-            let signature = List.hd(signatures);
-            let lens: lens_t = {
-              line: statement.ttop_loc.loc_start.pos_lnum,
-              signature,
-            };
-            Some(lens);
-          } else {
-            None;
-          };
+let data_hover_val =
+    (
+      ~location: Grain_parsing.Location.t,
+      ~t: Types.type_declaration,
+      ~valType: string,
+    ) => {
+  let sigStr = "data";
+  make_value(~location, ~valType, ~sigStr);
+};
 
-        | _ => None
-        };
-      },
-      program.statements,
-    );
+let print_tree = (stmts: list(Grain_typed.Typedtree.toplevel_stmt)) => {
+  let lenses = ref([]);
 
-  List.fold_left(
-    (acc, st: option(lens_t)) =>
-      switch (st) {
-      | None => acc
-      | Some(s) => List.append(acc, [s])
-      },
-    [],
-    lenses,
+  module Iterator =
+    TypedtreeIter.MakeIterator({
+      include TypedtreeIter.DefaultIteratorArgument;
+      let enter_expression = (exp: Grain_typed__Typedtree.expression) => {
+        let lens =
+          hover_val(~t=exp.exp_type, ~location=exp.exp_loc, ~valType="E");
+        lenses := List.append(lenses^, [lens]);
+      };
+      let enter_pattern = (pat: Grain_typed__Typedtree.pattern) => {
+        let lens =
+          hover_val(~t=pat.pat_type, ~location=pat.pat_loc, ~valType="P");
+        lenses := List.append(lenses^, [lens]);
+      };
+
+      let enter_data_declaration =
+          (d: Grain_typed__Typedtree.data_declaration) => {
+        let lens =
+          data_hover_val(~t=d.data_type, ~location=d.data_loc, ~valType="D");
+        lenses := List.append(lenses^, [lens]);
+      };
+    });
+
+  List.iter(
+    (cur: Grain_typed__Typedtree.toplevel_stmt) => {
+      let (file, startline, startchar) =
+        Location.get_pos_info(cur.ttop_loc.loc_start);
+      let (_, endline, endchar) =
+        Location.get_pos_info(cur.ttop_loc.loc_end);
+      let lens: lens_t = {
+        sl: startline,
+        sc: startchar,
+        el: endline,
+        ec: endchar,
+        s: "",
+        t: "S",
+      };
+
+      lenses := List.append(lenses^, [lens]);
+      switch (cur.ttop_desc) {
+      | TTopException(_)
+      | TTopForeign(_)
+      | TTopImport(_)
+      | TTopExport(_)
+      | TTopExpr(_)
+      | TTopLet(_) => Iterator.iter_toplevel_stmt(cur)
+      | TTopData(_) => Iterator.iter_toplevel_stmt(cur)
+      };
+    },
+    stmts,
   );
+
+  lenses;
+};
+
+let get_lenses_values = (program: Typedtree.typed_program) => {
+  let lenses = print_tree(program.statements);
+  lenses^;
 };

--- a/compiler/src/diagnostics/lenses.re
+++ b/compiler/src/diagnostics/lenses.re
@@ -1,15 +1,24 @@
 open Grain_typed;
 
+// Left as a string not a variant as this is opaque to the 
+// work done here and gets parsed into a string immediately anyway
+
+// t:
+// S statement
+// D data
+// E expression
+// P pattern
+
 [@deriving yojson]
 type lens_t = {
-  sl: int,
-  sc: int,
-  sb: int,
-  el: int,
-  ec: int,
-  eb: int,
-  s: string,
-  t: string,
+  sl: int,  // start line
+  sc: int,  // start character
+  sb: int,  // start BOL
+  el: int,  // end line
+  ec: int,  // end character
+  eb: int,  // end BOL
+  s: string, // type signature
+  t: string,  // lens stype
 };
 
 let get_raw_pos_info = (pos: Lexing.position) => (
@@ -132,16 +141,8 @@ let print_tree = (stmts: list(Grain_typed.Typedtree.toplevel_stmt)) => {
       };
 
       lenses := List.append(lenses^, [lens]);
-      switch (cur.ttop_desc) {
-      | TTopException(_)
-      | TTopForeign(_)
-      | TTopImport(_)
-      | TTopExport(_)
-      | TTopExpr(_)
-      | TTopLet(_) => Iterator.iter_toplevel_stmt(cur)
-      // this is separate as the original emitted an enter data
-      | TTopData(_) => Iterator.iter_toplevel_stmt(cur)
-      };
+      Iterator.iter_toplevel_stmt(cur);
+      
     },
     stmts,
   );

--- a/compiler/src/diagnostics/output.re
+++ b/compiler/src/diagnostics/output.re
@@ -11,6 +11,7 @@ type lsp_error = {
 [@deriving yojson]
 type lsp_result = {
   errors: list(lsp_error),
+  values: list(Lenses.lens_t),
   lenses: list(Lenses.lens_t),
 };
 let exn_to_lsp_error = (exn: exn): option(lsp_error) => {
@@ -39,9 +40,11 @@ let exn_to_lsp_error = (exn: exn): option(lsp_error) => {
   };
 };
 
+// kept lenses as an empty array so older LSPs don't crash
+
 let result_to_json =
-    (~errors: list(lsp_error), ~lenses: list(Lenses.lens_t)) => {
-  let result: lsp_result = {errors, lenses};
+    (~errors: list(lsp_error), ~values: list(Lenses.lens_t)) => {
+  let result: lsp_result = {errors, values, lenses: []};
   Yojson.Basic.pretty_to_string(
     Yojson.Safe.to_basic(lsp_result_to_yojson(result)),
   );


### PR DESCRIPTION
Updated LSP mode to return the full set of statements, patterns and expressions in a JSON format to the LSP server.

This is much better than the previous version as I use the built-in typedtreeiterator to get what I need (so all the hard work was done for me thanks!)

Values are returned in a new field in the results (values) and the old field (lenses) is returned as empty so older LSP clients just report empty values and don't potentially crash.

One question - I build my own type description for the record type and just return "Variant" for the hover for variants.  What would you like to see here?  Having the hover show the whole record or variant is a little strange as that's just a repeat of the code, but it's what Reason does.  Let me know and I'll update the PR