### PR TITLE
chore: Use mutable globals instead of wrapper functions for function exports

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -299,7 +299,7 @@ type constant =
 type binding =
   | MArgBind(int32, asmtype)
   | MLocalBind(int32, asmtype)
-  | MGlobalBind(int32, asmtype)
+  | MGlobalBind(string, asmtype)
   | MClosureBind(int32)
   | MSwapBind(int32, asmtype) /* Used like a register would be */
   | MImport(int32); /* Index into list of imports */
@@ -450,7 +450,6 @@ type import = {
 type export = {
   ex_name: Ident.t,
   ex_global_index: int32,
-  ex_getter_index: int32,
 };
 
 [@deriving sexp]


### PR DESCRIPTION
Closes #131.

Before exportable mutable globals were a thing, the only way to simulate the behavior was to have a "getter" function that could return the value from your module. This reduces overall code size and is more efficient for module startup.