### PR TITLE
feat: Allow unsafe wasm values in globals

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -299,7 +299,7 @@ type constant =
 type binding =
   | MArgBind(int32, asmtype)
   | MLocalBind(int32, asmtype)
-  | MGlobalBind(string, asmtype)
+  | MGlobalBind(string, asmtype, bool)
   | MClosureBind(int32)
   | MSwapBind(int32, asmtype) /* Used like a register would be */
   | MImport(int32); /* Index into list of imports */
@@ -476,7 +476,7 @@ type mash_program = {
   exports: list(export),
   main_body: block,
   main_body_stack_size: stack_size,
-  num_globals: int,
+  globals: list((int32, asmtype)),
   signature: Cmi_format.cmi_infos,
 };
 

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -371,8 +371,8 @@ and anf_expression_desc =
 
 [@deriving sexp]
 type import_shape =
-  | FunctionShape(int, int)
-  | GlobalShape;
+  | FunctionShape(list(allocation_type), list(allocation_type))
+  | GlobalShape(allocation_type);
 
 [@deriving sexp]
 type import_desc =

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -355,8 +355,8 @@ and anf_expression_desc =
 
 [@deriving sexp]
 type import_shape =
-  | FunctionShape(int, int)
-  | GlobalShape;
+  | FunctionShape(list(allocation_type), list(allocation_type))
+  | GlobalShape(allocation_type);
 
 [@deriving sexp]
 type import_desc =

--- a/compiler/test/input/unsafeWasmGlobals.gr
+++ b/compiler/test/input/unsafeWasmGlobals.gr
@@ -1,0 +1,11 @@
+import WasmI32 from "unsafe/wasmi32"
+import WasmI64 from "unsafe/wasmi64"
+import WasmF32 from "unsafe/wasmf32"
+import WasmF64 from "unsafe/wasmf64"
+
+import { _I32_VAL, _I64_VAL, _F32_VAL, _F64_VAL } from "unsafeWasmGlobalsExports"
+
+WasmI32.print(_I32_VAL)
+WasmI64.print(_I64_VAL)
+WasmF32.print(_F32_VAL)
+WasmF64.print(_F64_VAL)

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -161,9 +161,13 @@ let test_run =
 let test_run_file = (~heap_size=?, filename, name, expected, test_ctxt) => {
   let input_filename = "input/" ++ filename ++ ".gr";
   let outfile = "output/" ++ name;
-  let cstate =
-    compile_file(~hook=stop_after_compiled, ~outfile, input_filename);
-  let result = run_output(~heap_size?, cstate, test_ctxt);
+  let result =
+    Config.preserve_config(() => {
+      Config.include_dirs := ["test-libs", ...Config.include_dirs^];
+      let cstate =
+        compile_file(~hook=stop_after_compiled, ~outfile, input_filename);
+      run_output(~heap_size?, cstate, test_ctxt);
+    });
   assert_equal(~printer=Fun.id, expected ++ "\n", result);
 };
 

--- a/compiler/test/test-libs/unsafeWasmGlobalsExports.gr
+++ b/compiler/test/test-libs/unsafeWasmGlobalsExports.gr
@@ -1,0 +1,4 @@
+export let _I32_VAL = 42n
+export let _I64_VAL = 42N
+export let _F32_VAL = 42.w
+export let _F64_VAL = 42.W

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -279,6 +279,11 @@ let basic_functionality_tests = [
   te("fail1", "ignore(fail \"boo\")", "Failure: boo"),
   te("fail2", "if (false) { 3 } else { fail \"boo\" }", "Failure: boo"),
   tfile("toplevel_statements", "toplevelStatements", "1\n2\n3\n4\n5\nfoo"),
+  tfile(
+    "unsafe_wasm_globals",
+    "unsafeWasmGlobals",
+    "42n\n42N\n42.0w\n42.0W\nvoid",
+  ),
 ];
 
 /* Tests for functions: basic, directly-recursive, and mutually-recursive. */


### PR DESCRIPTION
This PR adds the global use functionality described in #517.