### PR TITLE
chore: Refactor bindings in the AST

### DIFF
--- a/compiler/src/middle_end/optimize.re
+++ b/compiler/src/middle_end/optimize.re
@@ -12,6 +12,7 @@ let optimization_passes = [
   Optimize_simple_binops.optimize,
   Optimize_dead_assignments.optimize,
   Optimize_dead_branches.optimize,
+  Optimize_dead_statements.optimize,
   Optimize_inline_wasm.optimize,
 ];
 

--- a/compiler/src/middle_end/optimize_dead_statements.re
+++ b/compiler/src/middle_end/optimize_dead_statements.re
@@ -1,0 +1,23 @@
+open Anftree;
+open Grain_typed;
+
+let get_comp_purity = c =>
+  Option.value(~default=false) @@ Analyze_purity.comp_expression_purity(c);
+
+module DSEArg: Anf_mapper.MapArgument = {
+  include Anf_mapper.DefaultMapArgument;
+
+  let leave_anf_expression = ({anf_desc: desc} as a) =>
+    switch (desc) {
+    | AESeq(hd, tl) when get_comp_purity(hd) => tl
+    | AESeq(_)
+    | AELet(_)
+    | AEComp(_) => a
+    };
+};
+
+module DSEMapper = Anf_mapper.MakeMap(DSEArg);
+
+let optimize = anfprog => {
+  DSEMapper.map_anf_program(anfprog);
+};

--- a/compiler/src/middle_end/optimize_dead_statements.rei
+++ b/compiler/src/middle_end/optimize_dead_statements.rei
@@ -1,0 +1,3 @@
+/** Optimization pass which removes all dead statements. */
+
+let optimize: Optimization_pass.t;

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -212,8 +212,8 @@ module Exp = {
     mk(~loc?, ~attributes?, PExpArrayGet(a, b));
   let array_set = (~loc=?, ~attributes=?, a, b, c) =>
     mk(~loc?, ~attributes?, PExpArraySet(a, b, c));
-  let let_ = (~loc=?, ~attributes=?, a, b, c, d) =>
-    mk(~loc?, ~attributes?, PExpLet(a, b, c, d));
+  let let_ = (~loc=?, ~attributes=?, a, b, c) =>
+    mk(~loc?, ~attributes?, PExpLet(a, b, c));
   let match = (~loc=?, ~attributes=?, a, b) =>
     mk(~loc?, ~attributes?, PExpMatch(a, b));
   let prim1 = (~loc=?, ~attributes=?, a, b) =>

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -147,8 +147,7 @@ module Exp: {
       ~attributes: attributes=?,
       rec_flag,
       mut_flag,
-      list(value_binding),
-      expression
+      list(value_binding)
     ) =>
     expression;
   let match:

--- a/compiler/src/parsing/ast_iterator.re
+++ b/compiler/src/parsing/ast_iterator.re
@@ -58,9 +58,7 @@ module E = {
       sub.expr(sub, e);
       iter_loc(sub, f);
       sub.expr(sub, v);
-    | PExpLet(r, m, vbs, e) =>
-      List.iter(sub.value_binding(sub), vbs);
-      sub.expr(sub, e);
+    | PExpLet(r, m, vbs) => List.iter(sub.value_binding(sub), vbs)
     | PExpMatch(e, mbs) =>
       sub.expr(sub, e);
       List.iter(sub.match_branch(sub), mbs);

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -67,15 +67,8 @@ module E = {
         map_loc(sub, f),
         sub.expr(sub, v),
       )
-    | PExpLet(r, m, vbs, e) =>
-      let_(
-        ~loc,
-        ~attributes,
-        r,
-        m,
-        List.map(sub.value_binding(sub), vbs),
-        sub.expr(sub, e),
-      )
+    | PExpLet(r, m, vbs) =>
+      let_(~loc, ~attributes, r, m, List.map(sub.value_binding(sub), vbs))
     | PExpMatch(e, mbs) =>
       match(
         ~loc,

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -405,10 +405,10 @@ attributes :
   | [AT id_str eols? { $2 }]* { $1 }
 
 let_expr :
-  | attributes LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Recursive Immutable $4 (Exp.block []) }
-  | attributes LET value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonrecursive Immutable $3 (Exp.block []) }
-  | attributes LET REC MUT value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Recursive Mutable $5 (Exp.block []) }
-  | attributes LET MUT value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonrecursive Mutable $4 (Exp.block []) }
+  | attributes LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Recursive Immutable $4 }
+  | attributes LET value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonrecursive Immutable $3 }
+  | attributes LET REC MUT value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Recursive Mutable $5 }
+  | attributes LET MUT value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonrecursive Mutable $4 }
 
 if_expr :
   | IF lparen expr rparen eols? block_or_expr { Exp.if_ ~loc:(symbol_rloc dyp) $3 $6 (Exp.block []) }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -430,7 +430,7 @@ and expression_desc =
   | PExpRecord(list((loc(Identifier.t), expression)))
   | PExpRecordGet(expression, loc(Identifier.t))
   | PExpRecordSet(expression, loc(Identifier.t), expression)
-  | PExpLet(rec_flag, mut_flag, list(value_binding), expression)
+  | PExpLet(rec_flag, mut_flag, list(value_binding))
   | PExpMatch(expression, list(match_branch))
   | PExpPrim1(prim1, expression)
   | PExpPrim2(prim2, expression, expression)

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -273,7 +273,7 @@ let no_empty_record_patterns = (errs, super) => {
   };
   let iter_binds = (self, {pexp_desc: desc, pexp_loc: loc} as e) => {
     switch (desc) {
-    | PExpLet(_, _, vbs, _) =>
+    | PExpLet(_, _, vbs) =>
       List.iter(
         fun
         | {pvb_pat: {ppat_desc: PPatRecord(fields, _)}} =>
@@ -307,7 +307,7 @@ let only_functions_oh_rhs_letrec = (errs, super) => {
   };
   let iter_binds = (self, {pexp_desc: desc, pexp_loc: loc} as e) => {
     switch (desc) {
-    | PExpLet(Recursive, _, vbs, _) =>
+    | PExpLet(Recursive, _, vbs) =>
       List.iter(
         fun
         | {pvb_expr: {pexp_desc: PExpLambda(_)}} => ()
@@ -333,7 +333,7 @@ let no_letrec_mut = (errs, super) => {
   };
   let iter_binds = (self, {pexp_desc: desc, pexp_loc: loc} as e) => {
     switch (desc) {
-    | PExpLet(Recursive, Mutable, vbs, _) =>
+    | PExpLet(Recursive, Mutable, vbs) =>
       errs := [NoLetRecMut(loc), ...errs^]
     | _ => ()
     };

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -437,7 +437,7 @@ and expression_desc =
       Types.label_description,
       expression,
     )
-  | TExpLet(rec_flag, mut_flag, list(value_binding), expression)
+  | TExpLet(rec_flag, mut_flag, list(value_binding))
   | TExpMatch(expression, list(match_branch), partial)
   | TExpPrim1(prim1, expression)
   | TExpPrim2(prim2, expression, expression)

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -408,7 +408,7 @@ and expression_desc =
       Types.label_description,
       expression,
     )
-  | TExpLet(rec_flag, mut_flag, list(value_binding), expression)
+  | TExpLet(rec_flag, mut_flag, list(value_binding))
   | TExpMatch(expression, list(match_branch), partial)
   | TExpPrim1(prim1, expression)
   | TExpPrim2(prim2, expression, expression)

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -193,9 +193,8 @@ module MakeIterator =
     | TExpNull
     | TExpIdent(_)
     | TExpConstant(_) => ()
-    | TExpLet(recflag, mutflag, binds, body) =>
-      iter_bindings(Nonexported, recflag, mutflag, binds);
-      iter_expression(body);
+    | TExpLet(recflag, mutflag, binds) =>
+      iter_bindings(Nonexported, recflag, mutflag, binds)
     | TExpLambda(branches, _) => iter_match_branches(branches)
     | TExpApp(exp, args) =>
       iter_expression(exp);

--- a/compiler/src/typed/typedtreeMap.re
+++ b/compiler/src/typed/typedtreeMap.re
@@ -190,13 +190,8 @@ module MakeMap =
       | TExpNull
       | TExpIdent(_)
       | TExpConstant(_) => exp.exp_desc
-      | TExpLet(recflag, mutflag, binds, body) =>
-        TExpLet(
-          recflag,
-          mutflag,
-          map_bindings(recflag, mutflag, binds),
-          map_expression(body),
-        )
+      | TExpLet(recflag, mutflag, binds) =>
+        TExpLet(recflag, mutflag, map_bindings(recflag, mutflag, binds))
       | TExpLambda(branches, p) =>
         TExpLambda(map_match_branches(branches), p)
       | TExpApp(exp, args) =>

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -1200,7 +1200,7 @@ let import_tests = [
   te(
     "import_all_except_multiple_error2",
     "import * except {x, y} from \"exportStar\"; {print(x); print(y); z}",
-    "Unbound value y",
+    "Unbound value x",
   ),
   te(
     "import_all_except_error_constructor",
@@ -1449,16 +1449,10 @@ let optimization_tests = [
   tfinalanf(
     "test_const_propagation_shadowing",
     "{\n  let x = 5;\n  let y = 12;\n  let z = y;\n  {\n    let y = x;\n    x\n  }\n  x + y}",
-    AExp.seq(
+    AExp.comp(
       Comp.imm(
         ~allocation_type=HeapAllocated,
-        Imm.const(Const_number(Const_number_int(5L))),
-      ),
-      AExp.comp(
-        Comp.imm(
-          ~allocation_type=HeapAllocated,
-          Imm.const(Const_number(Const_number_int(17L))),
-        ),
+        Imm.const(Const_number(Const_number_int(17L))),
       ),
     ),
   ),


### PR DESCRIPTION
This PR refactors `let` bindings in the AST to not have bodies, i.e. work the same way that toplevel bindings do. This makes things a little cleaner (as can be seen by the chunk of code deleted from `parser_header`). As an added bonus, compilation errors are now reported in top-down order, which can be seen in the test changes.