### PR TITLE
chore!: Refactor value tags

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -8,7 +8,7 @@ let wasm_type =
   | F32Type => Type.float32
   | F64Type => Type.float64;
 
-let encoded_int32 = n => n * 2;
+let encoded_int32 = n => n * 2 + 1;
 
 let const_int32 = n => Literal.int32(Int32.of_int(n));
 let const_int64 = n => Literal.int64(Int64.of_int(n));
@@ -29,8 +29,8 @@ let grain_number_min = (-0x3fffffff); // 0xC0000001
 
 let rec compile_const = (c): Literal.t => {
   let identity: 'a. 'a => 'a = x => x;
-  let conv_int32 = Int32.(mul(of_int(2)));
-  let conv_int64 = Int64.(mul(of_int(2)));
+  let conv_int32 = n => Int32.(add(mul(2l, n), 1l));
+  let conv_int64 = n => Int64.(add(mul(2L, n), 1L));
   let conv_float32 = identity;
   let conv_float64 = identity;
   switch (c) {

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -482,6 +482,6 @@ type mash_program = {
   signature: Cmi_format.cmi_infos,
 };
 
-let const_true = MConstLiteral(MConstI32(Int32.of_int(0xFFFFFFFF)));
-let const_false = MConstLiteral(MConstI32(Int32.of_int(0x7FFFFFFF)));
-let const_void = MConstLiteral(MConstI32(Int32.of_int(0x6FFFFFFF)));
+let const_true = MConstLiteral(MConstI32(Int32.of_int(0xFFFFFFFE)));
+let const_false = MConstLiteral(MConstI32(Int32.of_int(0x7FFFFFFE)));
+let const_void = MConstLiteral(MConstI32(Int32.of_int(0x6FFFFFFE)));

--- a/compiler/src/codegen/value_tags.re
+++ b/compiler/src/codegen/value_tags.re
@@ -8,7 +8,9 @@ type heap_tag_type =
   | ADTType
   | RecordType
   | ArrayType
-  | BoxedNumberType;
+  | BoxedNumberType
+  | LambdaType
+  | TupleType;
 
 let tag_val_of_heap_tag_type =
   fun
@@ -17,16 +19,20 @@ let tag_val_of_heap_tag_type =
   | ADTType => 3
   | RecordType => 4
   | ArrayType => 5
-  | BoxedNumberType => 6;
+  | BoxedNumberType => 6
+  | LambdaType => 7
+  | TupleType => 8;
 
 let heap_tag_type_of_tag_val =
   fun
-  | x when x == 1 => StringType
-  | x when x == 2 => CharType
-  | x when x == 3 => ADTType
-  | x when x == 4 => RecordType
-  | x when x == 5 => ArrayType
-  | x when x == 6 => BoxedNumberType
+  | 1 => StringType
+  | 2 => CharType
+  | 3 => ADTType
+  | 4 => RecordType
+  | 5 => ArrayType
+  | 6 => BoxedNumberType
+  | 7 => LambdaType
+  | 8 => TupleType
   | x => failwith(Printf.sprintf("Unknown tag type: %d", x));
 
 [@deriving sexp]
@@ -47,35 +53,29 @@ let tag_val_of_boxed_number_tag_type =
 
 let boxed_number_tag_type_of_tag_val =
   fun
-  | x when x == 1 => BoxedFloat32
-  | x when x == 2 => BoxedFloat64
-  | x when x == 3 => BoxedInt32
-  | x when x == 4 => BoxedInt64
-  | x when x == 5 => BoxedRational
+  | 1 => BoxedFloat32
+  | 2 => BoxedFloat64
+  | 3 => BoxedInt32
+  | 4 => BoxedInt64
+  | 5 => BoxedRational
   | x => failwith(Printf.sprintf("Unknown boxed num tag type: %d", x));
 
 [@deriving sexp]
 type tag_type =
   | NumberTagType
   | ConstTagType
-  | TupleTagType
-  | LambdaTagType
   | GenericHeapType(option(heap_tag_type));
 
 let and_mask_of_tag_type =
   fun
   | NumberTagType => 0b0001
-  | ConstTagType => 0b1111
-  | TupleTagType => 0b0111
-  | LambdaTagType => 0b0111
+  | ConstTagType => 0b0111
   | GenericHeapType(_) => 0b0111;
 
 let tag_val_of_tag_type =
   fun
-  | NumberTagType => 0b0000
-  | ConstTagType => 0b1111
-  | TupleTagType => 0b0001
-  | LambdaTagType => 0b0101
-  | GenericHeapType(_) => 0b0011;
+  | NumberTagType => 0b0001
+  | ConstTagType => 0b0110
+  | GenericHeapType(_) => 0b0000;
 
 let shift_amount_of_tag_type = tt => 31 - tag_val_of_tag_type(tt);

--- a/compiler/test/stdlib/wasmi32.test.gr
+++ b/compiler/test/stdlib/wasmi32.test.gr
@@ -63,8 +63,8 @@ let test = () => {
   assert WasmI32.eq(WasmI32.extendS16(0x8000n), 0xffff8000n)
 
   // Grain conversion tests
-  assert WasmI32.eq(WasmI32.fromGrain(true), -1n)
-  assert (WasmI32.toGrain(-1n): Bool)
+  assert WasmI32.eq(WasmI32.fromGrain(true), 0xfffffffen)
+  assert (WasmI32.toGrain(0xfffffffen): Bool)
   assert WasmI32.toInt32(45n) == 45l
   assert WasmI32.ofInt32(45l) == 45n
 }

--- a/runtime/src/core/primitives.js
+++ b/runtime/src/core/primitives.js
@@ -1,3 +1,3 @@
-export const GRAIN_TRUE = 0xffffffff | 0;
-export const GRAIN_FALSE = 0x7fffffff | 0;
-export const GRAIN_VOID = 0x6fffffff | 0;
+export const GRAIN_TRUE = 0xfffffffe | 0;
+export const GRAIN_FALSE = 0x7ffffffe | 0;
+export const GRAIN_VOID = 0x6ffffffe | 0;

--- a/runtime/src/core/tags.js
+++ b/runtime/src/core/tags.js
@@ -12,13 +12,11 @@ import {
 import { GRAIN_TRUE, GRAIN_FALSE, GRAIN_VOID } from "./primitives";
 
 export const GRAIN_NUMBER_TAG_MASK = 0b0001;
-export const GRAIN_TUPLE_TAG_MASK = 0b0111;
+export const GRAIN_GENERIC_TAG_MASK = 0b0111;
 
-export const GRAIN_NUMBER_TAG_TYPE = 0b0000;
-export const GRAIN_CONST_TAG_TYPE = 0b1111;
-export const GRAIN_TUPLE_TAG_TYPE = 0b0001;
-export const GRAIN_LAMBDA_TAG_TYPE = 0b0101;
-export const GRAIN_GENERIC_HEAP_TAG_TYPE = 0b0011;
+export const GRAIN_NUMBER_TAG_TYPE = 0b0001;
+export const GRAIN_CONST_TAG_TYPE = 0b0111;
+export const GRAIN_GENERIC_HEAP_TAG_TYPE = 0b0000;
 
 export const GRAIN_STRING_HEAP_TAG = 1;
 export const GRAIN_CHAR_HEAP_TAG = 2;
@@ -26,6 +24,8 @@ export const GRAIN_ADT_HEAP_TAG = 3;
 export const GRAIN_RECORD_HEAP_TAG = 4;
 export const GRAIN_ARRAY_HEAP_TAG = 5;
 export const GRAIN_BOXED_NUM_HEAP_TAG = 6;
+export const GRAIN_LAMBDA_HEAP_TAG = 7;
+export const GRAIN_TUPLE_HEAP_TAG = 8;
 
 export const GRAIN_FLOAT32_BOXED_NUM_TAG = 1;
 export const GRAIN_FLOAT64_BOXED_NUM_TAG = 2;
@@ -45,13 +45,9 @@ function getAndMask(tag) {
 export function getTagType(n, quiet) {
   if (n === GRAIN_TRUE || n === GRAIN_FALSE || n === GRAIN_VOID) {
     return GRAIN_CONST_TAG_TYPE;
-  } else if (!(n & GRAIN_NUMBER_TAG_MASK)) {
+  } else if (n & GRAIN_NUMBER_TAG_MASK) {
     return GRAIN_NUMBER_TAG_TYPE;
-  } else if ((n & GRAIN_TUPLE_TAG_MASK) === GRAIN_TUPLE_TAG_TYPE) {
-    return GRAIN_TUPLE_TAG_TYPE;
-  } else if ((n & GRAIN_TUPLE_TAG_MASK) === GRAIN_LAMBDA_TAG_TYPE) {
-    return GRAIN_LAMBDA_TAG_TYPE;
-  } else if ((n & GRAIN_TUPLE_TAG_MASK) === GRAIN_GENERIC_HEAP_TAG_TYPE) {
+  } else if ((n & GRAIN_GENERIC_TAG_MASK) === GRAIN_GENERIC_HEAP_TAG_TYPE) {
     return GRAIN_GENERIC_HEAP_TAG_TYPE;
   } else {
     if (!quiet) {

--- a/stdlib/stdlib-external/ascutils/console.ts
+++ b/stdlib/stdlib-external/ascutils/console.ts
@@ -1,14 +1,12 @@
 import { fd_write } from 'bindings/wasi'
 import { calloc, free } from './grainRuntime'
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './tags';
 
 export declare function debug(value: u64): void
 export declare function tracepoint(n: u32): void
 
 // Implementation of writeStringLn from as-wasi: https://github.com/jedisct1/as-wasi
 // (MIT License)
-export function log(grainString: u32): void {
-  let ptr = grainString & ~GRAIN_GENERIC_HEAP_TAG_TYPE
+export function log(ptr: u32): void {
   let iov = calloc(32)
   store<u32>(iov, ptr + 8)
   store<u32>(iov, load<u32>(ptr + 4), sizeof<usize>())

--- a/stdlib/stdlib-external/ascutils/dataStructures.ts
+++ b/stdlib/stdlib-external/ascutils/dataStructures.ts
@@ -4,20 +4,20 @@ import {
   GRAIN_ARRAY_HEAP_TAG,
   GRAIN_STRING_HEAP_TAG,
   GRAIN_CHAR_HEAP_TAG,
+  GRAIN_TUPLE_HEAP_TAG,
   GRAIN_BOXED_NUM_HEAP_TAG,
   GRAIN_INT32_BOXED_NUM_TAG,
   GRAIN_INT64_BOXED_NUM_TAG,
   GRAIN_FLOAT32_BOXED_NUM_TAG,
   GRAIN_FLOAT64_BOXED_NUM_TAG,
   GRAIN_RATIONAL_BOXED_NUM_TAG,
-  GRAIN_GENERIC_HEAP_TAG_TYPE,
 } from './tags'
 
 /**
  * Allocates a new Grain array.
  *
  * @param {u32} numElts The number of elements to be contained in this array
- * @returns {u32} The (untagged) pointer to the array
+ * @returns {u32} The pointer to the array
  */
 export function allocateArray(numElts: u32): u32 {
   let arr = malloc((numElts + 2) * 4)
@@ -31,7 +31,7 @@ export function allocateArray(numElts: u32): u32 {
 /**
  * Stores an item in a Grain array.
  *
- * @param {u32} array The (untagged) array to store the item in
+ * @param {u32} array The array to store the item in
  * @param {u32} idx The index to store the item
  * @param {u32} item The item to store
  */
@@ -44,21 +44,34 @@ export function storeInArray(arr: u32, idx: u32, item: u32): void {
  * Allocates a new Grain tuple.
  *
  * @param {u32} numElts The number of elements to be contained in this tuple
- * @returns {u32} The (untagged) pointer to the tuple
+ * @returns {u32} The pointer to the tuple
  */
 export function allocateTuple(numElts: u32): u32 {
-  let tuple = malloc((numElts + 1) * 4)
+  let tuple = malloc((numElts + 2) * 4)
 
-  store<u32>(tuple, numElts)
+  store<u32>(tuple, GRAIN_TUPLE_HEAP_TAG)
+  store<u32>(tuple, numElts, 4)
 
   return tuple
+}
+
+/**
+ * Stores an item in a Grain tuple.
+ *
+ * @param {u32} tuple The tuple to store the item in
+ * @param {u32} idx The index to store the item
+ * @param {u32} item The item to store
+ */
+@inline
+export function storeInTuple(tuple: u32, idx: u32, item: u32): void {
+  store<u32>(tuple + idx * 4, item, 8)
 }
 
 /**
  * Allocates a new Grain string.
  *
  * @param {u32} size The size (in bytes) of the string to allocate
- * @returns {u32} The (untagged) pointer to the string
+ * @returns {u32} The pointer to the string
  */
 export function allocateString(size: u32): u32 {
   let str = malloc(size + 8)
@@ -72,7 +85,7 @@ export function allocateString(size: u32): u32 {
 /**
  * Allocates a new Grain char.
  *
- * @returns {u32} The (untagged) pointer to the char
+ * @returns {u32} The pointer to the char
  */
 export function allocateChar(): u32 {
   let char = malloc(8)
@@ -85,14 +98,14 @@ export function allocateChar(): u32 {
 export function singleByteString(char: u8): u32 {
   let s = allocateString(1)
   store<u8>(s, char, 8)
-  return s | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return s
 }
 
 export function twoByteString(char1: u8, char2: u8): u32 {
   let s = allocateString(2)
   store<u8>(s, char1, 8)
   store<u8>(s, char2, 8 + 1)
-  return s | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return s
 }
 
 // [TODO] should probably migrate over the accessors in numbers.ts
@@ -119,7 +132,7 @@ export function allocateInt64(): u32 {
 export function newInt64(value: i64): u32 {
   let ptr = allocateInt64()
   store<i64>(ptr + 8, value)
-  return ptr | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return ptr
 }
 
 /**
@@ -133,13 +146,13 @@ export function rawInt64Ptr(wrappedInt64: u32): u32 {
 // @ts-ignore: decorator
 @inline
 export function loadInt64(xptr: u32): i64 {
-  return load<i64>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i64>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function loadInt64Unsigned(xptr: u32): u64 {
-  return load<u64>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<u64>(xptr, 2 * 4)
 }
 
 /**
@@ -163,7 +176,7 @@ export function allocateInt32(): u32 {
 export function newInt32(value: i32): u32 {
   let ptr = allocateInt32()
   store<i32>(ptr + 8, value)
-  return ptr | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return ptr
 }
 
 /**
@@ -177,13 +190,13 @@ export function rawInt32Ptr(wrappedInt32: u32): u32 {
 // @ts-ignore: decorator
 @inline
 export function loadInt32(xptr: u32): i32 {
-  return load<i32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i32>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function loadInt32Unsigned(xptr: u32): u32 {
-  return load<u32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<u32>(xptr, 2 * 4)
 }
 
 // FLOATS
@@ -209,7 +222,7 @@ export function allocateFloat32(): u32 {
 export function newFloat32(value: f32): u32 {
   let ptr = allocateFloat32()
   store<f32>(ptr + 8, value)
-  return ptr | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return ptr
 }
 
 /**
@@ -223,7 +236,7 @@ export function rawFloat32Ptr(wrappedFloat32: u32): u32 {
 // @ts-ignore: decorator
 @inline
 export function loadFloat32(xptr: u32): f32 {
-  return load<f32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<f32>(xptr, 2 * 4)
 }
 
 /**
@@ -247,7 +260,7 @@ export function allocateFloat64(): u32 {
 export function newFloat64(value: f64): u32 {
   let ptr = allocateFloat64()
   store<f64>(ptr + 8, value)
-  return ptr | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return ptr
 }
 
 /**
@@ -261,7 +274,7 @@ export function rawFloat64Ptr(wrappedFloat64: u32): u32 {
 // @ts-ignore: decorator
 @inline
 export function loadFloat64(xptr: u32): f64 {
-  return load<f64>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<f64>(xptr, 2 * 4)
 }
 
 // RATIONALS
@@ -288,7 +301,7 @@ export function newRational(numerator: i32, denominator: i32): u32 {
   let ptr = allocateRational()
   store<i32>(ptr + 8, numerator)
   store<i32>(ptr + 12, denominator)
-  return ptr | GRAIN_GENERIC_HEAP_TAG_TYPE
+  return ptr
 }
 
 /**
@@ -310,13 +323,13 @@ export function rawRationalDenominatorPtr(wrappedRational: u32): u32 {
 // @ts-ignore: decorator
 @inline
 export function loadRationalNumerator(xptr: u32): i32 {
-  return load<i32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i32>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function loadRationalDenominator(xptr: u32): u32 {
-  return load<u32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 3 * 4)
+  return load<u32>(xptr, 3 * 4)
 }
 
 
@@ -352,10 +365,16 @@ export function loadAdtVariant(ptr: u32): u32 {
  *
  * @export
  * @param {u32} ptr Untagged pointer to the string
- * @returns {u32} The (untagged) string size (in bytes)
+ * @returns {u32} The string size (in bytes)
  */
 // @ts-ignore: decorator
 @inline
 export function stringSize(ptr: u32): u32 {
   return load<u32>(ptr, 4)
+}
+
+// @ts-ignore: decorator
+@inline
+export function tagSimpleNumber(x: i32): u32 {
+  return (x << 1) ^ 1
 }

--- a/stdlib/stdlib-external/ascutils/numberUtils.ts
+++ b/stdlib/stdlib-external/ascutils/numberUtils.ts
@@ -1,6 +1,5 @@
 import { decRef, malloc } from './grainRuntime'
 import { allocateString, singleByteString, stringSize } from './dataStructures'
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './tags';
 import { CharCode } from './charCodes'
 
 /*
@@ -907,14 +906,13 @@ function utoa64_any_core(buffer: usize, num: u64, offset: usize, radix: i32): vo
 // Note that all of the characters used in the strings produced in this file are ASCII,
 // so we can safely just halve the size of the string.
 // [TODO] (#475) Optimization: Make the functions in this file directly produce UTF-8
-function fixEncoding(utf16StringRaw: u32): u32 {
-  let utf16String = utf16StringRaw & ~GRAIN_GENERIC_HEAP_TAG_TYPE
-  let utf16Size = stringSize(utf16StringRaw)
+function fixEncoding(utf16String: u32): u32 {
+  let utf16Size = stringSize(utf16String)
   let utf8Size = utf16Size >> 1
   let ret = allocateString(utf8Size)
   String.UTF8.encodeUnsafe(<usize>(utf16String + 8), utf8Size, ret + 8, false)
-  decRef(utf16StringRaw)
-  return ret | GRAIN_GENERIC_HEAP_TAG_TYPE
+  decRef(utf16String)
+  return ret
 }
 
 export function utoa32(value: u32, radix: i32): u32 {
@@ -1334,14 +1332,14 @@ export function dtoa(value: f64): u32 {
     store<u8>(ret, CharCode._0, 8)
     store<u8>(ret, CharCode.DOT, 8 + 1)
     store<u8>(ret, CharCode._0, 8 + 2)
-    return ret | GRAIN_GENERIC_HEAP_TAG_TYPE
+    return ret
   } else if (!isFinite(value)) {
     if (isNaN(value)) {
       let ret = allocateString(3)
       store<u8>(ret, CharCode.N, 8)
       store<u8>(ret, CharCode.a, 8 + 1)
       store<u8>(ret, CharCode.N, 8 + 2)
-      return ret | GRAIN_GENERIC_HEAP_TAG_TYPE
+      return ret
     } else if (value < 0) {
       let ret = allocateString(9)
       store<u8>(ret, CharCode.MINUS, 8)
@@ -1353,7 +1351,7 @@ export function dtoa(value: f64): u32 {
       store<u8>(ret, CharCode.i, 8 + 6)
       store<u8>(ret, CharCode.t, 8 + 7)
       store<u8>(ret, CharCode.y, 8 + 8)
-      return ret | GRAIN_GENERIC_HEAP_TAG_TYPE
+      return ret
     } else {
       let ret = allocateString(8)
       store<u8>(ret, CharCode.I, 8)
@@ -1364,13 +1362,13 @@ export function dtoa(value: f64): u32 {
       store<u8>(ret, CharCode.i, 8 + 5)
       store<u8>(ret, CharCode.t, 8 + 6)
       store<u8>(ret, CharCode.y, 8 + 7)
-      return ret | GRAIN_GENERIC_HEAP_TAG_TYPE
+      return ret
     }
   }
   var size = dtoa_core(get_dtoa_buf(), value);
   var result = allocateString(size);
   String.UTF8.encodeUnsafe(get_dtoa_buf(), size, result + 8, false)
-  return result | GRAIN_GENERIC_HEAP_TAG_TYPE;
+  return result;
 }
 
 

--- a/stdlib/stdlib-external/ascutils/primitives.ts
+++ b/stdlib/stdlib-external/ascutils/primitives.ts
@@ -1,3 +1,3 @@
-export const GRAIN_TRUE: u32 = 0xFFFFFFFF
-export const GRAIN_FALSE: u32 = 0x7FFFFFFF
-export const GRAIN_VOID: u32 = 0x6FFFFFFF
+export const GRAIN_TRUE: u32 = 0xFFFFFFFE
+export const GRAIN_FALSE: u32 = 0x7FFFFFFE
+export const GRAIN_VOID: u32 = 0x6FFFFFFE

--- a/stdlib/stdlib-external/ascutils/tags.ts
+++ b/stdlib/stdlib-external/ascutils/tags.ts
@@ -1,8 +1,6 @@
-export const GRAIN_NUMBER_TAG_TYPE: i32       = 0b0000;
-export const GRAIN_CONST_TAG_TYPE: i32        = 0b1111;
-export const GRAIN_TUPLE_TAG_TYPE: i32        = 0b0001;
-export const GRAIN_LAMBDA_TAG_TYPE: i32       = 0b0101;
-export const GRAIN_GENERIC_HEAP_TAG_TYPE: i32 = 0b0011;
+export const GRAIN_NUMBER_TAG_TYPE: i32       = 0b0001;
+export const GRAIN_CONST_TAG_TYPE: i32        = 0b0110;
+export const GRAIN_GENERIC_HEAP_TAG_TYPE: i32 = 0b0000;
 
 export const GRAIN_NUMBER_TAG_MASK: i32 = 0b0001;
 export const GRAIN_GENERIC_TAG_MASK: i32 = 0b0111;
@@ -13,6 +11,8 @@ export const GRAIN_ADT_HEAP_TAG: i32 = 3;
 export const GRAIN_RECORD_HEAP_TAG: i32 = 4;
 export const GRAIN_ARRAY_HEAP_TAG: i32 = 5;
 export const GRAIN_BOXED_NUM_HEAP_TAG: i32 = 6;
+export const GRAIN_LAMBDA_HEAP_TAG: i32 = 7;
+export const GRAIN_TUPLE_HEAP_TAG: i32 = 8;
 
 export const GRAIN_FILE_DESCRIPTOR_TYPE_ID: i32 = 9;
 

--- a/stdlib/stdlib-external/float32.ts
+++ b/stdlib/stdlib-external/float32.ts
@@ -1,4 +1,3 @@
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './ascutils/tags'
 import { newFloat32, loadFloat32 } from "./ascutils/dataStructures";
 import { GRAIN_FALSE, GRAIN_TRUE } from "./ascutils/primitives";
 

--- a/stdlib/stdlib-external/float64.ts
+++ b/stdlib/stdlib-external/float64.ts
@@ -1,4 +1,3 @@
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './ascutils/tags'
 import { newFloat64, loadFloat64 } from "./ascutils/dataStructures";
 import { GRAIN_FALSE, GRAIN_TRUE } from "./ascutils/primitives";
 

--- a/stdlib/stdlib-external/int32.ts
+++ b/stdlib/stdlib-external/int32.ts
@@ -1,4 +1,3 @@
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './ascutils/tags'
 import { newInt32, rawInt32Ptr, loadInt32, loadInt32Unsigned } from "./ascutils/dataStructures";
 import { GRAIN_FALSE, GRAIN_TRUE } from "./ascutils/primitives";
 import {

--- a/stdlib/stdlib-external/int64.ts
+++ b/stdlib/stdlib-external/int64.ts
@@ -1,4 +1,3 @@
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from './ascutils/tags'
 import { newInt64, rawInt64Ptr, loadInt64, loadInt64Unsigned } from "./ascutils/dataStructures";
 import { GRAIN_FALSE, GRAIN_TRUE } from "./ascutils/primitives";
 import {

--- a/stdlib/stdlib-external/numbers.ts
+++ b/stdlib/stdlib-external/numbers.ts
@@ -78,7 +78,7 @@ function encodeBool(b: bool): u32 {
 // @ts-ignore: decorator
 @inline
 function tagSimple(x: i32): u32 {
-  return x << 1
+  return (x << 1) ^ 1
 }
 
 // @ts-ignore: decorator
@@ -236,43 +236,43 @@ function safeI64Multiply(x: i64, y: i64): i64 {
 // @ts-ignore: decorator
 @inline
 export function boxedNumberTag(xptr: u32): u32 {
-  return load<u32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 1 * 4)
+  return load<u32>(xptr, 1 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedInt32Number(xptr: u32): i32 {
-  return load<i32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i32>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedInt64Number(xptr: u32): i64 {
-  return load<i64>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i64>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedFloat32Number(xptr: u32): f32 {
-  return load<f32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<f32>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedFloat64Number(xptr: u32): f64 {
-  return load<f64>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<f64>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedRationalNumerator(xptr: u32): i32 {
-  return load<i32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
+  return load<i32>(xptr, 2 * 4)
 }
 
 // @ts-ignore: decorator
 @inline
 export function boxedRationalDenominator(xptr: u32): u32 {
-  return load<u32>(xptr & ~GRAIN_GENERIC_HEAP_TAG_TYPE, 3 * 4)
+  return load<u32>(xptr, 3 * 4)
 }
 
 
@@ -363,13 +363,7 @@ function isSimpleNumber(x: u32): bool {
 @inline
 function isBoxedNumber(x: u32): bool {
   return ((x & GRAIN_GENERIC_TAG_MASK) == GRAIN_GENERIC_HEAP_TAG_TYPE) &&
-    ((load<u32>(x ^ GRAIN_GENERIC_HEAP_TAG_TYPE) == GRAIN_BOXED_NUM_HEAP_TAG))
-}
-
-// @ts-ignore: decorator
-@inline
-function boxedNumberPtr(x: u32): u32 {
-  return x ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  (load<u32>(x) == GRAIN_BOXED_NUM_HEAP_TAG)
 }
 
 // @ts-ignore: decorator
@@ -388,14 +382,13 @@ export function isNumber(x: u32): bool {
   *       export them!
   */
 
-function numberEqualSimpleHelp(x: u32, yTagged: u32): bool {
+function numberEqualSimpleHelp(x: u32, y: u32): bool {
   // PRECONDITION: x is a "simple" number (value tag is 0) and x !== y and isNumber(y)
-  if (isSimpleNumber(yTagged)) {
+  if (isSimpleNumber(y)) {
     // x !== y, so they must be different
     return false
   }
   let xval = untagSimple(x) // <- actual int value of x
-  let y = boxedNumberPtr(yTagged)
   let yBoxedNumberTag = boxedNumberTag(y)
   switch (yBoxedNumberTag) {
     case GRAIN_INT32_BOXED_NUM_TAG: {

--- a/stdlib/stdlib-external/sys/env.ts
+++ b/stdlib/stdlib-external/sys/env.ts
@@ -2,9 +2,7 @@ import { malloc, free, throwError } from "../ascutils/grainRuntime";
 
 import { GRAIN_ERR_SYSTEM } from "../ascutils/errors";
 
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from "../ascutils/tags";
-
-import { allocateArray, allocateString } from "../ascutils/dataStructures";
+import { allocateArray, allocateString, tagSimpleNumber } from "../ascutils/dataStructures";
 
 import {
   errno,
@@ -21,7 +19,7 @@ export function argv(): u32 {
   let err = args_sizes_get(argcPtr, argvBufSizePtr);
   if (err !== errno.SUCCESS) {
     free(argcPtr);
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0);
   }
 
   let argc = load<u32>(argcPtr);
@@ -35,7 +33,7 @@ export function argv(): u32 {
     free(argcPtr);
     free(argvPtr);
     free(argvBufPtr);
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0);
   }
 
   let arr = allocateArray(argc);
@@ -51,14 +49,14 @@ export function argv(): u32 {
     let grainStrPtr = allocateString(strLength);
     memory.copy(grainStrPtr + 8, strPtr, strLength);
 
-    store<u32>(arr + i, grainStrPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4);
+    store<u32>(arr + i, grainStrPtr, 2 * 4);
   }
 
   free(argcPtr);
   free(argvPtr);
   free(argvBufPtr);
 
-  return arr | GRAIN_GENERIC_HEAP_TAG_TYPE;
+  return arr;
 }
 
 export function env(): u32 {
@@ -68,7 +66,7 @@ export function env(): u32 {
   let err = environ_sizes_get(envcPtr, envvBufSizePtr);
   if (err !== errno.SUCCESS) {
     free(envcPtr);
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0);
   }
 
   let envc = load<u32>(envcPtr);
@@ -82,7 +80,7 @@ export function env(): u32 {
     free(envcPtr);
     free(envvPtr);
     free(envvBufPtr);
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0);
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0);
   }
 
   let arr = allocateArray(envc);
@@ -98,12 +96,12 @@ export function env(): u32 {
     let grainStrPtr = allocateString(strLength);
     memory.copy(grainStrPtr + 8, strPtr, strLength);
 
-    store<u32>(arr + i, grainStrPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4);
+    store<u32>(arr + i, grainStrPtr, 2 * 4);
   }
 
   free(envcPtr);
   free(envvPtr);
   free(envvBufPtr);
 
-  return arr | GRAIN_GENERIC_HEAP_TAG_TYPE;
+  return arr;
 }

--- a/stdlib/stdlib-external/sys/file.ts
+++ b/stdlib/stdlib-external/sys/file.ts
@@ -41,11 +41,9 @@ import {
 
 import { GRAIN_ERR_SYSTEM } from "../ascutils/errors";
 
-import { GRAIN_GENERIC_HEAP_TAG_TYPE, GRAIN_STRING_HEAP_TAG, GRAIN_TUPLE_TAG_TYPE, GRAIN_ARRAY_HEAP_TAG } from "../ascutils/tags";
-
 import { GRAIN_VOID } from "../ascutils/primitives";
 
-import { loadAdtVal, loadAdtVariant, stringSize, allocateString, allocateTuple, allocateInt64, allocateArray } from '../ascutils/dataStructures'
+import { loadAdtVal, loadAdtVariant, stringSize, allocateString, allocateTuple, allocateInt64, allocateArray, storeInTuple, tagSimpleNumber } from '../ascutils/dataStructures'
 
 namespace glookupflag {
   // @ts-ignore: decorator
@@ -56,147 +54,147 @@ namespace glookupflag {
 namespace goflag {
   // @ts-ignore: decorator
   @inline
-  export const Create: u32 = 0
+  export const Create: u32 = 1
   // @ts-ignore: decorator
   @inline
-  export const Directory: u32 = 2
+  export const Directory: u32 = 3
   // @ts-ignore: decorator
   @inline
-  export const Exclusive: u32 = 4
+  export const Exclusive: u32 = 5
   // @ts-ignore: decorator
   @inline
-  export const Truncate: u32 = 6
+  export const Truncate: u32 = 7
 }
 
 namespace grights {
   // @ts-ignore decorator
   @inline
-  export const FdDatasync: u32 = 0
+  export const FdDatasync: u32 = 1
   // @ts-ignore decorator
   @inline
-  export const FdRead: u32 = 2
+  export const FdRead: u32 = 3
   // @ts-ignore decorator
   @inline
-  export const FdSeek: u32 = 4
+  export const FdSeek: u32 = 5
   // @ts-ignore decorator
   @inline
-  export const FdSetFlags: u32 = 6
+  export const FdSetFlags: u32 = 7
   // @ts-ignore decorator
   @inline
-  export const FdSync: u32 = 8
+  export const FdSync: u32 = 9
   // @ts-ignore decorator
   @inline
-  export const FdTell: u32 = 10
+  export const FdTell: u32 = 11
   // @ts-ignore decorator
   @inline
-  export const FdWrite: u32 = 12
+  export const FdWrite: u32 = 13
   // @ts-ignore decorator
   @inline
-  export const FdAdvise: u32 = 14
+  export const FdAdvise: u32 = 15
   // @ts-ignore decorator
   @inline
-  export const FdAllocate: u32 = 16
+  export const FdAllocate: u32 = 17
   // @ts-ignore decorator
   @inline
-  export const PathCreateDirectory: u32 = 18
+  export const PathCreateDirectory: u32 = 19
   // @ts-ignore decorator
   @inline
-  export const PathCreateFile: u32 = 20
+  export const PathCreateFile: u32 = 21
   // @ts-ignore decorator
   @inline
-  export const PathLinkSource: u32 = 22
+  export const PathLinkSource: u32 = 23
   // @ts-ignore decorator
   @inline
-  export const PathLinkTarget: u32 = 24
+  export const PathLinkTarget: u32 = 25
   // @ts-ignore decorator
   @inline
-  export const PathOpen: u32 = 26
+  export const PathOpen: u32 = 27
   // @ts-ignore decorator
   @inline
-  export const FdReaddir: u32 = 28
+  export const FdReaddir: u32 = 29
   // @ts-ignore decorator
   @inline
-  export const PathReadlink: u32 = 30
+  export const PathReadlink: u32 = 31
   // @ts-ignore decorator
   @inline
-  export const PathRenameSource: u32 = 32
+  export const PathRenameSource: u32 = 33
   // @ts-ignore decorator
   @inline
-  export const PathRenameTarget: u32 = 34
+  export const PathRenameTarget: u32 = 35
   // @ts-ignore decorator
   @inline
-  export const PathFilestats: u32 = 36
+  export const PathFilestats: u32 = 37
   // @ts-ignore decorator
   @inline
-  export const PathSetSize: u32 = 38
+  export const PathSetSize: u32 = 39
   // @ts-ignore decorator
   @inline
-  export const PathSetTimes: u32 = 40
+  export const PathSetTimes: u32 = 41
   // @ts-ignore decorator
   @inline
-  export const FdFilestats: u32 = 42
+  export const FdFilestats: u32 = 43
   // @ts-ignore decorator
   @inline
-  export const FdSetSize: u32 = 44
+  export const FdSetSize: u32 = 45
   // @ts-ignore decorator
   @inline
-  export const FdSetTimes: u32 = 46
+  export const FdSetTimes: u32 = 47
   // @ts-ignore decorator
   @inline
-  export const PathSymlink: u32 = 48
+  export const PathSymlink: u32 = 49
   // @ts-ignore decorator
   @inline
-  export const PathRemoveDirectory: u32 = 50
+  export const PathRemoveDirectory: u32 = 51
   // @ts-ignore decorator
   @inline
-  export const PathUnlinkFile: u32 = 52
+  export const PathUnlinkFile: u32 = 53
   // @ts-ignore decorator
   @inline
-  export const PollFdReadwrite: u32 = 54
+  export const PollFdReadwrite: u32 = 55
   // @ts-ignore decorator
   @inline
-  export const SockShutdown: u32 = 56
+  export const SockShutdown: u32 = 57
 }
 
 namespace gfdflag {
   // @ts-ignore decorator
   @inline
-  export const Append: u32 = 0
+  export const Append: u32 = 1
   // @ts-ignore decorator
   @inline
-  export const Dsync: u32 = 2
+  export const Dsync: u32 = 3
   // @ts-ignore decorator
   @inline
-  export const Nonblock: u32 = 4
+  export const Nonblock: u32 = 5
   // @ts-ignore decorator
   @inline
-  export const Rsync: u32 = 6
+  export const Rsync: u32 = 7
   // @ts-ignore decorator
   @inline
-  export const Sync: u32 = 8
+  export const Sync: u32 = 9
 }
 
 function combineLookupflags(dirflags: u32): u32 {
   let combinedDirFlags: u32 = 0
-  let listPtr = dirflags ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let listPtr = dirflags
   while (loadAdtVariant(listPtr) !== 0) {
-    let adt = loadAdtVal(listPtr, 0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    let adt = loadAdtVal(listPtr, 0)
     switch (loadAdtVariant(adt)) {
       case glookupflag.SymlinkFollow: {
         combinedDirFlags = combinedDirFlags | lookupflags.SYMLINK_FOLLOW
         break
       }
     }
-    listPtr = loadAdtVal(listPtr, 1) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    listPtr = loadAdtVal(listPtr, 1)
   }
   return combinedDirFlags
 }
 
 function combineOFlags(openflags: u32): u16 {
   let combinedOFlags: u16 = 0
-  let listPtr = openflags ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let listPtr = openflags
   while (loadAdtVariant(listPtr) !== 0) {
-    let adt = loadAdtVal(listPtr, 0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    let adt = loadAdtVal(listPtr, 0)
     switch (loadAdtVariant(adt)) {
       case goflag.Create: {
         combinedOFlags = combinedOFlags | oflags.CREAT
@@ -215,16 +213,16 @@ function combineOFlags(openflags: u32): u16 {
         break
       }
     }
-    listPtr = loadAdtVal(listPtr, 1) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    listPtr = loadAdtVal(listPtr, 1)
   }
   return combinedOFlags
 }
 
 function combineRights(grightsl: u32): u64 {
   let combinedRights: u64 = 0
-  let listPtr = grightsl ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let listPtr = grightsl
   while (loadAdtVariant(listPtr) !== 0) {
-    let adt = loadAdtVal(listPtr, 0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    let adt = loadAdtVal(listPtr, 0)
     switch (loadAdtVariant(adt)) {
       case grights.FdDatasync: {
         combinedRights = combinedRights | rights.FD_DATASYNC
@@ -343,7 +341,7 @@ function combineRights(grightsl: u32): u64 {
         break
       }
     }
-    listPtr = loadAdtVal(listPtr, 1) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    listPtr = loadAdtVal(listPtr, 1)
   }
 
   return combinedRights
@@ -351,9 +349,9 @@ function combineRights(grightsl: u32): u64 {
 
 function combineFdFlags(flagsl: u32): u16 {
   let combinedFdFlags: u16 = 0
-  let listPtr = flagsl ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let listPtr = flagsl
   while (loadAdtVariant(listPtr) !== 0) {
-    let adt = loadAdtVal(listPtr, 0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    let adt = loadAdtVal(listPtr, 0)
     switch (loadAdtVariant(adt)) {
       case gfdflag.Append: {
         combinedFdFlags = combinedFdFlags | fdflags.APPEND
@@ -376,7 +374,7 @@ function combineFdFlags(flagsl: u32): u16 {
         break
       }
     }
-    listPtr = loadAdtVal(listPtr, 1) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    listPtr = loadAdtVal(listPtr, 1)
   }
 
   return combinedFdFlags
@@ -391,12 +389,10 @@ export function pathOpen(
   fsRightsInheriting: u32,
   fsFlags: u32
 ): u32 {
-  dirfd = dirfd ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let dirfdval = loadAdtVal(dirfd, 0) >> 1
   
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  path = path ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathLength = stringSize(path)
   path += 8 // Offset the string pointer to the start of the string
 
@@ -425,17 +421,16 @@ export function pathOpen(
   )
   if (err !== errno.SUCCESS) {
     free(newFd)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   // Tag fd
-  store<u32>(newFd, load<u32>(newFd, 5 * 4) << 1, 5 * 4)
+  store<u32>(newFd, tagSimpleNumber(load<u32>(newFd, 5 * 4)), 5 * 4)
   
-  return newFd ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  return newFd
 }
 
 export function fdRead(fdPtr: u32, n: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   n = n >> 1
@@ -452,27 +447,25 @@ export function fdRead(fdPtr: u32, n: u32): u32 {
   if (err !== errno.SUCCESS) {
     free(iovs)
     free(strPtr)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   nread = load<u32>(nread)
   
   let tuple = allocateTuple(2)
 
-  store<u32>(tuple, strPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-  store<u32>(tuple, nread << 1, 2 * 4)
+  storeInTuple(tuple, 0, strPtr)
+  storeInTuple(tuple, 1, tagSimpleNumber(nread))
   store<u32>(strPtr, nread, 4)
 
   free(iovs)
 
-  return tuple ^ GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function fdPread(fdPtr: u32, offsetPtr: u32, n: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  offsetPtr = offsetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let offset = load<u64>(offsetPtr, 4)
 
   n = n >> 1
@@ -489,28 +482,27 @@ export function fdPread(fdPtr: u32, offsetPtr: u32, n: u32): u32 {
   if (err !== errno.SUCCESS) {
     free(iovs)
     free(strPtr)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   nread = load<u32>(nread)
   
   let tuple = allocateTuple(2)
 
-  store<u32>(tuple, strPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-  store<u32>(tuple, nread << 1, 2 * 4)
+  storeInTuple(tuple, 0, strPtr)
+  storeInTuple(tuple, 1, tagSimpleNumber(nread))
   store<u32>(strPtr, nread, 4)
 
   free(iovs)
 
-  return tuple ^ GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function fdWrite(fdPtr: u32, data: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let iovs = malloc(3 * 4)
-  let strPtr = data ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let strPtr = data
 
   store<u32>(iovs, strPtr + (2 * 4))
   store<u32>(iovs, load<u32>(strPtr, 4), 4)
@@ -520,27 +512,25 @@ export function fdWrite(fdPtr: u32, data: u32): u32 {
   let err = fd_write(fd, iovs, 1, nwritten)
   if (err !== errno.SUCCESS) {
     free(iovs)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   nwritten = load<u32>(nwritten)
   
   free(iovs)
 
-  return nwritten << 1
+  return tagSimpleNumber(nwritten)
 }
 
 export function fdPwrite(fdPtr: u32, data: u32, offsetPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
   
   let iovs = malloc(3 * 4)
-  let strPtr = data ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let strPtr = data
   
   store<u32>(iovs, strPtr + (2 * 4))
   store<u32>(iovs, load<u32>(strPtr, 4), 4)
 
-  offsetPtr = offsetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let offset = load<u64>(offsetPtr, 4)
 
   let nwritten = iovs + (3 * 4)
@@ -548,72 +538,65 @@ export function fdPwrite(fdPtr: u32, data: u32, offsetPtr: u32): u32 {
   let err = fd_pwrite(fd, iovs, 1, offset, nwritten)
   if (err !== errno.SUCCESS) {
     free(iovs)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   nwritten = load<u32>(nwritten)
   
   free(iovs)
 
-  return nwritten << 1
+  return tagSimpleNumber(nwritten)
 }
 
 export function fdAllocate(fdPtr: u32, offsetPtr: u32, sizePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  offsetPtr = offsetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let offset = load<u64>(offsetPtr, 4)
 
-  sizePtr = sizePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let size = load<u64>(sizePtr, 4)
   
   let err = fd_allocate(fd, offset, size)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdClose(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let err = fd_close(fd)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdDatasync(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let err = fd_datasync(fd)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSync(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let err = fd_sync(fd)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdStats(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let structPtr = malloc(24)
@@ -621,7 +604,7 @@ export function fdStats(fdPtr: u32): u32 {
   let err = fd_fdstat_get(fd, changetype<fdstat>(structPtr))
   if (err !== errno.SUCCESS) {
     free(structPtr)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let filetype = load<u8>(structPtr)
@@ -639,24 +622,23 @@ export function fdStats(fdPtr: u32): u32 {
   store<u64>(rightsInheritingPtr, rightsInheriting, 4)
 
   let tuple = allocateTuple(4)
-  store<u32>(tuple, filetype << 1, 4)
-  store<u32>(tuple, fdflagsPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
-  store<u32>(tuple, rightsPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 3 * 4)
-  store<u32>(tuple, rightsInheritingPtr | GRAIN_GENERIC_HEAP_TAG_TYPE, 4 * 4)
+  storeInTuple(tuple, 0, tagSimpleNumber(filetype))
+  storeInTuple(tuple, 1, fdflagsPtr)
+  storeInTuple(tuple, 2, rightsPtr)
+  storeInTuple(tuple, 3, rightsInheritingPtr)
 
   free(structPtr)
 
-  return tuple | GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function fdSetFlags(fdPtr: u32, flagsPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let flags: u16 = 0
-  let listPtr = flagsPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  let listPtr = flagsPtr
   while (loadAdtVariant(listPtr) !== 0) {
-    let adt = loadAdtVal(listPtr, 0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    let adt = loadAdtVal(listPtr, 0)
     switch (loadAdtVariant(adt)) {
       case gfdflag.Append: {
         flags = flags | fdflags.APPEND
@@ -679,19 +661,18 @@ export function fdSetFlags(fdPtr: u32, flagsPtr: u32): u32 {
         break
       }
     }
-    listPtr = loadAdtVal(listPtr, 1) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    listPtr = loadAdtVal(listPtr, 1)
   }
   
   let err = fd_fdstat_set_flags(fd, flags)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSetRights(fdPtr: u32, rightsPtr: u32, rightsInheritingPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let rights = combineRights(rightsPtr)
@@ -699,14 +680,13 @@ export function fdSetRights(fdPtr: u32, rightsPtr: u32, rightsInheritingPtr: u32
   
   let err = fd_fdstat_set_rights(fd, rights, rightsInheriting)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdFilestats(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let stats = malloc(64)
@@ -716,7 +696,7 @@ export function fdFilestats(fdPtr: u32): u32 {
   let err = fd_filestat_get(fd, filestats)
   if (err !== errno.SUCCESS) {
     free(stats)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let tuple = allocateTuple(8)
@@ -736,91 +716,82 @@ export function fdFilestats(fdPtr: u32): u32 {
   let ctim = allocateInt64()
   store<u64>(ctim, filestats.ctim, 4)
 
-  store<u32>(tuple, dev ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-  store<u32>(tuple, ino ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
-  store<u32>(tuple, filestats.filetype << 1, 3 * 4)
-  store<u32>(tuple, nlink ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4 * 4)
-  store<u32>(tuple, size ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 5 * 4)
-  store<u32>(tuple, atim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 6 * 4)
-  store<u32>(tuple, mtim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 7 * 4)
-  store<u32>(tuple, ctim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 8 * 4)
+  storeInTuple(tuple, 0, dev)
+  storeInTuple(tuple, 1, ino)
+  storeInTuple(tuple, 2, tagSimpleNumber(filestats.filetype))
+  storeInTuple(tuple, 3, nlink)
+  storeInTuple(tuple, 4, size)
+  storeInTuple(tuple, 5, atim)
+  storeInTuple(tuple, 6, mtim)
+  storeInTuple(tuple, 7, ctim)
 
   free(stats)
 
-  return tuple ^ GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function fdSetSize(fdPtr: u32, sizePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  sizePtr = sizePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let size = load<u64>(sizePtr, 4)
 
   let err = fd_filestat_set_size(fd, size)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSetAccessTime(fdPtr: u32, timePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  timePtr = timePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let time = load<u64>(timePtr, 4)
 
   let err = fd_filestat_set_times(fd, time, 0, fstflags.SET_ATIM)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSetAccessTimeNow(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let err = fd_filestat_set_times(fd, 0, 0, fstflags.SET_ATIM_NOW)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSetModifiedTime(fdPtr: u32, timePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  timePtr = timePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let time = load<u64>(timePtr, 4)
 
   let err = fd_filestat_set_times(fd, 0, time, fstflags.SET_MTIM)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSetModifiedTimeNow(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let err = fd_filestat_set_times(fd, 0, 0, fstflags.SET_MTIM_NOW)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdReaddir(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   const structWidth = 24
@@ -835,7 +806,7 @@ export function fdReaddir(fdPtr: u32): u32 {
   if (err !== errno.SUCCESS) {
     free(buf)
     free(bufUsed)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let used = load<u32>(bufUsed)
@@ -843,7 +814,7 @@ export function fdReaddir(fdPtr: u32): u32 {
   if (used <= 0) {
     free(buf)
     free(bufUsed)
-    return allocateArray(0) ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+    return allocateArray(0)
   }
 
   bufLen = load<u32>(buf, 16) + structWidth * 2
@@ -875,7 +846,7 @@ export function fdReaddir(fdPtr: u32): u32 {
         bufs = next
       }
       free(bufUsed)
-      throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+      throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
     }
 
     if (load<u32>(bufUsed) !== bufLen) {
@@ -903,13 +874,13 @@ export function fdReaddir(fdPtr: u32): u32 {
     let dirname = allocateString(dirnameLen)
     memory.copy(dirname + 8, dirent + structWidth, dirnameLen)
 
-    let filetype = load<u8>(dirent, 20) << 1
+    let filetype = tagSimpleNumber(load<u8>(dirent, 20))
     
-    store<u32>(tuple, inode ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-    store<u32>(tuple, dirname ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
-    store<u32>(tuple, filetype, 3 * 4)
+    storeInTuple(tuple, 0, inode)
+    storeInTuple(tuple, 1, dirname)
+    storeInTuple(tuple, 2, filetype)
 
-    store<u32>(arr + i * 4, tuple ^ GRAIN_TUPLE_TAG_TYPE, 8)
+    store<u32>(arr + i * 4, tuple, 8)
 
     let next = load<u32>(bufs, 4)
     free(bufs)
@@ -918,32 +889,27 @@ export function fdReaddir(fdPtr: u32): u32 {
     bufs = next
   }
   
-  return arr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  return arr
 }
 
 export function fdRenumber(fromFdPtr: u32, toFdPtr: u32): u32 {
-  fromFdPtr = fromFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fromFd = loadAdtVal(fromFdPtr, 0) >> 1
 
-  toFdPtr = toFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let toFd = loadAdtVal(toFdPtr, 0) >> 1
 
   let err = fd_renumber(fromFd, toFd)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function fdSeek(fdPtr: u32, offsetPtr: u32, whencePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  offsetPtr = offsetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let offset = load<u64>(offsetPtr, 4)
 
-  whencePtr = whencePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let whence = u8(load<u32>(whencePtr, 12) >> 1)
 
   let newoffset = allocateInt64()
@@ -951,14 +917,13 @@ export function fdSeek(fdPtr: u32, offsetPtr: u32, whencePtr: u32): u32 {
   
   let err = fd_seek(fd, offset, whence, newoffsetPtr)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
-  return newoffset ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  return newoffset
 }
 
 export function fdTell(fdPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let offset = allocateInt64()
@@ -966,17 +931,15 @@ export function fdTell(fdPtr: u32): u32 {
   
   let err = fd_tell(fd, offsetPtr)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
-  return offset ^ GRAIN_GENERIC_HEAP_TAG_TYPE
+  return offset
 }
 
 export function pathCreateDirectory(fdPtr: u32, stringPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  stringPtr = stringPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   
   let size = load<u32>(stringPtr, 4)
 
@@ -984,19 +947,17 @@ export function pathCreateDirectory(fdPtr: u32, stringPtr: u32): u32 {
   
   let err = path_create_directory(fd, stringPtr, size)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathFilestats(fdPtr: u32, dirflags: u32, pathPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
   
@@ -1007,7 +968,7 @@ export function pathFilestats(fdPtr: u32, dirflags: u32, pathPtr: u32): u32 {
   let err = path_filestat_get(fd, combinedDirFlags, pathPtr, pathSize, filestats)
   if (err !== errno.SUCCESS) {
     free(stats)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let tuple = allocateTuple(8)
@@ -1027,164 +988,143 @@ export function pathFilestats(fdPtr: u32, dirflags: u32, pathPtr: u32): u32 {
   let ctim = allocateInt64()
   store<u64>(ctim, filestats.ctim, 4)
 
-  store<u32>(tuple, dev ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-  store<u32>(tuple, ino ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 2 * 4)
-  store<u32>(tuple, filestats.filetype << 1, 3 * 4)
-  store<u32>(tuple, nlink ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4 * 4)
-  store<u32>(tuple, size ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 5 * 4)
-  store<u32>(tuple, atim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 6 * 4)
-  store<u32>(tuple, mtim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 7 * 4)
-  store<u32>(tuple, ctim ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 8 * 4)
+  storeInTuple(tuple, 0, dev)
+  storeInTuple(tuple, 1, ino)
+  storeInTuple(tuple, 2, tagSimpleNumber(filestats.filetype))
+  storeInTuple(tuple, 3, nlink)
+  storeInTuple(tuple, 4, size)
+  storeInTuple(tuple, 5, atim)
+  storeInTuple(tuple, 6, mtim)
+  storeInTuple(tuple, 7, ctim)
 
   free(stats)
 
-  return tuple ^ GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function pathSetAccessTime(fdPtr: u32, dirflags: u32, pathPtr: u32, timePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
-  timePtr = timePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let time = load<u64>(timePtr, 4)
 
   let err = path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, time, 0, fstflags.SET_ATIM)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathSetAccessTimeNow(fdPtr: u32, dirflags: u32, pathPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
   let err = path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0, 0, fstflags.SET_ATIM_NOW)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathSetModifiedTime(fdPtr: u32, dirflags: u32, pathPtr: u32, timePtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
-  timePtr = timePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let time = load<u64>(timePtr, 4)
 
   let err = path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0, time, fstflags.SET_MTIM)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathSetModifiedTimeNow(fdPtr: u32, dirflags: u32, pathPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
   let err = path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0, 0, fstflags.SET_MTIM_NOW)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathLink(sourceFdPtr: u32, dirflags: u32, sourcePtr: u32, targetFdPtr: u32, targetPtr: u32): u32 {
-  sourceFdPtr = sourceFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let sourceFd = loadAdtVal(sourceFdPtr, 0) >> 1
 
-  targetFdPtr = targetFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let targetFd = loadAdtVal(targetFdPtr, 0) >> 1
 
   let combinedDirFlags = combineLookupflags(dirflags)
 
-  sourcePtr = sourcePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let sourceSize = load<u32>(sourcePtr, 4)
   sourcePtr += 8
 
-  targetPtr = targetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let targetSize = load<u32>(targetPtr, 4)
   targetPtr += 8
 
   let err = path_link(sourceFd, combinedDirFlags, sourcePtr, sourceSize, targetFd, targetPtr, targetSize)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathSymlink(fdPtr: u32, sourcePtr: u32, targetPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  sourcePtr = sourcePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let sourceSize = load<u32>(sourcePtr, 4)
   sourcePtr += 8
 
-  targetPtr = targetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let targetSize = load<u32>(targetPtr, 4)
   targetPtr += 8
 
   let err = path_symlink(sourcePtr, sourceSize, fd, targetPtr, targetSize)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathUnlink(fdPtr: u32, pathPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
   let err = path_unlink_file(fd, pathPtr, pathSize)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathReadlink(fdPtr: u32, pathPtr: u32, size: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
@@ -1199,53 +1139,47 @@ export function pathReadlink(fdPtr: u32, pathPtr: u32, size: u32): u32 {
   if (err !== errno.SUCCESS) {
     free(grainStrPtr)
     free(nread)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let tuple = allocateTuple(2)
 
-  store<u32>(tuple, grainStrPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE, 4)
-  store<u32>(tuple, load<u32>(nread) << 1, 2 * 4)
+  storeInTuple(tuple, 0, grainStrPtr)
+  storeInTuple(tuple, 1, tagSimpleNumber(load<u32>(nread)))
 
   free(nread)
 
-  return tuple ^ GRAIN_TUPLE_TAG_TYPE
+  return tuple
 }
 
 export function pathRemoveDirectory(fdPtr: u32, pathPtr: u32): u32 {
-  fdPtr = fdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let fd = loadAdtVal(fdPtr, 0) >> 1
 
-  pathPtr = pathPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let pathSize = load<u32>(pathPtr, 4)
   pathPtr += 8
 
   let err = path_remove_directory(fd, pathPtr, pathSize)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID
 }
 
 export function pathRename(sourceFdPtr: u32, sourcePtr: u32, targetFdPtr: u32, targetPtr: u32): u32 {
-  sourceFdPtr = sourceFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let sourceFd = loadAdtVal(sourceFdPtr, 0) >> 1
 
-  targetFdPtr = targetFdPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let targetFd = loadAdtVal(targetFdPtr, 0) >> 1
 
-  sourcePtr = sourcePtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let sourceSize = load<u32>(sourcePtr, 4)
   sourcePtr += 8
 
-  targetPtr = targetPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let targetSize = load<u32>(targetPtr, 4)
   targetPtr += 8
 
   let err = path_rename(sourceFd, sourcePtr, sourceSize, targetFd, targetPtr, targetSize)
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   return GRAIN_VOID

--- a/stdlib/stdlib-external/sys/proc.ts
+++ b/stdlib/stdlib-external/sys/proc.ts
@@ -9,9 +9,9 @@ import {
 
 import { GRAIN_ERR_SYSTEM } from "../ascutils/errors";
 
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from "../ascutils/tags";
-
 import { GRAIN_VOID } from "../ascutils/primitives";
+
+import { tagSimpleNumber } from "../ascutils/dataStructures"
 
 export function exit(code: u32): u32 {
   code = code >> 1
@@ -20,11 +20,10 @@ export function exit(code: u32): u32 {
 }
 
 export function sigRaise(signalPtr: u32): u32 {
-  signalPtr = signalPtr ^ GRAIN_GENERIC_HEAP_TAG_TYPE
   let signal = load<u32>(signalPtr, 3 * 4) >> 1
   let err = proc_raise(u8(signal))
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
   return GRAIN_VOID
 }
@@ -32,7 +31,7 @@ export function sigRaise(signalPtr: u32): u32 {
 export function schedYield(): u32 {
   let err = sched_yield()
   if (err !== errno.SUCCESS) {
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
   return GRAIN_VOID
 }

--- a/stdlib/stdlib-external/sys/random.ts
+++ b/stdlib/stdlib-external/sys/random.ts
@@ -4,16 +4,18 @@ import { GRAIN_ERR_SYSTEM } from "../ascutils/errors"
 
 import { errno, random_get } from "bindings/wasi"
 
+import { tagSimpleNumber } from "../ascutils/dataStructures"
+
 export function random(): u32 {
   let buf = malloc(4)
 
   let err = random_get(buf, 4)
   if (err !== errno.SUCCESS) {
     free(buf)
-    throwError(GRAIN_ERR_SYSTEM, err << 1, 0)
+    throwError(GRAIN_ERR_SYSTEM, tagSimpleNumber(err), 0)
   }
 
   let rand = load<u32>(buf)
   free(buf)
-  return rand << 1
+  return tagSimpleNumber(rand)
 }

--- a/stdlib/stdlib-external/sys/time.ts
+++ b/stdlib/stdlib-external/sys/time.ts
@@ -2,8 +2,6 @@ import { free, throwError } from "../ascutils/grainRuntime"
 
 import { GRAIN_ERR_SYSTEM } from "../ascutils/errors"
 
-import { GRAIN_GENERIC_HEAP_TAG_TYPE } from "../ascutils/tags"
-
 import { allocateInt64 } from "../ascutils/dataStructures"
 
 import { errno, clock_time_get, clockid } from "bindings/wasi"
@@ -17,7 +15,7 @@ function getClockTime(clockid: u32, precision: u64): u32 {
     throwError(GRAIN_ERR_SYSTEM, err, 0);
   }
 
-  return int64Ptr | GRAIN_GENERIC_HEAP_TAG_TYPE;
+  return int64Ptr;
 }
 
 export function realTime(): u32 {

--- a/stdlib/unsafe/wasmf32.gr
+++ b/stdlib/unsafe/wasmf32.gr
@@ -40,7 +40,6 @@ export primitive demoteF64: WasmF64 -> WasmF32 = "@wasm.demote_float64"
 // Grain Conversions
 @disableGC
 export let toFloat32 = (n) => {
-  let _GRAIN_GENERIC_HEAP_TAG = 0b0011n
   let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
   let _GRAIN_FLOAT32_BOXED_NUM_TAG = 1n
   
@@ -49,12 +48,12 @@ export let toFloat32 = (n) => {
   WasmI32.store(ptr, _GRAIN_FLOAT32_BOXED_NUM_TAG, 4n)
   store(ptr, n, 8n)
 
-  WasmI32.toGrain(WasmI32.xor(ptr, _GRAIN_GENERIC_HEAP_TAG)) : Float32
+  WasmI32.toGrain(ptr) : Float32
 }
 
 @disableGC
 export let ofFloat32 = (n: Float32) => {
-  let ptr = WasmI32.xor(WasmI32.fromGrain(n), 3n)
+  let ptr = WasmI32.fromGrain(n)
   load(ptr, 8n)
 }
 

--- a/stdlib/unsafe/wasmf64.gr
+++ b/stdlib/unsafe/wasmf64.gr
@@ -40,7 +40,6 @@ export primitive promoteF32: WasmF32 -> WasmF64 = "@wasm.promote_float32"
 // Grain Conversions
 @disableGC
 export let toFloat64 = (n) => {
-  let _GRAIN_GENERIC_HEAP_TAG = 0b0011n
   let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
   let _GRAIN_FLOAT64_BOXED_NUM_TAG = 2n
   
@@ -49,12 +48,12 @@ export let toFloat64 = (n) => {
   WasmI32.store(ptr, _GRAIN_FLOAT64_BOXED_NUM_TAG, 4n)
   store(ptr, n, 8n)
 
-  WasmI32.toGrain(WasmI32.xor(ptr, _GRAIN_GENERIC_HEAP_TAG)) : Float64
+  WasmI32.toGrain(ptr) : Float64
 }
 
 @disableGC
 export let ofFloat64 = (n: Float64) => {
-  let ptr = WasmI32.xor(WasmI32.fromGrain(n), 3n)
+  let ptr = WasmI32.fromGrain(n)
   load(ptr, 8n)
 }
 

--- a/stdlib/unsafe/wasmi32.gr
+++ b/stdlib/unsafe/wasmi32.gr
@@ -59,7 +59,6 @@ export primitive toGrain : WasmI32 -> a = "@wasm.toGrain"
 
 @disableGC
 export let toInt32 = (n) => {
-  let _GRAIN_GENERIC_HEAP_TAG = 0b0011n
   let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
   let _GRAIN_INT32_BOXED_NUM_TAG = 3n
   
@@ -68,12 +67,12 @@ export let toInt32 = (n) => {
   store(ptr, _GRAIN_INT32_BOXED_NUM_TAG, 4n)
   store(ptr, n, 8n)
 
-  toGrain(xor(ptr, _GRAIN_GENERIC_HEAP_TAG)) : Int32
+  toGrain(ptr) : Int32
 }
 
 @disableGC
 export let ofInt32 = (n: Int32) => {
-  let ptr = xor(fromGrain(n), 3n)
+  let ptr = fromGrain(n)
   load(ptr, 8n)
 }
 

--- a/stdlib/unsafe/wasmi64.gr
+++ b/stdlib/unsafe/wasmi64.gr
@@ -62,7 +62,6 @@ export primitive extendS32 : WasmI64 -> WasmI64 = "@wasm.extend_s32_int64"
 // Grain Conversions
 @disableGC
 export let toInt64 = (n) => {
-  let _GRAIN_GENERIC_HEAP_TAG = 0b0011n
   let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
   let _GRAIN_INT64_BOXED_NUM_TAG = 4n
   
@@ -71,12 +70,12 @@ export let toInt64 = (n) => {
   WasmI32.store(ptr, _GRAIN_INT64_BOXED_NUM_TAG, 4n)
   store(ptr, n, 8n)
 
-  WasmI32.toGrain(WasmI32.xor(ptr, _GRAIN_GENERIC_HEAP_TAG)) : Int64
+  WasmI32.toGrain(ptr) : Int64
 }
 
 @disableGC
 export let ofInt64 = (n: Int64) => {
-  let ptr = WasmI32.xor(WasmI32.fromGrain(n), 3n)
+  let ptr = WasmI32.fromGrain(n)
   load(ptr, 8n)
 }
 


### PR DESCRIPTION
This PR reworks our value tags a bit:

|           | old   | new   |
|-----------|-------|-------|
| numbers   | 0bxx0 | 0bxx1 |
| tuples    | 0b001 | none  |
| closures  | 0b101 | none  |
| constants | 0b111 | 0b110 |
| generic   | 0b011 | 0b000 |

The purpose of this change is to correct a small oversight we made long ago. It increases overall performance slightly and reduces compiled module size slightly by eliminating the need to tag or untag pointers to heap values. This structure is similar to how OCaml tags values. Additionally, this change makes the tags easier to understand for FFI users, and for those of us that write low-level compiler code, makes it less likely for us to make mistakes.

This is a breaking change for FFI users, but will hopefully make writing FFI bindings much easier in the future.