### PR TITLE
feat: Optimize local mutations

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -179,6 +179,8 @@ type prim1 =
     | Not
     | Box
     | Unbox
+    | BoxBind
+    | UnboxBind
     | Ignore
     | ArrayLength
     | Assert
@@ -417,6 +419,7 @@ and instr_desc =
   | MAdtOp(adt_op, immediate)
   | MRecordOp(record_op, immediate)
   | MStore(list((binding, instr))) /* Items in the same list have their backpatching delayed until the end of that list */
+  | MSet(binding, instr)
   | MDrop(instr) /* Ignore the result of an expression. Used for sequences. */
   | MTracepoint(int) /* Prints a message to the console; for compiler debugging */
 

--- a/compiler/src/middle_end/analyze_closure_scoped_vars.re
+++ b/compiler/src/middle_end/analyze_closure_scoped_vars.re
@@ -1,0 +1,40 @@
+open Anftree;
+open Anf_iterator;
+open Grain_typed;
+
+let closure_scoped_vars = ref(Ident.Set.empty);
+
+let is_closure_scoped_var = id => {
+  Ident.Set.mem(id, closure_scoped_vars^);
+};
+
+module CSVArg: Anf_iterator.IterArgument = {
+  include Anf_iterator.DefaultIterArgument;
+
+  let leave_comp_expression = ({comp_desc: desc} as c) =>
+    switch (desc) {
+    | CLambda(_) =>
+      closure_scoped_vars :=
+        Ident.Set.union(closure_scoped_vars^, Anf_utils.comp_free_vars(c))
+    | _ => ()
+    };
+
+  let leave_anf_expression = ({anf_desc: desc}) => {
+    switch (desc) {
+    | AELet(Global, _, _, binds, _) =>
+      /* Assume that all globals are closure scope, since globals could
+         appear in a closure scope in another module */
+      let ids = List.map(fst, binds);
+      closure_scoped_vars :=
+        Ident.Set.union(closure_scoped_vars^, Ident.Set.of_list(ids));
+    | _ => ()
+    };
+  };
+};
+
+module CSVIterator = Anf_iterator.MakeIter(CSVArg);
+
+let analyze = anfprog => {
+  closure_scoped_vars := Ident.Set.empty;
+  CSVIterator.iter_anf_program(anfprog);
+};

--- a/compiler/src/middle_end/analyze_closure_scoped_vars.rei
+++ b/compiler/src/middle_end/analyze_closure_scoped_vars.rei
@@ -1,0 +1,6 @@
+open Anf_iterator;
+open Grain_typed;
+
+let is_closure_scoped_var: Ident.t => bool;
+
+let analyze: Analysis_pass.t;

--- a/compiler/src/middle_end/analyze_tail_calls.re
+++ b/compiler/src/middle_end/analyze_tail_calls.re
@@ -56,6 +56,7 @@ let rec analyze_comp_expression =
     false;
   | CBoxAssign(_)
   | CAssign(_)
+  | CLocalAssign(_)
   | CTuple(_)
   | CArray(_)
   | CArrayGet(_)
@@ -87,14 +88,14 @@ let rec analyze_comp_expression =
 and analyze_anf_expression =
     (is_tail, {anf_desc: desc, anf_analyses: analyses}) =>
   switch (desc) {
-  | AELet(_, Nonrecursive, binds, body) =>
+  | AELet(_, Nonrecursive, _, binds, body) =>
     /* None of these binds are in tail position */
     List.iter(
       ((_, exp)) => ignore @@ analyze_comp_expression(false, exp),
       binds,
     );
     analyze_anf_expression(is_tail, body);
-  | AELet(_, Recursive, binds, body) =>
+  | AELet(_, Recursive, _, binds, body) =>
     List.iter(((id, _)) => push_tail_callable_name(id), binds);
     List.iter(
       ((_, {comp_desc, comp_analyses} as bind)) =>

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -122,6 +122,8 @@ module Comp = {
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrimN(p, args));
   let box_assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CBoxAssign(a1, a2));
+  let local_assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
+    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CLocalAssign(a1, a2));
   let assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CAssign(a1, a2));
   let tuple = (~loc=?, ~attributes=?, ~env=?, elts) =>
@@ -287,8 +289,17 @@ module AExp = {
     anf_env: or_default_env(env),
     anf_analyses: ref([]),
   };
-  let let_ = (~loc=?, ~env=?, ~global=Nonglobal, rec_flag, binds, body) =>
-    mk(~loc?, ~env?, AELet(global, rec_flag, binds, body));
+  let let_ =
+      (
+        ~loc=?,
+        ~env=?,
+        ~global=Nonglobal,
+        ~mut_flag=Immutable,
+        rec_flag,
+        binds,
+        body,
+      ) =>
+    mk(~loc?, ~env?, AELet(global, rec_flag, mut_flag, binds, body));
   let seq = (~loc=?, ~env=?, hd, tl) => mk(~loc?, ~env?, AESeq(hd, tl));
   let comp = (~loc=?, ~env=?, e) => mk(~loc?, ~env?, AEComp(e));
 };

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -99,6 +99,16 @@ module Comp: {
       imm_expression
     ) =>
     comp_expression;
+  let local_assign:
+    (
+      ~loc: loc=?,
+      ~attributes: attributes=?,
+      ~allocation_type: allocation_type,
+      ~env: env=?,
+      Ident.t,
+      imm_expression
+    ) =>
+    comp_expression;
   let assign:
     (
       ~loc: loc=?,
@@ -303,6 +313,7 @@ module AExp: {
       ~loc: loc=?,
       ~env: env=?,
       ~global: global_flag=?,
+      ~mut_flag: mut_flag=?,
       rec_flag,
       list((ident, comp_expression)),
       anf_expression

--- a/compiler/src/middle_end/anf_iterator.re
+++ b/compiler/src/middle_end/anf_iterator.re
@@ -53,6 +53,7 @@ module MakeIter = (Iter: IterArgument) => {
     | CAssign(lhs, rhs) =>
       iter_imm_expression(lhs);
       iter_imm_expression(rhs);
+    | CLocalAssign(lhs, rhs) => iter_imm_expression(rhs)
     | CTuple(elts) => List.iter(iter_imm_expression, elts)
     | CArray(elts) => List.iter(iter_imm_expression, elts)
     | CArrayGet(arg1, arg2) =>
@@ -111,7 +112,7 @@ module MakeIter = (Iter: IterArgument) => {
   and iter_anf_expression = ({anf_desc: desc} as anf) => {
     Iter.enter_anf_expression(anf);
     switch (desc) {
-    | AELet(_, _, bindings, body) =>
+    | AELet(_, _, _, bindings, body) =>
       List.iter(((ident, bind)) => iter_comp_expression(bind), bindings);
       iter_anf_expression(body);
     | AESeq(hd, tl) =>

--- a/compiler/src/middle_end/anf_mapper.re
+++ b/compiler/src/middle_end/anf_mapper.re
@@ -52,8 +52,12 @@ module MakeMap = (Iter: MapArgument) => {
         let rhs = map_imm_expression(rhs);
         CBoxAssign(lhs, rhs);
       | CAssign(lhs, rhs) =>
+        let lhs = map_imm_expression(lhs);
         let rhs = map_imm_expression(rhs);
         CAssign(lhs, rhs);
+      | CLocalAssign(id, rhs) =>
+        let rhs = map_imm_expression(rhs);
+        CLocalAssign(id, rhs);
       | CTuple(elts) => CTuple(List.map(map_imm_expression, elts))
       | CArray(elts) => CArray(List.map(map_imm_expression, elts))
       | CArrayGet(arg1, arg2) =>
@@ -139,7 +143,7 @@ module MakeMap = (Iter: MapArgument) => {
     let {anf_desc: desc} as anf = Iter.enter_anf_expression(anf);
     let d =
       switch (desc) {
-      | AELet(g, r, bindings, body) =>
+      | AELet(g, r, m, bindings, body) =>
         let bindings =
           List.map(
             ((ident, bind)) => {
@@ -149,7 +153,7 @@ module MakeMap = (Iter: MapArgument) => {
             bindings,
           );
         let body = map_anf_expression(body);
-        AELet(g, r, bindings, body);
+        AELet(g, r, m, bindings, body);
       | AESeq(hd, tl) =>
         let hd = map_comp_expression(hd);
         let tl = map_anf_expression(tl);

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -10,7 +10,7 @@ let rec anf_free_vars_help = (env, a: anf_expression) =>
       anf_free_vars_help(env, rest),
     )
   | AEComp(c) => comp_free_vars_help(env, c)
-  | AELet(_, recflag, binds, body) =>
+  | AELet(_, recflag, _, binds, body) =>
     let with_names =
       List.fold_left((acc, (id, _)) => Ident.Set.add(id, acc), env, binds);
     let free_binds =
@@ -90,6 +90,7 @@ and comp_free_vars_help = (env, c: comp_expression) =>
       imm_free_vars_help(env, arg1),
       imm_free_vars_help(env, arg2),
     )
+  | CLocalAssign(arg1, arg2) => imm_free_vars_help(env, arg2)
   | CApp((fn, _), args, _) =>
     List.fold_left(
       (acc, a) => Ident.Set.union(imm_free_vars_help(env, a), acc),
@@ -175,7 +176,7 @@ let tuple_zero = (0, 0, 0, 0);
 
 let rec anf_count_vars = a =>
   switch (a.anf_desc) {
-  | AELet(global, recflag, binds, body) =>
+  | AELet(global, recflag, mutflag, binds, body) =>
     let max_binds =
       List.fold_left(tuple_max, tuple_zero) @@
       List.map(((_, c)) => comp_count_vars(c), binds);

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -162,6 +162,8 @@ type prim1 =
     | Not
     | Box
     | Unbox
+    | BoxBind
+    | UnboxBind
     | Ignore
     | ArrayLength
     | Assert
@@ -313,6 +315,7 @@ and comp_expression_desc =
   | CPrimN(primn, list(imm_expression))
   | CBoxAssign(imm_expression, imm_expression)
   | CAssign(imm_expression, imm_expression)
+  | CLocalAssign(Ident.t, imm_expression)
   | CTuple(list(imm_expression))
   | CArray(list(imm_expression))
   | CArrayGet(imm_expression, imm_expression)
@@ -365,6 +368,7 @@ and anf_expression_desc =
   | AELet(
       global_flag,
       rec_flag,
+      mut_flag,
       list((Ident.t, comp_expression)),
       anf_expression,
     )

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -163,6 +163,8 @@ type prim1 =
     | Not
     | Box
     | Unbox
+    | BoxBind
+    | UnboxBind
     | Ignore
     | ArrayLength
     | Assert
@@ -298,6 +300,7 @@ and comp_expression_desc =
   | CPrimN(primn, list(imm_expression))
   | CBoxAssign(imm_expression, imm_expression)
   | CAssign(imm_expression, imm_expression)
+  | CLocalAssign(Ident.t, imm_expression)
   | CTuple(list(imm_expression))
   | CArray(list(imm_expression))
   | CArrayGet(imm_expression, imm_expression)
@@ -349,6 +352,7 @@ and anf_expression_desc =
   | AELet(
       global_flag,
       rec_flag,
+      mut_flag,
       list((Ident.t, comp_expression)),
       anf_expression,
     )

--- a/compiler/src/middle_end/optimize.re
+++ b/compiler/src/middle_end/optimize.re
@@ -4,6 +4,7 @@ let analysis_passes = [
   Analyze_purity.analyze,
   Analyze_tail_calls.analyze,
   Analyze_inline_wasm.analyze,
+  Analyze_closure_scoped_vars.analyze,
 ];
 
 let optimization_passes = [
@@ -14,6 +15,7 @@ let optimization_passes = [
   Optimize_dead_branches.optimize,
   Optimize_dead_statements.optimize,
   Optimize_inline_wasm.optimize,
+  Optimize_local_mutations.optimize,
 ];
 
 module ClearAnalysesArg: Anf_iterator.IterArgument = {

--- a/compiler/src/middle_end/optimize_constants.re
+++ b/compiler/src/middle_end/optimize_constants.re
@@ -13,7 +13,7 @@ module ConstantPropagationArg: Anf_mapper.MapArgument = {
 
   let enter_anf_expression = ({anf_desc: desc} as a) => {
     switch (desc) {
-    | AELet(g, r, binds, body) =>
+    | AELet(g, r, Immutable, binds, body) =>
       List.iter(
         ((id, v)) =>
           switch (v) {

--- a/compiler/src/middle_end/optimize_dead_assignments.re
+++ b/compiler/src/middle_end/optimize_dead_assignments.re
@@ -26,10 +26,11 @@ module DAEArg: Anf_mapper.MapArgument = {
 
   let leave_anf_expression = ({anf_desc: desc} as a) =>
     switch (desc) {
-    | AELet(Global, _, _, _)
+    | AELet(Global, _, _, _, _)
+    | AELet(_, _, Mutable, _, _)
     | AESeq(_)
     | AEComp(_) => a
-    | AELet(g, Nonrecursive, [(bind, value)], body) =>
+    | AELet(g, Nonrecursive, _, [(bind, value)], body) =>
       switch (body.anf_desc) {
       | AEComp({comp_desc: CImmExpr({imm_desc: ImmId(id)})})
           when Ident.same(id, bind) => {
@@ -43,7 +44,7 @@ module DAEArg: Anf_mapper.MapArgument = {
           a;
         }
       }
-    | AELet(g, r, binds, body) =>
+    | AELet(g, r, m, binds, body) =>
       let new_binds =
         List.fold_right(
           ((id, v), tl) =>
@@ -57,7 +58,7 @@ module DAEArg: Anf_mapper.MapArgument = {
         );
       switch (new_binds) {
       | [] => body
-      | _ => {...a, anf_desc: AELet(g, r, new_binds, body)}
+      | _ => {...a, anf_desc: AELet(g, r, m, new_binds, body)}
       };
     };
 };

--- a/compiler/src/middle_end/optimize_local_mutations.re
+++ b/compiler/src/middle_end/optimize_local_mutations.re
@@ -1,0 +1,48 @@
+open Anftree;
+open Grain_typed;
+open Analyze_closure_scoped_vars;
+
+module LocalMutationsArg: Anf_mapper.MapArgument = {
+  include Anf_mapper.DefaultMapArgument;
+
+  let leave_anf_expression = ({anf_desc: desc} as a) => {
+    switch (desc) {
+    | AELet(g, r, m, binds, b) =>
+      let mut_flag = ref(m);
+      let binds =
+        List.map(
+          ((bind_id, expr)) => {
+            switch (expr.comp_desc) {
+            | CPrim1(BoxBind, arg) when !is_closure_scoped_var(bind_id) =>
+              mut_flag := Mutable;
+              (bind_id, {...expr, comp_desc: CImmExpr(arg)});
+            | _ => (bind_id, expr)
+            }
+          },
+          binds,
+        );
+      {...a, anf_desc: AELet(g, r, mut_flag^, binds, b)};
+    | _ => a
+    };
+  };
+
+  let leave_comp_expression = ({comp_desc: desc} as c) =>
+    switch (desc) {
+    | CAssign({imm_desc: ImmId(id)}, arg) when !is_closure_scoped_var(id) => {
+        ...c,
+        comp_desc: CLocalAssign(id, arg),
+      }
+    | CPrim1(UnboxBind, {imm_desc: ImmId(id)} as arg)
+        when !is_closure_scoped_var(id) => {
+        ...c,
+        comp_desc: CImmExpr(arg),
+      }
+    | _ => c
+    };
+};
+
+module LocalMutationsMapper = Anf_mapper.MakeMap(LocalMutationsArg);
+
+let optimize = anfprog => {
+  LocalMutationsMapper.map_anf_program(anfprog);
+};

--- a/compiler/src/middle_end/optimize_local_mutations.rei
+++ b/compiler/src/middle_end/optimize_local_mutations.rei
@@ -1,0 +1,3 @@
+/** Optimization pass which optimizes boxes used locally into local mutations. */
+
+let optimize: Optimization_pass.t;

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -304,6 +304,8 @@ type prim1 =
   | Not
   | Box
   | Unbox
+  | BoxBind
+  | UnboxBind
   | Ignore
   | ArrayLength
   | Assert

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -103,11 +103,13 @@ let prim1_type =
   | Incr
   | Decr => (Builtin_types.type_number, Builtin_types.type_number)
   | Not => (Builtin_types.type_bool, Builtin_types.type_bool)
-  | Box => {
+  | Box
+  | BoxBind => {
       let var = newvar(~name="a", ());
       (var, Builtin_types.type_box(var));
     }
-  | Unbox => {
+  | Unbox
+  | UnboxBind => {
       let var = newvar(~name="a", ());
       (Builtin_types.type_box(var), var);
     }

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -174,6 +174,8 @@ type prim1 =
     | Not
     | Box
     | Unbox
+    | BoxBind
+    | UnboxBind
     | Ignore
     | ArrayLength
     | Assert

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -173,6 +173,8 @@ type prim1 =
     | Not
     | Box
     | Unbox
+    | BoxBind
+    | UnboxBind
     | Ignore
     | ArrayLength
     | Assert

--- a/compiler/test/input/letMutForLoop.gr
+++ b/compiler/test/input/letMutForLoop.gr
@@ -1,0 +1,10 @@
+import WasmI64 from "unsafe/wasmi64"
+
+@disableGC
+let foo = () => {
+  for (let mut x = 0N; WasmI64.ltS(x, 5N); x = WasmI64.add(x, 1N)) {
+    WasmI64.print(x)
+  }
+}
+
+foo()

--- a/compiler/test/test-libs/letMutExport.gr
+++ b/compiler/test/test-libs/letMutExport.gr
@@ -1,0 +1,1 @@
+export let mut x = 3


### PR DESCRIPTION
This PR optimizes `let mut` to use function locals instead of boxes, where possible. (It's not possible to do this when the mutable variable is closed over, which is why `let mut` uses boxes under the hood.)

In addition to some performance gains, this also makes it possible to use `let mut` with unsafe wasm values, and there's a test that showcases this.