### PR TITLE
feat: Export compiled functions from modules

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -460,6 +460,7 @@ type export = {
 [@deriving sexp]
 type mash_function = {
   index: int32,
+  name: option(string),
   args: list(asmtype),
   return_type: asmtype,
   body: block,

--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -139,7 +139,7 @@ let rec analyze_comp_expression =
       List.for_all(x => x, branches_purities);
     | CApp(_) => false
     | CAppBuiltin(_) => false
-    | CLambda(_, (body, _)) =>
+    | CLambda(_, _, (body, _)) =>
       analyze_anf_expression(body);
       true;
     | CNumber(_)

--- a/compiler/src/middle_end/analyze_tail_calls.re
+++ b/compiler/src/middle_end/analyze_tail_calls.re
@@ -39,7 +39,7 @@ let rec analyze_comp_expression =
     /* While this loop itself is not in tail position, we still want to analyze the body. */
     ignore @@ analyze_anf_expression(false, body);
     false;
-  | CLambda(args, (body, _)) =>
+  | CLambda(_, args, (body, _)) =>
     /* While this lambda itself is not in tail position, we still want to analyze the body. */
     ignore @@ analyze_anf_expression(true, body);
     false;
@@ -100,7 +100,7 @@ and analyze_anf_expression =
     List.iter(
       ((_, {comp_desc, comp_analyses} as bind)) =>
         switch (comp_desc) {
-        | CLambda(args, (body, _)) =>
+        | CLambda(_, args, (body, _)) =>
           if (analyze_anf_expression(true, body)) {
             push_tail_recursive(comp_analyses);
           }

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -262,13 +262,13 @@ module Comp = {
       ~env?,
       CAppBuiltin(modname, name, args),
     );
-  let lambda = (~loc=?, ~attributes=?, ~env=?, args, body) =>
+  let lambda = (~loc=?, ~attributes=?, ~env=?, ~name=?, args, body) =>
     mk(
       ~loc?,
       ~attributes?,
       ~allocation_type=HeapAllocated,
       ~env?,
-      CLambda(args, body),
+      CLambda(name, args, body),
     );
   let string = (~loc=?, ~attributes=?, ~env=?, s) =>
     mk(

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -294,6 +294,7 @@ module Comp: {
       ~loc: loc=?,
       ~attributes: attributes=?,
       ~env: env=?,
+      ~name: string=?,
       list((ident, allocation_type)),
       (anf_expression, allocation_type)
     ) =>

--- a/compiler/src/middle_end/anf_iterator.re
+++ b/compiler/src/middle_end/anf_iterator.re
@@ -97,7 +97,7 @@ module MakeIter = (Iter: IterArgument) => {
       iter_imm_expression(f);
       List.iter(iter_imm_expression, args);
     | CAppBuiltin(_, _, args) => List.iter(iter_imm_expression, args)
-    | CLambda(idents, (expr, _)) => iter_anf_expression(expr)
+    | CLambda(_, idents, (expr, _)) => iter_anf_expression(expr)
     | CString(s) => ()
     | CChar(c) => ()
     | CNumber(i) => ()

--- a/compiler/src/middle_end/anf_mapper.re
+++ b/compiler/src/middle_end/anf_mapper.re
@@ -124,9 +124,9 @@ module MakeMap = (Iter: MapArgument) => {
         CApp((f, fty), args, tail);
       | CAppBuiltin(mod_, f, args) =>
         CAppBuiltin(mod_, f, List.map(map_imm_expression, args))
-      | CLambda(idents, (expr, alloc_ty)) =>
+      | CLambda(name, idents, (expr, alloc_ty)) =>
         let expr = map_anf_expression(expr);
-        CLambda(idents, (expr, alloc_ty));
+        CLambda(name, idents, (expr, alloc_ty));
       | CString(s) => CString(s)
       | CChar(c) => CChar(c)
       | CNumber(i) => CNumber(i)

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -35,7 +35,7 @@ let rec anf_free_vars_help = (env, a: anf_expression) =>
 
 and comp_free_vars_help = (env, c: comp_expression) =>
   switch (c.comp_desc) {
-  | CLambda(args, (body, _)) =>
+  | CLambda(_, args, (body, _)) =>
     anf_free_vars_help(
       Ident.Set.union(
         env,

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -340,6 +340,7 @@ and comp_expression_desc =
     )
   | CAppBuiltin(string, string, list(imm_expression))
   | CLambda(
+      option(string),
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
     )

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -325,6 +325,7 @@ and comp_expression_desc =
     )
   | CAppBuiltin(string, string, list(imm_expression))
   | CLambda(
+      option(string),
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
     )


### PR DESCRIPTION
This PR makes  (exported) Grain compiled functions have wasm function exports, i.e. if you compile the program `export let foo = x => 6` you'll see this in the compiled output:

![image](https://user-images.githubusercontent.com/7244034/107156251-41108f00-694b-11eb-94ab-f927c03bd032.png)
![image](https://user-images.githubusercontent.com/7244034/107156256-4b328d80-694b-11eb-9dc6-a6d47d613d28.png)

This does two important things: 1) other languages (or the Grain compiler) can call Grain functions directly, as opposed to via loading the function pointer from the closure and using `call_indirect`, and 2) debugging compiled wasm output is much easier because the functions have their original source names.

There's not really a great way to write a test for this, but this functionality will be exercised heavily in the coming PRs.