### PR TITLE
fix: One-sided if results in any type

### DIFF
--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1080,7 +1080,7 @@ and type_expect_ =
         (ifso, ifnot);
       };
 
-    re({
+    rue({
       exp_desc: TExpIf(cond, ifso, ifnot),
       exp_loc: loc,
       exp_extra: [],

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -263,6 +263,11 @@ let basic_functionality_tests = [
   t("if4", "if (false) 1 else if (false) 2 else {3}", "3"),
   t("if_one_sided", "if (3 < 4) print(5)", "5\nvoid"),
   t("if_one_sided2", "if (3 > 4) print(5)", "void"),
+  te(
+    "if_one_sided_type_err",
+    "let foo = (if (false) { 5; }); let bar = foo + 5; bar",
+    "has type Void but",
+  ),
   t("int32_1", "42l", "42"),
   t("int64_1", "99999999999999999L", "99999999999999999"),
   t("int64_pun_1", "9999999 * 99999999", "999999890000001"),


### PR DESCRIPTION
Obviously not something that's very common, but something that I came across.