### PR TITLE
feat: Allow pattern matching on unsafe wasm i32s

### DIFF
--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -947,6 +947,26 @@ let prepare_match_branches = branches => {
       | Const_char(_) => Builtin_types.type_char
       };
     };
+    let equality_operator = c => {
+      switch (c) {
+      | Const_number(_)
+      | Const_int32(_)
+      | Const_int64(_)
+      | Const_float32(_)
+      | Const_float64(_)
+      | Const_string(_)
+      | Const_char(_) => Eq
+      | Const_void
+      | Const_bool(_)
+      | Const_wasmi32(_) => Is
+      | Const_wasmi64(_)
+      | Const_wasmf32(_)
+      | Const_wasmf64(_) =>
+        failwith(
+          "Pattern matching not supported on low-level i64/f32/f64 types.",
+        )
+      };
+    };
     let add_constant_guard = (id, c, loc) => {
       let ty = type_constant(c);
       let vd = make_vd(id, ty);
@@ -959,7 +979,7 @@ let prepare_match_branches = branches => {
           );
         let ident = make_expr(~ty, ident, env, loc);
         let const = make_expr(~ty, TExpConstant(c), env, loc);
-        make_expr(TExpPrim2(Eq, ident, const), env, loc);
+        make_expr(TExpPrim2(equality_operator(c), ident, const), env, loc);
       };
       switch (guard^) {
       | Some(g) =>

--- a/compiler/test/input/patternMatchUnsafeWasm.gr
+++ b/compiler/test/input/patternMatchUnsafeWasm.gr
@@ -1,0 +1,22 @@
+@disableGC
+let test = () => {
+  @disableGC
+  let foo = (val) => {
+    match (val) {
+      1n => print(1),
+      2n => print(2),
+      3n => print(3),
+      4n => print(4),
+      5n => print(5),
+      6n => print(6),
+      _ => print("other")
+    }
+  }
+  foo(0n)
+  foo(1n)
+  foo(5n)
+  foo(8n)
+  foo(42n)
+}
+
+test()

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -283,6 +283,11 @@ let basic_functionality_tests = [
     "unsafeWasmGlobals",
     "42n\n42N\n42.0w\n42.0W\nvoid",
   ),
+  tfile(
+    "pattern_match_unsafe_wasm",
+    "patternMatchUnsafeWasm",
+    "other\n1\n5\nother\nother\nvoid",
+  ),
 ];
 
 /* Tests for functions: basic, directly-recursive, and mutually-recursive. */


### PR DESCRIPTION
It's not necessarily _hard_ to get i64/f32/f64s working, but it's not a feature we desperately need right now.