### PR TITLE
feat: Implement printing support in Grain

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -458,6 +458,7 @@ type mash_program = {
   main_body_stack_size: stack_size,
   globals: list((int32, asmtype)),
   signature: Cmi_format.cmi_infos,
+  type_metadata: list(Types.type_metadata),
 };
 
 let const_true = MConstLiteral(MConstI32(Int32.of_int(0xFFFFFFFE)));

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -1137,5 +1137,6 @@ let transl_anf_program =
         [],
       ),
     signature: anf_prog.signature,
+    type_metadata: anf_prog.type_metadata,
   };
 };

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -378,6 +378,7 @@ type anf_program = {
   env: [@sexp.opaque] Env.t,
   imports: list(import_spec),
   signature: Cmi_format.cmi_infos,
+  type_metadata: list(type_metadata),
   analyses: [@sexp.opaque] ref(list(analysis)),
 };
 

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -362,6 +362,7 @@ type anf_program = {
   env: Env.t,
   imports: list(import_spec),
   signature: Cmi_format.cmi_infos,
+  type_metadata: list(type_metadata),
   analyses: ref(list(analysis)),
 };
 

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -101,6 +101,12 @@ and value_unbound_reason =
   | ValUnboundGhostRecursive;
 
 [@deriving (sexp, yojson)]
+type type_metadata =
+  | ADTMetadata(int, list((int, string)))
+  | RecordMetadata(int, list(string))
+  | ExceptionMetadata(int, int, string);
+
+[@deriving (sexp, yojson)]
 type value_kind =
   | TValReg
   | TValPrim(string)

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -414,6 +414,13 @@ let unsound_optimizations =
     false,
   );
 
+let elide_type_info =
+  toggle_flag(
+    ~names=["elide-type-info"],
+    ~doc="Don't include runtime type information used by toString/print",
+    false,
+  );
+
 let source_map =
   toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -66,6 +66,10 @@ let debug: ref(bool);
 
 let unsound_optimizations: ref(bool);
 
+/** Whether or not to include runtime type information used by toString/print */
+
+let elide_type_info: ref(bool);
+
 /** Whether or not to generate source maps. */
 
 let source_map: ref(bool);

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -413,7 +413,7 @@ let function_tests = [
      let item = Calzone(Peppers, WholeWheat,)
      item
     ",
-    "<enum value>",
+    "Calzone(Peppers, WholeWheat)",
   ),
   t("lam_destructure_1", "((_) => 5)(\"foo\")", "5"),
   t("lam_destructure_2", "let foo = (_) => 5; foo(\"foo\")", "5"),
@@ -594,7 +594,7 @@ let array_tests = [
 ];
 
 let record_tests = [
-  t("record_1", "record Rec {foo: Number}; {foo: 4}", "<record value>"),
+  t("record_1", "record Rec {foo: Number}; {foo: 4}", "{\n  foo: 4\n}"),
   t(
     "record_2",
     "export record Rec {foo: Number}; {foo: 4}",
@@ -1976,8 +1976,26 @@ let char_tests = [
   te("unicode_err3", "let x = '\\u{110000}'", "Illegal unicode code point"),
 ];
 
+let print_tests = [
+  t(
+    "elided_type_info_1",
+    "/* grainc-flags --elide-type-info */ enum Foo { Foo }; Foo",
+    "<enum value>",
+  ),
+  t(
+    "elided_type_info_2",
+    "/* grainc-flags --elide-type-info */ record Foo { foo: String }; { foo: \"foo\" }",
+    "<record value>",
+  ),
+  t(
+    "print_double_exception",
+    "exception Foo; exception Bar; print(Foo); print(Bar)",
+    "Foo\nBar\nvoid",
+  ),
+];
+
 let exception_tests = [
-  t("exception_1", "exception Foo; Foo", "<enum value>"),
+  t("exception_1", "exception Foo; Foo", "Foo"),
   t("exception_2", "export exception Foo; Foo", "Foo"),
   t(
     "exception_3",
@@ -1998,11 +2016,11 @@ let enum_tests = [
     "adtprint",
     "Foo\nBar\nBaz(\"baz\")\nQux(5, \"qux\", false)\nQuux\nFlip(\"flip\")\nvoid",
   ),
-  t("adtprint_nonexported", "enum Foo { Foo }; Foo", "<enum value>"),
+  t("adtprint_nonexported", "enum Foo { Foo }; Foo", "Foo"),
   t(
     "adt_trailing",
     "enum Topping { Cheese(Bool,), Pepperoni }; Pepperoni",
-    "<enum value>",
+    "Pepperoni",
   ),
 ];
 
@@ -2163,6 +2181,7 @@ let tests =
   @ optimization_tests
   @ char_tests
   @ string_tests
+  @ print_tests
   @ enum_tests
   @ export_tests
   @ comment_tests

--- a/docs/contributor/printing.md
+++ b/docs/contributor/printing.md
@@ -1,0 +1,55 @@
+# Printing in Grain
+
+One of Grain's most developer-focused features is the ability to print any value without having to first define a printer. Some type information is kept around at runtime that allows this to work. As this does take up some extra memory and a few extra CPU cycles, this behavior can be disabled via the `--elide-type-info` flag, which may be useful in a production setting where this functionality is no longer needed.
+
+This document is primarily aimed at describing the data format used to store the names of enum variants and record fields. For more information on information stored with each individual value, see the document on [data representations](./data_representations.md).
+
+## The Master Type Metadata List
+
+Grain reserves a single 32-bit word in the runtime heap space as a pointer to all available printing information. This is done to allow modules to register their printing information without needing to depend on any other modules, and by extension, it allows them to register their information before printing is available.
+
+The data is structured as a linked list. To register its printing information, a module just needs to cons its information onto the list. Here's what the payload for a single module looks like:
+
+```plaintext
++0  32-bit pointer to next block
++4  32-bit module id
++8  32-bit number of types contained in the block, where a type is an enum or record declaration
++12 n-bit type information
+```
+
+Here is the layout for a single enum type:
+
+```plaintext
++0  32-bit size of complete type info block
++4  32-bit type id
+<start repeated pattern>
++0  32-bit size of constructor name block
++4  32-bit constructor id
++8  32-bit length of constructor name
++12 n-bit string
+<end repeated pattern>
+```
+
+And here is the layout for a single record type:
+
+```plaintext
++0  32-bit size of complete type info block
++4  32-bit type id
+<start repeated pattern>
++0  32-bit size of record field name block
++4  32-bit length of record field name
++8  n-bit string
+<end repeated pattern>
+```
+
+The block sizes are all necessary as padding is added to keep alignment.
+
+### Considerations
+
+#### Data Format
+
+You may have looked at the data format and thought that it might be easier to use if all of the strings were allocated individually. This is probably true, but ideally we'll move this information into the module's `data` section. When that happens, it won't be possible to have pointers in the block as the data must be purely static.
+
+#### Efficiency
+
+This format is admittedly inefficient. The worst case lookup on any given type is O(_kn_) where _k_ is the number of modules loaded and _n_ is the number of types defined in the module. Constant-time lookups on module information would be fairly easy to obtain at the expense of memory.

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -13,7 +13,8 @@ import WasmI32, {
   ne as (!=),
   geS as (>=),
   gtS as (>),
-  leS as (<=)
+  leS as (<=),
+  ltS as (<)
 } from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF32 from "runtime/unsafe/wasmf32"
@@ -22,12 +23,7 @@ import Memory from "runtime/unsafe/memory"
 import Tags from "runtime/unsafe/tags"
 import NumberUtils from "runtime/numberUtils"
 
-import { allocateString } from "runtime/dataStructures"
-
-import foreign wasm variantExists: (WasmI32, WasmI32, WasmI32) -> Bool from "grainRuntime"
-import foreign wasm getVariantName: (WasmI32, WasmI32, WasmI32) -> String from "grainRuntime"
-import foreign wasm recordTypeExists: (WasmI32, WasmI32) -> Bool from "grainRuntime"
-import foreign wasm getRecordFieldName: (WasmI32, WasmI32, WasmI32) -> String from "grainRuntime"
+import { allocateString, allocateArray } from "runtime/dataStructures"
 
 import foreign wasm fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
 
@@ -36,6 +32,98 @@ primitive (&&) : (Bool, Bool) -> Bool = "@and"
 primitive (||) : (Bool, Bool) -> Bool = "@or"
 
 enum StringList { [], [...](String, StringList) }
+
+let _RUNTIME_TYPE_METADATA_PTR = 256n
+
+@disableGC
+let findTypeMetadata = (moduleId, typeId) => {
+  let mut metadataPtr = WasmI32.load(_RUNTIME_TYPE_METADATA_PTR, 0n)
+  let mut modData = -1n
+  let mut modTypesCount = 0n
+  while (metadataPtr != 0n) {
+    if (WasmI32.load(metadataPtr, 4n) == moduleId) {
+      modData = metadataPtr + 12n
+      modTypesCount = WasmI32.load(metadataPtr, 8n)
+      break
+    }
+    metadataPtr = WasmI32.load(metadataPtr, 0n)
+  }
+
+  if (modData == -1n) {
+    -1n
+  } else {
+    let mut typeData = -1n
+    for (let mut i = 0n; i < modTypesCount; i += 1n) {
+      if (WasmI32.load(modData, 4n) == typeId) {
+        typeData = modData
+        break
+      }
+      modData += WasmI32.load(modData, 0n)
+    }
+
+    typeData
+  }
+}
+
+@disableGC
+let getVariantName = (variant) => {
+  let moduleId = WasmI32.load(variant, 4n) >> 1n
+  let typeId = WasmI32.load(variant, 8n) >> 1n
+  let variantId = WasmI32.load(variant, 12n) >> 1n
+
+  let mut block = findTypeMetadata(moduleId, typeId)
+
+  if (block == -1n) {
+    -1n
+  } else {
+    let sectionLength = WasmI32.load(block, 0n)
+    block += 8n
+
+    let end = block + sectionLength
+    let mut result = -1n
+    while (block < end) {
+      if (WasmI32.load(block, 4n) == variantId) {
+        let length = WasmI32.load(block, 8n)
+        let str = allocateString(length)
+        Memory.copy(str + 8n, block + 12n, length)
+        result = str
+        break
+      }
+      block += WasmI32.load(block, 0n)
+    }
+
+    result
+  }
+}
+
+@disableGC
+let getRecordFieldNames = (record_) => {
+  let moduleId = WasmI32.load(record_, 4n) >> 1n
+  let typeId = WasmI32.load(record_, 8n) >> 1n
+  let arity = WasmI32.load(record_, 12n)
+
+  let mut fields = findTypeMetadata(moduleId, typeId)
+
+  if (fields == -1n) {
+    -1n
+  } else {
+    fields += 8n
+    
+    let fieldArray = allocateArray(arity)
+
+    let mut fieldOffset = 0n
+    for (let mut i = 0n; i < arity; i += 1n) {
+      let fieldLength = WasmI32.load(fields + fieldOffset, 4n)
+      let fieldName = allocateString(fieldLength)
+      Memory.copy(fieldName + 8n, fields + fieldOffset + 8n, fieldLength)
+      WasmI32.store(fieldArray + (i * 4n), fieldName, 8n)
+
+      fieldOffset += WasmI32.load(fields + fieldOffset, 0n)
+    }
+
+    fieldArray
+  }
+}
 
 @disableGC
 let rec totalBytes = (acc, list) => {
@@ -93,7 +181,7 @@ export let concat = (s1: String, s2: String) => {
 }
 
 @disableGC
-let isListVariant = (variant) => {
+let isListVariant = (variant: String) => {
   // Only lists can start with `[`, so only need to check for that
   // Sort of a hack until we have a better solution
   WasmI32.load8U(WasmI32.fromGrain(variant), 8n) == 0x5Bn
@@ -140,15 +228,12 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
       // [ <value type tag>, <module_tag>, <type_tag>, <variant_tag>, <arity>, elts ... ]
-      // these are tagged ints
-      let moduleId = WasmI32.load(ptr, 4n) >> 1n
-      let typeId = WasmI32.load(ptr, 8n) >> 1n
-      let variantId = WasmI32.load(ptr, 12n) >> 1n
+      let variantName = getVariantName(ptr)
 
-      if (!variantExists(moduleId, typeId, variantId)) {
+      if (variantName == -1n) {
         "<enum value>"
       } else {
-        let variantName = getVariantName(moduleId, typeId, variantId)
+        let variantName = WasmI32.toGrain(variantName): String
         // Check if this is a list
         if (isListVariant(variantName)) {
           listToString(ptr, extraIndents)
@@ -178,11 +263,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       }
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
-      // these are tagged ints
-      let moduleId = WasmI32.load(ptr, 4n) >> 1n
-      let typeId = WasmI32.load(ptr, 8n) >> 1n
       let recordArity = WasmI32.load(ptr, 12n)
-      if (!recordTypeExists(moduleId, typeId) || recordArity == 0n) {
+      let fields = getRecordFieldNames(ptr)
+      if (fields == -1n) {
         "<record value>"
       } else {
         let padAmount = (extraIndents + 1n) * 2n
@@ -193,7 +276,7 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         let colspace = ": "
         let comlf = ",\n"
         for (let mut i = recordArity * 4n - 4n; i >= 0n;  i -= 4n) {
-          let fieldName = getRecordFieldName(moduleId, typeId, i / 4n)
+          let fieldName = WasmI32.toGrain(WasmI32.load(fields + i, 8n)): String
           let fieldValue = toStringHelp(WasmI32.load(ptr + i, 16n), extraIndents + 1n, false)
           Memory.incRef(WasmI32.fromGrain(spacePadding))
           Memory.incRef(WasmI32.fromGrain(fieldName))
@@ -217,6 +300,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         Memory.decRef(WasmI32.fromGrain(spacePadding))
         Memory.decRef(WasmI32.fromGrain(colspace))
         Memory.decRef(WasmI32.fromGrain(comlf))
+
+        Memory.free(fields) // Avoid double-free of record field names
 
         string
       }


### PR DESCRIPTION
This PR reimplements some support for printing from JS into Grain. As an added bonus, there is no longer a requirement that types be exported to be able to print them. 🎉 

Included in this PR is a new compiler flag, `--elide-type-information`, which allows you to save a bit of space by not including the information for `print`.

@phated I'm not sure if we want to label this as a breaking change—if anyone depended on the semantics of `toString` for non-exported types this would be a breaking change for them.