### PR TITLE
chore: Refactor runtime setup

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -664,9 +664,7 @@ let get_components = c =>
 
 type compilation_mode =
   | Normal /* Standard compilation with regular bells and whistles */
-  | ManagedRuntime /* Normal mode, but no Pervasives yet */
-  | Runtime /* GC doesn't exist yet, allocations happen in runtime heap */
-  | MemoryAllocation /* You _are_ the memory allocator and control the pointer to the runtime heap  */;
+  | Runtime /* GC doesn't exist yet, allocations happen in runtime heap */;
 
 let current_unit = ref(("", "", Normal));
 
@@ -677,26 +675,6 @@ let get_unit = () => current_unit^;
 let is_runtime_mode = () => {
   switch (current_unit^) {
   | (_, _, Runtime) => true
-  | (_, _, MemoryAllocation) => true
-  | (_, _, ManagedRuntime) => false
-  | (_, _, Normal) => false
-  };
-};
-
-let is_managed_runtime_mode = () => {
-  switch (current_unit^) {
-  | (_, _, Runtime) => false
-  | (_, _, MemoryAllocation) => false
-  | (_, _, ManagedRuntime) => true
-  | (_, _, Normal) => false
-  };
-};
-
-let is_malloc_mode = () => {
-  switch (current_unit^) {
-  | (_, _, Runtime) => false
-  | (_, _, MemoryAllocation) => true
-  | (_, _, ManagedRuntime) => false
   | (_, _, Normal) => false
   };
 };

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -162,15 +162,11 @@ let add_signature: (signature, t) => t;
 /* Remember the current compilation unit: modname * filename * compilation mode. */
 type compilation_mode =
   | Normal
-  | ManagedRuntime
-  | Runtime
-  | MemoryAllocation;
+  | Runtime;
 
 let set_unit: ((string, string, compilation_mode)) => unit;
 let get_unit: unit => (string, string, compilation_mode);
 let is_runtime_mode: unit => bool;
-let is_managed_runtime_mode: unit => bool;
-let is_malloc_mode: unit => bool;
 
 /* Insertion of all fields of a signature, relative to the given path.
    Used to implement open. Returns None if the path refers to a functor,

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -863,7 +863,7 @@ let initial_env = () => {
   let env = initial;
   let (unit_name, source, mode) = Env.get_unit();
   let implicit_modules =
-    if (Env.is_managed_runtime_mode()) {
+    if (Grain_utils.Config.no_pervasives^) {
       List.filter(
         ((name, _, _)) => name != "Pervasives",
         implicit_modules^,
@@ -892,8 +892,6 @@ let initial_env = () => {
 let get_compilation_mode = () => {
   switch (Grain_utils.Config.compilation_mode^) {
   | Some("runtime") => Env.Runtime
-  | Some("managed-runtime") => Env.ManagedRuntime
-  | Some("malloc") => Env.MemoryAllocation
   | _ => Env.Normal
   };
 };

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -342,12 +342,7 @@ let compilation_mode =
     ~names=["compilation-mode"],
     ~conv=
       option_conv(
-        Cmdliner.Arg.enum([
-          ("normal", "normal"),
-          ("managed-runtime", "managed-runtime"),
-          ("runtime", "runtime"),
-          ("malloc", "malloc"),
-        ]),
+        Cmdliner.Arg.enum([("normal", "normal"), ("runtime", "runtime")]),
       ),
     ~doc="Compilation mode (advanced use only)",
     None,
@@ -398,6 +393,13 @@ let sexp_locs_enabled =
     ~doc=
       "Hide locations from intermediate trees. Only has an effect with `--cdebug'.",
     true,
+  );
+
+let no_pervasives =
+  toggle_flag(
+    ~names=["no-pervasives"],
+    ~doc="Don't automatically import the Grain Pervasives module.",
+    false,
   );
 
 let no_gc =

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -14,6 +14,10 @@ let verbose: ref(bool);
 
 let sexp_locs_enabled: ref(bool);
 
+/** Whether or not to automatically import Pervasives */
+
+let no_pervasives: ref(bool);
+
 /** Whether to enable garbage collection */
 
 let no_gc: ref(bool);

--- a/docs/contributor/runtime.md
+++ b/docs/contributor/runtime.md
@@ -1,0 +1,14 @@
+# The Grain Runtime
+
+When we speak of the Grain runtime, we largely mean the memory allocator, garbage collector, and anything else that needs to exist before these faculties are available (those are the modules in the stdlib/runtime folder). These are essential to all Grain programs, and some care must be taken to compile them. For that reason, these modules are compiled with the `--compilation-mode=runtime` flag. In this mode, there is no access to Pervasives and all allocations happen in the runtime heap.
+
+## The Runtime Heap
+
+Currently, the Grain runtime heap spans half a WebAssembly page of memory. The low 1K of memory is reserved for Binaryen optimizations, the next few bytes are reserved for some static pointers (which we'll go over next), and the rest of half-page is space used for runtime allocations. It's important to note that this space is unmanaged. After all, we don't have a memory manager yet—we want to compile the memory manager. Allocations are done just by incrementing a bytes counter. This means that no space can be reclaimed—as such, runtime modules should do no dynamic allocations. Ideally, the only allocations that should occur are for the closures of top-level functions that are used by other modules.
+
+## Static Runtime Pointers
+
+There are a handful of static pointers that all modules have access to.
+
+- `0x400`: The next position in the runtime heap to allocate from. When a runtime allocation is done, this value at this address is advanced by the allocation amount.
+- `0x408`: The pointer to the linked list of runtime type information. More information on this can be found in [printing.md](./printing.md).

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -1,4 +1,4 @@
-/* grainc-flags --compilation-mode=malloc */
+/* grainc-flags --compilation-mode=runtime */
 
 /*
  * This module implements a generic memory allocator.

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -1,4 +1,4 @@
-/* grainc-flags --compilation-mode=managed-runtime */
+/* grainc-flags --no-pervasives */
 
 import WasmI32, {
   add as (+),
@@ -33,7 +33,7 @@ primitive (||) : (Bool, Bool) -> Bool = "@or"
 
 enum StringList { [], [...](String, StringList) }
 
-let _RUNTIME_TYPE_METADATA_PTR = 256n
+let _RUNTIME_TYPE_METADATA_PTR = 0x408n
 
 @disableGC
 let findTypeMetadata = (moduleId, typeId) => {


### PR DESCRIPTION
This PR refactors the runtime setup to be simpler and better handle the upcoming changes to exceptions and static linking.

This PR goes from 4 compilation modes down to just two, `Normal` and `Runtime`. `--compilation-mode=malloc` is now the same as `--compilation-mode=runtime`, since a static pointer has been allocated for the runtime heap pointer. `--compilation-mode=managed-runtime` has been superseded by `--no-pervasives` 🎉 

I also added some documentation about how the runtime works!