### PR TITLE
chore: utilize `Function_table.unlimited` to set the max table size

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3052,7 +3052,7 @@ let compile_tables = (wasm_mod, env, {functions, imports} as prog) => {
   Function_table.set_function_table(
     wasm_mod,
     table_size,
-    max_int,
+    Function_table.unlimited,
     function_names,
     Expression.global_get(
       wasm_mod,


### PR DESCRIPTION
This uses the new constant introduced in binaryen.ml 0.9.0 (which internally is `-1`, the value that binaryen uses for unlimited size).