### PR TITLE
fix: Properly incRef exception printers

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -2288,7 +2288,18 @@ let compile_prim1 = (wasm_mod, env, p1, arg): Expression.t => {
         Expression.const(wasm_mod, const_void()),
       ],
     )
-  | Throw => call_exception_printer(wasm_mod, env, [compiled_arg])
+  | Throw =>
+    Expression.block(
+      wasm_mod,
+      gensym_label("throw"),
+      [
+        Expression.drop(
+          wasm_mod,
+          call_exception_printer(wasm_mod, env, [compiled_arg]),
+        ),
+        Expression.unreachable(wasm_mod),
+      ],
+    )
   | Box => failwith("Unreachable case; should never get here: Box")
   | Unbox => failwith("Unreachable case; should never get here: Unbox")
   | BoxBind => failwith("Unreachable case; should never get here: BoxBind")

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -23,6 +23,11 @@ let exists = (check, result) =>
   | Not_found => false
   };
 
+let not_exists = (check, result) =>
+  try(Str.search_forward(Str.regexp_string(check), result, 0) < 0) {
+  | Not_found => true
+  };
+
 /* Read a file into a string */
 let string_of_file = file_name => {
   let inchan = open_in(file_name);
@@ -258,6 +263,7 @@ let test_err =
     (
       ~num_pages=?,
       ~print_output=true,
+      ~check_exists=true,
       program_str,
       outfile,
       errmsg,
@@ -279,7 +285,8 @@ let test_err =
     | exn => Printexc.to_string(exn)
     };
 
-  assert_equal(errmsg, result, ~cmp=exists, ~printer=Fun.id);
+  let cmp = check_exists ? exists : not_exists;
+  assert_equal(errmsg, result, ~cmp, ~printer=Fun.id);
 };
 
 let test_run_file_err = (filename, name, errmsg, test_ctxt) => {

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -72,8 +72,10 @@ let tgcerr = (~todo=?, name, heap_size, program, expected) =>
     expected,
   );
 
-let te = (~todo=?, name, program, expected) =>
-  name >:: wrap_todo(todo) @@ test_err(program, name, expected);
+let te = (~todo=?, ~check_exists=true, name, program, expected) =>
+  name
+  >:: wrap_todo(todo) @@
+  test_err(~check_exists, program, name, expected);
 
 /** Tests that the file input/`input_file`.gr produces the given output */
 
@@ -2012,6 +2014,12 @@ let exception_tests = [
     "throw_exception_2",
     "exception HorribleError(String, Bool, Number); let _ = throw HorribleError(\"oh no\", false, 1/3)",
     "HorribleError(\"oh no\", false, 1/3)",
+  ),
+  te(
+    ~check_exists=false,
+    "throw_exception_3",
+    "exception HorribleError(String, Bool, Number); let _ = throw HorribleError(\"oh no\", false, 1/3); print(\"shouldn't be printed\")",
+    "shouldn't be printed",
   ),
   te(
     "exception_register_1",

--- a/stdlib/exception.gr
+++ b/stdlib/exception.gr
@@ -1,7 +1,9 @@
 import WasmI32 from "runtime/unsafe/wasmi32"
+import Memory from "runtime/unsafe/memory"
 import Exception from "runtime/exception"
 
 @disableGC
 export let registerPrinter = (f: Exception -> Option<String>) => {
+  Memory.incRef(WasmI32.fromGrain(f))
   Exception.printers = WasmI32.fromGrain((f, Exception.printers))
 }

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -107,12 +107,17 @@ enum Result<t, e> { Ok(t), Err(e) }
 let identity = (x) => x
 
 // Setup exception printing
-Exception.dangerouslyRegisterPrinter(e => {
-  match (e) {
-    Failure(msg) => Some("Failure: " ++ msg),
-    InvalidArgument(msg) => Some("Invalid argument: " ++ msg),
-    _ => None
-  }
-})
+@disableGC
+let setupExceptions = () => {
+  Exception.dangerouslyRegisterPrinter(e => {
+    match (e) {
+      Failure(msg) => Some("Failure: " ++ msg),
+      InvalidArgument(msg) => Some("Invalid argument: " ++ msg),
+      _ => None
+    }
+  })
 
-Exception.registerBasePrinter(e => Some(toString(e)))
+  Exception.dangerouslyRegisterBasePrinter(e => Some(toString(e)))
+}
+
+setupExceptions()

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -11,7 +11,11 @@ enum Option<a> { Some(a), None }
 
 export let mut printers = 0n
 
-export let registerBasePrinter = (f) => {
+// These functions are dangerous because they leak runtime memory and perform
+// no GC operations. As such, they should only be called by this module and/or
+// modules that understand these restrictions, namely Pervasives.
+
+export let dangerouslyRegisterBasePrinter = (f) => {
   let mut current = printers
   while (true) {
     // There will be at least one printer registered by the time this is called
@@ -28,8 +32,6 @@ export let registerBasePrinter = (f) => {
 }
 
 export let dangerouslyRegisterPrinter = (f) => {
-  // This is dangerous because it leaks runtime memory.
-  // This should only be called by this module and Pervasives.
   printers = WasmI32.fromGrain((f, printers))
 }
 


### PR DESCRIPTION
chore!: Rename `registerBasePrinter` to `dangerouslyRegisterBasePrinter` in runtime/exception
fix: Throwing an exception now traps immediately in all cases

I added a test for the last fix, but there isn't a great way to test that the incRefs weren't happening. However, it gets exercised pretty well by changes in the linker PR.