### PR TITLE
chore(cli): Remove flagged-respawn for built-in v8 method

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -1,122 +1,108 @@
 #!/usr/bin/env node
 
-const v8flags = require("v8flags");
-const flaggedRespawn = require("flagged-respawn");
+// https://github.com/grain-lang/grain/issues/114
+const v8 = require("v8");
+/* From the Node.js docs:
+ *
+ *   The v8.setFlagsFromString() method can be used to programmatically set V8 command-line flags.
+ *   This method should be used with care. Changing settings after the VM has started may result
+ *   in unpredictable behavior, including crashes and data loss; or it may simply do nothing.
+ *
+ * This seems to work for our needs with Node 14, but we should be cautious when updating.
+ */
+v8.setFlagsFromString("--experimental-wasm-bigint");
+v8.setFlagsFromString("--experimental-wasm-return-call");
 
-v8flags(onFlags);
+const { execSync } = require("child_process");
+const path = require("path");
 
-function onFlags(err, flags) {
-  if (err) {
-    console.error("Encountered error when retrieving v8 flags: ", err);
-    process.exit(1);
-  }
+let program = require("commander");
+// Workaround to defer loading of the grain runtime until the memory settings have been parsed
+let actions = {
+  get compile() {
+    return require("./compile.js");
+  },
+  get run() {
+    return require("./run.js");
+  },
+  get lsp() {
+    return require("./lsp.js");
+  },
+};
 
-  // https://github.com/grain-lang/grain/issues/114
-  flaggedRespawn(
-    flags,
-    process.argv,
-    ["--experimental-wasm-bigint", "--experimental-wasm-return-call"],
-    onRespawn
-  );
+let pervasivesPath = require.resolve("@grain/stdlib");
+let stdlibPath = path.dirname(pervasivesPath);
+
+function list(val) {
+  return val.split(",");
 }
 
-function onRespawn(ready, proc, argv) {
-  if (!ready) {
-    // Respawning
-    return;
-  }
-
-  const { execSync } = require("child_process");
-  const path = require("path");
-
-  let program = require("commander");
-  // Workaround to defer loading of the grain runtime until the memory settings have been parsed
-  let actions = {
-    get compile() {
-      return require("./compile.js");
-    },
-    get run() {
-      return require("./run.js");
-    },
-    get lsp() {
-      return require("./lsp.js");
-    },
-  };
-
-  let pervasivesPath = require.resolve("@grain/stdlib");
-  let stdlibPath = path.dirname(pervasivesPath);
-
-  function list(val) {
-    return val.split(",");
-  }
-
-  function num(val) {
-    return Number.parseInt(val, 10);
-  }
-
-  function graincVersion() {
-    const grainc = path.join(__dirname, "grainc.exe");
-
-    return execSync(`${grainc} --version`).toString().trim();
-  }
-
-  program
-    .option("-v, --version", "output CLI and compiler versions")
-    .on("option:version", () => {
-      console.log(`Grain cli ${require("../package.json").version}`);
-      console.log(`Grain compiler ${graincVersion()}`);
-      process.exit(0);
-    })
-    .description("Compile and run Grain programs. 🌾")
-    .option("-p, --print-output", "print the output of the program")
-    .option("-g, --graceful", "return a 0 exit code if the program errors")
-    .option(
-      "-I, --include-dirs <dirs>",
-      "include directories the runtime should find wasm modules",
-      list,
-      []
-    )
-    .option("-f, --cflags <cflags>", "pass flags to the Grain compiler")
-    .option(
-      "-S, --stdlib <path>",
-      "override the standard libary with your own",
-      stdlibPath
-    )
-    .option("--limitMemory <size>", "maximum allowed heap size", num, -1)
-    .option(
-      "--init-memory-pages <size>",
-      "number of pages used to initialize the grain runtime"
-    )
-    .on("option:init-memory-pages", (pages) => {
-      // Workaround for the runtime's memory being initialized statically on module load
-      process.env.GRAIN_INIT_MEMORY_PAGES = parseInt(pages, 10);
-    })
-    // The root command that compiles & runs
-    .arguments("<file>")
-    .action(function (file) {
-      actions.run(actions.compile(file, program), program);
-    });
-
-  program
-    .command("compile <file>")
-    .description("compile a grain program into wasm")
-    .action(function (file) {
-      actions.compile(file, program);
-    });
-
-  program
-    .command("lsp <file>")
-    .description("check a grain file for LSP")
-    .action(function (file) {
-      actions.lsp(file, program);
-    });
-
-  program
-    .command("run <file>")
-    .description("run a wasm file with the grain runtime")
-    .action(function (wasmFile) {
-      actions.run(wasmFile, program);
-    });
-
-  program.parse(argv);
+function num(val) {
+  return Number.parseInt(val, 10);
 }
+
+function graincVersion() {
+  const grainc = path.join(__dirname, "grainc.exe");
+
+  return execSync(`${grainc} --version`).toString().trim();
+}
+
+program
+  .option("-v, --version", "output CLI and compiler versions")
+  .on("option:version", () => {
+    console.log(`Grain cli ${require("../package.json").version}`);
+    console.log(`Grain compiler ${graincVersion()}`);
+    process.exit(0);
+  })
+  .description("Compile and run Grain programs. 🌾")
+  .option("-p, --print-output", "print the output of the program")
+  .option("-g, --graceful", "return a 0 exit code if the program errors")
+  .option(
+    "-I, --include-dirs <dirs>",
+    "include directories the runtime should find wasm modules",
+    list,
+    []
+  )
+  .option("-f, --cflags <cflags>", "pass flags to the Grain compiler")
+  .option(
+    "-S, --stdlib <path>",
+    "override the standard libary with your own",
+    stdlibPath
+  )
+  .option("--limitMemory <size>", "maximum allowed heap size", num, -1)
+  .option(
+    "--init-memory-pages <size>",
+    "number of pages used to initialize the grain runtime"
+  )
+  .on("option:init-memory-pages", (pages) => {
+    // Workaround for the runtime's memory being initialized statically on module load
+    process.env.GRAIN_INIT_MEMORY_PAGES = parseInt(pages, 10);
+  })
+  // The root command that compiles & runs
+  .arguments("<file>")
+  .action(function (file) {
+    actions.run(actions.compile(file, program), program);
+  });
+
+program
+  .command("compile <file>")
+  .description("compile a grain program into wasm")
+  .action(function (file) {
+    actions.compile(file, program);
+  });
+
+program
+  .command("lsp <file>")
+  .description("check a grain file for LSP")
+  .action(function (file) {
+    actions.lsp(file, program);
+  });
+
+program
+  .command("run <file>")
+  .description("run a wasm file with the grain runtime")
+  .action(function (wasmFile) {
+    actions.run(wasmFile, program);
+  });
+
+program.parse(process.argv);

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,9 +32,7 @@
   "dependencies": {
     "@grain/runtime": "*",
     "@grain/stdlib": "*",
-    "commander": "^5.1.0",
-    "flagged-respawn": "^1.0.1",
-    "v8flags": "^3.2.0"
+    "commander": "^5.1.0"
   },
   "devDependencies": {
     "prettier": "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,11 +1435,6 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-flagged-respawn@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
-  integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
-
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -3535,13 +3530,6 @@ v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
-
-v8flags@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
-  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
-  dependencies:
-    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
I ripped out v8flags and flagged-respawn in favor of `v8.setFlagsFromString` because flagged-respawn doesn't work with pkg.