### PR TITLE
feat!: Static linking of Grain modules

### DIFF
--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -48,6 +48,18 @@
     (grain (>= 0))))
 
 (package
+  (name grain_linking)
+  (synopsis "The Grain linker")
+  (depends
+    (reason (>= 3.6.0))
+    (ppx_sexp_conv (>= 0.14.0))
+    (sexplib (>= 0.14.0))
+    (binaryen (= 0.9.1))
+    (ocamlgraph (>= 2.0.0))
+    (grain_utils (>= 0))
+    (grain_codegen (>= 0))))
+
+(package
   (name grain_codegen)
   (synopsis "Grain WebAssembly code generation")
   (depends

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -29,6 +29,7 @@
     "@opam/fp": "0.0.1",
     "@opam/fs": "0.0.2",
     "@opam/grain_dypgen": "0.2",
+    "@opam/ocamlgraph": ">= 2.0.0",
     "@opam/ppx_deriving_yojson": ">= 3.5.2",
     "@opam/ppx_expect": ">= 0.14.0",
     "@opam/ppx_sexp_conv": ">= 0.14.0",
@@ -44,6 +45,7 @@
     "@opam/ounit": ">= 2.0.0"
   },
   "resolutions": {
+    "@grain/binaryen.ml": "grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00",
     "@opam/ocamlfind": "1.8.1",
     "@opam/fp": "facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87",
     "@opam/fs": "facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "786e2a240ac8342bc0795d844f02e36d",
+  "checksum": "80fc96151626b194066ff2c3e33fc4fb",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -347,8 +347,8 @@
         "@opam/dune@opam:2.8.5@83fb0224"
       ]
     },
-    "@opam/ppxlib@opam:0.22.0@d2d2223a": {
-      "id": "@opam/ppxlib@opam:0.22.0@d2d2223a",
+    "@opam/ppxlib@opam:0.22.0@17206ba4": {
+      "id": "@opam/ppxlib@opam:0.22.0@17206ba4",
       "name": "@opam/ppxlib",
       "version": "opam:0.22.0",
       "source": {
@@ -426,13 +426,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/sexplib0@opam:v0.14.0@ddeb6438",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -455,13 +455,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -483,14 +483,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
-        "@opam/octavius@opam:1.2.2@b328d1f1",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
+        "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
-        "@opam/octavius@opam:1.2.2@b328d1f1",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
+        "@opam/octavius@opam:1.2.2@2c6624f5",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -513,13 +513,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/time_now@opam:v0.14.0@5e4046b3",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -541,12 +541,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -568,14 +568,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
@@ -600,7 +600,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
@@ -608,7 +608,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/stdio@opam:v0.14.0@a624e254",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_inline_test@opam:v0.14.1@2e4fdd8d",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
@@ -632,12 +632,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -661,14 +661,14 @@
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_deriving@opam:5.2.1@479736f0",
         "@opam/dune@opam:2.8.5@83fb0224", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_deriving@opam:5.2.1@479736f0",
         "@opam/dune@opam:2.8.5@83fb0224"
       ]
@@ -692,7 +692,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.8.1@b7dc3072",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/cppo@opam:1.6.7@c28ac3ae",
@@ -700,7 +700,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocamlfind@opam:1.8.1@b7dc3072",
         "@opam/dune@opam:2.8.5@83fb0224"
@@ -749,12 +749,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -776,12 +776,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/dune@opam:2.8.5@83fb0224", "@opam/base@opam:v0.14.1@d14008e2"
       ]
     },
@@ -803,7 +803,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -813,7 +813,7 @@
         "@opam/dune@opam:2.8.5@83fb0224", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_js_style@opam:v0.14.0@10b020a8",
         "@opam/ppx_hash@opam:v0.14.0@8e9618e4",
@@ -841,7 +841,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -850,7 +850,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_here@opam:v0.14.0@5ccc1c01",
         "@opam/ppx_compare@opam:v0.14.0@615de7a6",
@@ -940,8 +940,8 @@
       ],
       "devDependencies": [ "@opam/ounit2@opam:2.2.4@1877225e" ]
     },
-    "@opam/octavius@opam:1.2.2@b328d1f1": {
-      "id": "@opam/octavius@opam:1.2.2@b328d1f1",
+    "@opam/octavius@opam:1.2.2@2c6624f5": {
+      "id": "@opam/octavius@opam:1.2.2@2c6624f5",
       "name": "@opam/octavius",
       "version": "opam:1.2.2",
       "source": {
@@ -963,6 +963,32 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/dune@opam:2.8.5@83fb0224"
+      ]
+    },
+    "@opam/ocamlgraph@opam:2.0.0@3dafd524": {
+      "id": "@opam/ocamlgraph@opam:2.0.0@3dafd524",
+      "name": "@opam/ocamlgraph",
+      "version": "opam:2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/20/20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609#sha256:20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609",
+          "archive:https://github.com/backtracking/ocamlgraph/releases/download/2.0.0/ocamlgraph-2.0.0.tbz#sha256:20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609"
+        ],
+        "opam": {
+          "name": "ocamlgraph",
+          "version": "2.0.0",
+          "path": "esy.lock/opam/ocamlgraph.2.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@0d088929",
+        "@opam/dune@opam:2.8.5@83fb0224", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@0d088929",
+        "@opam/dune@opam:2.8.5@83fb0224"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@b7dc3072": {
@@ -1291,12 +1317,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/js_of_ocaml@opam:3.9.0@db27df96",
         "@opam/dune@opam:2.8.5@83fb0224", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "ocaml@4.11.0@d41d8cd9", "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/js_of_ocaml@opam:3.9.0@db27df96",
         "@opam/dune@opam:2.8.5@83fb0224"
       ]
@@ -1320,7 +1346,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/ocamlfind@opam:1.8.1@b7dc3072",
         "@opam/menhir@opam:20210310@50de9216",
         "@opam/dune@opam:2.8.5@83fb0224",
@@ -1329,7 +1355,7 @@
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/menhir@opam:20210310@50de9216",
         "@opam/dune@opam:2.8.5@83fb0224",
         "@opam/cmdliner@opam:1.0.4@93208aac"
@@ -1354,13 +1380,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/js_of_ocaml-compiler@opam:3.9.1@19f5797f",
         "@opam/dune@opam:2.8.5@83fb0224", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.11.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppxlib@opam:0.22.0@d2d2223a",
+        "@opam/ppxlib@opam:0.22.0@17206ba4",
         "@opam/js_of_ocaml-compiler@opam:3.9.1@19f5797f",
         "@opam/dune@opam:2.8.5@83fb0224"
       ]
@@ -1839,6 +1865,7 @@
         "@opam/ppx_sexp_conv@opam:v0.14.3@1ee195f4",
         "@opam/ppx_expect@opam:v0.14.1@cee36131",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
+        "@opam/ocamlgraph@opam:2.0.0@3dafd524",
         "@opam/grain_dypgen@opam:0.2@ef01d3b4",
         "@opam/fs@github:facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
         "@opam/fp@github:facebookexperimental/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
@@ -1846,7 +1873,7 @@
         "@opam/dune-build-info@opam:2.8.5@1dae72be",
         "@opam/dune@opam:2.8.5@83fb0224",
         "@opam/cmdliner@opam:1.0.4@93208aac",
-        "@grain/binaryen.ml@0.9.1@d41d8cd9"
+        "@grain/binaryen.ml@github:grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ounit@opam:2.2.4@cb017d08",
@@ -1855,14 +1882,16 @@
       ],
       "installConfig": { "pnp": false }
     },
-    "@grain/binaryen.ml@0.9.1@d41d8cd9": {
-      "id": "@grain/binaryen.ml@0.9.1@d41d8cd9",
+    "@grain/binaryen.ml@github:grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00@d41d8cd9": {
+      "id":
+        "@grain/binaryen.ml@github:grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00@d41d8cd9",
       "name": "@grain/binaryen.ml",
-      "version": "0.9.1",
+      "version":
+        "github:grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.9.1.tgz#sha1:d42c53b0625352185abdd7a3940cf546d8193828"
+          "github:grain-lang/binaryen.ml#8a21a8a6ce6abad71f36e5f13492a7c7a625cb00"
         ]
       },
       "overrides": [],

--- a/compiler/esy.lock/opam/ocamlgraph.2.0.0/opam
+++ b/compiler/esy.lock/opam/ocamlgraph.2.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "A generic graph library for OCaml"
+description: "Provides both graph data structures and graph algorithms"
+maintainer: ["filliatr@lri.fr"]
+authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+license: "LGPL-2.1-only"
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+homepage: "https://github.com/backtracking/ocamlgraph/"
+bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "stdlib-shims"
+  "dune" {>= "2.0" & !with-test | >= "2.8"}
+  "graphics" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+x-commit-hash: "f97d342db06ccdbc11354303b5f225ae433f7ef3"
+url {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.0.0/ocamlgraph-2.0.0.tbz"
+  checksum: [
+    "sha256=20fe267797de5322088a4dfb52389b2ea051787952a8a4f6ed70fcb697482609"
+    "sha512=c4973ac03bdff52d1c8a1ed01c81e0fbe2f76486995e57ff4e4a11bcc7b1793556139d52a81ff14ee8c8de52f1b40e4bd359e60a2ae626cc630ebe8bccefb3f1"
+  ]
+}

--- a/compiler/esy.lock/opam/octavius.1.2.2/opam
+++ b/compiler/esy.lock/opam/octavius.1.2.2/opam
@@ -1,4 +1,3 @@
-version: "1.2.2"
 opam-version: "2.0"
 maintainer: ["leo@lpw25.net"]
 authors: ["Leo White <leo@lpw25.net>"]

--- a/compiler/esy.lock/opam/ppxlib.0.22.0/opam
+++ b/compiler/esy.lock/opam/ppxlib.0.22.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0"
+  "sexplib0" {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}

--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -99,7 +99,13 @@ let compile_file = (name, outfile_arg) => {
     if (Grain_utils.Config.debug^) {
       Compile.save_mashed(name, default_mashtree_filename(outfile));
     };
-    ignore(Compile.compile_file(~outfile, name));
+    let hook =
+      if (Grain_utils.Config.statically_link^) {
+        Compile.stop_after_assembled;
+      } else {
+        Compile.stop_after_object_file_emitted;
+      };
+    ignore(Compile.compile_file(~hook, ~outfile, name));
   }) {
   | exn =>
     let bt =

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -363,17 +363,17 @@ and instr_desc =
   | MImmediate(immediate)
   | MCallKnown({
       func: string,
-      func_type: (list(asmtype), asmtype),
+      func_type: (list(asmtype), list(asmtype)),
       args: list(immediate),
     })
   | MCallIndirect({
       func: immediate,
-      func_type: (list(asmtype), asmtype),
+      func_type: (list(asmtype), list(asmtype)),
       args: list(immediate),
     })
   | MReturnCallIndirect({
       func: immediate,
-      func_type: (list(asmtype), asmtype),
+      func_type: (list(asmtype), list(asmtype)),
       args: list(immediate),
     })
   | MError(grain_error, list(immediate))
@@ -437,7 +437,7 @@ type mash_function = {
   index: int32,
   name: option(string),
   args: list(asmtype),
-  return_type: asmtype,
+  return_type: list(asmtype),
   body: block,
   stack_size,
   attrs: attributes,

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -2,9 +2,9 @@
  (name grain)
  (public_name grain)
  ;; Note: 'dyp' is provided by the 'dypgen' OPAM package
- (libraries cmdliner compiler-libs.common grain_codegen grain_middle_end
-   grain_parsing grain_typed grain_utils grain_diagnostics oUnit
-   ppx_sexp_conv.runtime-lib sexplib)
+ (libraries cmdliner compiler-libs.common grain_codegen grain_linking
+   grain_middle_end grain_parsing grain_typed grain_utils grain_diagnostics
+   oUnit ppx_sexp_conv.runtime-lib sexplib)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/compiler/src/linking/dune
+++ b/compiler/src/linking/dune
@@ -1,0 +1,8 @@
+(library
+ (name grain_linking)
+ (public_name grain_linking)
+ (synopsis "The Grain linker")
+ (libraries compiler-libs.common grain_codegen grain_utils
+   ppx_sexp_conv.runtime-lib sexplib ocamlgraph binaryen)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -1,0 +1,617 @@
+open Grain_codegen;
+open Compmod;
+open Grain_typed;
+open Cmi_format;
+open Binaryen;
+open Graph;
+
+module String = {
+  type t = string;
+  let compare = compare;
+  let hash = Hashtbl.hash;
+  let equal = (==);
+  let default = "";
+};
+
+module G = Imperative.Digraph.Concrete(String);
+module Topo = Topological.Make(G);
+
+let dependency_graph = G.create(~size=10, ());
+let modules: Hashtbl.t(string, Module.t) = Hashtbl.create(10);
+
+let main_module = "main";
+
+let grain_main = "_gmain";
+let grain_start = "_start";
+let function_table = "tbl";
+
+let resolve = mod_name => {
+  // Remove GRAIN$MODULE$ and add extension
+  let mod_name =
+    Printf.sprintf("%s.gr.wasm", Str.string_after(mod_name, 13));
+  let rec resolve =
+    fun
+    | [] => raise(Not_found)
+    | [base, ...rest] => {
+        let fullpath = Filename.concat(base, mod_name);
+        if (Sys.file_exists(fullpath)) {
+          let ic = open_in_bin(fullpath);
+          let length = in_channel_length(ic);
+          let module_bytes = Bytes.create(length);
+          really_input(ic, module_bytes, 0, length);
+          Module.read(module_bytes);
+        } else {
+          resolve(rest);
+        };
+      };
+  resolve(Grain_utils.Config.module_search_path());
+};
+
+let is_grain_module = mod_name => {
+  Str.string_match(Str.regexp_string("GRAIN$MODULE$"), mod_name, 0);
+};
+
+let is_main_module = mod_name => mod_name == main_module;
+
+let rec build_dependency_graph = mod_name => {
+  if (!Hashtbl.mem(modules, mod_name)) {
+    Hashtbl.add(modules, mod_name, resolve(mod_name));
+  };
+  let wasm_mod = Hashtbl.find(modules, mod_name);
+  let num_globals = Global.get_num_globals(wasm_mod);
+  for (i in 0 to num_globals - 1) {
+    let global = Global.get_global_by_index(wasm_mod, i);
+    let imported_module = Import.global_import_get_module(global);
+    if (is_grain_module(imported_module)) {
+      if (!Hashtbl.mem(modules, imported_module)) {
+        build_dependency_graph(imported_module);
+      };
+      G.add_edge(dependency_graph, mod_name, imported_module);
+    };
+  };
+  let num_funcs = Function.get_num_functions(wasm_mod);
+  for (i in 0 to num_funcs - 1) {
+    let func = Function.get_function_by_index(wasm_mod, i);
+    let imported_module = Import.function_import_get_module(func);
+    if (is_grain_module(imported_module)) {
+      if (!Hashtbl.mem(modules, imported_module)) {
+        build_dependency_graph(imported_module);
+      };
+      G.add_edge(dependency_graph, mod_name, imported_module);
+    };
+  };
+};
+
+let gensym_counter = ref(0);
+let gensym = name => {
+  incr(gensym_counter);
+  Printf.sprintf("%s.linked.%d", name, gensym_counter^);
+};
+
+let exported_names: Hashtbl.t(string, Hashtbl.t(string, string)) =
+  Hashtbl.create(10);
+
+let is_global_imported = global =>
+  Import.global_import_get_base(global) != "";
+let is_function_imported = func =>
+  Import.function_import_get_base(func) != "";
+
+let rec globalize_names = (local_names, expr) => {
+  let kind = Expression.get_kind(expr);
+  switch (kind) {
+  | Invalid => failwith("Invalid expression")
+  | Nop => ()
+  | Block =>
+    let internal_name = Expression.block_get_name(expr);
+    Option.iter(
+      internal_name => {
+        let new_name = gensym(internal_name);
+        Hashtbl.add(local_names, internal_name, new_name);
+
+        Expression.block_set_name(expr, new_name);
+      },
+      internal_name,
+    );
+
+    let num_children = Expression.block_get_num_children(expr);
+    for (i in 0 to num_children - 1) {
+      globalize_names(local_names, Expression.block_get_child_at(expr, i));
+    };
+  | If =>
+    globalize_names(local_names, Expression.if_get_condition(expr));
+    globalize_names(local_names, Expression.if_get_if_true(expr));
+    Option.iter(
+      globalize_names(local_names),
+      Expression.if_get_if_false(expr),
+    );
+  | Loop =>
+    let internal_name = Expression.loop_get_name(expr);
+    let new_name = gensym(internal_name);
+    Hashtbl.add(local_names, internal_name, new_name);
+
+    Expression.loop_set_name(expr, new_name);
+
+    globalize_names(local_names, Expression.loop_get_body(expr));
+  | Break =>
+    let internal_name = Expression.break_get_name(expr);
+    Expression.break_set_name(
+      expr,
+      Hashtbl.find(local_names, internal_name),
+    );
+
+    Option.iter(
+      globalize_names(local_names),
+      Expression.break_get_condition(expr),
+    );
+    Option.iter(
+      globalize_names(local_names),
+      Expression.break_get_value(expr),
+    );
+  | Switch =>
+    let num_names = Expression.switch_get_num_names(expr);
+    for (i in 0 to num_names - 1) {
+      let internal_name = Expression.switch_get_name_at(expr, i);
+      Expression.switch_set_name_at(
+        expr,
+        i,
+        Hashtbl.find(local_names, internal_name),
+      );
+    };
+
+    let internal_default_name = Expression.switch_get_default_name(expr);
+    Option.iter(
+      name =>
+        Expression.switch_set_default_name(
+          expr,
+          Hashtbl.find(local_names, name),
+        ),
+      internal_default_name,
+    );
+
+    globalize_names(local_names, Expression.switch_get_condition(expr));
+    Option.iter(
+      globalize_names(local_names),
+      Expression.switch_get_value(expr),
+    );
+  | Call =>
+    let internal_name = Expression.call_get_target(expr);
+    Expression.call_set_target(
+      expr,
+      Hashtbl.find(local_names, internal_name),
+    );
+
+    let num_operands = Expression.call_get_num_operands(expr);
+    for (i in 0 to num_operands - 1) {
+      globalize_names(local_names, Expression.call_get_operand_at(expr, i));
+    };
+  | CallIndirect =>
+    globalize_names(local_names, Expression.call_indirect_get_target(expr));
+
+    Expression.call_indirect_set_table(expr, function_table);
+
+    let num_operands = Expression.call_indirect_get_num_operands(expr);
+    for (i in 0 to num_operands - 1) {
+      globalize_names(
+        local_names,
+        Expression.call_indirect_get_operand_at(expr, i),
+      );
+    };
+  | LocalGet => ()
+  | LocalSet =>
+    globalize_names(local_names, Expression.local_set_get_value(expr))
+  | GlobalGet =>
+    let internal_name = Expression.global_get_get_name(expr);
+    Expression.global_get_set_name(
+      expr,
+      Hashtbl.find(local_names, internal_name),
+    );
+  | GlobalSet =>
+    let internal_name = Expression.global_set_get_name(expr);
+    Expression.global_set_set_name(
+      expr,
+      Hashtbl.find(local_names, internal_name),
+    );
+    globalize_names(local_names, Expression.global_set_get_value(expr));
+  | Load => globalize_names(local_names, Expression.load_get_ptr(expr))
+  | Store =>
+    globalize_names(local_names, Expression.store_get_ptr(expr));
+    globalize_names(local_names, Expression.store_get_value(expr));
+  | MemoryCopy =>
+    globalize_names(local_names, Expression.memory_copy_get_dest(expr));
+    globalize_names(local_names, Expression.memory_copy_get_source(expr));
+    globalize_names(local_names, Expression.memory_copy_get_size(expr));
+  | MemoryFill =>
+    globalize_names(local_names, Expression.memory_fill_get_dest(expr));
+    globalize_names(local_names, Expression.memory_fill_get_value(expr));
+    globalize_names(local_names, Expression.memory_fill_get_size(expr));
+  | Const => ()
+  | Unary => globalize_names(local_names, Expression.unary_get_value(expr))
+  | Binary =>
+    globalize_names(local_names, Expression.binary_get_left(expr));
+    globalize_names(local_names, Expression.binary_get_right(expr));
+  | Select =>
+    globalize_names(local_names, Expression.select_get_if_true(expr));
+    globalize_names(local_names, Expression.select_get_if_false(expr));
+    globalize_names(local_names, Expression.select_get_condition(expr));
+  | Drop => globalize_names(local_names, Expression.drop_get_value(expr))
+  | Return => globalize_names(local_names, Expression.return_get_value(expr))
+  | MemorySize => ()
+  | MemoryGrow =>
+    globalize_names(local_names, Expression.memory_grow_get_delta(expr))
+  | Unreachable => ()
+  | TupleMake =>
+    let num_operands = Expression.tuple_make_get_num_operands(expr);
+    for (i in 0 to num_operands - 1) {
+      globalize_names(
+        local_names,
+        Expression.tuple_make_get_operand_at(expr, i),
+      );
+    };
+  | TupleExtract =>
+    globalize_names(local_names, Expression.tuple_extract_get_tuple(expr))
+  | AtomicRMW
+  | AtomicCmpxchg
+  | AtomicWait
+  | AtomicNotify
+  | AtomicFence
+  | SIMDExtract
+  | SIMDReplace
+  | SIMDShuffle
+  | SIMDTernary
+  | SIMDShift
+  | SIMDLoad
+  | SIMDLoadStoreLane
+  | SIMDWiden
+  | Prefetch
+  | MemoryInit
+  | DataDrop
+  | Pop
+  | RefNull
+  | RefIs
+  | RefFunc
+  | RefEq
+  | Try
+  | Throw
+  | Rethrow
+  | I31New
+  | I31Get
+  | CallRef
+  | RefTest
+  | RefCast
+  | BrOn
+  | RttCanon
+  | RttSub
+  | StructNew
+  | StructGet
+  | StructSet
+  | ArrayNew
+  | ArrayGet
+  | ArraySet
+  | ArrayLen
+  | RefAs => failwith("Linking NYI for wasm instruction")
+  };
+};
+
+let type_of_repr = repr => {
+  Types.(
+    switch (repr) {
+    | WasmI32 => Type.int32
+    | WasmI64 => Type.int64
+    | WasmF32 => Type.float32
+    | WasmF64 => Type.float64
+    }
+  );
+};
+
+let write_exports = (linked_mod, {cmi_sign}, exported_names) => {
+  Types.(
+    Type_utils.(
+      List.iter(
+        item => {
+          switch (item) {
+          | TSigValue(id, {val_repr: ReprFunction(args, rets)}) =>
+            let name = Ident.name(id);
+            let exported_name = "GRAIN$EXPORT$" ++ name;
+            let internal_name = Hashtbl.find(exported_names, exported_name);
+            let get_closure = () =>
+              Expression.global_get(linked_mod, internal_name, Type.int32);
+            let arguments =
+              List.mapi(
+                (i, arg) =>
+                  Expression.local_get(linked_mod, i, type_of_repr(arg)),
+                args,
+              );
+            let arguments = [get_closure(), ...arguments];
+            let call_arg_types =
+              Type.create(
+                Array.of_list(List.map(type_of_repr, [WasmI32, ...args])),
+              );
+            let call_result_types =
+              Type.create(
+                Array.of_list(
+                  List.map(type_of_repr, rets == [] ? [WasmI32] : rets),
+                ),
+              );
+            let func_ptr =
+              Expression.load(linked_mod, 4, 8, 2, Type.int32, get_closure());
+            let function_call =
+              Expression.call_indirect(
+                linked_mod,
+                function_table,
+                func_ptr,
+                arguments,
+                call_arg_types,
+                call_result_types,
+              );
+            let function_body =
+              switch (rets) {
+              | [] => Expression.drop(linked_mod, function_call)
+              | _ => function_call
+              };
+            let arg_types =
+              Type.create(Array.of_list(List.map(type_of_repr, args)));
+            let result_types =
+              Type.create(Array.of_list(List.map(type_of_repr, rets)));
+            ignore @@
+            Function.add_function(
+              linked_mod,
+              name,
+              arg_types,
+              result_types,
+              [||],
+              function_body,
+            );
+            ignore @@ Export.add_function_export(linked_mod, name, name);
+          | TSigValue(_)
+          | TSigType(_)
+          | TSigTypeExt(_)
+          | TSigModule(_)
+          | TSigModType(_) => ()
+          }
+        },
+        cmi_sign,
+      )
+    )
+  );
+};
+
+let table_offset = ref(0);
+let module_id = ref(0);
+
+let link_all = (linked_mod, dependencies, signature) => {
+  table_offset := 0;
+
+  let link_one = dep => {
+    let local_names: Hashtbl.t(string, string) = Hashtbl.create(128);
+
+    let wasm_mod = Hashtbl.find(modules, dep);
+
+    let num_globals = Global.get_num_globals(wasm_mod);
+    for (i in 0 to num_globals - 1) {
+      let global = Global.get_global_by_index(wasm_mod, i);
+      if (is_global_imported(global)) {
+        let imported_module = Import.global_import_get_module(global);
+        if (is_grain_module(imported_module)) {
+          let imported_name = Import.global_import_get_base(global);
+          let internal_name = Global.get_name(global);
+          let new_name =
+            Hashtbl.find(
+              Hashtbl.find(exported_names, imported_module),
+              imported_name,
+            );
+          Hashtbl.add(local_names, internal_name, new_name);
+        } else {
+          let imported_name = Import.global_import_get_base(global);
+          let internal_name = Global.get_name(global);
+          let new_name = gensym(internal_name);
+          Hashtbl.add(local_names, internal_name, new_name);
+
+          if (imported_module == "grainRuntime") {
+            let value =
+              switch (imported_name) {
+              | "relocBase" =>
+                Expression.const(
+                  wasm_mod,
+                  Literal.int32(Int32.of_int(table_offset^)),
+                )
+              | "moduleRuntimeId" =>
+                incr(module_id);
+                Expression.const(
+                  wasm_mod,
+                  Literal.int32(Int32.of_int(module_id^)),
+                );
+              | value =>
+                failwith(
+                  Printf.sprintf("Unknown Grain runtime value `%s`", value),
+                )
+              };
+            ignore @@
+            Global.add_global(linked_mod, new_name, Type.int32, false, value);
+          } else {
+            let ty = Global.get_type(global);
+            let mut = Global.is_mutable(global);
+            Import.add_global_import(
+              linked_mod,
+              new_name,
+              imported_module,
+              imported_name,
+              ty,
+              mut,
+            );
+          };
+        };
+      } else {
+        let internal_name = Global.get_name(global);
+        let new_name = gensym(internal_name);
+        Hashtbl.add(local_names, internal_name, new_name);
+
+        let ty = Global.get_type(global);
+        let mut = Global.is_mutable(global);
+        let init = Global.get_init_expr(global);
+
+        globalize_names(local_names, init);
+        ignore @@ Global.add_global(linked_mod, new_name, ty, mut, init);
+      };
+    };
+
+    let num_functions = Function.get_num_functions(wasm_mod);
+    let funcs =
+      List.init(num_functions, Function.get_function_by_index(wasm_mod));
+    let (imported_funcs, funcs) =
+      List.partition(is_function_imported, funcs);
+
+    List.iter(
+      func => {
+        let imported_module = Import.function_import_get_module(func);
+        if (is_grain_module(imported_module)) {
+          let imported_name = Import.function_import_get_base(func);
+          let internal_name = Function.get_name(func);
+          let new_name =
+            Hashtbl.find(
+              Hashtbl.find(exported_names, imported_module),
+              imported_name,
+            );
+          Hashtbl.add(local_names, internal_name, new_name);
+        } else {
+          let imported_name = Import.function_import_get_base(func);
+          let internal_name = Function.get_name(func);
+          let new_name = gensym(internal_name);
+          Hashtbl.add(local_names, internal_name, new_name);
+
+          let params = Function.get_params(func);
+          let results = Function.get_results(func);
+          Import.add_function_import(
+            linked_mod,
+            new_name,
+            imported_module,
+            imported_name,
+            params,
+            results,
+          );
+        };
+      },
+      imported_funcs,
+    );
+
+    List.iter(
+      func => {
+        let internal_name = Function.get_name(func);
+        let new_name = gensym(internal_name);
+        Hashtbl.add(local_names, internal_name, new_name);
+
+        let params = Function.get_params(func);
+        let results = Function.get_results(func);
+        let num_locals = Function.get_num_vars(func);
+        let locals = Array.init(num_locals, i => Function.get_var(func, i));
+        let body = Function.get_body(func);
+        globalize_names(local_names, body);
+        ignore @@
+        Function.add_function(
+          linked_mod,
+          new_name,
+          params,
+          results,
+          locals,
+          body,
+        );
+      },
+      funcs,
+    );
+
+    let num_exports = Export.get_num_exports(wasm_mod);
+    let local_exported_names: Hashtbl.t(string, string) = Hashtbl.create(10);
+    for (i in 0 to num_exports - 1) {
+      let export = Export.get_export_by_index(wasm_mod, i);
+      let export_kind = Export.export_get_kind(export);
+      if (export_kind == Export.external_function
+          || export_kind == Export.external_global) {
+        let exported_name = Export.get_name(export);
+        let internal_name = Export.get_value(export);
+        let new_internal_name = Hashtbl.find(local_names, internal_name);
+        Hashtbl.add(local_exported_names, exported_name, new_internal_name);
+      };
+    };
+    Hashtbl.add(exported_names, dep, local_exported_names);
+    if (is_main_module(dep)) {
+      write_exports(linked_mod, signature, local_exported_names);
+    };
+
+    let num_element_segments = Table.get_num_element_segments(wasm_mod);
+    for (i in 0 to num_element_segments - 1) {
+      let segment = Table.get_element_segment_by_index(wasm_mod, i);
+      let name = Table.element_segment_get_name(segment);
+      let new_name = gensym(name);
+      let size = Table.element_segment_get_length(segment);
+      let elems =
+        List.init(size, i =>
+          Hashtbl.find(
+            local_names,
+            Table.element_segment_get_data(segment, i),
+          )
+        );
+      ignore @@
+      Table.add_active_element_segment(
+        linked_mod,
+        function_table,
+        new_name,
+        elems,
+        Expression.const(
+          wasm_mod,
+          Literal.int32(Int32.of_int(table_offset^)),
+        ),
+      );
+      table_offset := table_offset^ + size;
+    };
+  };
+  List.iter(link_one, dependencies);
+  ignore @@ Table.add_table(linked_mod, function_table, table_offset^, -1);
+  Memory.set_memory(linked_mod, 64, Memory.unlimited, "memory", [], false);
+
+  let starts =
+    List.map(
+      dep => {
+        Expression.drop(
+          linked_mod,
+          Expression.call(
+            linked_mod,
+            Hashtbl.find(Hashtbl.find(exported_names, dep), grain_main),
+            [],
+            Type.int32,
+          ),
+        )
+      },
+      dependencies,
+    );
+
+  let start_name = gensym(grain_start);
+  ignore @@
+  Function.add_function(
+    linked_mod,
+    start_name,
+    Type.none,
+    Type.none,
+    [||],
+    Expression.block(linked_mod, gensym("start"), starts),
+  );
+  ignore @@ Export.add_function_export(linked_mod, start_name, grain_start);
+};
+
+let link_modules = ({asm: wasm_mod, signature}) => {
+  G.clear(dependency_graph);
+  Hashtbl.clear(modules);
+  Hashtbl.add(modules, main_module, wasm_mod);
+  build_dependency_graph(main_module);
+  let dependencies =
+    Topo.fold((dep, acc) => [dep, ...acc], dependency_graph, []);
+  let linked_mod = Module.create();
+  link_all(linked_mod, dependencies, signature);
+
+  let features = Module.get_features(wasm_mod);
+  let _ = Module.set_features(linked_mod, features);
+  let _ = Module.set_low_memory_unused(1);
+  if (Module.validate(linked_mod) != 1) {
+    failwith("Generated invalid linked module");
+  };
+  Module.optimize(linked_mod);
+  linked_mod;
+};

--- a/compiler/src/linking/linkmod.re
+++ b/compiler/src/linking/linkmod.re
@@ -1,0 +1,6 @@
+open Grain_codegen;
+
+let statically_link_wasm_module = prog => {
+  let linked_asm = Link.link_modules(prog);
+  {...prog, asm: linked_asm};
+};

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -9,38 +9,6 @@ type env = Env.t;
 type ident = Ident.t;
 type attributes = Asttypes.attributes;
 
-let rec get_allocation_type = (env, ty) => {
-  switch (ty.desc) {
-  | TTyConstr(path, _, _) => Env.find_type(path, env).type_allocation
-  | TTyLink(linked) => get_allocation_type(env, linked)
-  | TTyVar(_)
-  | TTyArrow(_)
-  | TTyTuple(_)
-  | TTyRecord(_)
-  | TTyUniVar(_)
-  | TTyPoly(_)
-  | TTySubst(_) => HeapAllocated
-  };
-};
-
-let rec get_fn_allocation_type = (env, ty) => {
-  switch (ty.desc) {
-  | TTyLink(linked) => get_fn_allocation_type(env, linked)
-  | TTyArrow(args, ret, _) => (
-      List.map(get_allocation_type(env), args),
-      get_allocation_type(env, ret),
-    )
-  | TTyConstr(_)
-  | TTyVar(_)
-  | TTyTuple(_)
-  | TTyRecord(_)
-  | TTyUniVar(_)
-  | TTyPoly(_)
-  | TTySubst(_) =>
-    failwith("get_fn_allocation_type: function type was non-function")
-  };
-};
-
 let default_loc = Location.dummy_loc;
 let default_env = Env.empty;
 let default_attributes = [];

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -9,10 +9,6 @@ type env = Env.t;
 type ident = Ident.t;
 type attributes = Asttypes.attributes;
 
-let get_allocation_type: (Env.t, type_expr) => allocation_type;
-let get_fn_allocation_type:
-  (Env.t, type_expr) => (list(allocation_type), allocation_type);
-
 module Imm: {
   let mk: (~loc: loc=?, ~env: env=?, imm_expression_desc) => imm_expression;
   let id: (~loc: loc=?, ~env: env=?, ident) => imm_expression;

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -2,6 +2,7 @@ open Grain_parsing;
 open Grain_typed;
 open Types;
 open Typedtree;
+open Type_utils;
 open Anftree;
 open Anf_helper;
 
@@ -652,7 +653,7 @@ let rec transl_imm =
       MatchCompiler.compile_result(
         ~allocation_type,
         ~partial,
-        Matchcomp.convert_match_branches(branches),
+        Matchcomp.convert_match_branches(env, branches),
         transl_anf_expression,
         transl_imm,
         exp_ans,
@@ -1097,7 +1098,7 @@ and transl_comp_expression =
       MatchCompiler.compile_result(
         ~allocation_type,
         ~partial,
-        Matchcomp.convert_match_branches(branches),
+        Matchcomp.convert_match_branches(env, branches),
         transl_anf_expression,
         transl_imm,
         exp_ans,
@@ -1389,6 +1390,12 @@ let rec transl_anf_statement =
     | TTyArrow(_) =>
       let (argsty, retty) =
         get_fn_allocation_type(env, desc.tvd_desc.ctyp_type);
+      let retty =
+        if (returns_void(desc.tvd_desc.ctyp_type)) {
+          [];
+        } else {
+          [retty];
+        };
       (
         None,
         [
@@ -1397,7 +1404,7 @@ let rec transl_anf_statement =
             desc.tvd_id,
             desc.tvd_mod.txt,
             desc.tvd_name.txt,
-            FunctionShape(argsty, [retty]),
+            FunctionShape(argsty, retty),
           ),
         ],
       );

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -9,6 +9,7 @@ open Grain_typed;
 open Grain_utils;
 open Types;
 open Typedtree;
+open Type_utils;
 
 /** The type for compiled match pattern decision trees.
     These trees are evaluated with respect to a stack of values. */
@@ -907,11 +908,12 @@ let rec compile_matrix = mtx =>
 /* Currently, this only desugars constant patterns into guard expressions,
  * but could be extended to do any other necessary preprocessing.
  */
-let prepare_match_branches = branches => {
+let prepare_match_branches = (env, branches) => {
   let map_branch = branch => {
     let guard = ref(branch.mb_guard);
     let make_vd = (id, ty) => {
       val_type: ty,
+      val_repr: Type_utils.repr_of_type(env, ty),
       val_kind: TValReg,
       val_fullpath: PIdent(id),
       val_mutable: false,
@@ -1040,8 +1042,8 @@ let prepare_match_branches = branches => {
 };
 
 let convert_match_branches =
-    (match_branches: list(Typedtree.match_branch)): conversion_result => {
-  let match_branches = prepare_match_branches(match_branches);
+    (env, match_branches: list(Typedtree.match_branch)): conversion_result => {
+  let match_branches = prepare_match_branches(env, match_branches);
   let mtx = make_matrix(match_branches);
   /*prerr_string "Initial matrix:\n";
     prerr_string (Sexplib.Sexp.to_string_hum (Sexplib.Conv.sexp_of_list

--- a/compiler/src/middle_end/optimize_tail_calls.re
+++ b/compiler/src/middle_end/optimize_tail_calls.re
@@ -21,6 +21,9 @@ module TailCallsArg: Anf_mapper.MapArgument = {
 
 module TailCallsMapper = Anf_mapper.MakeMap(TailCallsArg);
 
-let optimize = anfprog => {
-  TailCallsMapper.map_anf_program(anfprog);
-};
+let optimize = anfprog =>
+  if (Grain_utils.Config.experimental_tail_call^) {
+    TailCallsMapper.map_anf_program(anfprog);
+  } else {
+    anfprog;
+  };

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1718,6 +1718,12 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                 | existentials =>
                   Btype.newgenty(TTyPoly(val_type, existentials))
                 };
+              let val_repr =
+                switch (desc.cstr_args) {
+                | [] => ReprValue(WasmI32)
+                | args =>
+                  ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+                };
               let get_path = name =>
                 switch (path) {
                 | PIdent(_) => PIdent(Ident.create(name))
@@ -1728,6 +1734,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                 };
               let val_desc = {
                 val_type,
+                val_repr,
                 val_fullpath: get_path(desc.cstr_name),
                 val_kind: TValConstructor(desc),
                 val_loc: desc.cstr_loc,
@@ -1770,6 +1777,11 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
             | [] => val_type
             | existentials => Btype.newgenty(TTyPoly(val_type, existentials))
             };
+          let val_repr =
+            switch (desc.cstr_args) {
+            | [] => ReprValue(WasmI32)
+            | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+            };
           let get_path = name =>
             switch (path) {
             | PIdent(_) => PIdent(Ident.create(name))
@@ -1780,6 +1792,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
             };
           let val_desc = {
             val_type,
+            val_repr,
             val_fullpath: get_path(desc.cstr_name),
             val_kind: TValConstructor(desc),
             val_loc: desc.cstr_loc,
@@ -1843,8 +1856,14 @@ and store_type = (~check, id, info, env) => {
           | [] => val_type
           | existentials => Btype.newgenty(TTyPoly(val_type, existentials))
           };
+        let val_repr =
+          switch (desc.cstr_args) {
+          | [] => ReprValue(WasmI32)
+          | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+          };
         let val_desc = {
           val_type,
+          val_repr,
           val_fullpath: PIdent(Ident.create(desc.cstr_name)),
           val_kind: TValConstructor(desc),
           val_loc: desc.cstr_loc,
@@ -1930,8 +1949,14 @@ and store_extension = (~check, id, ext, env) => {
       | [] => val_type
       | existentials => Btype.newgenty(TTyPoly(val_type, existentials))
       };
+    let val_repr =
+      switch (cstr.cstr_args) {
+      | [] => ReprValue(WasmI32)
+      | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+      };
     {
       val_type,
+      val_repr,
       val_fullpath: PIdent(Ident.create(cstr.cstr_name)),
       val_kind: TValConstructor(cstr),
       val_mutable: false,

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -264,6 +264,7 @@ let type_declaration = (s, decl) => {
 
 let value_description = (s, descr) => {
   val_type: type_expr(s, descr.val_type),
+  val_repr: descr.val_repr,
   val_kind: descr.val_kind,
   val_fullpath: Path.PIdent(Ident.create("<unknown>")),
   val_mutable: descr.val_mutable,

--- a/compiler/src/typed/type_utils.re
+++ b/compiler/src/typed/type_utils.re
@@ -1,0 +1,99 @@
+open Types;
+
+let rec get_allocation_type = (env, ty) => {
+  switch (ty.desc) {
+  | TTyConstr(path, _, _) => Env.find_type(path, env).type_allocation
+  | TTySubst(linked)
+  | TTyLink(linked) => get_allocation_type(env, linked)
+  | TTyVar(_)
+  | TTyArrow(_)
+  | TTyTuple(_)
+  | TTyRecord(_)
+  | TTyUniVar(_)
+  | TTyPoly(_) => HeapAllocated
+  };
+};
+
+let rec get_fn_allocation_type = (env, ty) => {
+  switch (ty.desc) {
+  | TTySubst(linked)
+  | TTyLink(linked) => get_fn_allocation_type(env, linked)
+  | TTyArrow(args, ret, _) => (
+      List.map(get_allocation_type(env), args),
+      get_allocation_type(env, ret),
+    )
+  | TTyConstr(_)
+  | TTyVar(_)
+  | TTyTuple(_)
+  | TTyRecord(_)
+  | TTyUniVar(_)
+  | TTyPoly(_) =>
+    failwith("get_fn_allocation_type: function type was non-function")
+  };
+};
+
+let rec is_function = ty => {
+  switch (ty.desc) {
+  | TTySubst(linked)
+  | TTyLink(linked) => is_function(linked)
+  | TTyArrow(_) => true
+  | TTyConstr(_)
+  | TTyVar(_)
+  | TTyTuple(_)
+  | TTyRecord(_)
+  | TTyUniVar(_)
+  | TTyPoly(_) => false
+  };
+};
+
+let rec is_void = ty => {
+  switch (ty.desc) {
+  | TTySubst(linked)
+  | TTyLink(linked) => is_void(linked)
+  | TTyConstr(path, _, _) when path == Builtin_types.path_void => true
+  | TTyConstr(_)
+  | TTyArrow(_)
+  | TTyVar(_)
+  | TTyTuple(_)
+  | TTyRecord(_)
+  | TTyUniVar(_)
+  | TTyPoly(_) => false
+  };
+};
+
+let rec returns_void = ty => {
+  switch (ty.desc) {
+  | TTySubst(linked)
+  | TTyLink(linked) => returns_void(linked)
+  | TTyArrow(args, ret, _) => is_void(ret)
+  | TTyConstr(_)
+  | TTyVar(_)
+  | TTyTuple(_)
+  | TTyRecord(_)
+  | TTyUniVar(_)
+  | TTyPoly(_) =>
+    failwith("get_fn_allocation_type: function type was non-function")
+  };
+};
+
+let wasm_repr_of_allocation_type = alloc_type => {
+  switch (alloc_type) {
+  | StackAllocated(repr) => repr
+  | HeapAllocated => WasmI32
+  };
+};
+
+let repr_of_type = (env, ty) =>
+  if (is_function(ty)) {
+    let (args, ret) = get_fn_allocation_type(env, ty);
+    let args = List.map(wasm_repr_of_allocation_type, args);
+    let rets =
+      if (returns_void(ty)) {
+        [];
+      } else {
+        [wasm_repr_of_allocation_type(ret)];
+      };
+    ReprFunction(args, rets);
+  } else {
+    ReprValue(wasm_repr_of_allocation_type(get_allocation_type(env, ty)));
+  };

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -254,6 +254,7 @@ let maybe_add_pattern_variables_ghost = (loc_let, env, pv) =>
           id,
           {
             val_type: ty,
+            val_repr: Type_utils.repr_of_type(env, ty),
             val_fullpath: Path.PIdent(id),
             val_kind: TValUnbound(ValUnboundGhostRecursive),
             val_loc: loc_let,

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -931,6 +931,7 @@ let transl_value_decl = (env, loc, valdecl) => {
        raise (Error(valdecl.pval_loc, Val_in_structure)) */
     | [prim] => {
         val_type: ty,
+        val_repr: Type_utils.repr_of_type(env, ty),
         val_kind: TValPrim(prim),
         Types.val_loc: loc,
         val_fullpath: Path.PIdent(Ident.create("<bogus>")) /*val_attributes = valdecl.pval_attributes*/,
@@ -938,6 +939,7 @@ let transl_value_decl = (env, loc, valdecl) => {
       }
     | _ => {
         val_type: ty,
+        val_repr: Type_utils.repr_of_type(env, ty),
         val_kind: TValReg,
         Types.val_loc: loc,
         val_fullpath: Path.PIdent(Ident.create("<bogus>")) /*val_attributes = valdecl.pval_attributes*/,

--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -1065,6 +1065,7 @@ let add_pattern_variables = (~check=?, ~check_as=?, ~mut=false, env) => {
           id,
           {
             val_type: ty,
+            val_repr: Type_utils.repr_of_type(env, ty),
             val_kind: TValReg,
             Types.val_loc: loc,
             val_fullpath: Path.PIdent(id),

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -114,8 +114,26 @@ type value_kind =
   | TValConstructor(constructor_description);
 
 [@deriving (sexp, yojson)]
+type allocation_type =
+  | StackAllocated(wasm_repr)
+  | HeapAllocated
+
+[@deriving (sexp, yojson)]
+and wasm_repr =
+  | WasmI32
+  | WasmI64
+  | WasmF32
+  | WasmF64;
+
+[@deriving (sexp, yojson)]
+type val_repr =
+  | ReprFunction(list(wasm_repr), list(wasm_repr))
+  | ReprValue(wasm_repr);
+
+[@deriving (sexp, yojson)]
 type value_description = {
   val_type: type_expr,
+  val_repr,
   val_kind: value_kind,
   val_fullpath: Path.t,
   val_mutable: bool,
@@ -154,18 +172,6 @@ type extension_constructor = {
   [@sexp_drop_if sexp_locs_disabled]
   ext_loc: Location.t,
 };
-
-[@deriving (sexp, yojson)]
-type allocation_type =
-  | StackAllocated(wasm_repr)
-  | HeapAllocated
-
-[@deriving (sexp, yojson)]
-and wasm_repr =
-  | WasmI32
-  | WasmI64
-  | WasmF32
-  | WasmF64;
 
 [@deriving (sexp, yojson)]
 type type_declaration = {

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -348,6 +348,16 @@ let compilation_mode =
     None,
   );
 
+let statically_link =
+  toggle_flag(~names=["no-link"], ~doc="Disable static linking", true);
+
+let experimental_tail_call =
+  toggle_flag(
+    ~names=["experimental-wasm-tail-call"],
+    ~doc="Enables tail-call optimization",
+    false,
+  );
+
 let recursive_types =
   toggle_flag(
     ~names=["recursive-types"],

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -50,6 +50,14 @@ let principal: ref(bool);
 
 let compilation_mode: ref(option(string));
 
+/** Statically link modules after compilation */
+
+let statically_link: ref(bool);
+
+/** Enable tail-call optimizations */
+
+let experimental_tail_call: ref(bool);
+
 /** Whether to allow cyclic types. */
 
 let recursive_types: ref(bool);

--- a/compiler/test/input/sinister-tail-call.gr
+++ b/compiler/test/input/sinister-tail-call.gr
@@ -1,3 +1,4 @@
+/* grainc-flags --experimental-wasm-tail-call */
 // Contrived example to test *ADVANCED* tail calls
 
 let rec isEvenHelp = (n, b) => {

--- a/runtime/src/core/grain-module.js
+++ b/runtime/src/core/grain-module.js
@@ -89,7 +89,7 @@ export class GrainModule {
     return this.instantiated.exports;
   }
 
-  get isGrainModule() {
+  get isStartable() {
     return !!this.exports["_start"];
   }
 
@@ -105,8 +105,14 @@ export class GrainModule {
     wasi.start(this.instantiated);
   }
 
+  runUnboxed() {
+    // Only the tests currently rely on this.
+    wasi.setMemory(this.requiredExport("memory"));
+    return this.requiredExport("_gmain")();
+  }
+
   get tableSize() {
-    return this.requiredExport("GRAIN$TABLE_SIZE");
+    return this.exports["GRAIN$TABLE_SIZE"];
   }
 
   get types() {
@@ -207,13 +213,6 @@ export class GrainModule {
     }
     //console.log(`Instantiated: ${this._instantiated}.`);
     //console.log(`fields: ${Object.keys(this._instantiated)}`);
-  }
-
-  async runUnboxed() {
-    // This works because we use @wasmer/wasi, but will break in the future.
-    // Only the tests currently rely on this.
-    wasi.setMemory(this.requiredExport("memory"));
-    return await this.requiredExport("_start")();
   }
 }
 

--- a/runtime/src/core/runner.js
+++ b/runtime/src/core/runner.js
@@ -48,7 +48,7 @@ export class GrainRunner {
       throw new Error(`Failed to ensure string module.`);
     }
     await this.load(STRING_MODULE, located);
-    await located.start();
+    located.start();
   }
 
   grainValueToString(v) {
@@ -125,8 +125,8 @@ export class GrainRunner {
         // This is a good point to debug when modules are loaded:
         // console.log(`Located module: ${imp.module}`);
         await this.load(imp.module, located);
-        if (located.isGrainModule) {
-          await located.start();
+        if (located.isStartable) {
+          located.start();
         }
         this.ptrZero = this.ptr;
         this.imports[imp.module] = located.exports;
@@ -136,8 +136,9 @@ export class GrainRunner {
     // All of the dependencies have been loaded. Now we can instantiate with the import object.
     await mod.instantiate(this.imports, this);
     this.idMap[this.imports["grainRuntime"]["moduleRuntimeId"]] = name;
-    if (mod.isGrainModule) {
-      this.imports["grainRuntime"]["relocBase"] += mod.tableSize;
+    if (mod.isStartable) {
+      this.imports["grainRuntime"]["relocBase"] += mod.tableSize || 0;
+
       ++this.imports["grainRuntime"]["moduleRuntimeId"];
     }
     if (!(name in this.modules)) {


### PR DESCRIPTION
Closes #28.

feat: Support for more WebAssembly runtimes, including Wasmtime and Wasmer
fix!: Correct type signature for `_start`
chore!: Introduce `_gmain` for old behavior of `_start`
chore!: Tail calls must be enabled explicitly via `--experimental-wasm-tail-call`

_Still a draft as this depends on a number of PRs in https://github.com/grain-lang/binaryen.ml/pulls, but everything is finished._

# Static Linking

This PR implements a static linker for Grain modules, which allows us to keep our separate compilation but produce a single wasm file that works with the existing runtime and more runtimes than ever before, including Wasmtime, Wasmer, and Wasm3. This PR may not be enormous, but it's riding on the back of more than two months of hard work! 🎉 

## Important info

`grainc` will perform linking by default. This means that `grain compile hello.gr && wasmtime hello.gr.wasm` will work without having to worry about flags / wondering why that _doesn't_ work. Linking can be disabled via the `--no-link` flag.

Since most wasm runtimes don't support tail calls yet, they're now off by default, and can be enabled via `--experimental-wasm-tail-call`.

`-p` in the `grain` CLI is now deprecated, as it doesn't (and can't) work for linked modules. The tests still rely on it, but once we implement snapshot testing, we can remove it.

## Other info

Given this is implemented via Binaryen, I learned a ton and can probably contribute some info back to https://github.com/WebAssembly/binaryen/issues/2767. The approach used isn't too far off from being able to work generically (and I even considered implementing the linker directly in Binaryen.ml), though modules would need to adhere to certain constraints.

## Other thoughts

We may want to consider renaming the `Compiled` step in `compile.re`. It's sort of an odd name now, but I can't quite think of anything better. 