### PR TITLE
Runtime cleanup in preparation of pkg

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -2,7 +2,8 @@
   "name": "@grain/runtime",
   "version": "0.2.0",
   "description": "The JavaScript runtime for the Grain language.",
-  "main": "src/index.js",
+  "main": "dist/grain-runtime.js",
+  "broswer": "dist/grain-runtime-browser.js",
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",
@@ -36,21 +37,19 @@
     "url": "https://github.com/grain-lang/grain/issues"
   },
   "homepage": "https://grain-lang.org",
+  "dependencies": {},
   "devDependencies": {
+    "@wasmer/wasi": "^0.11.2",
+    "@wasmer/wasmfs": "^0.11.2",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "fast-text-encoding": "^1.0.0",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.16",
+    "wasm-sourcemap": "^1.0.0",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
     "webpack-merge": "^4.2.2"
-  },
-  "dependencies": {
-    "@wasmer/wasi": "^0.11.2",
-    "@wasmer/wasmfs": "^0.11.2",
-    "fast-text-encoding": "^1.0.0",
-    "treeify": "^1.1.0",
-    "wasm-sourcemap": "^1.0.0"
   }
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "The JavaScript runtime for the Grain language.",
   "main": "dist/grain-runtime.js",
-  "broswer": "dist/grain-runtime-browser.js",
+  "browser": "dist/grain-runtime-browser.js",
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -61,7 +61,7 @@ export async function GrainNodeRunner(path) {
   return loaded.run();
 }
 
-export default async function GrainRunner(uri) {
+export default async function DefaultGrainRunner(uri) {
   let runner = buildGrainRunner();
   let loaded = await runner.loadURL(uri);
   return loaded.run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3400,11 +3400,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-treeify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
-  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
-
 trim-newlines@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"


### PR DESCRIPTION
This PR moves our runtime deps to devDeps because the `pkg` tool tries to pull in everything in `dependencies`, which causes a bunch of issues. However, we just bundle and ship the bundles anyway, so I changed the `main` and `browser` fields to point at the produced `dist` files.

I also removed treeify because it didn't seem to be used. And I fixed an issue with the re-used identifier `GrainRunner`... no idea why babel casually allows that but real JS runtimes throw.