### PR TITLE
chore(stdlib)!: Replace JS entrypoint with locator file

### DIFF
--- a/stdlib/index.js
+++ b/stdlib/index.js
@@ -1,0 +1,1 @@
+module.exports = __dirname;

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -2,7 +2,7 @@
   "name": "@grain/stdlib",
   "version": "0.2.0",
   "description": "The standard library for the Grain language.",
-  "main": "pervasives.gr",
+  "main": "index.js",
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
This replaces the `main` file in the stdlib's `package.json` to point to a valid JS file, which just exports the `__dirname` of the location of the stdlib.

This is necessary because the `pkg` tool parses the `main` entrypoint and it needs to be valid JS, otherwise the packaging fails. Having the `index.js` export the `__dirname` is just a neat trick so you can do `const stdlibLocation = require('@grain/stdlib')`