### PR TITLE
fix(grainc): Only print compiler backtraces in debug mode

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -110,11 +110,12 @@ let compile_file = (name, outfile_arg) => {
       };
     Grain_parsing.Location.report_exception(Format.err_formatter, exn);
     Option.iter(
-      s => {
-        prerr_string("Backtrace:\n");
-        prerr_string(s);
-        prerr_string("\n");
-      },
+      s =>
+        if (Grain_utils.Config.debug^) {
+          prerr_string("Backtrace:\n");
+          prerr_string(s);
+          prerr_string("\n");
+        },
       bt,
     );
     exit(2);


### PR DESCRIPTION
There's really no need to see these backtraces when you aren't in grainc debug mode.