### PR TITLE
ci: Add most simple release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+on:
+  push:
+    branches: [ $default-branch ]
+
+jobs:
+  release-please:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          command: manifest


### PR DESCRIPTION
This adds a Release workflow that currently just runs release-please. I'll expand upon this to generate the Packaged Grain binaries and attach them to the release.