### PR TITLE
chore: Use main branch name in workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,7 @@
 name: Publish Docker image (HEAD)
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ['v*.*.*']
 jobs:
   push_to_registries:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [main]
 
 jobs:
   release-please:


### PR DESCRIPTION
Doesn't seem like that `$default-branch` thing works outside of templates. I also fixed the docker workflow branch name.