### PR TITLE
chore(cli): Remove debug flag from lsp exec call

### DIFF
--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -6,7 +6,7 @@ const exec = require("./exec");
 
 module.exports = (file, options) => {
   try {
-    exec(`-g --lsp ${file}`, options, { stdio: "inherit" });
+    exec(`--lsp ${file}`, options, { stdio: "inherit" });
     process.exit();
   } catch (e) {
     if (options.graceful) {


### PR DESCRIPTION
I'm not sure why the debug flag was added to the lsp command, but it causes .modsig and .wast files to be generated all over the place. I think we should remove it unless @ng-marcus or @ospencer has a reason it needs to be there.