### PR TITLE
ci: Add Binary creation & upload to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,100 @@ jobs:
   release-please:
     name: Create Release
     runs-on: ubuntu-latest
+    outputs:
+      # Remap these names because they are quite confusing
+      release_created: ${{ steps.release.outputs.releases_created }}
+      upload_url: ${{ steps.release.outputs['.--upload_url'] }}
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: manifest
+
+  build-pkg:
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
+    name: Build Packaged Grain
+    runs-on: ubuntu-latest
+    steps:
+      # Many of these steps are the same as building the compiler for tests
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '14'
+          check-latest: true
+
+      - name: Setup environment
+        run: |
+          yarn config set prefix $(npm config get prefix)
+          yarn global add shx
+
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Set up runtime and CLI
+        run: |
+          yarn
+
+      - name: Esy setup
+        run: |
+          yarn compiler prepare
+
+      - name: Esy cache
+        id: esy-cache
+        uses: actions/cache@v2
+        with:
+          path: compiler/_export
+          key:  ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
+
+      - name: Import esy cache
+        if: steps.esy-cache.outputs.cache-hit == 'true'
+        run: |
+          yarn compiler import-dependencies
+          shx rm -rf compiler/_export
+
+      - name: Build compiler
+        run: |
+          yarn compiler build
+
+      # To avoid bundling the wrong grainc.exe for the platform
+      # TODO(#589): Actually bundle these once users can install them locally
+      - name: Remove grainc.exe
+        run: |
+          shx rm cli/bin/grainc.exe
+
+      # This will log a warning because we removed the grainc.exe file
+      - name: Build Binaries
+        run: |
+          yarn cli build-pkg --target win-x64,mac-x64,linux-x64
+
+      - name: Upload Binary (Windows)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release-please.outputs.upload_url }}
+          asset_path: ./pkg/grain-win.exe
+          asset_name: grain-win-x64.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Binary (Mac)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release-please.outputs.upload_url }}
+          asset_path: ./pkg/grain-macos
+          asset_name: grain-mac-x64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Binary (Linux)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release-please.outputs.upload_url }}
+          asset_path: ./pkg/grain-linux
+          asset_name: grain-linux-x64
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
I tested this workflow in my personal fork: https://github.com/phated/grain/releases/tag/grain-v0.4.0

I think we should just manually do the npm publishes on stdlib and runtime for the 0.3.0 release (since they don't exist yet). I'll open an issue to automate that.