### PR TITLE
feat(cli)!: Pass compiler flags from the CLI to grainc directly

### DIFF
--- a/cli/bin/compile.js
+++ b/cli/bin/compile.js
@@ -1,9 +1,14 @@
 const exec = require("./exec");
 
-module.exports = (file, options) => {
+module.exports = (file, program) => {
+  const options = program.opts();
   try {
-    exec(file, options, { stdio: "inherit" });
-    return file.replace(/\.gr$/, ".gr.wasm");
+    exec(file, program, { stdio: "inherit" });
+    if (options.o) {
+      return options.o;
+    } else {
+      return file.replace(/\.gr$/, ".gr.wasm");
+    }
   } catch (e) {
     if (options.graceful) {
       process.exit();

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -17,10 +17,15 @@ function getGrainc() {
 
 const grainc = getGrainc();
 
-function exec(commandOrFile = "", options = {}, execOpts = { stdio: "pipe" }) {
-  let cflags = options.cflags ? options.cflags : "";
-  let stdlib = options.stdlib ? `--stdlib=${options.stdlib}` : "";
-  return execSync(`${grainc} ${stdlib} ${cflags} ${commandOrFile}`, execOpts);
+function exec(commandOrFile = "", program, execOpts = { stdio: "pipe" }) {
+  const flags = [];
+  program.options.forEach((option) => {
+    if (!option.grainc) return;
+    const flag = option.toFlag();
+    if (flag) flags.push(flag);
+  });
+
+  return execSync(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 module.exports = exec;

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -40,8 +40,34 @@ function num(val) {
 }
 
 function graincVersion() {
-  return exec("--version").toString().trim();
+  return exec("--version", program).toString().trim();
 }
+
+class GraincOption extends program.Option {
+  grainc = true;
+
+  toFlag() {
+    const value = program.opts()[this.attributeName()];
+
+    if (value instanceof Array && value.length > 0) {
+      return `${this.long || this.short} ${value.join(",")}`;
+    } else if (typeof value === "string" || typeof value === "number") {
+      return `${this.long || this.short} ${value}`;
+    } else if (
+      (this.negate && value === false) ||
+      (!this.negate && value === true)
+    ) {
+      return this.long || this.short;
+    }
+  }
+}
+
+program.graincOption = function (flags, description, parser, defaultValue) {
+  const option = new GraincOption(flags, description);
+  if (parser) option.argParser(parser);
+  if (typeof defaultValue !== "undefined") option.default(defaultValue);
+  return program.addOption(option);
+};
 
 program
   .option("-v, --version", "output CLI and compiler versions")
@@ -51,24 +77,61 @@ program
     process.exit(0);
   })
   .description("Compile and run Grain programs. 🌾")
-  .option("-p, --print-output", "print the output of the program")
+  .addOption(new program.Option("-p, --print-output").hideHelp())
   .option("-g, --graceful", "return a 0 exit code if the program errors")
-  .option(
+  .graincOption(
     "-I, --include-dirs <dirs>",
-    "include directories the runtime should find wasm modules",
+    "add additional dependency include directories",
     list,
     []
   )
-  .option("-f, --cflags <cflags>", "pass flags to the Grain compiler")
-  .option(
+  .graincOption(
     "-S, --stdlib <path>",
     "override the standard libary with your own",
+    null,
     stdlibPath
   )
   .option("--limitMemory <size>", "maximum allowed heap size", num, -1)
   .option(
     "--init-memory-pages <size>",
     "number of pages used to initialize the grain runtime"
+  )
+  .graincOption(
+    "--compilation-mode <mode>",
+    "compilation mode (advanced use only)"
+  )
+  .graincOption(
+    "--elide-type-info",
+    "don't include runtime type information used by toString/print"
+  )
+  .graincOption(
+    "--experimental-wasm-tail-call",
+    "enables tail-call optimization"
+  )
+  .graincOption("-g", "compile with debugging information")
+  .graincOption(
+    "--hide-locs",
+    "hide locations from intermediate trees. Only has an effect with `--verbose`"
+  )
+  .graincOption("--lsp", "generate lsp errors and warnings only")
+  .graincOption("--no-color", "disable colored output")
+  .graincOption("--no-gc", "turn off reference counting garbage collection")
+  .graincOption("--no-link", "disable static linking")
+  .graincOption(
+    "--no-pervasives",
+    "don't automatically import the Grain Pervasives module"
+  )
+  .graincOption("-o <filename>", "output filename")
+  .graincOption("--O0", "disable optimizations")
+  .graincOption(
+    "--parser-debug-level <level>",
+    "debugging level for parser output"
+  )
+  .graincOption("--source-map", "generate source maps")
+  .graincOption("--strict-sequence", "enable strict sequencing")
+  .graincOption(
+    "--verbose",
+    "print critical information at various stages of compilation"
   )
   .on("option:init-memory-pages", (pages) => {
     // Workaround for the runtime's memory being initialized statically on module load
@@ -77,7 +140,7 @@ program
   // The root command that compiles & runs
   .arguments("<file>")
   .action(function (file) {
-    actions.run(actions.compile(file, program), program);
+    actions.run(actions.compile(file, program), program.opts());
   });
 
 program
@@ -98,7 +161,7 @@ program
   .command("run <file>")
   .description("run a wasm file with the grain runtime")
   .action(function (wasmFile) {
-    actions.run(wasmFile, program);
+    actions.run(wasmFile, program.opts());
   });
 
 program.parse(process.argv);

--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -4,12 +4,12 @@ const exec = require("./exec");
 // and we get the compiler output in stdout
 // we still take the file name so we have it available
 
-module.exports = (file, options) => {
+module.exports = (file, program) => {
   try {
-    exec(`--lsp ${file}`, options, { stdio: "inherit" });
+    exec(`--lsp ${file}`, program, { stdio: "inherit" });
     process.exit();
   } catch (e) {
-    if (options.graceful) {
+    if (options.opts().graceful) {
       process.exit();
     } else {
       process.exit(1);

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@grain/runtime": "*",
     "@grain/stdlib": "*",
-    "commander": "^5.1.0"
+    "commander": "^7.2.0"
   },
   "devDependencies": {
     "@phated/pkg": "4.5.1-grain",

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -311,7 +311,7 @@ let optimizations_enabled =
 
 let include_dirs =
   opt(
-    ~names=["I"],
+    ~names=["I", "include-dirs"],
     ~conv=Cmdliner.Arg.(list(dir)),
     ~doc="Extra library include directories",
     ~docv="DIR",
@@ -330,12 +330,8 @@ let stdlib_dir =
 let color_enabled =
   toggle_flag(~names=["no-color"], ~doc="Disable colored output", true);
 
-let principal =
-  toggle_flag(
-    ~names=["principal-types"],
-    ~doc="Enable principal types",
-    false,
-  );
+// TODO: (#612) Add compiler flag when feature is complete or remove entirely
+let principal = ref(false);
 
 let compilation_mode =
   opt(
@@ -358,12 +354,8 @@ let experimental_tail_call =
     false,
   );
 
-let recursive_types =
-  toggle_flag(
-    ~names=["recursive-types"],
-    ~doc="Enable recursive types",
-    false,
-  );
+// TODO: (#612) Add compiler flag when feature is complete or remove entirely
+let recursive_types = ref(false);
 
 let strict_sequence =
   toggle_flag(
@@ -392,8 +384,8 @@ let debug =
 
 let verbose =
   toggle_flag(
-    ~names=["cdebug"],
-    ~doc="Print internal debug messages",
+    ~names=["verbose"],
+    ~doc="Print critical information at various stages of compilation",
     false,
   );
 
@@ -401,7 +393,7 @@ let sexp_locs_enabled =
   toggle_flag(
     ~names=["hide-locs"],
     ~doc=
-      "Hide locations from intermediate trees. Only has an effect with `--cdebug'.",
+      "Hide locations from intermediate trees. Only has an effect with `--verbose'.",
     true,
   );
 
@@ -416,13 +408,6 @@ let no_gc =
   toggle_flag(
     ~names=["no-gc"],
     ~doc="Turn off reference counting garbage collection.",
-    false,
-  );
-
-let unsound_optimizations =
-  toggle_flag(
-    ~names=["Ounsound"],
-    ~doc="Compile with optimizations which may remove runtime errors",
     false,
   );
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -14,7 +14,7 @@ let module_search_path_from_base_path: string => list(string);
 let verbose: ref(bool);
 
 /** Whether locations should be shown in s-expression-converted trees
-    (primarily useful with --cdebug). */
+    (primarily useful with --verbose). */
 
 let sexp_locs_enabled: ref(bool);
 
@@ -77,10 +77,6 @@ let parser_debug_level: ref(int);
 /** Whether debugging information should be included in the compiled output. */
 
 let debug: ref(bool);
-
-/** Whether optimizations which could elide runtime errors should be performed. */
-
-let unsound_optimizations: ref(bool);
 
 /** Whether or not to include runtime type information used by toString/print */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,10 +1017,10 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
chore(cli)!: Remove `-f` CLI option
chore(compiler)!: Remove --principal-types and --recursive-types compiler flags
chore(compiler)!: Rename --cdebug to --verbose