### PR TITLE
fix(compiler): Resolve names when doing CRC checks

### DIFF
--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -339,7 +339,8 @@ module Dependency_graph =
             file_older(srcpath, objpath)
             && List.for_all(
                  ((name, crc)) => {
-                   let out_file_name = get_output_name(name);
+                   let resolved = resolve_unit(name);
+                   let out_file_name = get_output_name(resolved);
                    Fs_access.file_exists(out_file_name)
                    && (
                      switch (crc) {


### PR DESCRIPTION
This seems to be the underlying issue of why large portions of the dependency graph would be recompiled unnecessarily. With my checks, it looks like only changed files are recompiled.