### PR TITLE
fix(cli): Correct typo in lsp catch block

### DIFF
--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -9,7 +9,7 @@ module.exports = (file, program) => {
     exec(`--lsp ${file}`, program, { stdio: "inherit" });
     process.exit();
   } catch (e) {
-    if (options.opts().graceful) {
+    if (program.opts().graceful) {
       process.exit();
     } else {
       process.exit(1);


### PR DESCRIPTION
Whoops, typo. Too late to get in this release, but it just causes a crash to crash so 🤷 