### PR TITLE
feat(cli)!: Split -g into --debug and --wat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ notes.org
 node_modules/
 *.wasm
 *.wasm.map
-*.wasm.wast
-*.wasm.modsig
+*.wat
+*.modsig
 .tern-port
 setup.data
 setup.ml

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -108,7 +108,8 @@ program
     "--experimental-wasm-tail-call",
     "enables tail-call optimization"
   )
-  .graincOption("-g", "compile with debugging information")
+  .graincOption("--debug", "compile with debugging information")
+  .graincOption("--wat", "additionally produce a WebAssembly Text (.wat) file")
   .graincOption(
     "--hide-locs",
     "hide locations from intermediate trees. Only has an effect with `--verbose`"

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -5,16 +5,18 @@ open Compmod;
 let emit_module = ({asm, signature}, outfile) => {
   Files.ensure_parent_directory_exists(outfile);
   if (Config.debug^) {
-    let asm_string = Binaryen.Module.write_text(asm);
     let sig_string =
       Sexplib.Sexp.to_string_hum(Cmi_format.sexp_of_cmi_infos(signature));
-    let wast_file = outfile ++ ".wast";
-    let sig_file = outfile ++ ".modsig";
-    let oc = open_out(wast_file);
-    output_string(oc, asm_string);
-    close_out(oc);
+    let sig_file = Files.replace_extension(outfile, "modsig");
     let oc = open_out(sig_file);
     output_string(oc, sig_string);
+    close_out(oc);
+  };
+  if (Config.wat^) {
+    let asm_string = Binaryen.Module.write_text(asm);
+    let wat_file = Files.replace_extension(outfile, "wat");
+    let oc = open_out(wat_file);
+    output_string(oc, asm_string);
     close_out(oc);
   };
   let source_map_name =

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -377,8 +377,15 @@ let parser_debug_level =
 
 let debug =
   toggle_flag(
-    ~names=["g"],
+    ~names=["debug"],
     ~doc="Compile with debugging information",
+    false,
+  );
+
+let wat =
+  toggle_flag(
+    ~names=["wat"],
+    ~doc="Additionally produce a WebAssembly Text (.wat) file",
     false,
   );
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -78,6 +78,10 @@ let parser_debug_level: ref(int);
 
 let debug: ref(bool);
 
+/** Also produce a WebAssembly Text (.wat) file. */
+
+let wat: ref(bool);
+
 /** Whether or not to include runtime type information used by toString/print */
 
 let elide_type_info: ref(bool);

--- a/compiler/src/utils/files.re
+++ b/compiler/src/utils/files.re
@@ -9,6 +9,10 @@ let remove_extension = baseName => {
   };
 };
 
+let replace_extension = (baseName, newExt) => {
+  Printf.sprintf("%s.%s", remove_extension(baseName), newExt);
+};
+
 // These utilities are needed until https://github.com/facebookexperimental/reason-native/pull/251
 // is merged into the reason-native/fp library to support Windows-style separators
 let normalize_separators = path => {


### PR DESCRIPTION
This PR splits the `-g` `grainc` flag into `--debug` and `--wat`. The WebAssembly Text files produced are now named with a `.gr.wat` extension instead of `.gr.wasm.wast` to no longer use the deprecated `wast` name, and to match `.gr.wasm` <-> `.gr.wat`.