### PR TITLE
revert: "chore!: rename Queue/Stack lib methods (#625)"

### DIFF
--- a/compiler/test/stdlib/queue.test.gr
+++ b/compiler/test/stdlib/queue.test.gr
@@ -2,27 +2,27 @@ import Queue from "queue"
 
 let empty = Queue.make()
 // 1 <- 2 <- 3
-let sampleQueue = Queue.push(3, Queue.push(2, Queue.push(1, empty)))
+let sampleQueue = Queue.enqueue(3, Queue.enqueue(2, Queue.enqueue(1, empty)))
 
 // Queue.isEmpty
 
 assert Queue.isEmpty(empty)
 assert !Queue.isEmpty(sampleQueue)
 
-// Queue.peek
+// Queue.head
 
-assert Queue.peek(empty) == None
-assert Queue.peek(sampleQueue) == Some(1)
+assert Queue.head(empty) == None
+assert Queue.head(sampleQueue) == Some(1)
 
-// Queue.push
+// Queue.enqueue
 
-assert Queue.peek(Queue.push(1, empty)) == Some(1)
-assert Queue.peek(Queue.push(4, sampleQueue)) == Some(1)
+assert Queue.head(Queue.enqueue(1, empty)) == Some(1)
+assert Queue.head(Queue.enqueue(4, sampleQueue)) == Some(1)
 
-// Queue.pop
+// Queue.dequeue
 
-assert Queue.isEmpty(Queue.pop(empty))
-assert Queue.isEmpty(Queue.pop(Queue.push(1, empty)))
-assert Queue.isEmpty(Queue.pop(Queue.pop(Queue.pop(sampleQueue))))
-assert Queue.peek(Queue.pop(sampleQueue)) == Some(2)
-assert Queue.peek(Queue.pop(Queue.push(4, Queue.pop(sampleQueue)))) == Some(3)
+assert Queue.isEmpty(Queue.dequeue(empty))
+assert Queue.isEmpty(Queue.dequeue(Queue.enqueue(1, empty)))
+assert Queue.isEmpty(Queue.dequeue(Queue.dequeue(Queue.dequeue(sampleQueue))))
+assert Queue.head(Queue.dequeue(sampleQueue)) == Some(2)
+assert Queue.head(Queue.dequeue(Queue.enqueue(4, Queue.dequeue(sampleQueue)))) == Some(3)

--- a/compiler/test/stdlib/stack.test.gr
+++ b/compiler/test/stdlib/stack.test.gr
@@ -9,20 +9,20 @@ let sampleStack = Stack.push(3, Stack.push(2, Stack.push(1, empty)))
 assert Stack.isEmpty(empty)
 assert !Stack.isEmpty(sampleStack)
 
-// Stack.peek
+// Stack.head
 
-assert Stack.peek(empty) == None
-assert Stack.peek(sampleStack) == Some(3)
+assert Stack.head(empty) == None
+assert Stack.head(sampleStack) == Some(3)
 
 // Stack.push
 
-assert Stack.peek(Stack.push(1, empty)) == Some(1)
-assert Stack.peek(Stack.push(4, sampleStack)) == Some(4)
+assert Stack.head(Stack.push(1, empty)) == Some(1)
+assert Stack.head(Stack.push(4, sampleStack)) == Some(4)
 
 // Stack.pop
 
 assert Stack.isEmpty(Stack.pop(empty))
 assert Stack.isEmpty(Stack.pop(Stack.push(1, empty)))
 assert Stack.isEmpty(Stack.pop(Stack.pop(Stack.pop(sampleStack))))
-assert Stack.peek(Stack.pop(sampleStack)) == Some(2)
-assert Stack.peek(Stack.pop(Stack.push(4, Stack.pop(sampleStack)))) == Some(2)
+assert Stack.head(Stack.pop(sampleStack)) == Some(2)
+assert Stack.head(Stack.pop(Stack.push(4, Stack.pop(sampleStack)))) == Some(2)

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -13,21 +13,21 @@ export let isEmpty = (queue) => {
     }
 }
 
-export let peek = (queue) => {
+export let head = (queue) => {
     match (queue) {
         { forwards: [], backwards: [] } => None,
         { forwards, backwards } => List.head(forwards)
     }
 }
 
-export let push = (value, queue) => {
+export let enqueue = (value, queue) => {
     match (queue) {
         { forwards: [], backwards: [] } => { forwards: [value], backwards: [] },
         { forwards, backwards } => { forwards, backwards: [value, ...backwards] }
     }
 }
 
-export let pop = (queue) => {
+export let dequeue = (queue) => {
     match (queue) {
         { forwards: [], backwards: [] } => queue,
         { forwards: [head], backwards: [] } => { forwards: [], backwards: [] },

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -15,7 +15,7 @@ export let isEmpty = (stack) => {
     }
 }
 
-export let peek = (stack) => {
+export let head = (stack) => {
     match (stack) {
         { data: [] } => None,
         { data } => List.head(data)


### PR DESCRIPTION
Reverts grain-lang/grain#625

Pulling out this breaking change so we can release some bug fixes before 0.4.0.