### PR TITLE
Bytes

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,6 +10,7 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
+v8.setFlagsFromString("--experimental-wasm-bigint");
 v8.setFlagsFromString("--experimental-wasm-return-call");
 
 const program = require("commander");

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,7 +10,6 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
-v8.setFlagsFromString("--experimental-wasm-bigint");
 v8.setFlagsFromString("--experimental-wasm-return-call");
 
 const program = require("commander");

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1587,7 +1587,7 @@ let call_lambda = (~tail=false, wasm_mod, env, func, (argsty, retty), args) => {
   );
 };
 
-let allocate_bytes_from_buffer = (wasm_mod, env, buf, tag, label) => {
+let allocate_byte_like_from_buffer = (wasm_mod, env, buf, tag, label) => {
   let ints_to_push: list(int64) = buf_to_ints(buf);
   let get_swap = () => get_swap(wasm_mod, env, 0);
   let tee_swap = tee_swap(~skip_incref=true, wasm_mod, env, 0);
@@ -1632,7 +1632,7 @@ let allocate_bytes_from_buffer = (wasm_mod, env, buf, tag, label) => {
 let allocate_string = (wasm_mod, env, str) => {
   let buf = Buffer.create(80);
   Buffer.add_string(buf, str);
-  allocate_bytes_from_buffer(
+  allocate_byte_like_from_buffer(
     wasm_mod,
     env,
     buf,
@@ -1644,7 +1644,7 @@ let allocate_string = (wasm_mod, env, str) => {
 let allocate_bytes = (wasm_mod, env, bytes) => {
   let buf = Buffer.create(80);
   Buffer.add_bytes(buf, bytes);
-  allocate_bytes_from_buffer(wasm_mod, env, buf, BytesType, "allocate_bytes");
+  allocate_byte_like_from_buffer(wasm_mod, env, buf, BytesType, "allocate_bytes");
 };
 
 let allocate_char = (wasm_mod, env, char) => {

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1587,7 +1587,7 @@ let call_lambda = (~tail=false, wasm_mod, env, func, (argsty, retty), args) => {
   );
 };
 
-let allocate_buffer = (wasm_mod, env, buf, len, tag, label) => {
+let allocate_bytes_from_buffer = (wasm_mod, env, buf, len, tag, label) => {
   let ints_to_push: list(int64) = buf_to_ints(buf);
   let get_swap = () => get_swap(wasm_mod, env, 0);
   let tee_swap = tee_swap(~skip_incref=true, wasm_mod, env, 0);
@@ -1632,7 +1632,7 @@ let allocate_buffer = (wasm_mod, env, buf, len, tag, label) => {
 let allocate_string = (wasm_mod, env, str) => {
   let buf = Buffer.create(80);
   Buffer.add_string(buf, str);
-  allocate_buffer(
+  allocate_bytes_from_buffer(
     wasm_mod,
     env,
     buf,
@@ -1645,7 +1645,7 @@ let allocate_string = (wasm_mod, env, str) => {
 let allocate_bytes = (wasm_mod, env, bytes) => {
   let buf = Buffer.create(80);
   Buffer.add_bytes(buf, bytes);
-  allocate_buffer(
+  allocate_bytes_from_buffer(
     wasm_mod,
     env,
     buf,

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1644,13 +1644,7 @@ let allocate_string = (wasm_mod, env, str) => {
 let allocate_bytes = (wasm_mod, env, bytes) => {
   let buf = Buffer.create(80);
   Buffer.add_bytes(buf, bytes);
-  allocate_bytes_from_buffer(
-    wasm_mod,
-    env,
-    buf,
-    BytesType,
-    "allocate_bytes",
-  );
+  allocate_bytes_from_buffer(wasm_mod, env, buf, BytesType, "allocate_bytes");
 };
 
 let allocate_char = (wasm_mod, env, char) => {

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1587,7 +1587,7 @@ let call_lambda = (~tail=false, wasm_mod, env, func, (argsty, retty), args) => {
   );
 };
 
-let allocate_bytes_from_buffer = (wasm_mod, env, buf, len, tag, label) => {
+let allocate_bytes_from_buffer = (wasm_mod, env, buf, tag, label) => {
   let ints_to_push: list(int64) = buf_to_ints(buf);
   let get_swap = () => get_swap(wasm_mod, env, 0);
   let tee_swap = tee_swap(~skip_incref=true, wasm_mod, env, 0);
@@ -1607,7 +1607,7 @@ let allocate_bytes_from_buffer = (wasm_mod, env, buf, len, tag, label) => {
       ~offset=4,
       wasm_mod,
       get_swap(),
-      Expression.Const.make(wasm_mod, const_int32 @@ len),
+      Expression.Const.make(wasm_mod, const_int32 @@ Buffer.length(buf)),
     ),
   ];
   let elts =
@@ -1636,7 +1636,6 @@ let allocate_string = (wasm_mod, env, str) => {
     wasm_mod,
     env,
     buf,
-    String.length(str),
     StringType,
     "allocate_string",
   );
@@ -1649,7 +1648,6 @@ let allocate_bytes = (wasm_mod, env, bytes) => {
     wasm_mod,
     env,
     buf,
-    Bytes.length(bytes),
     BytesType,
     "allocate_bytes",
   );

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1644,7 +1644,13 @@ let allocate_string = (wasm_mod, env, str) => {
 let allocate_bytes = (wasm_mod, env, bytes) => {
   let buf = Buffer.create(80);
   Buffer.add_bytes(buf, bytes);
-  allocate_byte_like_from_buffer(wasm_mod, env, buf, BytesType, "allocate_bytes");
+  allocate_byte_like_from_buffer(
+    wasm_mod,
+    env,
+    buf,
+    BytesType,
+    "allocate_bytes",
+  );
 };
 
 let allocate_char = (wasm_mod, env, char) => {

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1646,7 +1646,7 @@ let allocate_bytes = (wasm_mod, env, bytes) => {
       tee_swap(
         heap_allocate(wasm_mod, env, 2 + 2 * List.length(ints_to_push)),
       ),
-      Expression.const(
+      Expression.Const.make(
         wasm_mod,
         const_int32(tag_val_of_heap_tag_type(BytesType)),
       ),
@@ -1655,7 +1655,7 @@ let allocate_bytes = (wasm_mod, env, bytes) => {
       ~offset=4,
       wasm_mod,
       get_swap(),
-      Expression.const(wasm_mod, const_int32 @@ Bytes.length(bytes)),
+      Expression.Const.make(wasm_mod, const_int32 @@ Bytes.length(bytes)),
     ),
   ];
   let elts =
@@ -1666,11 +1666,11 @@ let allocate_bytes = (wasm_mod, env, bytes) => {
           ~offset=8 * (idx + 1),
           wasm_mod,
           get_swap(),
-          Expression.const(wasm_mod, wrap_int64(i)),
+          Expression.Const.make(wasm_mod, wrap_int64(i)),
         ),
       ints_to_push,
     );
-  Expression.block(
+  Expression.Block.make(
     wasm_mod,
     gensym_label("allocate_bytes"),
     List.concat([preamble, elts, [get_swap()]]),

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -299,6 +299,7 @@ type allocation_type =
   | MArray(list(immediate))
   | MRecord(immediate, list((string, immediate)))
   | MADT(immediate, immediate, list(immediate)) /* Type Tag, Variant Tag, Elements */
+  | MBytes(bytes)
   | MString(string)
   | MChar(string)
   | MInt32(int32)

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -458,6 +458,7 @@ let compile_const = (c: Asttypes.constant) =>
   | Const_number(Const_number_int(i)) => MConstI32(Int64.to_int32(i))
   | Const_number(_) =>
     failwith("compile_const: Const_number float/rational post-ANF")
+  | Const_bytes(_) => failwith("compile_const: Const_bytes post-ANF")
   | Const_string(_) => failwith("compile_const: Const_string post-ANF")
   | Const_char(_) => failwith("compile_const: Const_char post-ANF")
   | Const_int32(i32) => MConstI32(i32)
@@ -733,6 +734,7 @@ let rec compile_comp = (env, c) => {
           List.map(compile_imm(env), args),
         ),
       )
+    | CBytes(b) => MAllocate(MBytes(b))
     | CString(s) => MAllocate(MString(s))
     | CChar(c) => MAllocate(MChar(c))
     | CNumber(Const_number_int(n))

--- a/compiler/src/codegen/value_tags.re
+++ b/compiler/src/codegen/value_tags.re
@@ -10,7 +10,8 @@ type heap_tag_type =
   | ArrayType
   | BoxedNumberType
   | LambdaType
-  | TupleType;
+  | TupleType
+  | BytesType;
 
 let tag_val_of_heap_tag_type =
   fun
@@ -21,7 +22,8 @@ let tag_val_of_heap_tag_type =
   | ArrayType => 5
   | BoxedNumberType => 6
   | LambdaType => 7
-  | TupleType => 8;
+  | TupleType => 8
+  | BytesType => 9;
 
 let heap_tag_type_of_tag_val =
   fun
@@ -33,6 +35,7 @@ let heap_tag_type_of_tag_val =
   | 6 => BoxedNumberType
   | 7 => LambdaType
   | 8 => TupleType
+  | 9 => BytesType
   | x => failwith(Printf.sprintf("Unknown tag type: %d", x));
 
 [@deriving sexp]

--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -124,6 +124,7 @@ let rec analyze_comp_expression =
     | CInt64(_)
     | CFloat32(_)
     | CFloat64(_)
+    | CBytes(_)
     | CString(_)
     | CChar(_) => true
     };

--- a/compiler/src/middle_end/analyze_tail_calls.re
+++ b/compiler/src/middle_end/analyze_tail_calls.re
@@ -71,6 +71,7 @@ let rec analyze_comp_expression =
   | CSetRecordItem(_)
   | CContinue
   | CBreak
+  | CBytes(_)
   | CString(_)
   | CChar(_)
   | CNumber(_)

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -253,6 +253,14 @@ module Comp = {
       ~env?,
       CLambda(name, args, body),
     );
+  let bytes = (~loc=?, ~attributes=?, ~env=?, b) =>
+    mk(
+      ~loc?,
+      ~attributes?,
+      ~allocation_type=HeapAllocated,
+      ~env?,
+      CBytes(b),
+    );
   let string = (~loc=?, ~attributes=?, ~env=?, s) =>
     mk(
       ~loc?,

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -297,6 +297,9 @@ module Comp: {
       (anf_expression, allocation_type)
     ) =>
     comp_expression;
+  let bytes:
+    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, bytes) =>
+    comp_expression;
   let string:
     (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, string) =>
     comp_expression;

--- a/compiler/src/middle_end/anf_iterator.re
+++ b/compiler/src/middle_end/anf_iterator.re
@@ -98,6 +98,7 @@ module MakeIter = (Iter: IterArgument) => {
       List.iter(iter_imm_expression, args);
     | CAppBuiltin(_, _, args) => List.iter(iter_imm_expression, args)
     | CLambda(_, idents, (expr, _)) => iter_anf_expression(expr)
+    | CBytes(s) => ()
     | CString(s) => ()
     | CChar(c) => ()
     | CNumber(i) => ()

--- a/compiler/src/middle_end/anf_mapper.re
+++ b/compiler/src/middle_end/anf_mapper.re
@@ -127,6 +127,7 @@ module MakeMap = (Iter: MapArgument) => {
       | CLambda(name, idents, (expr, alloc_ty)) =>
         let expr = map_anf_expression(expr);
         CLambda(name, idents, (expr, alloc_ty));
+      | CBytes(b) => CBytes(b)
       | CString(s) => CString(s)
       | CChar(c) => CChar(c)
       | CNumber(i) => CNumber(i)

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -144,6 +144,7 @@ and comp_free_vars_help = (env, c: comp_expression) =>
   | CInt64(_)
   | CFloat32(_)
   | CFloat64(_)
+  | CBytes(_)
   | CString(_)
   | CChar(_) => Ident.Set.empty
   | CImmExpr(i) => imm_free_vars_help(env, i)

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -320,6 +320,7 @@ and comp_expression_desc =
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
     )
+  | CBytes(bytes)
   | CString(string)
   | CChar(string)
   | CNumber(Asttypes.number_type)

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -305,6 +305,7 @@ and comp_expression_desc =
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
     )
+  | CBytes(bytes)
   | CString(string)
   | CChar(string)
   | CNumber(Asttypes.number_type)

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -133,6 +133,7 @@ let transl_const =
   | Const_int64(i) => Right(("int64", Comp.int64(i)))
   | Const_float64(i) => Right(("float64", Comp.float64(i)))
   | Const_float32(i) => Right(("float32", Comp.float32(i)))
+  | Const_bytes(b) => Right(("bytes", Comp.bytes(b)))
   | Const_string(s) => Right(("str", Comp.string(s)))
   | Const_char(c) => Right(("char", Comp.char(c)))
   | _ => Left(Imm.const(c))

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -940,6 +940,7 @@ let prepare_match_branches = (env, branches) => {
       | Const_wasmi64(_) => Builtin_types.type_wasmi64
       | Const_wasmf32(_) => Builtin_types.type_wasmf32
       | Const_wasmf64(_) => Builtin_types.type_wasmf64
+      | Const_bytes(_) => Builtin_types.type_bytes
       | Const_string(_) => Builtin_types.type_string
       | Const_char(_) => Builtin_types.type_char
       };
@@ -951,6 +952,7 @@ let prepare_match_branches = (env, branches) => {
       | Const_int64(_)
       | Const_float32(_)
       | Const_float64(_)
+      | Const_bytes(_)
       | Const_string(_)
       | Const_char(_) => Eq
       | Const_void

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -46,6 +46,7 @@ let ident_cons = {
 };
 
 module Const = {
+  let bytes = b => PConstBytes(b);
   let string = s => PConstString(s);
   let char = c => PConstChar(c);
   let number = i => PConstNumber(i);

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -22,6 +22,7 @@ let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
 [@deriving (sexp, yojson)]
 type constant =
   | Const_number(number_type)
+  | Const_bytes(bytes)
   | Const_string(string)
   | Const_char(string)
   | Const_int32(int32)

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -122,6 +122,7 @@ type constant =
   | PConstWasmF64(string)
   | PConstBool(bool)
   | PConstVoid
+  | PConstBytes(string)
   | PConstString(string)
   | PConstChar(string)
 

--- a/compiler/src/typed/builtin_types.re
+++ b/compiler/src/typed/builtin_types.re
@@ -50,7 +50,8 @@ and ident_char = ident_create("Char")
 and ident_void = ident_create("Void")
 and ident_box = ident_create("Box")
 and ident_array = ident_create("Array")
-and ident_fd = ident_create("FileDescriptor");
+and ident_fd = ident_create("FileDescriptor")
+and ident_bytes = ident_create("Bytes");
 
 let path_number = PIdent(ident_number)
 and path_exception = PIdent(ident_exception)
@@ -69,7 +70,8 @@ and path_char = PIdent(ident_char)
 and path_void = PIdent(ident_void)
 and path_box = PIdent(ident_box)
 and path_array = PIdent(ident_array)
-and path_fd = PIdent(ident_fd);
+and path_fd = PIdent(ident_fd)
+and path_bytes = PIdent(ident_bytes);
 
 let type_number = newgenty(TTyConstr(path_number, [], ref(TMemNil)))
 and type_exception = newgenty(TTyConstr(path_exception, [], ref(TMemNil)))
@@ -90,7 +92,8 @@ and type_box = var => newgenty(TTyConstr(path_box, [var], ref(TMemNil)))
 and type_array = var =>
   newgenty(TTyConstr(path_array, [var], ref(TMemNil)))
 and type_fd = newgenty(TTyConstr(path_fd, [], ref(TMemNil)))
-and type_lambda = (args, res) => newgenty(TTyArrow(args, res, TComOk));
+and type_lambda = (args, res) => newgenty(TTyArrow(args, res, TComOk))
+and type_bytes = newgenty(TTyConstr(path_bytes, [], ref(TMemNil)));
 
 let all_predef_exns = [];
 
@@ -174,7 +177,8 @@ let initial_env = (add_type, empty_env) =>
   |> add_type(ident_char, decl_abstr(path_char))
   |> add_type(ident_void, decl_void)
   |> add_type(ident_array, decl_array)
-  |> add_type(ident_fd, decl_abstr(path_fd));
+  |> add_type(ident_fd, decl_abstr(path_fd))
+  |> add_type(ident_bytes, decl_abstr(path_bytes));
 
 let builtin_values =
   List.map(

--- a/compiler/src/typed/builtin_types.re
+++ b/compiler/src/typed/builtin_types.re
@@ -46,12 +46,12 @@ and ident_float32 = ident_create("Float32")
 and ident_float64 = ident_create("Float64")
 and ident_bool = ident_create("Bool")
 and ident_string = ident_create("String")
+and ident_bytes = ident_create("Bytes")
 and ident_char = ident_create("Char")
 and ident_void = ident_create("Void")
 and ident_box = ident_create("Box")
 and ident_array = ident_create("Array")
-and ident_fd = ident_create("FileDescriptor")
-and ident_bytes = ident_create("Bytes");
+and ident_fd = ident_create("FileDescriptor");
 
 let path_number = PIdent(ident_number)
 and path_exception = PIdent(ident_exception)
@@ -66,12 +66,12 @@ and path_float32 = PIdent(ident_float32)
 and path_float64 = PIdent(ident_float64)
 and path_bool = PIdent(ident_bool)
 and path_string = PIdent(ident_string)
+and path_bytes = PIdent(ident_bytes)
 and path_char = PIdent(ident_char)
 and path_void = PIdent(ident_void)
 and path_box = PIdent(ident_box)
 and path_array = PIdent(ident_array)
-and path_fd = PIdent(ident_fd)
-and path_bytes = PIdent(ident_bytes);
+and path_fd = PIdent(ident_fd);
 
 let type_number = newgenty(TTyConstr(path_number, [], ref(TMemNil)))
 and type_exception = newgenty(TTyConstr(path_exception, [], ref(TMemNil)))
@@ -86,14 +86,14 @@ and type_wasmf32 = newgenty(TTyConstr(path_wasmf32, [], ref(TMemNil)))
 and type_wasmf64 = newgenty(TTyConstr(path_wasmf64, [], ref(TMemNil)))
 and type_bool = newgenty(TTyConstr(path_bool, [], ref(TMemNil)))
 and type_string = newgenty(TTyConstr(path_string, [], ref(TMemNil)))
+and type_bytes = newgenty(TTyConstr(path_bytes, [], ref(TMemNil)))
 and type_char = newgenty(TTyConstr(path_char, [], ref(TMemNil)))
 and type_void = newgenty(TTyConstr(path_void, [], ref(TMemNil)))
 and type_box = var => newgenty(TTyConstr(path_box, [var], ref(TMemNil)))
 and type_array = var =>
   newgenty(TTyConstr(path_array, [var], ref(TMemNil)))
 and type_fd = newgenty(TTyConstr(path_fd, [], ref(TMemNil)))
-and type_lambda = (args, res) => newgenty(TTyArrow(args, res, TComOk))
-and type_bytes = newgenty(TTyConstr(path_bytes, [], ref(TMemNil)));
+and type_lambda = (args, res) => newgenty(TTyArrow(args, res, TComOk));
 
 let all_predef_exns = [];
 

--- a/compiler/src/typed/checkertypes.re
+++ b/compiler/src/typed/checkertypes.re
@@ -70,6 +70,7 @@ let type_constant =
   | Const_wasmf64(_) => instance_def(Builtin_types.type_wasmf64)
   | Const_bool(_) => instance_def(Builtin_types.type_bool)
   | Const_void => instance_def(Builtin_types.type_void)
+  | Const_bytes(_) => instance_def(Builtin_types.type_bytes)
   | Const_string(_) => instance_def(Builtin_types.type_string)
   | Const_char(_) => instance_def(Builtin_types.type_char);
 
@@ -215,6 +216,7 @@ let constant:
       }
     | PConstBool(b) => Ok(Const_bool(b))
     | PConstVoid => Ok(Const_void)
+    | PConstBytes(s) => Ok(Const_bytes(Bytes.of_string(s)))
     | PConstString(s) => Ok(Const_string(s))
     | PConstChar(c) => Ok(Const_char(c))
     };

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -260,7 +260,8 @@ let const_compare = (x, y) =>
   | (Const_bool(b1), Const_bool(b2)) =>
     Stdlib.compare(if (b1) {1} else {0}, if (b2) {1} else {0})
   | (
-      Const_number(_) | Const_bytes(_) | Const_string(_) | Const_char(_) | Const_bool(_) |
+      Const_number(_) | Const_bytes(_) | Const_string(_) | Const_char(_) |
+      Const_bool(_) |
       Const_float32(_) |
       Const_float64(_) |
       Const_wasmi32(_) |
@@ -2126,6 +2127,7 @@ let inactive = (~partial, pat) =>
       | TPatArray(_) => false
       | TPatConstant(c) =>
         switch (c) {
+        | Const_bytes(_)
         | Const_string(_)
         | Const_char(_)
         | Const_void

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -141,6 +141,7 @@ let all_coherent = column => {
       | (Const_wasmf64(_), Const_wasmf64(_))
       | (Const_bool(_), Const_bool(_))
       | (Const_void, Const_void)
+      | (Const_bytes(_), Const_bytes(_))
       | (Const_string(_), Const_string(_))
       | (Const_char(_), Const_char(_)) => true
       | (
@@ -152,6 +153,7 @@ let all_coherent = column => {
           Const_wasmf64(_) |
           Const_bool(_) |
           Const_void |
+          Const_bytes(_) |
           Const_string(_) |
           Const_char(_),
           _,
@@ -252,12 +254,13 @@ let first_column = simplified_matrix => List.map(fst, simplified_matrix);
 
 let const_compare = (x, y) =>
   switch (x, y) {
+  | (Const_bytes(b1), Const_bytes(b2)) => Bytes.compare(b1, b2)
   | (Const_string(s1), Const_string(s2)) => String.compare(s1, s2)
   | (Const_char(c1), Const_char(c2)) => String.compare(c1, c2)
   | (Const_bool(b1), Const_bool(b2)) =>
     Stdlib.compare(if (b1) {1} else {0}, if (b2) {1} else {0})
   | (
-      Const_number(_) | Const_string(_) | Const_char(_) | Const_bool(_) |
+      Const_number(_) | Const_bytes(_) | Const_string(_) | Const_char(_) | Const_bool(_) |
       Const_float32(_) |
       Const_float64(_) |
       Const_wasmi32(_) |
@@ -1786,6 +1789,7 @@ let untype_constant =
   | Const_wasmi64(i) => Parsetree.PConstWasmI64(Int64.to_string(i))
   | Const_wasmf32(f) => Parsetree.PConstWasmF32(Float.to_string(f))
   | Const_wasmf64(f) => Parsetree.PConstWasmF64(Float.to_string(f))
+  | Const_bytes(b) => Parsetree.PConstBytes(Bytes.to_string(b))
   | Const_string(s) => Parsetree.PConstString(s)
   | Const_char(c) => Parsetree.PConstChar(c)
   | Const_bool(b) => Parsetree.PConstBool(b)

--- a/compiler/src/typed/printpat.re
+++ b/compiler/src/typed/printpat.re
@@ -31,6 +31,7 @@ let pretty_const = c =>
   | Const_number(Const_number_float(f)) => Printf.sprintf("%f", f)
   | Const_number(Const_number_rational(n, d)) =>
     Printf.sprintf("%ld/%ld", n, d)
+  | Const_bytes(b) => Printf.sprintf("%S", Bytes.to_string(b))
   | Const_string(s) => Printf.sprintf("%S", s)
   | Const_char(c) => Printf.sprintf("%S", c)
   | Const_float64(f)

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -3,179 +3,179 @@ import Int32 from "int32";
 
 
 // Bytes.empty
-assert Bytes.empty == Bytes.empty;
+assert Bytes.empty == Bytes.empty
 
 
 // Bytes.length
-assert Bytes.length(Bytes.empty) == 0;
+assert Bytes.length(Bytes.empty) == 0
 
 
 // Bytes.make
 let bytes = Bytes.make(64)
-assert Bytes.length(bytes) == 64;
+assert Bytes.length(bytes) == 64
 
 
 // Bytes.setInt8, Bytes.getInt8S, Bytes.getInt8U
 let bytes = Bytes.make(1);
-Bytes.setInt8(bytes, 0, 0x000000ffl);
-assert Bytes.getInt8S(bytes, 0) == 0xffffffffl;
-assert Bytes.getInt8U(bytes, 0) == 0x000000ffl;
+Bytes.setInt8(0, 0x000000ffl, bytes)
+assert Bytes.getInt8S(0, bytes) == 0xffffffffl
+assert Bytes.getInt8U(0, bytes) == 0x000000ffl
 
 
 // Bytes.setInt16, Bytes.getInt16S, Bytes.getInt16U
-let bytes = Bytes.make(8);
-Bytes.setInt16(bytes, 0, 0x0000ffffl);
-Bytes.setInt16(bytes, 2, 0x00000001l);
-Bytes.setInt16(bytes, 4, 0x00000002l);
-Bytes.setInt16(bytes, 6, 0xffffff9cl);
-assert Bytes.getInt16S(bytes, 0) == 0xffffffffl;
-assert Bytes.getInt16U(bytes, 0) == 0x0000ffffl;
-assert Bytes.getInt16S(bytes, 1) == 0x000001ffl;
-assert Bytes.getInt16U(bytes, 1) == 0x000001ffl;
-assert Bytes.getInt16S(bytes, 2) == 0x00000001l;
-assert Bytes.getInt16U(bytes, 2) == 0x00000001l;
-assert Bytes.getInt16S(bytes, 3) == 0x00000200l;
-assert Bytes.getInt16U(bytes, 3) == 0x00000200l;
-assert Bytes.getInt16S(bytes, 4) == 0x00000002l;
-assert Bytes.getInt16U(bytes, 4) == 0x00000002l;
-assert Bytes.getInt16S(bytes, 5) == 0xffff9c00l;
-assert Bytes.getInt16U(bytes, 5) == 0x00009c00l;
-assert Bytes.getInt16S(bytes, 6) == 0xffffff9cl;
-assert Bytes.getInt16U(bytes, 6) == 0x0000ff9cl;
+let bytes = Bytes.make(8)
+Bytes.setInt16(0, 0x0000ffffl, bytes)
+Bytes.setInt16(2, 0x00000001l, bytes)
+Bytes.setInt16(4, 0x00000002l, bytes)
+Bytes.setInt16(6, 0xffffff9cl, bytes)
+assert Bytes.getInt16S(0, bytes) == 0xffffffffl
+assert Bytes.getInt16U(0, bytes) == 0x0000ffffl
+assert Bytes.getInt16S(1, bytes) == 0x000001ffl
+assert Bytes.getInt16U(1, bytes) == 0x000001ffl
+assert Bytes.getInt16S(2, bytes) == 0x00000001l
+assert Bytes.getInt16U(2, bytes) == 0x00000001l
+assert Bytes.getInt16S(3, bytes) == 0x00000200l
+assert Bytes.getInt16U(3, bytes) == 0x00000200l
+assert Bytes.getInt16S(4, bytes) == 0x00000002l
+assert Bytes.getInt16U(4, bytes) == 0x00000002l
+assert Bytes.getInt16S(5, bytes) == 0xffff9c00l
+assert Bytes.getInt16U(5, bytes) == 0x00009c00l
+assert Bytes.getInt16S(6, bytes) == 0xffffff9cl
+assert Bytes.getInt16U(6, bytes) == 0x0000ff9cl
 
 
 // Bytes.setInt32, Bytes.getInt32
-let bytes = Bytes.make(4);
-Bytes.setInt32(bytes, 0, 0x7fffffffl);
-assert Bytes.getInt32(bytes, 0) == 0x7fffffffl;
+let bytes = Bytes.make(4)
+Bytes.setInt32(0, 0x7fffffffl, bytes)
+assert Bytes.getInt32(0, bytes) == 0x7fffffffl
 
 
 // Bytes.setFloat32, Bytes.getFloat32
-let bytes = Bytes.make(4);
-Bytes.setFloat32(bytes, 0, 42.0f);
-assert Bytes.getFloat32(bytes, 0) == 42.0f;
+let bytes = Bytes.make(4)
+Bytes.setFloat32(0, 42.0f, bytes)
+assert Bytes.getFloat32(0, bytes) == 42.0f
 
 
 // Bytes.setInt64, Bytes.getInt64
-let bytes = Bytes.make(8);
-Bytes.setInt64(bytes, 0, 0x7fffffffffffffffL);
-assert Bytes.getInt64(bytes, 0) == 0x7fffffffffffffffL;
+let bytes = Bytes.make(8)
+Bytes.setInt64(0, 0x7fffffffffffffffL, bytes)
+assert Bytes.getInt64(0, bytes) == 0x7fffffffffffffffL
 
 
 // Bytes.setFloat64, Bytes.getFloat64
-let bytes = Bytes.make(8);
-Bytes.setFloat64(bytes, 0, 42.0d);
-assert Bytes.getFloat64(bytes, 0) == 42.0d;
+let bytes = Bytes.make(8)
+Bytes.setFloat64(0, 42.0d, bytes)
+assert Bytes.getFloat64(0, bytes) == 42.0d
 
 
 // Bytes.copy
-let bytes0 = Bytes.make(8);
-assert Bytes.length(bytes0) == 8;
+let bytes0 = Bytes.make(8)
+assert Bytes.length(bytes0) == 8
 for (let mut i = 0; i < 8; i+= 1) {
-  Bytes.setInt8(bytes0, i, Int32.fromNumber(i));
+  Bytes.setInt8(i, Int32.fromNumber(i), bytes0)
 }
 let bytes1 = Bytes.copy(bytes0);
-assert Bytes.length(bytes1) == Bytes.length(bytes0);
+assert Bytes.length(bytes1) == Bytes.length(bytes0)
 for (let mut i = 0; i < 8; i += 1) {
-  assert Bytes.getInt8S(bytes1, i) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i, bytes1) == Bytes.getInt8S(i, bytes0)
 }
 
 
 // Bytes.sub
-let bytes2 = Bytes.sub(bytes1, 0, 8);
-assert Bytes.length(bytes2) == Bytes.length(bytes1);
+let bytes2 = Bytes.sub(0, 8, bytes1)
+assert Bytes.length(bytes2) == Bytes.length(bytes1)
 for (let mut i = 0; i < 8; i += 1) {
-  assert Bytes.getInt8S(bytes2, i) == Bytes.getInt8S(bytes1, i);
+  assert Bytes.getInt8S(i, bytes2) == Bytes.getInt8S(i, bytes1)
 }
-let bytes3 = Bytes.sub(bytes2, 4, 2);
+let bytes3 = Bytes.sub(4, 2, bytes2)
 assert Bytes.length(bytes3) == 2;
 for (let mut i = 0; i < Bytes.length(bytes3); i += 1) {
-  assert Bytes.getInt8S(bytes3, i) == Bytes.getInt8S(bytes2, i + 4);
+  assert Bytes.getInt8S(i, bytes3) == Bytes.getInt8S(i + 4, bytes2)
 }
-let bytes4 = Bytes.sub(bytes2, 1, 6);
-assert Bytes.length(bytes4) == 6;
+let bytes4 = Bytes.sub(1, 6, bytes2)
+assert Bytes.length(bytes4) == 6
 for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
-  assert Bytes.getInt8S(bytes4, i) == Bytes.getInt8S(bytes2, i + 1);
+  assert Bytes.getInt8S(i, bytes4) == Bytes.getInt8S(i + 1, bytes2);
 }
 
 
 // Bytes.extend
-let bytes5 = Bytes.extend(bytes0, 0, 0);
-assert Bytes.length(bytes5) == Bytes.length(bytes0);
+let bytes5 = Bytes.extend(0, 0, bytes0)
+assert Bytes.length(bytes5) == Bytes.length(bytes0)
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
-  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, 1, 1);
-assert Bytes.length(bytes5) == (Bytes.length(bytes0) + 2);
-assert Bytes.getInt8S(bytes5, 0) == 0l;
-assert Bytes.getInt8S(bytes5, 9) == 0l;
+let bytes5 = Bytes.extend(1, 1, bytes0)
+assert Bytes.length(bytes5) == (Bytes.length(bytes0) + 2)
+assert Bytes.getInt8S(0, bytes5) == 0l
+assert Bytes.getInt8S(9, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
-  assert Bytes.getInt8S(bytes5, i + 1) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i + 1, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, 3, 0);
-assert Bytes.length(bytes5) == 11;
-assert Bytes.getInt8S(bytes5, 0) == 0l;
-assert Bytes.getInt8S(bytes5, 1) == 0l;
-assert Bytes.getInt8S(bytes5, 2) == 0l;
+let bytes5 = Bytes.extend(3, 0, bytes0)
+assert Bytes.length(bytes5) == 11
+assert Bytes.getInt8S(0, bytes5) == 0l
+assert Bytes.getInt8S(1, bytes5) == 0l
+assert Bytes.getInt8S(2, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
-  assert Bytes.getInt8S(bytes5, i + 3) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i + 3, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, 0, 3);
-assert Bytes.length(bytes5) == 11;
-assert Bytes.getInt8S(bytes5, 8) == 0l;
-assert Bytes.getInt8S(bytes5, 9) == 0l;
-assert Bytes.getInt8S(bytes5, 10) == 0l;
+let bytes5 = Bytes.extend(0, 3, bytes0)
+assert Bytes.length(bytes5) == 11
+assert Bytes.getInt8S(8, bytes5) == 0l
+assert Bytes.getInt8S(9, bytes5) == 0l
+assert Bytes.getInt8S(10, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
-  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, -4, 0);
-assert Bytes.length(bytes5) == 4;
+let bytes5 = Bytes.extend(-4, 0, bytes0)
+assert Bytes.length(bytes5) == 4
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
-  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i + 4);
+  assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i + 4, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, 0, -4);
-assert Bytes.length(bytes5) == 4;
+let bytes5 = Bytes.extend(0, -4, bytes0)
+assert Bytes.length(bytes5) == 4
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
-  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+  assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(bytes0, -4, -4);
-assert Bytes.length(bytes5) == 0;
+let bytes5 = Bytes.extend(-4, -4, bytes0)
+assert Bytes.length(bytes5) == 0
 
 // Bytes.blit
-let srcBytes = Bytes.copy(bytes0);
-let dstBytes = Bytes.make(16);
-Bytes.blit(srcBytes, 0, dstBytes, 8, 8);
+let srcBytes = Bytes.copy(bytes0)
+let dstBytes = Bytes.make(16)
+Bytes.blit(0, 8, 8, srcBytes, dstBytes)
 for (let mut i = 0; i < 16; i += 1) {
   if (i < 8) {
-    assert Bytes.getInt8S(dstBytes, i) == 0l;  
+    assert Bytes.getInt8S(i, dstBytes) == 0l
   } else {
-    assert Bytes.getInt8S(dstBytes, i) == Bytes.getInt8S(srcBytes, i - 8);
+    assert Bytes.getInt8S(i, dstBytes) == Bytes.getInt8S(i - 8, srcBytes)
   }
 }
 
 
 // Bytes.append
-let bytesA = Bytes.make(16);
+let bytesA = Bytes.make(16)
 for (let mut i = 0; i < 16; i += 1) {
-  Bytes.setInt8(bytesA, i, 1l);
+  Bytes.setInt8(i, 1l, bytesA)
 }
 let bytesB = Bytes.make(16);
 for (let mut i = 0; i < 16; i += 1) {
-  Bytes.setInt8(bytesB, i, 2l);
+  Bytes.setInt8(i, 2l, bytesB)
 }
-let bytesC = Bytes.append(bytesA, bytesB);
+let bytesC = Bytes.append(bytesA, bytesB)
 for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
     if (i < 16) {
-    assert Bytes.getInt8S(bytesC, i) == 1l;
+    assert Bytes.getInt8S(i, bytesC) == 1l
   } else {
-    assert Bytes.getInt8S(bytesC, i) == 2l;
+    assert Bytes.getInt8S(i, bytesC) == 2l
   }
 }
-let bytesD = Bytes.append(bytesB, bytesA);
+let bytesD = Bytes.append(bytesB, bytesA)
 for (let mut i = 0; i < Bytes.length(bytesD); i += 1) {
     if (i < 16) {
-    assert Bytes.getInt8S(bytesD, i) == 2l;
+    assert Bytes.getInt8S(i, bytesD) == 2l
   } else {
-    assert Bytes.getInt8S(bytesD, i) == 1l;
+    assert Bytes.getInt8S(i, bytesD) == 1l
   }
 }

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,6 +1,7 @@
 import Bytes from "bytes"
 import Int32 from "int32"
 import Array from "array"
+import String from "string"
 
 // Bytes.empty
 assert Bytes.empty == Bytes.empty
@@ -145,6 +146,17 @@ for (let mut i = 8; i < 16; i += 1) {
     assert Bytes.getInt8S(i, dstBytes) == Bytes.getInt8S(i - 8, srcBytes)
   }
 }
+let srcBytes = Bytes.make(32)
+let len = Bytes.length(srcBytes)
+let halfLen = len / 2
+for (let mut i = 0; i < len; i += 1) {
+  let value = if (i < halfLen) { 0x01l } else { 0x00l }
+  Bytes.setInt8(i, value, srcBytes)
+}
+Bytes.move(0, halfLen, halfLen, srcBytes, srcBytes)
+for (let mut i = 0; i < len; i += 1) {
+  assert Bytes.getInt8U(i, srcBytes) == 0x01l
+}
 
 
 // Bytes.concat
@@ -182,6 +194,23 @@ Array.forEachi((n, i) => {
 }, xs)
 let str = Bytes.toString(bytes)
 assert str == "Let's get this 🍞"
+
+
+// Bytes.fromString
+let bytes = Bytes.fromString("Let's get this 🍞")
+Array.forEachi((n, i) => {
+  assert Bytes.getInt8U(i, bytes) == n
+}, xs)
+let str = Bytes.toString(bytes)
+assert str == "Let's get this 🍞"
+
+
+// Bytes.fill
+let bytes = Bytes.fromString("🍞🍞🍞🍞🍞🍞🍞🍞")
+Bytes.fill(0xffl, bytes)
+for (let mut i = 0; i < Bytes.length(bytes); i += 1) {
+  assert Bytes.getInt8U(i, bytes) == 0xffl
+}
 
 
 // Bytes equality

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,5 +1,5 @@
 import Bytes from "bytes";
-import Int32 from "int32"
+import Int32 from "int32";
 
 
 // Bytes.empty

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -81,18 +81,18 @@ for (let mut i = 0; i < 8; i += 1) {
 }
 
 
-// Bytes.sub
-let bytes2 = Bytes.sub(0, 8, bytes1)
+// Bytes.slice
+let bytes2 = Bytes.slice(0, 8, bytes1)
 assert Bytes.length(bytes2) == Bytes.length(bytes1)
 for (let mut i = 0; i < 8; i += 1) {
   assert Bytes.getInt8S(i, bytes2) == Bytes.getInt8S(i, bytes1)
 }
-let bytes3 = Bytes.sub(4, 2, bytes2)
+let bytes3 = Bytes.slice(4, 2, bytes2)
 assert Bytes.length(bytes3) == 2
 for (let mut i = 0; i < Bytes.length(bytes3); i += 1) {
   assert Bytes.getInt8S(i, bytes3) == Bytes.getInt8S(i + 4, bytes2)
 }
-let bytes4 = Bytes.sub(1, 6, bytes2)
+let bytes4 = Bytes.slice(1, 6, bytes2)
 assert Bytes.length(bytes4) == 6
 for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
   assert Bytes.getInt8S(i, bytes4) == Bytes.getInt8S(i + 1, bytes2)

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -107,24 +107,16 @@ for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
 }
 let bytes5 = Bytes.extend(1, 1, bytes0)
 assert Bytes.length(bytes5) == (Bytes.length(bytes0) + 2)
-assert Bytes.getInt8S(0, bytes5) == 0l
-assert Bytes.getInt8S(9, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i + 1, bytes5) == Bytes.getInt8S(i, bytes0)
 }
 let bytes5 = Bytes.extend(3, 0, bytes0)
 assert Bytes.length(bytes5) == 11
-assert Bytes.getInt8S(0, bytes5) == 0l
-assert Bytes.getInt8S(1, bytes5) == 0l
-assert Bytes.getInt8S(2, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i + 3, bytes5) == Bytes.getInt8S(i, bytes0)
 }
 let bytes5 = Bytes.extend(0, 3, bytes0)
 assert Bytes.length(bytes5) == 11
-assert Bytes.getInt8S(8, bytes5) == 0l
-assert Bytes.getInt8S(9, bytes5) == 0l
-assert Bytes.getInt8S(10, bytes5) == 0l
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
@@ -141,11 +133,12 @@ for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
 let bytes5 = Bytes.extend(-4, -4, bytes0)
 assert Bytes.length(bytes5) == 0
 
-// Bytes.blit
+
+// Bytes.move
 let srcBytes = Bytes.copy(bytes0)
 let dstBytes = Bytes.make(16)
-Bytes.blit(0, 8, 8, srcBytes, dstBytes)
-for (let mut i = 0; i < 16; i += 1) {
+Bytes.move(0, 8, 8, srcBytes, dstBytes)
+for (let mut i = 8; i < 16; i += 1) {
   if (i < 8) {
     assert Bytes.getInt8S(i, dstBytes) == 0l
   } else {

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,6 +1,6 @@
 import Bytes from "bytes";
 import Int32 from "int32";
-
+import Array from "array";
 
 // Bytes.empty
 assert Bytes.empty == Bytes.empty
@@ -172,3 +172,15 @@ for (let mut i = 0; i < Bytes.length(bytesD); i += 1) {
     assert Bytes.getInt8S(i, bytesD) == 1l
   }
 }
+
+
+// Bytes.toString
+let xs = [> 0x4cl, 0x65l, 0x74l, 0x27l, 0x73l, 0x20l, 0x67l, 0x65l, 0x74l, 0x20l, 0x74l, 0x68l, 0x69l, 0x73l, 0x20l, 0xf0l, 0x9fl, 0x8dl, 0x9el]
+let bytes = Bytes.make(Array.length(xs))
+Array.forEachi((n, i) => {
+  Bytes.setInt8(i, n, bytes)
+}, xs)
+let str = Bytes.toString(bytes)
+print(str)
+assert str == "Let's get this 🍞"
+

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -141,7 +141,6 @@ for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
 let bytes5 = Bytes.extend(bytes0, -4, -4);
 assert Bytes.length(bytes5) == 0;
 
-
 // Bytes.blit
 let srcBytes = Bytes.copy(bytes0);
 let dstBytes = Bytes.make(16);

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,6 +1,6 @@
 import Bytes from "bytes";
-import { coerceInt32ToNumber, coerceNumberToInt32 } from "runtime/numbers"
-import { tagSimpleNumber } from "runtime/dataStructures"
+import Int32 from "int32"
+
 
 // Bytes.empty
 assert Bytes.empty == Bytes.empty;
@@ -67,12 +67,12 @@ let bytes = Bytes.make(8);
 Bytes.setFloat64(bytes, 0, 42.0d);
 assert Bytes.getFloat64(bytes, 0) == 42.0d;
 
-// Bytes.copy
 
+// Bytes.copy
 let bytes0 = Bytes.make(8);
 assert Bytes.length(bytes0) == 8;
 for (let mut i = 0; i < 8; i+= 1) {
-  Bytes.setInt8(bytes0, i, coerceNumberToInt32(i));
+  Bytes.setInt8(bytes0, i, Int32.fromNumber(i));
 }
 let bytes1 = Bytes.copy(bytes0);
 assert Bytes.length(bytes1) == Bytes.length(bytes0);
@@ -97,6 +97,7 @@ assert Bytes.length(bytes4) == 6;
 for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
   assert Bytes.getInt8S(bytes4, i) == Bytes.getInt8S(bytes2, i + 1);
 }
+
 
 // Bytes.extend
 let bytes5 = Bytes.extend(bytes0, 0, 0);
@@ -127,7 +128,6 @@ assert Bytes.getInt8S(bytes5, 10) == 0l;
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
 }
-
 let bytes5 = Bytes.extend(bytes0, -4, 0);
 assert Bytes.length(bytes5) == 4;
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
@@ -141,6 +141,7 @@ for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
 let bytes5 = Bytes.extend(bytes0, -4, -4);
 assert Bytes.length(bytes5) == 0;
 
+
 // Bytes.blit
 let srcBytes = Bytes.copy(bytes0);
 let dstBytes = Bytes.make(16);
@@ -153,17 +154,16 @@ for (let mut i = 0; i < 16; i += 1) {
   }
 }
 
+
 // Bytes.append
 let bytesA = Bytes.make(16);
 for (let mut i = 0; i < 16; i += 1) {
   Bytes.setInt8(bytesA, i, 1l);
 }
-
 let bytesB = Bytes.make(16);
 for (let mut i = 0; i < 16; i += 1) {
   Bytes.setInt8(bytesB, i, 2l);
 }
-
 let bytesC = Bytes.append(bytesA, bytesB);
 for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
     if (i < 16) {

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -147,7 +147,7 @@ for (let mut i = 8; i < 16; i += 1) {
 }
 
 
-// Bytes.append
+// Bytes.concat
 let bytesA = Bytes.make(16)
 for (let mut i = 0; i < 16; i += 1) {
   Bytes.setInt8(i, 1l, bytesA)
@@ -156,7 +156,7 @@ let bytesB = Bytes.make(16);
 for (let mut i = 0; i < 16; i += 1) {
   Bytes.setInt8(i, 2l, bytesB)
 }
-let bytesC = Bytes.append(bytesA, bytesB)
+let bytesC = Bytes.concat(bytesA, bytesB)
 for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
   if (i < 16) {
     assert Bytes.getInt8S(i, bytesC) == 1l
@@ -164,7 +164,7 @@ for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
     assert Bytes.getInt8S(i, bytesC) == 2l
   }
 }
-let bytesD = Bytes.append(bytesB, bytesA)
+let bytesD = Bytes.concat(bytesB, bytesA)
 for (let mut i = 0; i < Bytes.length(bytesD); i += 1) {
   if (i < 16) {
     assert Bytes.getInt8S(i, bytesD) == 2l

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -184,3 +184,9 @@ let str = Bytes.toString(bytes)
 print(str)
 assert str == "Let's get this 🍞"
 
+
+// Bytes equality
+let bytesCopy = Bytes.copy(bytes)
+assert bytesCopy == bytes
+Bytes.setInt8(0, 0l, bytesCopy)
+assert bytesCopy != bytes

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,0 +1,4 @@
+import Bytes from "bytes";
+
+let buf = Bytes.make(64)
+assert Bytes.length(buf) == 64;

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -99,38 +99,38 @@ for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
 }
 
 
-// Bytes.extend
-let bytes5 = Bytes.extend(0, 0, bytes0)
+// Bytes.resize
+let bytes5 = Bytes.resize(0, 0, bytes0)
 assert Bytes.length(bytes5) == Bytes.length(bytes0)
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
   assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(1, 1, bytes0)
+let bytes5 = Bytes.resize(1, 1, bytes0)
 assert Bytes.length(bytes5) == (Bytes.length(bytes0) + 2)
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i + 1, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(3, 0, bytes0)
+let bytes5 = Bytes.resize(3, 0, bytes0)
 assert Bytes.length(bytes5) == 11
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i + 3, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(0, 3, bytes0)
+let bytes5 = Bytes.resize(0, 3, bytes0)
 assert Bytes.length(bytes5) == 11
 for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
   assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(-4, 0, bytes0)
+let bytes5 = Bytes.resize(-4, 0, bytes0)
 assert Bytes.length(bytes5) == 4
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
   assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i + 4, bytes0)
 }
-let bytes5 = Bytes.extend(0, -4, bytes0)
+let bytes5 = Bytes.resize(0, -4, bytes0)
 assert Bytes.length(bytes5) == 4
 for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
   assert Bytes.getInt8S(i, bytes5) == Bytes.getInt8S(i, bytes0)
 }
-let bytes5 = Bytes.extend(-4, -4, bytes0)
+let bytes5 = Bytes.resize(-4, -4, bytes0)
 assert Bytes.length(bytes5) == 0
 
 

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,11 +1,182 @@
 import Bytes from "bytes";
+import { coerceInt32ToNumber, coerceNumberToInt32 } from "runtime/numbers"
+import { tagSimpleNumber } from "runtime/dataStructures"
 
-// Bytes equality
+// Bytes.empty
 assert Bytes.empty == Bytes.empty;
 
-// Bytes length
+
+// Bytes.length
 assert Bytes.length(Bytes.empty) == 0;
 
-let bytes = Bytes.make(64)
 
+// Bytes.make
+let bytes = Bytes.make(64)
 assert Bytes.length(bytes) == 64;
+
+
+// Bytes.setInt8, Bytes.getInt8S, Bytes.getInt8U
+let bytes = Bytes.make(1);
+Bytes.setInt8(bytes, 0, 0x000000ffl);
+assert Bytes.getInt8S(bytes, 0) == 0xffffffffl;
+assert Bytes.getInt8U(bytes, 0) == 0x000000ffl;
+
+
+// Bytes.setInt16, Bytes.getInt16S, Bytes.getInt16U
+let bytes = Bytes.make(8);
+Bytes.setInt16(bytes, 0, 0x0000ffffl);
+Bytes.setInt16(bytes, 2, 0x00000001l);
+Bytes.setInt16(bytes, 4, 0x00000002l);
+Bytes.setInt16(bytes, 6, 0xffffff9cl);
+assert Bytes.getInt16S(bytes, 0) == 0xffffffffl;
+assert Bytes.getInt16U(bytes, 0) == 0x0000ffffl;
+assert Bytes.getInt16S(bytes, 1) == 0x000001ffl;
+assert Bytes.getInt16U(bytes, 1) == 0x000001ffl;
+assert Bytes.getInt16S(bytes, 2) == 0x00000001l;
+assert Bytes.getInt16U(bytes, 2) == 0x00000001l;
+assert Bytes.getInt16S(bytes, 3) == 0x00000200l;
+assert Bytes.getInt16U(bytes, 3) == 0x00000200l;
+assert Bytes.getInt16S(bytes, 4) == 0x00000002l;
+assert Bytes.getInt16U(bytes, 4) == 0x00000002l;
+assert Bytes.getInt16S(bytes, 5) == 0xffff9c00l;
+assert Bytes.getInt16U(bytes, 5) == 0x00009c00l;
+assert Bytes.getInt16S(bytes, 6) == 0xffffff9cl;
+assert Bytes.getInt16U(bytes, 6) == 0x0000ff9cl;
+
+
+// Bytes.setInt32, Bytes.getInt32
+let bytes = Bytes.make(4);
+Bytes.setInt32(bytes, 0, 0x7fffffffl);
+assert Bytes.getInt32(bytes, 0) == 0x7fffffffl;
+
+
+// Bytes.setFloat32, Bytes.getFloat32
+let bytes = Bytes.make(4);
+Bytes.setFloat32(bytes, 0, 42.0f);
+assert Bytes.getFloat32(bytes, 0) == 42.0f;
+
+
+// Bytes.setInt64, Bytes.getInt64
+let bytes = Bytes.make(8);
+Bytes.setInt64(bytes, 0, 0x7fffffffffffffffL);
+assert Bytes.getInt64(bytes, 0) == 0x7fffffffffffffffL;
+
+
+// Bytes.setFloat64, Bytes.getFloat64
+let bytes = Bytes.make(8);
+Bytes.setFloat64(bytes, 0, 42.0d);
+assert Bytes.getFloat64(bytes, 0) == 42.0d;
+
+// Bytes.copy
+
+let bytes0 = Bytes.make(8);
+assert Bytes.length(bytes0) == 8;
+for (let mut i = 0; i < 8; i+= 1) {
+  Bytes.setInt8(bytes0, i, coerceNumberToInt32(i));
+}
+let bytes1 = Bytes.copy(bytes0);
+assert Bytes.length(bytes1) == Bytes.length(bytes0);
+for (let mut i = 0; i < 8; i += 1) {
+  assert Bytes.getInt8S(bytes1, i) == Bytes.getInt8S(bytes0, i);
+}
+
+
+// Bytes.sub
+let bytes2 = Bytes.sub(bytes1, 0, 8);
+assert Bytes.length(bytes2) == Bytes.length(bytes1);
+for (let mut i = 0; i < 8; i += 1) {
+  assert Bytes.getInt8S(bytes2, i) == Bytes.getInt8S(bytes1, i);
+}
+let bytes3 = Bytes.sub(bytes2, 4, 2);
+assert Bytes.length(bytes3) == 2;
+for (let mut i = 0; i < Bytes.length(bytes3); i += 1) {
+  assert Bytes.getInt8S(bytes3, i) == Bytes.getInt8S(bytes2, i + 4);
+}
+let bytes4 = Bytes.sub(bytes2, 1, 6);
+assert Bytes.length(bytes4) == 6;
+for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
+  assert Bytes.getInt8S(bytes4, i) == Bytes.getInt8S(bytes2, i + 1);
+}
+
+// Bytes.extend
+let bytes5 = Bytes.extend(bytes0, 0, 0);
+assert Bytes.length(bytes5) == Bytes.length(bytes0);
+for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
+  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+}
+let bytes5 = Bytes.extend(bytes0, 1, 1);
+assert Bytes.length(bytes5) == (Bytes.length(bytes0) + 2);
+assert Bytes.getInt8S(bytes5, 0) == 0l;
+assert Bytes.getInt8S(bytes5, 9) == 0l;
+for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
+  assert Bytes.getInt8S(bytes5, i + 1) == Bytes.getInt8S(bytes0, i);
+}
+let bytes5 = Bytes.extend(bytes0, 3, 0);
+assert Bytes.length(bytes5) == 11;
+assert Bytes.getInt8S(bytes5, 0) == 0l;
+assert Bytes.getInt8S(bytes5, 1) == 0l;
+assert Bytes.getInt8S(bytes5, 2) == 0l;
+for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
+  assert Bytes.getInt8S(bytes5, i + 3) == Bytes.getInt8S(bytes0, i);
+}
+let bytes5 = Bytes.extend(bytes0, 0, 3);
+assert Bytes.length(bytes5) == 11;
+assert Bytes.getInt8S(bytes5, 8) == 0l;
+assert Bytes.getInt8S(bytes5, 9) == 0l;
+assert Bytes.getInt8S(bytes5, 10) == 0l;
+for (let mut i = 0; i < Bytes.length(bytes0); i += 1) {
+  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+}
+
+let bytes5 = Bytes.extend(bytes0, -4, 0);
+assert Bytes.length(bytes5) == 4;
+for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
+  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i + 4);
+}
+let bytes5 = Bytes.extend(bytes0, 0, -4);
+assert Bytes.length(bytes5) == 4;
+for (let mut i = 0; i < Bytes.length(bytes5); i += 1) {
+  assert Bytes.getInt8S(bytes5, i) == Bytes.getInt8S(bytes0, i);
+}
+let bytes5 = Bytes.extend(bytes0, -4, -4);
+assert Bytes.length(bytes5) == 0;
+
+// Bytes.blit
+let srcBytes = Bytes.copy(bytes0);
+let dstBytes = Bytes.make(16);
+Bytes.blit(srcBytes, 0, dstBytes, 8, 8);
+for (let mut i = 0; i < 16; i += 1) {
+  if (i < 8) {
+    assert Bytes.getInt8S(dstBytes, i) == 0l;  
+  } else {
+    assert Bytes.getInt8S(dstBytes, i) == Bytes.getInt8S(srcBytes, i - 8);
+  }
+}
+
+// Bytes.append
+let bytesA = Bytes.make(16);
+for (let mut i = 0; i < 16; i += 1) {
+  Bytes.setInt8(bytesA, i, 1l);
+}
+
+let bytesB = Bytes.make(16);
+for (let mut i = 0; i < 16; i += 1) {
+  Bytes.setInt8(bytesB, i, 2l);
+}
+
+let bytesC = Bytes.append(bytesA, bytesB);
+for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
+    if (i < 16) {
+    assert Bytes.getInt8S(bytesC, i) == 1l;
+  } else {
+    assert Bytes.getInt8S(bytesC, i) == 2l;
+  }
+}
+let bytesD = Bytes.append(bytesB, bytesA);
+for (let mut i = 0; i < Bytes.length(bytesD); i += 1) {
+    if (i < 16) {
+    assert Bytes.getInt8S(bytesD, i) == 2l;
+  } else {
+    assert Bytes.getInt8S(bytesD, i) == 1l;
+  }
+}

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,4 +1,11 @@
 import Bytes from "bytes";
 
-let buf = Bytes.make(64)
-assert Bytes.length(buf) == 64;
+// Bytes equality
+assert Bytes.empty == Bytes.empty;
+
+// Bytes length
+assert Bytes.length(Bytes.empty) == 0;
+
+let bytes = Bytes.make(64)
+
+assert Bytes.length(bytes) == 64;

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -1,6 +1,6 @@
-import Bytes from "bytes";
-import Int32 from "int32";
-import Array from "array";
+import Bytes from "bytes"
+import Int32 from "int32"
+import Array from "array"
 
 // Bytes.empty
 assert Bytes.empty == Bytes.empty
@@ -16,7 +16,7 @@ assert Bytes.length(bytes) == 64
 
 
 // Bytes.setInt8, Bytes.getInt8S, Bytes.getInt8U
-let bytes = Bytes.make(1);
+let bytes = Bytes.make(1)
 Bytes.setInt8(0, 0x000000ffl, bytes)
 assert Bytes.getInt8S(0, bytes) == 0xffffffffl
 assert Bytes.getInt8U(0, bytes) == 0x000000ffl
@@ -88,14 +88,14 @@ for (let mut i = 0; i < 8; i += 1) {
   assert Bytes.getInt8S(i, bytes2) == Bytes.getInt8S(i, bytes1)
 }
 let bytes3 = Bytes.sub(4, 2, bytes2)
-assert Bytes.length(bytes3) == 2;
+assert Bytes.length(bytes3) == 2
 for (let mut i = 0; i < Bytes.length(bytes3); i += 1) {
   assert Bytes.getInt8S(i, bytes3) == Bytes.getInt8S(i + 4, bytes2)
 }
 let bytes4 = Bytes.sub(1, 6, bytes2)
 assert Bytes.length(bytes4) == 6
 for (let mut i = 0; i < Bytes.length(bytes4); i += 1) {
-  assert Bytes.getInt8S(i, bytes4) == Bytes.getInt8S(i + 1, bytes2);
+  assert Bytes.getInt8S(i, bytes4) == Bytes.getInt8S(i + 1, bytes2)
 }
 
 
@@ -181,7 +181,6 @@ Array.forEachi((n, i) => {
   Bytes.setInt8(i, n, bytes)
 }, xs)
 let str = Bytes.toString(bytes)
-print(str)
 assert str == "Let's get this 🍞"
 
 

--- a/compiler/test/stdlib/bytes.test.gr
+++ b/compiler/test/stdlib/bytes.test.gr
@@ -158,7 +158,7 @@ for (let mut i = 0; i < 16; i += 1) {
 }
 let bytesC = Bytes.append(bytesA, bytesB)
 for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
-    if (i < 16) {
+  if (i < 16) {
     assert Bytes.getInt8S(i, bytesC) == 1l
   } else {
     assert Bytes.getInt8S(i, bytesC) == 2l
@@ -166,7 +166,7 @@ for (let mut i = 0; i < Bytes.length(bytesC); i += 1) {
 }
 let bytesD = Bytes.append(bytesB, bytesA)
 for (let mut i = 0; i < Bytes.length(bytesD); i += 1) {
-    if (i < 16) {
+  if (i < 16) {
     assert Bytes.getInt8S(i, bytesD) == 2l
   } else {
     assert Bytes.getInt8S(i, bytesD) == 1l

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -863,6 +863,7 @@ let stdlib_tests = [
   tlib("wasmf32.test"),
   tlib("wasmf64.test"),
   tlib("range.test"),
+  tlib("bytes.test"),
   tlib("string.test"),
   tlib("sys.file.test"),
   tlib("map.test"),

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,46 +1,505 @@
 import WasmI32 from "runtime/unsafe/wasmi32"
-import { coerceNumberToInt32} from "runtime/numbers"
-import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
+import WasmI64 from "runtime/unsafe/wasmi64"
+import WasmF32 from "runtime/unsafe/wasmf32"
+import WasmF64 from "runtime/unsafe/wasmf64"
+import {
+  tagSimpleNumber,
+  allocateBytes,
+  newInt32,
+  newFloat32,
+  newInt64,
+  newFloat64
+} from "runtime/dataStructures"
+import { coerceNumberToInt32, coerceNumberToInt64 } from "runtime/numbers"
+import Exception from "runtime/exception"
 
-// getInt8
-// setInt8
-// getInt8U
-// setInt8U
-// getInt16
-// setInt16
-// getInt16U
-// setInt16U
-// getInt32
-// setInt32
-// getInt64
-// setInt64
-// length
-// empty
-// copy
-// sub
-// extend
-// blit (though I'd love to find a better name for this)
-// append
+// -----------------------------------------------------------------------------
+// Conversion Utils
+// -----------------------------------------------------------------------------
 
-// Make a new Bytes buffer of n-bytes size
-// @param n: Number - The number of bytes to store
-// @returns Bytes
+/** Converts Number to WasmI32 */
 @disableGC
-export let make = (n: Number) => {
-  let n = coerceNumberToInt32(n);
-  let ptr = WasmI32.fromGrain(n)
-  let bytes = allocateBytes(WasmI32.load(ptr, 8n));
-  WasmI32.toGrain(bytes): Bytes
+let numberToWasmI32 = n => {
+  let i32 = coerceNumberToInt32(n);
+  let ptr = WasmI32.fromGrain(i32);
+  WasmI32.load(ptr, 8n)
 }
 
 @disableGC
-export let empty = make(0)
+let int32ToWasmI32 = (n: Int32) => {
+  WasmI32.load(WasmI32.fromGrain(n), 8n)
+}
 
-// Get the byte length of a Bytes buffer.
-// @param input: Bytes - The Bytes buffer to check
-// @returns Number
 @disableGC
+let float32ToWasmF32 = (n: Float32) => {
+  WasmF32.load(WasmI32.fromGrain(n), 8n)
+}
+
+@disableGC
+let int64ToWasmI64 = (n: Int64) => {
+  WasmI64.load(WasmI32.fromGrain(n), 8n)
+}
+
+@disableGC
+let float64ToWasmF64 = (n: Float64) => {
+  WasmF64.load(WasmI32.fromGrain(n), 8n)
+}
+
+@disableGC
+let wasmI32ToInt32 = (n: WasmI32) => {
+  WasmI32.toGrain(newInt32(n)) : Int32
+}
+
+@disableGC
+let wasmI32ToFloat32 = (n: WasmF32) => {
+  WasmI32.toGrain(newFloat32(n)) : Float32
+}
+
+@disableGC
+let wasmI64ToInt64 = (n: WasmI64) => {
+  WasmI32.toGrain(newInt64(n)) : Int64
+}
+
+@disableGC
+let wasmF64ToFloat64 = (n: WasmF64) => {
+  WasmI32.toGrain(newFloat64(n)) : Float64
+}
+
+// -----------------------------------------------------------------------------
+// Pointer Utils
+// -----------------------------------------------------------------------------
+
+/** Throws an exception if the index specified is out-of-bounds */
+@disableGC
+let ensureIndexIsInBounds = (i, byteSize, max) => {
+  let (+) = WasmI32.add;
+  let (<) = WasmI32.ltS;
+  let (>) = WasmI32.gtS;
+  if (i < 0n) {
+    throw Exception.IndexOutOfBounds
+  }
+  if ((i + byteSize) > max) {
+    throw Exception.IndexOutOfBounds
+  }
+}
+
+/** Gets the Bytes pointer and size */
+@disableGC
+let getPointerAndSize = (bytes) => {
+  let ptr = WasmI32.fromGrain(bytes);
+  let size = WasmI32.load(ptr, 4n);
+  (ptr, size)
+}
+
+/** Gets the Bytes pointer and byte offset */
+@disableGC
+let getPointerAndOffset = (bytes, byteSize, i) => {
+  let (+) = WasmI32.add;
+  let (*) = WasmI32.mul;
+  let (ptr, size) = getPointerAndSize(bytes);
+  let i = numberToWasmI32(i);
+  ensureIndexIsInBounds(i, byteSize, size);
+  let offset = 8n + i;
+  (ptr, offset)
+}
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+/**
+ * Sets a signed 8-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Int32 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
+  let byteSize = 1n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = int32ToWasmI32(v);
+  WasmI32.store8(ptr, value, offset);
+}
+
+/**
+ * Gets a signed 8-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int32
+ */
+@disableGC
+export let getInt8S = (b: Bytes, i: Number) => {
+  let byteSize = 1n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI32.load8S(ptr, offset);
+  wasmI32ToInt32(n)
+}
+
+/**
+ * Gets an unsigned 8-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int32
+ */
+@disableGC
+export let getInt8U = (b: Bytes, i: Number) => {
+  let byteSize = 1n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI32.load8U(ptr, offset);
+  wasmI32ToInt32(n)
+}
+
+/**
+ * Sets a signed 16-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Int32 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
+  let byteSize = 2n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = int32ToWasmI32(v);
+  WasmI32.store16(ptr, value, offset);
+}
+
+/**
+ * Gets a signed 16-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int32
+ */
+@disableGC
+export let getInt16S = (b: Bytes, i: Number) => {
+  let byteSize = 2n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI32.load16S(ptr, offset);
+  wasmI32ToInt32(n)
+}
+
+/**
+ * Gets an unsigned 16-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int32
+ */
+@disableGC
+export let getInt16U = (b: Bytes, i: Number) => {
+  let byteSize = 2n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI32.load16U(ptr, offset);
+  wasmI32ToInt32(n)
+
+}
+
+/**
+ * Sets a signed 32-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Int32 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
+  let byteSize = 4n;
+  let (bytesPtr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = int32ToWasmI32(v);
+  WasmI32.store(bytesPtr, value, offset);
+}
+
+/**
+ * Gets a signed 32-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int32
+ */
+@disableGC
+export let getInt32 = (b: Bytes, i: Number) => {
+  let byteSize = 4n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI32.load(ptr, offset);
+  wasmI32ToInt32(n)
+}
+
+/**
+ * Sets a 32-bit float starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Float32 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
+  let byteSize = 4n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = float32ToWasmF32(v);
+  WasmF32.store(ptr, value, offset);
+}
+
+/**
+ * Gets a 32-bit float starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Float32
+ */
+@disableGC
+export let getFloat32 = (b: Bytes, i: Number) => {
+  let byteSize = 4n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmF32.load(ptr, offset);
+  wasmI32ToFloat32(n)
+}
+
+/**
+ * Sets a signed 64-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Int64 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
+  let byteSize = 8n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = int64ToWasmI64(v);
+  WasmI64.store(ptr, value, offset);
+}
+
+/**
+ * Gets a signed 64-bit integer starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Int64
+ */
+@disableGC
+export let getInt64 = (b: Bytes, i: Number) => {
+  let byteSize = 8n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmI64.load(ptr, offset);
+  wasmI64ToInt64(n)
+}
+
+/**
+ * Sets a 64-bit float starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @param v: Float64 - The value to set
+ * @returns Void
+ */
+@disableGC
+export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
+  let byteSize = 8n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let value = float64ToWasmF64(v);
+  WasmF64.store(ptr, value, offset);
+}
+
+/**
+ * Gets a 64-bit float starting at the given byte index.
+ * @param b: Bytes - The Bytes buffer
+ * @param i: Number - The byte index
+ * @returns Float64
+ */
+@disableGC
+export let getFloat64 = (b: Bytes, i: Number) => {
+  let byteSize = 8n;
+  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let n = WasmF64.load(ptr, offset);
+  wasmF64ToFloat64(n)
+}
+
+/**
+ * Return a new Bytes buffer that contains the same bytes as the argument.
+ * @param b: Bytes - The Bytes buffer to copy
+ * @returns Bytes
+ */
+@disableGC
+export let copy = (b: Bytes) => {
+  let (<) = WasmI32.ltS;
+  let (+) = WasmI32.add;
+  let (src, size) = getPointerAndSize(b);
+  let dst = allocateBytes(size);
+  for (let mut i = 0n; i < size; i += 4n) {
+    let n = WasmI32.load(src, 8n + i);
+    WasmI32.store(dst, n, 8n + i);
+  }
+  WasmI32.toGrain(dst): Bytes
+}
+
+/**
+ * Returns a new Bytes buffer containing a subset of the original Bytes buffer.
+ * @param b: Bytes - The Bytes buffer get a subset of bytes from
+ * @param i: Number - The start position to copy from
+ * @param len: Number - The number of bytes to copy
+ * @returns Bytes
+ */
+@disableGC
+export let sub = (b: Bytes, i: Number, len: Number) => {
+  let (>) = WasmI32.gtS;
+  let (%) = WasmI32.remS;
+  let (==) = WasmI32.eq;
+  let (<) = WasmI32.ltS;
+  let (+) = WasmI32.add;
+  let (src, size) = getPointerAndSize(b);
+  let i = numberToWasmI32(i);
+  let len = numberToWasmI32(len);
+  if ((i + len) > size) {
+    throw Exception.InvalidArgument("The given index and length do not specify a valid range of bytes");
+  }
+  let dst = allocateBytes(len);
+  let offset = i;
+  if (i % 4n == 0n) {
+    // If possible, copy 4 bytes at a time
+    for (let mut i = 0n; i < len; i += 4n) {
+      let n = WasmI32.load(src, 8n + i + offset);
+      WasmI32.store(dst, n, 8n + i);
+    }
+  } else {
+    // Otherwise, copy 1 byte at a time
+    for (let mut i = 0n; i < len; i += 1n) {
+      let n = WasmI32.load8S(src, 8n + i + offset);
+      WasmI32.store8(dst, n, 8n + i);
+    }
+  }
+  WasmI32.toGrain(dst): Bytes
+}
+
+
+/**
+ * Returns a new Bytes buffer with unintialized bytes prepended/appended to it.
+ * If the `left` or `right` parameters are negative, bytes will be removed from the corresponding side instead of appended.
+ * @param b: Bytes - The Bytes buffer get a subset of bytes from
+ * @param left: Number - The number of uninitialized bytes to prepend
+ * @param right: Number - The number of uninitialized bytes to append
+ * @returns Bytes
+ */
+@disableGC
+export let extend = (b: Bytes, left: Number, right: Number) => {
+  let (<) = WasmI32.ltS;
+  let (>) = WasmI32.gtS;
+  let (+) = WasmI32.add;
+  let (*) = WasmI32.mul;
+  let (%) = WasmI32.remS;
+  let (src, size) = getPointerAndSize(b);
+  let left = numberToWasmI32(left);
+  let right = numberToWasmI32(right);
+  let newLen = size + left + right;
+  if (newLen < 0n) {
+    throw Exception.InvalidArgument("The resulting length is less than 0");
+  }
+  let dst = allocateBytes(newLen);
+  let (start, offset) = if (left < 0n) {
+    (left * -1n, left)
+  } else {
+    (0n, left)
+  };
+  let end = if (right < 0n) {
+    size + right
+  } else {
+    size
+  };
+  // Copy relevant range of bytes
+  if (start < size && end > start) {
+    if (start % 4n == 0n && offset % 4n == 0n) {
+      // If possible, copy 4 bytes at a time
+      for (let mut i = start; i < end; i += 4n) {
+        let n = WasmI32.load(src, 8n + i);
+        WasmI32.store(dst, n, 8n + i + offset);
+      }
+    } else {
+      // Otherwise, copy 1 byte at a time
+      for (let mut i = start; i < end; i += 1n) {
+        let n = WasmI32.load8S(src, 8n + i);
+        WasmI32.store8(dst, n, 8n + i + offset);
+      }
+    }
+  }
+  WasmI32.toGrain(dst): Bytes
+}
+
+
+/**
+ * Copies a range of bytes bytes from a source buffer to a given location in a destination buffer.
+ * @param src: Bytes - The source buffer
+ * @param srcPos: Number - The starting byte index to copy bytes from
+ * @param dst: Bytes - The destination buffer
+ * @param dstPos: Number - The starting byte index to copy bytes into
+ * @param len: Number - The amount of bytes to copy from the source buffer
+ * @returns Void
+ */
+@disableGC
+export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: Number) => {
+  let (>) = WasmI32.gtS;
+  let (<) = WasmI32.ltS;
+  let (+) = WasmI32.add;
+  let (%) = WasmI32.remS;
+  let (src, srcSize) = getPointerAndSize(src);
+  let (dst, dstSize) = getPointerAndSize(dst);
+  let srcPos = numberToWasmI32(srcPos);
+  let dstPos = numberToWasmI32(dstPos);
+  let len = numberToWasmI32(len);
+  if ((srcPos + len) > srcSize) {
+    throw Exception.InvalidArgument("Invalid source bytes range");
+  }
+  if ((dstPos + len) > dstSize) {
+    throw Exception.InvalidArgument("Invalid destination bytes range");
+  }
+  let end = srcPos + len;
+  if (srcPos % 4n == 0n && dstPos % 4n == 0n) {
+    // If possible, copy 4 bytes at a time
+    for (let mut i = srcPos; i < end; i += 4n) {
+      let n = WasmI32.load(src, 8n + i);
+      WasmI32.store(dst, n, 8n + i + dstPos);
+    }
+  } else {
+    // Otherwise, copy 1 byte at a time
+    for (let mut i = srcPos; i < end; i += 1n) {
+      let n = WasmI32.load8S(src, 8n + i);
+      WasmI32.store8(dst, n, 8n + i + dstPos);
+    }
+  }
+}
+
+/**
+ * Get the byte length of a Bytes buffer.
+ * @param input: Bytes - The Bytes buffer to check
+ * @returns Number
+ */
+ @disableGC
 export let length = (s: Bytes) => {
   let s = WasmI32.fromGrain(s)
   tagSimpleNumber(WasmI32.load(s, 4n))
 }
+
+/**
+ * Creates a new Bytes buffer that contains the bytes of both buffers a and b.
+ * @param a: Bytes - The buffer to be copied first
+ * @param b: Bytes - The buffer to be appended
+ * @returns Bytes
+ */
+export let append = (a: Bytes, b: Bytes) => {
+  let alen = length(a);
+  let blen = length(b);
+  let c = extend(a, 0, blen);
+  blit(b, 0, c, alen, blen);
+  c
+}
+
+/**
+ * Make a new Bytes buffer of n-bytes size.
+ * @param n: Number - The number of bytes to store
+ * @returns Bytes
+ */
+@disableGC
+export let make = (n: Number) => {
+  let bytes = allocateBytes(numberToWasmI32(n));
+  WasmI32.toGrain(bytes): Bytes
+}
+
+/**
+ * An empty Bytes buffer
+ */
+export let empty = make(0)
+

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -12,7 +12,7 @@ import {
   newInt64,
   newFloat64
 } from "runtime/dataStructures"
-import { coerceNumberToInt32, coerceNumberToInt64 } from "runtime/numbers"
+import { coerceNumberToInt32 } from "runtime/numbers"
 import Exception from "runtime/exception"
 
 // -----------------------------------------------------------------------------

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -22,8 +22,8 @@ import Exception from "runtime/exception"
 /** Converts Number to WasmI32 */
 @disableGC
 let numberToWasmI32 = n => {
-  let i32 = coerceNumberToInt32(n);
-  let ptr = WasmI32.fromGrain(i32);
+  let i32 = coerceNumberToInt32(n)
+  let ptr = WasmI32.fromGrain(i32)
   WasmI32.load(ptr, 8n)
 }
 
@@ -74,9 +74,9 @@ let wasmF64ToFloat64 = (n: WasmF64) => {
 /** Throws an exception if the index specified is out-of-bounds */
 @disableGC
 let ensureIndexIsInBounds = (i, byteSize, max) => {
-  let (+) = WasmI32.add;
-  let (<) = WasmI32.ltS;
-  let (>) = WasmI32.gtS;
+  let (+) = WasmI32.add
+  let (<) = WasmI32.ltS
+  let (>) = WasmI32.gtS
   if (i < 0n) {
     throw Exception.IndexOutOfBounds
   }
@@ -88,22 +88,22 @@ let ensureIndexIsInBounds = (i, byteSize, max) => {
 /** Gets the Bytes pointer and size */
 @disableGC
 let getPointerAndSize = (bytes) => {
-  let ptr = WasmI32.fromGrain(bytes);
-  let size = WasmI32.load(ptr, 4n);
+  let ptr = WasmI32.fromGrain(bytes)
+  let size = WasmI32.load(ptr, 4n)
   (ptr, size)
 }
 
 /** Gets the Bytes pointer and byte offset */
 @disableGC
 let getPointerAndOffset = (bytes, byteSize, i) => {
-  let (+) = WasmI32.add;
-  let (*) = WasmI32.mul;
-  let pointerAndSize = getPointerAndSize(bytes);
-  let (ptr, size) = pointerAndSize;
-  Memory.free(WasmI32.fromGrain(pointerAndSize));
-  let i = numberToWasmI32(i);
-  ensureIndexIsInBounds(i, byteSize, size);
-  let offset = 8n + i;
+  let (+) = WasmI32.add
+  let (*) = WasmI32.mul
+  let pointerAndSize = getPointerAndSize(bytes)
+  let (ptr, size) = pointerAndSize
+  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let i = numberToWasmI32(i)
+  ensureIndexIsInBounds(i, byteSize, size)
+  let offset = 8n + i
   (ptr, offset)
 }
 
@@ -120,12 +120,12 @@ let getPointerAndOffset = (bytes, byteSize, i) => {
  */
 @disableGC
 export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
-  let byteSize = 1n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = int32ToWasmI32(v);
-  WasmI32.store8(ptr, value, offset);
+  let byteSize = 1n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = int32ToWasmI32(v)
+  WasmI32.store8(ptr, value, offset)
 }
 
 /**
@@ -136,11 +136,11 @@ export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
  */
 @disableGC
 export let getInt8S = (b: Bytes, i: Number) => {
-  let byteSize = 1n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI32.load8S(ptr, offset);
+  let byteSize = 1n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI32.load8S(ptr, offset)
   wasmI32ToInt32(n)
 }
 
@@ -152,11 +152,11 @@ export let getInt8S = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let getInt8U = (b: Bytes, i: Number) => {
-  let byteSize = 1n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI32.load8U(ptr, offset);
+  let byteSize = 1n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI32.load8U(ptr, offset)
   wasmI32ToInt32(n)
 }
 
@@ -169,12 +169,12 @@ export let getInt8U = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
-  let byteSize = 2n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = int32ToWasmI32(v);
-  WasmI32.store16(ptr, value, offset);
+  let byteSize = 2n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = int32ToWasmI32(v)
+  WasmI32.store16(ptr, value, offset)
 }
 
 /**
@@ -185,11 +185,11 @@ export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
  */
 @disableGC
 export let getInt16S = (b: Bytes, i: Number) => {
-  let byteSize = 2n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI32.load16S(ptr, offset);
+  let byteSize = 2n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI32.load16S(ptr, offset)
   wasmI32ToInt32(n)
 }
 
@@ -201,11 +201,11 @@ export let getInt16S = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let getInt16U = (b: Bytes, i: Number) => {
-  let byteSize = 2n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI32.load16U(ptr, offset);
+  let byteSize = 2n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI32.load16U(ptr, offset)
   wasmI32ToInt32(n)
 
 }
@@ -219,12 +219,12 @@ export let getInt16U = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
-  let byteSize = 4n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = int32ToWasmI32(v);
-  WasmI32.store(ptr, value, offset);
+  let byteSize = 4n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = int32ToWasmI32(v)
+  WasmI32.store(ptr, value, offset)
 }
 
 /**
@@ -235,11 +235,11 @@ export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
  */
 @disableGC
 export let getInt32 = (b: Bytes, i: Number) => {
-  let byteSize = 4n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI32.load(ptr, offset);
+  let byteSize = 4n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI32.load(ptr, offset)
   wasmI32ToInt32(n)
 }
 
@@ -252,12 +252,12 @@ export let getInt32 = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
-  let byteSize = 4n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = float32ToWasmF32(v);
-  WasmF32.store(ptr, value, offset);
+  let byteSize = 4n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = float32ToWasmF32(v)
+  WasmF32.store(ptr, value, offset)
 }
 
 /**
@@ -268,11 +268,11 @@ export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
  */
 @disableGC
 export let getFloat32 = (b: Bytes, i: Number) => {
-  let byteSize = 4n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmF32.load(ptr, offset);
+  let byteSize = 4n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmF32.load(ptr, offset)
   wasmI32ToFloat32(n)
 }
 
@@ -285,12 +285,12 @@ export let getFloat32 = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
-  let byteSize = 8n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = int64ToWasmI64(v);
-  WasmI64.store(ptr, value, offset);
+  let byteSize = 8n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = int64ToWasmI64(v)
+  WasmI64.store(ptr, value, offset)
 }
 
 /**
@@ -301,11 +301,11 @@ export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
  */
 @disableGC
 export let getInt64 = (b: Bytes, i: Number) => {
-  let byteSize = 8n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmI64.load(ptr, offset);
+  let byteSize = 8n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmI64.load(ptr, offset)
   wasmI64ToInt64(n)
 }
 
@@ -318,12 +318,12 @@ export let getInt64 = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
-  let byteSize = 8n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let value = float64ToWasmF64(v);
-  WasmF64.store(ptr, value, offset);
+  let byteSize = 8n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let value = float64ToWasmF64(v)
+  WasmF64.store(ptr, value, offset)
 }
 
 /**
@@ -334,11 +334,11 @@ export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
  */
 @disableGC
 export let getFloat64 = (b: Bytes, i: Number) => {
-  let byteSize = 8n;
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
-  let (ptr, offset) = pointerAndOffset;
-  Memory.free(WasmI32.fromGrain(pointerAndOffset));
-  let n = WasmF64.load(ptr, offset);
+  let byteSize = 8n
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
+  let (ptr, offset) = pointerAndOffset
+  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let n = WasmF64.load(ptr, offset)
   wasmF64ToFloat64(n)
 }
 
@@ -349,13 +349,13 @@ export let getFloat64 = (b: Bytes, i: Number) => {
  */
 @disableGC
 export let copy = (b: Bytes) => {
-  let (<) = WasmI32.ltS;
-  let (+) = WasmI32.add;
-  let pointerAndSize = getPointerAndSize(b);
-  let (src, size) = pointerAndSize;
-  Memory.free(WasmI32.fromGrain(pointerAndSize));
-  let dst = allocateBytes(size);
-  Memory.copy(dst + 8n, src + 8n, size);
+  let (<) = WasmI32.ltS
+  let (+) = WasmI32.add
+  let pointerAndSize = getPointerAndSize(b)
+  let (src, size) = pointerAndSize
+  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let dst = allocateBytes(size)
+  Memory.copy(dst + 8n, src + 8n, size)
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -368,19 +368,19 @@ export let copy = (b: Bytes) => {
  */
 @disableGC
 export let sub = (b: Bytes, i: Number, len: Number) => {
-  let (>) = WasmI32.gtS;
-  let (+) = WasmI32.add;
-  let pointerAndSize = getPointerAndSize(b);
-  let (src, size) = pointerAndSize;
-  Memory.free(WasmI32.fromGrain(pointerAndSize));
-  let i = numberToWasmI32(i);
-  let len = numberToWasmI32(len);
+  let (>) = WasmI32.gtS
+  let (+) = WasmI32.add
+  let pointerAndSize = getPointerAndSize(b)
+  let (src, size) = pointerAndSize
+  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let i = numberToWasmI32(i)
+  let len = numberToWasmI32(len)
   if ((i + len) > size) {
-    throw Exception.InvalidArgument("The given index and length do not specify a valid range of bytes");
+    throw Exception.InvalidArgument("The given index and length do not specify a valid range of bytes")
   }
-  let dst = allocateBytes(len);
-  let offset = i;
-  Memory.copy(dst + 8n, src + 8n + i, len);
+  let dst = allocateBytes(len)
+  let offset = i
+  Memory.copy(dst + 8n, src + 8n + i, len)
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -395,33 +395,33 @@ export let sub = (b: Bytes, i: Number, len: Number) => {
  */
 @disableGC
 export let extend = (b: Bytes, left: Number, right: Number) => {
-  let (<) = WasmI32.ltS;
-  let (>) = WasmI32.gtS;
-  let (+) = WasmI32.add;
-  let (-) = WasmI32.sub;
-  let (*) = WasmI32.mul;
-  let pointerAndSize = getPointerAndSize(b);
-  let (src, size) = pointerAndSize;
-  Memory.free(WasmI32.fromGrain(pointerAndSize));
-  let left = numberToWasmI32(left);
-  let right = numberToWasmI32(right);
-  let newLen = size + left + right;
+  let (<) = WasmI32.ltS
+  let (>) = WasmI32.gtS
+  let (+) = WasmI32.add
+  let (-) = WasmI32.sub
+  let (*) = WasmI32.mul
+  let pointerAndSize = getPointerAndSize(b)
+  let (src, size) = pointerAndSize
+  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let left = numberToWasmI32(left)
+  let right = numberToWasmI32(right)
+  let newLen = size + left + right
   if (newLen < 0n) {
-    throw Exception.InvalidArgument("The resulting length is less than 0");
+    throw Exception.InvalidArgument("The resulting length is less than 0")
   }
-  let dst = allocateBytes(newLen);
+  let dst = allocateBytes(newLen)
   let (start, offset) = if (left < 0n) {
     (left * -1n, 0n)
   } else {
     (0n, left)
-  };
+  }
   let len = if (right < 0n) {
     (size + right) - start
   } else {
     size - start
   }
   if (len > 0n) {
-    Memory.copy(dst + 8n + offset, src + 8n + start, len);
+    Memory.copy(dst + 8n + offset, src + 8n + start, len)
   }
   WasmI32.toGrain(dst): Bytes
 }
@@ -438,25 +438,25 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
  */
 @disableGC
 export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: Number) => {
-  let (>) = WasmI32.gtS;
-  let (+) = WasmI32.add;
-  let srcPointerAndSize = getPointerAndSize(src);
-  let (src, srcSize) = srcPointerAndSize;
-  Memory.free(WasmI32.fromGrain(srcPointerAndSize));
-  let dstPointerAndSize = getPointerAndSize(dst);
-  let (dst, dstSize) = dstPointerAndSize;
-  Memory.free(WasmI32.fromGrain(dstPointerAndSize));
-  let srcPos = numberToWasmI32(srcPos);
-  let dstPos = numberToWasmI32(dstPos);
-  let len = numberToWasmI32(len);
+  let (>) = WasmI32.gtS
+  let (+) = WasmI32.add
+  let srcPointerAndSize = getPointerAndSize(src)
+  let (src, srcSize) = srcPointerAndSize
+  Memory.free(WasmI32.fromGrain(srcPointerAndSize))
+  let dstPointerAndSize = getPointerAndSize(dst)
+  let (dst, dstSize) = dstPointerAndSize
+  Memory.free(WasmI32.fromGrain(dstPointerAndSize))
+  let srcPos = numberToWasmI32(srcPos)
+  let dstPos = numberToWasmI32(dstPos)
+  let len = numberToWasmI32(len)
   if ((srcPos + len) > srcSize) {
-    throw Exception.InvalidArgument("Invalid source bytes range");
+    throw Exception.InvalidArgument("Invalid source bytes range")
   }
   if ((dstPos + len) > dstSize) {
-    throw Exception.InvalidArgument("Invalid destination bytes range");
+    throw Exception.InvalidArgument("Invalid destination bytes range")
   }
-  let end = srcPos + len;
-  Memory.copy(dst + 8n + dstPos, src + 8n + srcPos, len);
+  let end = srcPos + len
+  Memory.copy(dst + 8n + dstPos, src + 8n + srcPos, len)
 }
 
 /**
@@ -477,10 +477,10 @@ export let length = (s: Bytes) => {
  * @returns Bytes
  */
 export let append = (a: Bytes, b: Bytes) => {
-  let alen = length(a);
-  let blen = length(b);
-  let c = extend(a, 0, blen);
-  blit(b, 0, c, alen, blen);
+  let alen = length(a)
+  let blen = length(b)
+  let c = extend(a, 0, blen)
+  blit(b, 0, c, alen, blen)
   c
 }
 
@@ -491,7 +491,7 @@ export let append = (a: Bytes, b: Bytes) => {
  */
 @disableGC
 export let make = (n: Number) => {
-  let bytes = allocateBytes(numberToWasmI32(n));
+  let bytes = allocateBytes(numberToWasmI32(n))
   WasmI32.toGrain(bytes): Bytes
 }
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -42,10 +42,10 @@ let getSize = (ptr) => WasmI32.load(ptr, 4n)
 
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
- * @param {Number} i - The byte index
- * @param {Int32} v - The value to set
- * @param {Bytes} b - The Bytes buffer
- * @returns {Void}
+ * @param i: Number - The byte index
+ * @param v: Int32 - The value to set
+ * @param b: Bytes - The Bytes buffer
+ * @returns Void
  */
 @disableGC
 export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
@@ -299,7 +299,7 @@ export let getFloat64 = (i: Number, b: Bytes) => {
 }
 
 /**
- * Return a new Bytes buffer that contains the same bytes as the argument.
+ * Produces a copy of the input bytes.
  * @param b: Bytes - The Bytes buffer to copy
  * @returns Bytes
  */

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,3 +1,5 @@
+
+import Memory from "runtime/unsafe/memory"
 import WasmI32 from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF32 from "runtime/unsafe/wasmf32"
@@ -96,7 +98,9 @@ let getPointerAndSize = (bytes) => {
 let getPointerAndOffset = (bytes, byteSize, i) => {
   let (+) = WasmI32.add;
   let (*) = WasmI32.mul;
-  let (ptr, size) = getPointerAndSize(bytes);
+  let pointerAndSize = getPointerAndSize(bytes);
+  let (ptr, size) = pointerAndSize;
+  Memory.free(WasmI32.fromGrain(pointerAndSize));
   let i = numberToWasmI32(i);
   ensureIndexIsInBounds(i, byteSize, size);
   let offset = 8n + i;
@@ -117,7 +121,9 @@ let getPointerAndOffset = (bytes, byteSize, i) => {
 @disableGC
 export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
   let byteSize = 1n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = int32ToWasmI32(v);
   WasmI32.store8(ptr, value, offset);
 }
@@ -131,7 +137,9 @@ export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
 @disableGC
 export let getInt8S = (b: Bytes, i: Number) => {
   let byteSize = 1n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI32.load8S(ptr, offset);
   wasmI32ToInt32(n)
 }
@@ -145,7 +153,9 @@ export let getInt8S = (b: Bytes, i: Number) => {
 @disableGC
 export let getInt8U = (b: Bytes, i: Number) => {
   let byteSize = 1n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI32.load8U(ptr, offset);
   wasmI32ToInt32(n)
 }
@@ -160,7 +170,9 @@ export let getInt8U = (b: Bytes, i: Number) => {
 @disableGC
 export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
   let byteSize = 2n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = int32ToWasmI32(v);
   WasmI32.store16(ptr, value, offset);
 }
@@ -174,7 +186,9 @@ export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
 @disableGC
 export let getInt16S = (b: Bytes, i: Number) => {
   let byteSize = 2n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI32.load16S(ptr, offset);
   wasmI32ToInt32(n)
 }
@@ -188,7 +202,9 @@ export let getInt16S = (b: Bytes, i: Number) => {
 @disableGC
 export let getInt16U = (b: Bytes, i: Number) => {
   let byteSize = 2n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI32.load16U(ptr, offset);
   wasmI32ToInt32(n)
 
@@ -204,9 +220,11 @@ export let getInt16U = (b: Bytes, i: Number) => {
 @disableGC
 export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
   let byteSize = 4n;
-  let (bytesPtr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = int32ToWasmI32(v);
-  WasmI32.store(bytesPtr, value, offset);
+  WasmI32.store(ptr, value, offset);
 }
 
 /**
@@ -218,7 +236,9 @@ export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
 @disableGC
 export let getInt32 = (b: Bytes, i: Number) => {
   let byteSize = 4n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI32.load(ptr, offset);
   wasmI32ToInt32(n)
 }
@@ -233,7 +253,9 @@ export let getInt32 = (b: Bytes, i: Number) => {
 @disableGC
 export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
   let byteSize = 4n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = float32ToWasmF32(v);
   WasmF32.store(ptr, value, offset);
 }
@@ -247,7 +269,9 @@ export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
 @disableGC
 export let getFloat32 = (b: Bytes, i: Number) => {
   let byteSize = 4n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmF32.load(ptr, offset);
   wasmI32ToFloat32(n)
 }
@@ -262,7 +286,9 @@ export let getFloat32 = (b: Bytes, i: Number) => {
 @disableGC
 export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
   let byteSize = 8n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = int64ToWasmI64(v);
   WasmI64.store(ptr, value, offset);
 }
@@ -276,7 +302,9 @@ export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
 @disableGC
 export let getInt64 = (b: Bytes, i: Number) => {
   let byteSize = 8n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmI64.load(ptr, offset);
   wasmI64ToInt64(n)
 }
@@ -291,7 +319,9 @@ export let getInt64 = (b: Bytes, i: Number) => {
 @disableGC
 export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
   let byteSize = 8n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let value = float64ToWasmF64(v);
   WasmF64.store(ptr, value, offset);
 }
@@ -305,7 +335,9 @@ export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
 @disableGC
 export let getFloat64 = (b: Bytes, i: Number) => {
   let byteSize = 8n;
-  let (ptr, offset) = getPointerAndOffset(b, byteSize, i);
+  let pointerAndOffset = getPointerAndOffset(b, byteSize, i);
+  let (ptr, offset) = pointerAndOffset;
+  Memory.free(WasmI32.fromGrain(pointerAndOffset));
   let n = WasmF64.load(ptr, offset);
   wasmF64ToFloat64(n)
 }
@@ -319,7 +351,9 @@ export let getFloat64 = (b: Bytes, i: Number) => {
 export let copy = (b: Bytes) => {
   let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
-  let (src, size) = getPointerAndSize(b);
+  let pointerAndSize = getPointerAndSize(b);
+  let (src, size) = pointerAndSize;
+  Memory.free(WasmI32.fromGrain(pointerAndSize));
   let dst = allocateBytes(size);
   for (let mut i = 0n; i < size; i += 4n) {
     let n = WasmI32.load(src, 8n + i);
@@ -342,7 +376,9 @@ export let sub = (b: Bytes, i: Number, len: Number) => {
   let (==) = WasmI32.eq;
   let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
-  let (src, size) = getPointerAndSize(b);
+  let pointerAndSize = getPointerAndSize(b);
+  let (src, size) = pointerAndSize;
+  Memory.free(WasmI32.fromGrain(pointerAndSize));
   let i = numberToWasmI32(i);
   let len = numberToWasmI32(len);
   if ((i + len) > size) {
@@ -382,7 +418,9 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
   let (+) = WasmI32.add;
   let (*) = WasmI32.mul;
   let (%) = WasmI32.remS;
-  let (src, size) = getPointerAndSize(b);
+  let pointerAndSize = getPointerAndSize(b);
+  let (src, size) = pointerAndSize;
+  Memory.free(WasmI32.fromGrain(pointerAndSize));
   let left = numberToWasmI32(left);
   let right = numberToWasmI32(right);
   let newLen = size + left + right;
@@ -435,8 +473,12 @@ export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: 
   let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
   let (%) = WasmI32.remS;
-  let (src, srcSize) = getPointerAndSize(src);
-  let (dst, dstSize) = getPointerAndSize(dst);
+  let srcPointerAndSize = getPointerAndSize(src);
+  let (src, srcSize) = srcPointerAndSize;
+  Memory.free(WasmI32.fromGrain(srcPointerAndSize));
+  let dstPointerAndSize = getPointerAndSize(dst);
+  let (dst, dstSize) = dstPointerAndSize;
+  Memory.free(WasmI32.fromGrain(dstPointerAndSize));
   let srcPos = numberToWasmI32(srcPos);
   let dstPos = numberToWasmI32(dstPos);
   let len = numberToWasmI32(len);

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -4,7 +4,7 @@ import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF32 from "runtime/unsafe/wasmf32"
 import WasmF64 from "runtime/unsafe/wasmf64"
 import Conv from "runtime/unsafe/conv"
-import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
+import { tagSimpleNumber, allocateBytes, allocateString } from "runtime/dataStructures"
 import Exception from "runtime/exception"
 import Int32 from "int32"
 
@@ -305,7 +305,6 @@ export let getFloat64 = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let copy = (b: Bytes) => {
-  let (<) = WasmI32.ltS
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(b)
   let size = getSize(src)
@@ -416,13 +415,13 @@ export let move = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst:
 
 /**
  * Get the byte length of a Bytes buffer.
- * @param input: Bytes - The Bytes buffer to check
+ * @param b: Bytes - The Bytes buffer to check
  * @returns Number
  */
  @disableGC
-export let length = (s: Bytes) => {
-  let s = WasmI32.fromGrain(s)
-  tagSimpleNumber(WasmI32.load(s, 4n))
+export let length = (b: Bytes) => {
+  let b = WasmI32.fromGrain(b)
+  tagSimpleNumber(getSize(b))
 }
 
 /**
@@ -437,6 +436,22 @@ export let append = (a: Bytes, b: Bytes) => {
   let c = extend(0, blen, a)
   move(0, alen, blen, b, c)
   c
+}
+
+
+/**
+ * Creates a new String from a Bytes buffer.
+ * @param b: Bytes - The source buffer
+ * @returns String
+ */
+@disableGC
+export let toString = (b: Bytes) => {
+  let (+) = WasmI32.add
+  let src = WasmI32.fromGrain(b)
+  let size = getSize(src)
+  let dst = allocateString(size)
+  Memory.copy(dst + 8n, src + 8n, size)
+  WasmI32.toGrain(dst): String
 }
 
 /**

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -34,7 +34,7 @@ let numberToWasmI32 = n => {
 
 /** Throws an exception if the index specified is out-of-bounds */
 @disableGC
-let ensureIndexIsInBounds = (i, byteSize, max) => {
+let checkIndexIsInBounds = (i, byteSize, max) => {
   let (+) = WasmI32.add
   let (<) = WasmI32.ltS
   let (>) = WasmI32.gtS
@@ -62,7 +62,7 @@ export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store8(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -79,7 +79,7 @@ export let getInt8S = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let n = WasmI32.load8S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
@@ -96,7 +96,7 @@ export let getInt8U = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let n = WasmI32.load8U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
@@ -114,7 +114,7 @@ export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store16(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -131,7 +131,7 @@ export let getInt16S = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let n = WasmI32.load16S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
@@ -148,7 +148,7 @@ export let getInt16U = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let n = WasmI32.load16U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
@@ -166,7 +166,7 @@ export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -183,7 +183,7 @@ export let getInt32 = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let n = WasmI32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
@@ -201,7 +201,7 @@ export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromFloat32(v)
   WasmF32.store(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -218,7 +218,7 @@ export let getFloat32 = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let n = WasmF32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat32(n)
 }
@@ -236,7 +236,7 @@ export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
   let value = Conv.fromInt64(v)
   WasmI64.store(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -253,7 +253,7 @@ export let getInt64 = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
   let n = WasmI64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt64(n)
 }
@@ -271,7 +271,7 @@ export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
   let value = Conv.fromFloat64(v)
   WasmF64.store(ptr + offset, value, _VALUE_OFFSET)
 }
@@ -288,7 +288,7 @@ export let getFloat64 = (i: Number, b: Bytes) => {
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
+  checkIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
   let n = WasmF64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat64(n)
 }

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -449,6 +449,35 @@ export let toString = (b: Bytes) => {
 }
 
 /**
+ * Creates a new byte sequence from a String.
+ * @param str: String - The String to copy into a byte sequence
+ * @returns Bytes
+ */
+@disableGC
+export let fromString = (str: String) => {
+  let (+) = WasmI32.add
+  let src = WasmI32.fromGrain(str)
+  let size = getSize(src)
+  let dst = allocateBytes(size)
+  Memory.copy(dst + _VALUE_OFFSET, src + _VALUE_OFFSET, size)
+  WasmI32.toGrain(dst): Bytes
+}
+
+/**
+ * Fills a byte sequence with a given value.
+ * @param v: Int32 - The value to fill the byte sequence with
+ * @param b: Bytes - The byte sequence to fill
+ */
+@disableGC
+export let fill = (v: Int32, b: Bytes) => {
+  let (+) = WasmI32.add
+  let src = WasmI32.fromGrain(b)
+  let size = getSize(src)
+  let value = Conv.fromInt32(v)
+  Memory.fill(src + _VALUE_OFFSET, value, size)
+}
+
+/**
  * Make a new byte sequence of n-bytes size.
  * @param n: Number - The number of bytes to store
  * @returns Bytes

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,10 +1,23 @@
-import { allocateBytes } from "runtime/dataStructures"
+import WasmI32 from "runtime/unsafe/wasmi32"
+import { coerceNumberToInt32} from "runtime/numbers"
+import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
 
 // Make a new Bytes buffer of n-bytes size
-// @param byteLength: Number - The number of bytes to store
+// @param n: Number - The number of bytes to store
 // @returns Bytes
 @disableGC
-export let make = (byteLength: Number) => {
-  let buf = allocateBytes(byteLength);
+export let make = (n: Number) => {
+  let n = coerceNumberToInt32(n);
+  let ptr = WasmI32.fromGrain(n)
+  let buf = allocateBytes(WasmI32.load(ptr, 8n));
   WasmI32.toGrain(buf): Bytes
+}
+
+// Get the byte length of a Bytes buffer.
+// @param input: Bytes - The Bytes buffer to check
+// @returns Number
+@disableGC
+export let length = (s: Bytes) => {
+  let s = WasmI32.fromGrain(s)
+  tagSimpleNumber(WasmI32.load(s, 4n))
 }

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -2,6 +2,26 @@ import WasmI32 from "runtime/unsafe/wasmi32"
 import { coerceNumberToInt32} from "runtime/numbers"
 import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
 
+// getInt8
+// setInt8
+// getInt8U
+// setInt8U
+// getInt16
+// setInt16
+// getInt16U
+// setInt16U
+// getInt32
+// setInt32
+// getInt64
+// setInt64
+// length
+// empty
+// copy
+// sub
+// extend
+// blit (though I'd love to find a better name for this)
+// append
+
 // Make a new Bytes buffer of n-bytes size
 // @param n: Number - The number of bytes to store
 // @returns Bytes
@@ -9,9 +29,12 @@ import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
 export let make = (n: Number) => {
   let n = coerceNumberToInt32(n);
   let ptr = WasmI32.fromGrain(n)
-  let buf = allocateBytes(WasmI32.load(ptr, 8n));
-  WasmI32.toGrain(buf): Bytes
+  let bytes = allocateBytes(WasmI32.load(ptr, 8n));
+  WasmI32.toGrain(bytes): Bytes
 }
+
+@disableGC
+export let empty = make(0)
 
 // Get the byte length of a Bytes buffer.
 // @param input: Bytes - The Bytes buffer to check

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -379,7 +379,7 @@ export let resize = (left: Number, right: Number, b: Bytes) => {
 }
 
 /**
- * Copies a range of bytes bytes from a source buffer to a given location in a destination buffer.
+ * Copies a range of bytes from a source buffer to a given location in a destination buffer.
  * @param srcPos: Number - The starting byte index to copy bytes from
  * @param dstPos: Number - The starting byte index to copy bytes into
  * @param len: Number - The amount of bytes to copy from the source buffer

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -53,7 +53,7 @@ let getSize = (ptr) => WasmI32.load(ptr, _SIZE_OFFSET)
  * Sets a signed 8-bit integer starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -70,7 +70,7 @@ export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
 /**
  * Gets a signed 8-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int32
  */
 @disableGC
@@ -87,7 +87,7 @@ export let getInt8S = (i: Number, b: Bytes) => {
 /**
  * Gets an unsigned 8-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int32
  */
 @disableGC
@@ -105,7 +105,7 @@ export let getInt8U = (i: Number, b: Bytes) => {
  * Sets a signed 16-bit integer starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -122,7 +122,7 @@ export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
 /**
  * Gets a signed 16-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int32
  */
 @disableGC
@@ -139,7 +139,7 @@ export let getInt16S = (i: Number, b: Bytes) => {
 /**
  * Gets an unsigned 16-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int32
  */
 @disableGC
@@ -157,7 +157,7 @@ export let getInt16U = (i: Number, b: Bytes) => {
  * Sets a signed 32-bit integer starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -174,7 +174,7 @@ export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
 /**
  * Gets a signed 32-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int32
  */
 @disableGC
@@ -192,7 +192,7 @@ export let getInt32 = (i: Number, b: Bytes) => {
  * Sets a 32-bit float starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Float32 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -209,7 +209,7 @@ export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
 /**
  * Gets a 32-bit float starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Float32
  */
 @disableGC
@@ -227,7 +227,7 @@ export let getFloat32 = (i: Number, b: Bytes) => {
  * Sets a signed 64-bit integer starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Int64 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -244,7 +244,7 @@ export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
 /**
  * Gets a signed 64-bit integer starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Int64
  */
 @disableGC
@@ -262,7 +262,7 @@ export let getInt64 = (i: Number, b: Bytes) => {
  * Sets a 64-bit float starting at the given byte index.
  * @param i: Number - The byte index
  * @param v: Float64 - The value to set
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Void
  */
 @disableGC
@@ -279,7 +279,7 @@ export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
 /**
  * Gets a 64-bit float starting at the given byte index.
  * @param i: Number - The byte index
- * @param b: Bytes - The Bytes buffer
+ * @param b: Bytes - The byte sequence
  * @returns Float64
  */
 @disableGC
@@ -294,8 +294,8 @@ export let getFloat64 = (i: Number, b: Bytes) => {
 }
 
 /**
- * Return a new Bytes buffer that contains the same bytes as the argument.
- * @param b: Bytes - The Bytes buffer to copy
+ * Return a new byte sequence that contains the same bytes as the argument.
+ * @param b: Bytes - The byte sequence to copy
  * @returns Bytes
  */
 @disableGC
@@ -309,10 +309,10 @@ export let copy = (b: Bytes) => {
 }
 
 /**
- * Returns a new Bytes buffer containing a subset of the original Bytes buffer.
+ * Returns a new byte sequence containing a subset of the original byte sequence.
  * @param i: Number - The start position to copy from
  * @param len: Number - The number of bytes to copy
- * @param b: Bytes - The Bytes buffer get a subset of bytes from
+ * @param b: Bytes - The byte sequence get a subset of bytes from
  * @returns Bytes
  */
 @disableGC
@@ -334,11 +334,11 @@ export let slice = (i: Number, len: Number, b: Bytes) => {
 
 
 /**
- * Returns a new Bytes buffer with uninitialized bytes prepended/appended to it.
- * If the `left` or `right` parameters are negative, bytes will be removed from the corresponding side instead of appended.
+ * Add or remove bytes from the start and/or end of a byte sequence.
+ * A positive number represents bytes to add, while a negative number represents bytes to remove.
  * @param left: Number - The number of uninitialized bytes to prepend
  * @param right: Number - The number of uninitialized bytes to append
- * @param b: Bytes - The Bytes buffer get a subset of bytes from
+ * @param b: Bytes - The byte sequence get a subset of bytes from
  * @returns Bytes
  */
 @disableGC
@@ -409,8 +409,8 @@ export let move = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst:
 }
 
 /**
- * Get the byte length of a Bytes buffer.
- * @param b: Bytes - The Bytes buffer to check
+ * Get the byte length of a byte sequence.
+ * @param b: Bytes - The byte sequence to check
  * @returns Number
  */
  @disableGC
@@ -420,7 +420,7 @@ export let length = (b: Bytes) => {
 }
 
 /**
- * Creates a new Bytes buffer that contains the bytes of both buffers a and b.
+ * Creates a new byte sequence that contains the bytes of both buffers a and b.
  * @param a: Bytes - The buffer to be copied first
  * @param b: Bytes - The buffer to be copied last
  * @returns Bytes
@@ -434,7 +434,7 @@ export let concat = (a: Bytes, b: Bytes) => {
 }
 
 /**
- * Creates a new String from a Bytes buffer.
+ * Creates a new String from a byte sequence.
  * @param b: Bytes - The source buffer
  * @returns String
  */
@@ -449,7 +449,7 @@ export let toString = (b: Bytes) => {
 }
 
 /**
- * Make a new Bytes buffer of n-bytes size.
+ * Make a new byte sequence of n-bytes size.
  * @param n: Number - The number of bytes to store
  * @returns Bytes
  */
@@ -460,7 +460,7 @@ export let make = (n: Number) => {
 }
 
 /**
- * An empty Bytes buffer
+ * An empty byte sequence
  */
 export let empty = make(0)
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -52,13 +52,13 @@ let getPointerAndOffset = (bytes, byteSize, i) => {
 
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
+export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
   let byteSize = 1n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -69,12 +69,12 @@ export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
 
 /**
  * Gets a signed 8-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int32
  */
 @disableGC
-export let getInt8S = (b: Bytes, i: Number) => {
+export let getInt8S = (i: Number, b: Bytes) => {
   let byteSize = 1n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -85,12 +85,12 @@ export let getInt8S = (b: Bytes, i: Number) => {
 
 /**
  * Gets an unsigned 8-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int32
  */
 @disableGC
-export let getInt8U = (b: Bytes, i: Number) => {
+export let getInt8U = (i: Number, b: Bytes) => {
   let byteSize = 1n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -101,13 +101,13 @@ export let getInt8U = (b: Bytes, i: Number) => {
 
 /**
  * Sets a signed 16-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
+export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
   let byteSize = 2n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -118,12 +118,12 @@ export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
 
 /**
  * Gets a signed 16-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int32
  */
 @disableGC
-export let getInt16S = (b: Bytes, i: Number) => {
+export let getInt16S = (i: Number, b: Bytes) => {
   let byteSize = 2n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -134,30 +134,29 @@ export let getInt16S = (b: Bytes, i: Number) => {
 
 /**
  * Gets an unsigned 16-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int32
  */
 @disableGC
-export let getInt16U = (b: Bytes, i: Number) => {
+export let getInt16U = (i: Number, b: Bytes) => {
   let byteSize = 2n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load16U(ptr, offset)
   Conv.toInt32(n)
-
 }
 
 /**
  * Sets a signed 32-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Int32 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
+export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
   let byteSize = 4n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -168,12 +167,12 @@ export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
 
 /**
  * Gets a signed 32-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int32
  */
 @disableGC
-export let getInt32 = (b: Bytes, i: Number) => {
+export let getInt32 = (i: Number, b: Bytes) => {
   let byteSize = 4n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -184,13 +183,13 @@ export let getInt32 = (b: Bytes, i: Number) => {
 
 /**
  * Sets a 32-bit float starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Float32 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
+export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
   let byteSize = 4n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -201,12 +200,12 @@ export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
 
 /**
  * Gets a 32-bit float starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Float32
  */
 @disableGC
-export let getFloat32 = (b: Bytes, i: Number) => {
+export let getFloat32 = (i: Number, b: Bytes) => {
   let byteSize = 4n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -217,13 +216,13 @@ export let getFloat32 = (b: Bytes, i: Number) => {
 
 /**
  * Sets a signed 64-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Int64 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
+export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
   let byteSize = 8n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -234,12 +233,12 @@ export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
 
 /**
  * Gets a signed 64-bit integer starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Int64
  */
 @disableGC
-export let getInt64 = (b: Bytes, i: Number) => {
+export let getInt64 = (i: Number, b: Bytes) => {
   let byteSize = 8n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -250,13 +249,13 @@ export let getInt64 = (b: Bytes, i: Number) => {
 
 /**
  * Sets a 64-bit float starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
  * @param v: Float64 - The value to set
+ * @param b: Bytes - The Bytes buffer
  * @returns Void
  */
 @disableGC
-export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
+export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
   let byteSize = 8n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -267,12 +266,12 @@ export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
 
 /**
  * Gets a 64-bit float starting at the given byte index.
- * @param b: Bytes - The Bytes buffer
  * @param i: Number - The byte index
+ * @param b: Bytes - The Bytes buffer
  * @returns Float64
  */
 @disableGC
-export let getFloat64 = (b: Bytes, i: Number) => {
+export let getFloat64 = (i: Number, b: Bytes) => {
   let byteSize = 8n
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
@@ -300,13 +299,13 @@ export let copy = (b: Bytes) => {
 
 /**
  * Returns a new Bytes buffer containing a subset of the original Bytes buffer.
- * @param b: Bytes - The Bytes buffer get a subset of bytes from
  * @param i: Number - The start position to copy from
  * @param len: Number - The number of bytes to copy
+ * @param b: Bytes - The Bytes buffer get a subset of bytes from
  * @returns Bytes
  */
 @disableGC
-export let sub = (b: Bytes, i: Number, len: Number) => {
+export let sub = (i: Number, len: Number, b: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
   let pointerAndSize = getPointerAndSize(b)
@@ -327,13 +326,13 @@ export let sub = (b: Bytes, i: Number, len: Number) => {
 /**
  * Returns a new Bytes buffer with unintialized bytes prepended/appended to it.
  * If the `left` or `right` parameters are negative, bytes will be removed from the corresponding side instead of appended.
- * @param b: Bytes - The Bytes buffer get a subset of bytes from
  * @param left: Number - The number of uninitialized bytes to prepend
  * @param right: Number - The number of uninitialized bytes to append
+ * @param b: Bytes - The Bytes buffer get a subset of bytes from
  * @returns Bytes
  */
 @disableGC
-export let extend = (b: Bytes, left: Number, right: Number) => {
+export let extend = (left: Number, right: Number, b: Bytes) => {
   let (<) = WasmI32.ltS
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
@@ -369,15 +368,15 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
 
 /**
  * Copies a range of bytes bytes from a source buffer to a given location in a destination buffer.
- * @param src: Bytes - The source buffer
  * @param srcPos: Number - The starting byte index to copy bytes from
- * @param dst: Bytes - The destination buffer
  * @param dstPos: Number - The starting byte index to copy bytes into
  * @param len: Number - The amount of bytes to copy from the source buffer
+ * @param src: Bytes - The source buffer
+ * @param dst: Bytes - The destination buffer
  * @returns Void
  */
 @disableGC
-export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: Number) => {
+export let blit = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
   let srcPointerAndSize = getPointerAndSize(src)
@@ -413,14 +412,14 @@ export let length = (s: Bytes) => {
 /**
  * Creates a new Bytes buffer that contains the bytes of both buffers a and b.
  * @param a: Bytes - The buffer to be copied first
- * @param b: Bytes - The buffer to be appended
+ * @param b: Bytes - The buffer to be copied last
  * @returns Bytes
  */
 export let append = (a: Bytes, b: Bytes) => {
   let alen = length(a)
   let blen = length(b)
-  let c = extend(a, 0, blen)
-  blit(b, 0, c, alen, blen)
+  let c = extend(0, blen, a)
+  blit(0, alen, blen, b, c)
   c
 }
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -42,10 +42,10 @@ let getSize = (ptr) => WasmI32.load(ptr, 4n)
 
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
- * @param i: Number - The byte index
- * @param v: Int32 - The value to set
- * @param b: Bytes - The Bytes buffer
- * @returns Void
+ * @param {Number} i - The byte index
+ * @param {Int32} v - The value to set
+ * @param {Bytes} b - The Bytes buffer
+ * @returns {Void}
  */
 @disableGC
 export let setInt8 = (i: Number, v: Int32, b: Bytes) => {

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -349,10 +349,11 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
     throw Exception.InvalidArgument("The resulting length is less than 0")
   }
   let dst = allocateBytes(newLen)
-  let (start, offset) = if (left < 0n) {
-    (left * -1n, 0n)
-  } else {
-    (0n, left)
+  let mut offset = left;
+  let mut start = 0n;
+  if (left < 0n) {
+    start = left * -1n;
+    offset = 0n;
   }
   let len = if (right < 0n) {
     (size + right) - start

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -355,10 +355,7 @@ export let copy = (b: Bytes) => {
   let (src, size) = pointerAndSize;
   Memory.free(WasmI32.fromGrain(pointerAndSize));
   let dst = allocateBytes(size);
-  for (let mut i = 0n; i < size; i += 4n) {
-    let n = WasmI32.load(src + i, 8n);
-    WasmI32.store(dst + i, n, 8n);
-  }
+  Memory.copy(dst + 8n, src + 8n, size);
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -372,9 +369,6 @@ export let copy = (b: Bytes) => {
 @disableGC
 export let sub = (b: Bytes, i: Number, len: Number) => {
   let (>) = WasmI32.gtS;
-  let (%) = WasmI32.remS;
-  let (==) = WasmI32.eq;
-  let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
   let pointerAndSize = getPointerAndSize(b);
   let (src, size) = pointerAndSize;
@@ -386,19 +380,7 @@ export let sub = (b: Bytes, i: Number, len: Number) => {
   }
   let dst = allocateBytes(len);
   let offset = i;
-  if (i % 4n == 0n) {
-    // If possible, copy 4 bytes at a time
-    for (let mut i = 0n; i < len; i += 4n) {
-      let n = WasmI32.load(src + i + offset, 8n);
-      WasmI32.store(dst + i, n, 8n);
-    }
-  } else {
-    // Otherwise, copy 1 byte at a time
-    for (let mut i = 0n; i < len; i += 1n) {
-      let n = WasmI32.load8S(src + i + offset, 8n);
-      WasmI32.store8(dst + i, n, 8n);
-    }
-  }
+  Memory.copy(dst + 8n, src + 8n + i, len);
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -416,9 +398,8 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
   let (<) = WasmI32.ltS;
   let (>) = WasmI32.gtS;
   let (+) = WasmI32.add;
+  let (-) = WasmI32.sub;
   let (*) = WasmI32.mul;
-  let (%) = WasmI32.remS;
-  let (==) = WasmI32.eq;
   let pointerAndSize = getPointerAndSize(b);
   let (src, size) = pointerAndSize;
   Memory.free(WasmI32.fromGrain(pointerAndSize));
@@ -430,30 +411,17 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
   }
   let dst = allocateBytes(newLen);
   let (start, offset) = if (left < 0n) {
-    (left * -1n, left)
+    (left * -1n, 0n)
   } else {
     (0n, left)
   };
-  let end = if (right < 0n) {
-    size + right
+  let len = if (right < 0n) {
+    (size + right) - start
   } else {
-    size
-  };
-  // Copy relevant range of bytes
-  if (start < size && end > start) {
-    if (start % 4n == 0n && offset % 4n == 0n) {
-      // If possible, copy 4 bytes at a time
-      for (let mut i = start; i < end; i += 4n) {
-        let n = WasmI32.load(src + i, 8n);
-        WasmI32.store(dst + i + offset, n, 8n);
-      }
-    } else {
-      // Otherwise, copy 1 byte at a time
-      for (let mut i = start; i < end; i += 1n) {
-        let n = WasmI32.load8S(src + i, 8n);
-        WasmI32.store8(dst + i + offset, n, 8n);
-      }
-    }
+    size - start
+  }
+  if (len > 0n) {
+    Memory.copy(dst + 8n + offset, src + 8n + start, len);
   }
   WasmI32.toGrain(dst): Bytes
 }
@@ -471,10 +439,7 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
 @disableGC
 export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: Number) => {
   let (>) = WasmI32.gtS;
-  let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
-  let (%) = WasmI32.remS;
-  let (==) = WasmI32.eq;
   let srcPointerAndSize = getPointerAndSize(src);
   let (src, srcSize) = srcPointerAndSize;
   Memory.free(WasmI32.fromGrain(srcPointerAndSize));
@@ -491,19 +456,7 @@ export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: 
     throw Exception.InvalidArgument("Invalid destination bytes range");
   }
   let end = srcPos + len;
-  if (srcPos % 4n == 0n && dstPos % 4n == 0n) {
-    // If possible, copy 4 bytes at a time
-    for (let mut i = srcPos; i < end; i += 4n) {
-      let n = WasmI32.load(src + i, 8n);
-      WasmI32.store(dst + i + dstPos, n, 8n);
-    }
-  } else {
-    // Otherwise, copy 1 byte at a time
-    for (let mut i = srcPos; i < end; i += 1n) {
-      let n = WasmI32.load8S(src + i, 8n);
-      WasmI32.store8(dst + i + dstPos, n, 8n);
-    }
-  }
+  Memory.copy(dst + 8n + dstPos, src + 8n + srcPos, len);
 }
 
 /**

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -299,7 +299,7 @@ export let getFloat64 = (i: Number, b: Bytes) => {
 }
 
 /**
- * Produces a copy of the input bytes.
+ * Return a new Bytes buffer that contains the same bytes as the argument.
  * @param b: Bytes - The Bytes buffer to copy
  * @returns Bytes
  */
@@ -339,7 +339,7 @@ export let sub = (i: Number, len: Number, b: Bytes) => {
 
 
 /**
- * Returns a new Bytes buffer with unintialized bytes prepended/appended to it.
+ * Returns a new Bytes buffer with uninitialized bytes prepended/appended to it.
  * If the `left` or `right` parameters are negative, bytes will be removed from the corresponding side instead of appended.
  * @param left: Number - The number of uninitialized bytes to prepend
  * @param right: Number - The number of uninitialized bytes to append

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -356,8 +356,8 @@ export let copy = (b: Bytes) => {
   Memory.free(WasmI32.fromGrain(pointerAndSize));
   let dst = allocateBytes(size);
   for (let mut i = 0n; i < size; i += 4n) {
-    let n = WasmI32.load(src, 8n + i);
-    WasmI32.store(dst, n, 8n + i);
+    let n = WasmI32.load(src + i, 8n);
+    WasmI32.store(dst + i, n, 8n);
   }
   WasmI32.toGrain(dst): Bytes
 }
@@ -389,14 +389,14 @@ export let sub = (b: Bytes, i: Number, len: Number) => {
   if (i % 4n == 0n) {
     // If possible, copy 4 bytes at a time
     for (let mut i = 0n; i < len; i += 4n) {
-      let n = WasmI32.load(src, 8n + i + offset);
-      WasmI32.store(dst, n, 8n + i);
+      let n = WasmI32.load(src + i + offset, 8n);
+      WasmI32.store(dst + i, n, 8n);
     }
   } else {
     // Otherwise, copy 1 byte at a time
     for (let mut i = 0n; i < len; i += 1n) {
-      let n = WasmI32.load8S(src, 8n + i + offset);
-      WasmI32.store8(dst, n, 8n + i);
+      let n = WasmI32.load8S(src + i + offset, 8n);
+      WasmI32.store8(dst + i, n, 8n);
     }
   }
   WasmI32.toGrain(dst): Bytes
@@ -443,14 +443,14 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
     if (start % 4n == 0n && offset % 4n == 0n) {
       // If possible, copy 4 bytes at a time
       for (let mut i = start; i < end; i += 4n) {
-        let n = WasmI32.load(src, 8n + i);
-        WasmI32.store(dst, n, 8n + i + offset);
+        let n = WasmI32.load(src + i, 8n);
+        WasmI32.store(dst + i + offset, n, 8n);
       }
     } else {
       // Otherwise, copy 1 byte at a time
       for (let mut i = start; i < end; i += 1n) {
-        let n = WasmI32.load8S(src, 8n + i);
-        WasmI32.store8(dst, n, 8n + i + offset);
+        let n = WasmI32.load8S(src + i, 8n);
+        WasmI32.store8(dst + i + offset, n, 8n);
       }
     }
   }
@@ -492,14 +492,14 @@ export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: 
   if (srcPos % 4n == 0n && dstPos % 4n == 0n) {
     // If possible, copy 4 bytes at a time
     for (let mut i = srcPos; i < end; i += 4n) {
-      let n = WasmI32.load(src, 8n + i);
-      WasmI32.store(dst, n, 8n + i + dstPos);
+      let n = WasmI32.load(src + i, 8n);
+      WasmI32.store(dst + i + dstPos, n, 8n);
     }
   } else {
     // Otherwise, copy 1 byte at a time
     for (let mut i = srcPos; i < end; i += 1n) {
-      let n = WasmI32.load8S(src, 8n + i);
-      WasmI32.store8(dst, n, 8n + i + dstPos);
+      let n = WasmI32.load8S(src + i, 8n);
+      WasmI32.store8(dst + i + dstPos, n, 8n);
     }
   }
 }

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -418,6 +418,7 @@ export let extend = (b: Bytes, left: Number, right: Number) => {
   let (+) = WasmI32.add;
   let (*) = WasmI32.mul;
   let (%) = WasmI32.remS;
+  let (==) = WasmI32.eq;
   let pointerAndSize = getPointerAndSize(b);
   let (src, size) = pointerAndSize;
   Memory.free(WasmI32.fromGrain(pointerAndSize));
@@ -473,6 +474,7 @@ export let blit = (src: Bytes, srcPos: Number, dst: Bytes, dstPos: Number, len: 
   let (<) = WasmI32.ltS;
   let (+) = WasmI32.add;
   let (%) = WasmI32.remS;
+  let (==) = WasmI32.eq;
   let srcPointerAndSize = getPointerAndSize(src);
   let (src, srcSize) = srcPointerAndSize;
   Memory.free(WasmI32.fromGrain(srcPointerAndSize));

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,75 +1,18 @@
-
 import Memory from "runtime/unsafe/memory"
 import WasmI32 from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF32 from "runtime/unsafe/wasmf32"
 import WasmF64 from "runtime/unsafe/wasmf64"
-import {
-  tagSimpleNumber,
-  allocateBytes,
-  newInt32,
-  newFloat32,
-  newInt64,
-  newFloat64
-} from "runtime/dataStructures"
-import { coerceNumberToInt32 } from "runtime/numbers"
+import Conv from "runtime/unsafe/conv"
+import { tagSimpleNumber, allocateBytes } from "runtime/dataStructures"
 import Exception from "runtime/exception"
-
-// -----------------------------------------------------------------------------
-// Conversion Utils
-// -----------------------------------------------------------------------------
+import Int32 from "int32"
 
 /** Converts Number to WasmI32 */
 @disableGC
 let numberToWasmI32 = n => {
-  let i32 = coerceNumberToInt32(n)
-  let ptr = WasmI32.fromGrain(i32)
-  WasmI32.load(ptr, 8n)
+  Conv.fromInt32(Int32.fromNumber(n))
 }
-
-@disableGC
-let int32ToWasmI32 = (n: Int32) => {
-  WasmI32.load(WasmI32.fromGrain(n), 8n)
-}
-
-@disableGC
-let float32ToWasmF32 = (n: Float32) => {
-  WasmF32.load(WasmI32.fromGrain(n), 8n)
-}
-
-@disableGC
-let int64ToWasmI64 = (n: Int64) => {
-  WasmI64.load(WasmI32.fromGrain(n), 8n)
-}
-
-@disableGC
-let float64ToWasmF64 = (n: Float64) => {
-  WasmF64.load(WasmI32.fromGrain(n), 8n)
-}
-
-@disableGC
-let wasmI32ToInt32 = (n: WasmI32) => {
-  WasmI32.toGrain(newInt32(n)) : Int32
-}
-
-@disableGC
-let wasmI32ToFloat32 = (n: WasmF32) => {
-  WasmI32.toGrain(newFloat32(n)) : Float32
-}
-
-@disableGC
-let wasmI64ToInt64 = (n: WasmI64) => {
-  WasmI32.toGrain(newInt64(n)) : Int64
-}
-
-@disableGC
-let wasmF64ToFloat64 = (n: WasmF64) => {
-  WasmI32.toGrain(newFloat64(n)) : Float64
-}
-
-// -----------------------------------------------------------------------------
-// Pointer Utils
-// -----------------------------------------------------------------------------
 
 /** Throws an exception if the index specified is out-of-bounds */
 @disableGC
@@ -107,10 +50,6 @@ let getPointerAndOffset = (bytes, byteSize, i) => {
   (ptr, offset)
 }
 
-// -----------------------------------------------------------------------------
-// Public API
-// -----------------------------------------------------------------------------
-
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
  * @param b: Bytes - The Bytes buffer
@@ -124,7 +63,7 @@ export let setInt8 = (b: Bytes, i: Number, v: Int32) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = int32ToWasmI32(v)
+  let value = Conv.fromInt32(v)
   WasmI32.store8(ptr, value, offset)
 }
 
@@ -141,7 +80,7 @@ export let getInt8S = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load8S(ptr, offset)
-  wasmI32ToInt32(n)
+  Conv.toInt32(n)
 }
 
 /**
@@ -157,7 +96,7 @@ export let getInt8U = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load8U(ptr, offset)
-  wasmI32ToInt32(n)
+  Conv.toInt32(n)
 }
 
 /**
@@ -173,7 +112,7 @@ export let setInt16 = (b: Bytes, i: Number, v: Int32) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = int32ToWasmI32(v)
+  let value = Conv.fromInt32(v)
   WasmI32.store16(ptr, value, offset)
 }
 
@@ -190,7 +129,7 @@ export let getInt16S = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load16S(ptr, offset)
-  wasmI32ToInt32(n)
+  Conv.toInt32(n)
 }
 
 /**
@@ -206,7 +145,7 @@ export let getInt16U = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load16U(ptr, offset)
-  wasmI32ToInt32(n)
+  Conv.toInt32(n)
 
 }
 
@@ -223,7 +162,7 @@ export let setInt32 = (b: Bytes, i: Number, v: Int32) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = int32ToWasmI32(v)
+  let value = Conv.fromInt32(v)
   WasmI32.store(ptr, value, offset)
 }
 
@@ -240,7 +179,7 @@ export let getInt32 = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI32.load(ptr, offset)
-  wasmI32ToInt32(n)
+  Conv.toInt32(n)
 }
 
 /**
@@ -256,7 +195,7 @@ export let setFloat32 = (b: Bytes, i: Number, v: Float32) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = float32ToWasmF32(v)
+  let value = Conv.fromFloat32(v)
   WasmF32.store(ptr, value, offset)
 }
 
@@ -273,7 +212,7 @@ export let getFloat32 = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmF32.load(ptr, offset)
-  wasmI32ToFloat32(n)
+  Conv.toFloat32(n)
 }
 
 /**
@@ -289,7 +228,7 @@ export let setInt64 = (b: Bytes, i: Number, v: Int64) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = int64ToWasmI64(v)
+  let value = Conv.fromInt64(v)
   WasmI64.store(ptr, value, offset)
 }
 
@@ -306,7 +245,7 @@ export let getInt64 = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmI64.load(ptr, offset)
-  wasmI64ToInt64(n)
+  Conv.toInt64(n)
 }
 
 /**
@@ -322,7 +261,7 @@ export let setFloat64 = (b: Bytes, i: Number, v: Float64) => {
   let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let value = float64ToWasmF64(v)
+  let value = Conv.fromFloat64(v)
   WasmF64.store(ptr, value, offset)
 }
 
@@ -339,7 +278,7 @@ export let getFloat64 = (b: Bytes, i: Number) => {
   let (ptr, offset) = pointerAndOffset
   Memory.free(WasmI32.fromGrain(pointerAndOffset))
   let n = WasmF64.load(ptr, offset)
-  wasmF64ToFloat64(n)
+  Conv.toFloat64(n)
 }
 
 /**

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -9,9 +9,31 @@ import Exception from "runtime/exception"
 import Int32 from "int32"
 
 /** Converts Number to WasmI32 */
+// @disableGC
+// let numberToWasmI32 = n => {
+//   let m = WasmI32.fromGrain(n)
+//   if (WasmI32.eqz(WasmI32.and(m, 1n))) {
+//     let i32 = Int32.fromNumber(n)
+//     let res = Conv.fromInt32(i32)
+//     Memory.free(WasmI32.fromGrain(i32))
+//     res
+//   } else {
+//     // fast path
+//     WasmI32.shrU(m, 1n)
+//   }
+// }
 @disableGC
 let numberToWasmI32 = n => {
-  Conv.fromInt32(Int32.fromNumber(n))
+  let i32 = Int32.fromNumber(n)
+  let res = Conv.fromInt32(i32)
+  let ptr = WasmI32.fromGrain(i32)
+  // let (>) = Int32.gt;
+  // if (i32 > -1000l) {
+  //   Memory.free(ptr)
+  // } else {
+  //   print("yyy")
+  // }
+  res
 }
 
 /** Throws an exception if the index specified is out-of-bounds */
@@ -28,27 +50,8 @@ let ensureIndexIsInBounds = (i, byteSize, max) => {
   }
 }
 
-/** Gets the Bytes pointer and size */
-@disableGC
-let getPointerAndSize = (bytes) => {
-  let ptr = WasmI32.fromGrain(bytes)
-  let size = WasmI32.load(ptr, 4n)
-  (ptr, size)
-}
-
-/** Gets the Bytes pointer and byte offset */
-@disableGC
-let getPointerAndOffset = (bytes, byteSize, i) => {
-  let (+) = WasmI32.add
-  let (*) = WasmI32.mul
-  let pointerAndSize = getPointerAndSize(bytes)
-  let (ptr, size) = pointerAndSize
-  Memory.free(WasmI32.fromGrain(pointerAndSize))
-  let i = numberToWasmI32(i)
-  ensureIndexIsInBounds(i, byteSize, size)
-  let offset = 8n + i
-  (ptr, offset)
-}
+/** Gets the size of a Bytes via its ptr */
+let getSize = (ptr) => WasmI32.load(ptr, 4n)
 
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
@@ -59,12 +62,14 @@ let getPointerAndOffset = (bytes, byteSize, i) => {
  */
 @disableGC
 export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 1n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store8(ptr, value, offset)
+  WasmI32.store8(ptr + offset, value, 8n)
 }
 
 /**
@@ -75,11 +80,13 @@ export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
  */
 @disableGC
 export let getInt8S = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 1n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI32.load8S(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI32.load8S(ptr + offset, 8n)
   Conv.toInt32(n)
 }
 
@@ -91,11 +98,13 @@ export let getInt8S = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let getInt8U = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 1n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI32.load8U(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI32.load8U(ptr + offset, 8n)
   Conv.toInt32(n)
 }
 
@@ -108,12 +117,14 @@ export let getInt8U = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 2n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store16(ptr, value, offset)
+  WasmI32.store16(ptr + offset, value, 8n)
 }
 
 /**
@@ -124,11 +135,13 @@ export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
  */
 @disableGC
 export let getInt16S = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 2n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI32.load16S(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI32.load16S(ptr + offset, 8n)
   Conv.toInt32(n)
 }
 
@@ -140,11 +153,13 @@ export let getInt16S = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let getInt16U = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 2n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI32.load16U(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI32.load16U(ptr + offset, 8n)
   Conv.toInt32(n)
 }
 
@@ -157,12 +172,14 @@ export let getInt16U = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 4n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store(ptr, value, offset)
+  WasmI32.store(ptr + offset, value, 8n)
 }
 
 /**
@@ -173,11 +190,13 @@ export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
  */
 @disableGC
 export let getInt32 = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 4n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI32.load(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI32.load(ptr + offset, 8n)
   Conv.toInt32(n)
 }
 
@@ -190,12 +209,14 @@ export let getInt32 = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 4n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromFloat32(v)
-  WasmF32.store(ptr, value, offset)
+  WasmF32.store(ptr + offset, value, 8n)
 }
 
 /**
@@ -206,11 +227,13 @@ export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
  */
 @disableGC
 export let getFloat32 = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 4n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmF32.load(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmF32.load(ptr + offset, 8n)
   Conv.toFloat32(n)
 }
 
@@ -223,12 +246,14 @@ export let getFloat32 = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 8n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromInt64(v)
-  WasmI64.store(ptr, value, offset)
+  WasmI64.store(ptr + offset, value, 8n)
 }
 
 /**
@@ -239,11 +264,13 @@ export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
  */
 @disableGC
 export let getInt64 = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 8n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmI64.load(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmI64.load(ptr + offset, 8n)
   Conv.toInt64(n)
 }
 
@@ -256,12 +283,14 @@ export let getInt64 = (i: Number, b: Bytes) => {
  */
 @disableGC
 export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 8n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
   let value = Conv.fromFloat64(v)
-  WasmF64.store(ptr, value, offset)
+  WasmF64.store(ptr + offset, value, 8n)
 }
 
 /**
@@ -272,11 +301,13 @@ export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
  */
 @disableGC
 export let getFloat64 = (i: Number, b: Bytes) => {
+  let (+) = WasmI32.add
   let byteSize = 8n
-  let pointerAndOffset = getPointerAndOffset(b, byteSize, i)
-  let (ptr, offset) = pointerAndOffset
-  Memory.free(WasmI32.fromGrain(pointerAndOffset))
-  let n = WasmF64.load(ptr, offset)
+  let ptr = WasmI32.fromGrain(b)
+  let size = getSize(ptr)
+  let offset = numberToWasmI32(i)
+  ensureIndexIsInBounds(offset, byteSize, size)
+  let n = WasmF64.load(ptr + offset, 8n)
   Conv.toFloat64(n)
 }
 
@@ -289,9 +320,8 @@ export let getFloat64 = (i: Number, b: Bytes) => {
 export let copy = (b: Bytes) => {
   let (<) = WasmI32.ltS
   let (+) = WasmI32.add
-  let pointerAndSize = getPointerAndSize(b)
-  let (src, size) = pointerAndSize
-  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let src = WasmI32.fromGrain(b)
+  let size = getSize(src)
   let dst = allocateBytes(size)
   Memory.copy(dst + 8n, src + 8n, size)
   WasmI32.toGrain(dst): Bytes
@@ -308,9 +338,8 @@ export let copy = (b: Bytes) => {
 export let sub = (i: Number, len: Number, b: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
-  let pointerAndSize = getPointerAndSize(b)
-  let (src, size) = pointerAndSize
-  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let src = WasmI32.fromGrain(b)
+  let size = getSize(src)
   let i = numberToWasmI32(i)
   let len = numberToWasmI32(len)
   if ((i + len) > size) {
@@ -338,29 +367,32 @@ export let extend = (left: Number, right: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let (-) = WasmI32.sub
   let (*) = WasmI32.mul
-  let pointerAndSize = getPointerAndSize(b)
-  let (src, size) = pointerAndSize
-  Memory.free(WasmI32.fromGrain(pointerAndSize))
+  let src = WasmI32.fromGrain(b)
+  let size = getSize(src)
   let left = numberToWasmI32(left)
   let right = numberToWasmI32(right)
-  let newLen = size + left + right
-  if (newLen < 0n) {
+  let newSize = size + left + right
+  if (newSize < 0n) {
     throw Exception.InvalidArgument("The resulting length is less than 0")
   }
-  let dst = allocateBytes(newLen)
-  let mut offset = left;
-  let mut start = 0n;
+  let dst = allocateBytes(newSize)
+  let mut srcOffset = 0n;
+  let mut dstOffset = 0n;
   if (left < 0n) {
-    start = left * -1n;
-    offset = 0n;
+    srcOffset = left * -1n;
+    dstOffset = 0n;
+  }
+  if (left > 0n) {
+    srcOffset = 0n;
+    dstOffset = left;
   }
   let len = if (right < 0n) {
-    (size + right) - start
+    (size + right) - srcOffset
   } else {
-    size - start
+    size - srcOffset
   }
   if (len > 0n) {
-    Memory.copy(dst + 8n + offset, src + 8n + start, len)
+    Memory.copy(dst + 8n + dstOffset, src + 8n + srcOffset, len)
   }
   WasmI32.toGrain(dst): Bytes
 }
@@ -379,13 +411,11 @@ export let extend = (left: Number, right: Number, b: Bytes) => {
 export let blit = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
-  let srcPointerAndSize = getPointerAndSize(src)
-  let (src, srcSize) = srcPointerAndSize
-  Memory.free(WasmI32.fromGrain(srcPointerAndSize))
-  let dstPointerAndSize = getPointerAndSize(dst)
-  let (dst, dstSize) = dstPointerAndSize
-  Memory.free(WasmI32.fromGrain(dstPointerAndSize))
+  let src = WasmI32.fromGrain(src)
+  let srcSize = getSize(src)
   let srcPos = numberToWasmI32(srcPos)
+  let dst = WasmI32.fromGrain(dst)
+  let dstSize = getSize(dst)
   let dstPos = numberToWasmI32(dstPos)
   let len = numberToWasmI32(len)
   if ((srcPos + len) > srcSize) {

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -438,7 +438,6 @@ export let append = (a: Bytes, b: Bytes) => {
   c
 }
 
-
 /**
  * Creates a new String from a Bytes buffer.
  * @param b: Bytes - The source buffer

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -8,6 +8,15 @@ import { tagSimpleNumber, allocateBytes, allocateString } from "runtime/dataStru
 import Exception from "runtime/exception"
 import Int32 from "int32"
 
+let _SIZE_OFFSET = 4n;
+let _VALUE_OFFSET = 8n;
+let _INT8_BYTE_SIZE = 1n;
+let _INT16_BYTE_SIZE = 2n;
+let _INT32_BYTE_SIZE = 4n;
+let _FLOAT32_BYTE_SIZE = 4n;
+let _INT64_BYTE_SIZE = 8n;
+let _FLOAT64_BYTE_SIZE = 8n;
+
 /** Converts Number to WasmI32 */
 @disableGC
 let numberToWasmI32 = n => {
@@ -38,7 +47,7 @@ let ensureIndexIsInBounds = (i, byteSize, max) => {
 }
 
 /** Gets the size of a Bytes via its ptr */
-let getSize = (ptr) => WasmI32.load(ptr, 4n)
+let getSize = (ptr) => WasmI32.load(ptr, _SIZE_OFFSET)
 
 /**
  * Sets a signed 8-bit integer starting at the given byte index.
@@ -50,13 +59,12 @@ let getSize = (ptr) => WasmI32.load(ptr, 4n)
 @disableGC
 export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 1n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store8(ptr + offset, value, 8n)
+  WasmI32.store8(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -68,12 +76,11 @@ export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
 @disableGC
 export let getInt8S = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 1n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI32.load8S(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
+  let n = WasmI32.load8S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
 
@@ -86,12 +93,11 @@ export let getInt8S = (i: Number, b: Bytes) => {
 @disableGC
 export let getInt8U = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 1n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI32.load8U(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
+  let n = WasmI32.load8U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
 
@@ -105,13 +111,12 @@ export let getInt8U = (i: Number, b: Bytes) => {
 @disableGC
 export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 2n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store16(ptr + offset, value, 8n)
+  WasmI32.store16(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -123,12 +128,11 @@ export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
 @disableGC
 export let getInt16S = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 2n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI32.load16S(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
+  let n = WasmI32.load16S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
 
@@ -141,12 +145,11 @@ export let getInt16S = (i: Number, b: Bytes) => {
 @disableGC
 export let getInt16U = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 2n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI32.load16U(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
+  let n = WasmI32.load16U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
 
@@ -160,13 +163,12 @@ export let getInt16U = (i: Number, b: Bytes) => {
 @disableGC
 export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 4n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
-  WasmI32.store(ptr + offset, value, 8n)
+  WasmI32.store(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -178,12 +180,11 @@ export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
 @disableGC
 export let getInt32 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 4n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI32.load(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  let n = WasmI32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
 }
 
@@ -197,13 +198,12 @@ export let getInt32 = (i: Number, b: Bytes) => {
 @disableGC
 export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 4n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromFloat32(v)
-  WasmF32.store(ptr + offset, value, 8n)
+  WasmF32.store(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -215,12 +215,11 @@ export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
 @disableGC
 export let getFloat32 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 4n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmF32.load(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
+  let n = WasmF32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat32(n)
 }
 
@@ -234,13 +233,12 @@ export let getFloat32 = (i: Number, b: Bytes) => {
 @disableGC
 export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 8n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
   let value = Conv.fromInt64(v)
-  WasmI64.store(ptr + offset, value, 8n)
+  WasmI64.store(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -252,12 +250,11 @@ export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
 @disableGC
 export let getInt64 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 8n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmI64.load(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
+  let n = WasmI64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt64(n)
 }
 
@@ -271,13 +268,12 @@ export let getInt64 = (i: Number, b: Bytes) => {
 @disableGC
 export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 8n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
+  ensureIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
   let value = Conv.fromFloat64(v)
-  WasmF64.store(ptr + offset, value, 8n)
+  WasmF64.store(ptr + offset, value, _VALUE_OFFSET)
 }
 
 /**
@@ -289,12 +285,11 @@ export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
 @disableGC
 export let getFloat64 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
-  let byteSize = 8n
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
   let offset = numberToWasmI32(i)
-  ensureIndexIsInBounds(offset, byteSize, size)
-  let n = WasmF64.load(ptr + offset, 8n)
+  ensureIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
+  let n = WasmF64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat64(n)
 }
 
@@ -309,7 +304,7 @@ export let copy = (b: Bytes) => {
   let src = WasmI32.fromGrain(b)
   let size = getSize(src)
   let dst = allocateBytes(size)
-  Memory.copy(dst + 8n, src + 8n, size)
+  Memory.copy(dst + _VALUE_OFFSET, src + _VALUE_OFFSET, size)
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -333,7 +328,7 @@ export let sub = (i: Number, len: Number, b: Bytes) => {
   }
   let dst = allocateBytes(len)
   let offset = i
-  Memory.copy(dst + 8n, src + 8n + i, len)
+  Memory.copy(dst + _VALUE_OFFSET, src + _VALUE_OFFSET + i, len)
   WasmI32.toGrain(dst): Bytes
 }
 
@@ -378,7 +373,7 @@ export let extend = (left: Number, right: Number, b: Bytes) => {
     size - srcOffset
   }
   if (len > 0n) {
-    Memory.copy(dst + 8n + dstOffset, src + 8n + srcOffset, len)
+    Memory.copy(dst + _VALUE_OFFSET + dstOffset, src + _VALUE_OFFSET + srcOffset, len)
   }
   WasmI32.toGrain(dst): Bytes
 }
@@ -410,7 +405,7 @@ export let move = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst:
     throw Exception.InvalidArgument("Invalid destination bytes range")
   }
   let end = srcPos + len
-  Memory.copy(dst + 8n + dstPos, src + 8n + srcPos, len)
+  Memory.copy(dst + _VALUE_OFFSET + dstPos, src + _VALUE_OFFSET + srcPos, len)
 }
 
 /**
@@ -449,7 +444,7 @@ export let toString = (b: Bytes) => {
   let src = WasmI32.fromGrain(b)
   let size = getSize(src)
   let dst = allocateString(size)
-  Memory.copy(dst + 8n, src + 8n, size)
+  Memory.copy(dst + _VALUE_OFFSET, src + _VALUE_OFFSET, size)
   WasmI32.toGrain(dst): String
 }
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -342,7 +342,7 @@ export let slice = (i: Number, len: Number, b: Bytes) => {
  * @returns Bytes
  */
 @disableGC
-export let extend = (left: Number, right: Number, b: Bytes) => {
+export let resize = (left: Number, right: Number, b: Bytes) => {
   let (<) = WasmI32.ltS
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
@@ -428,7 +428,7 @@ export let length = (b: Bytes) => {
 export let concat = (a: Bytes, b: Bytes) => {
   let alen = length(a)
   let blen = length(b)
-  let c = extend(0, blen, a)
+  let c = resize(0, blen, a)
   move(0, alen, blen, b, c)
   c
 }

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -316,7 +316,7 @@ export let copy = (b: Bytes) => {
  * @returns Bytes
  */
 @disableGC
-export let sub = (i: Number, len: Number, b: Bytes) => {
+export let slice = (i: Number, len: Number, b: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(b)

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -425,7 +425,7 @@ export let length = (b: Bytes) => {
  * @param b: Bytes - The buffer to be copied last
  * @returns Bytes
  */
-export let append = (a: Bytes, b: Bytes) => {
+export let concat = (a: Bytes, b: Bytes) => {
   let alen = length(a)
   let blen = length(b)
   let c = extend(0, blen, a)

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,0 +1,10 @@
+import { allocateBytes } from "runtime/dataStructures"
+
+// Make a new Bytes buffer of n-bytes size
+// @param byteLength: Number - The number of bytes to store
+// @returns Bytes
+@disableGC
+export let make = (byteLength: Number) => {
+  let buf = allocateBytes(byteLength);
+  WasmI32.toGrain(buf): Bytes
+}

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -9,31 +9,18 @@ import Exception from "runtime/exception"
 import Int32 from "int32"
 
 /** Converts Number to WasmI32 */
-// @disableGC
-// let numberToWasmI32 = n => {
-//   let m = WasmI32.fromGrain(n)
-//   if (WasmI32.eqz(WasmI32.and(m, 1n))) {
-//     let i32 = Int32.fromNumber(n)
-//     let res = Conv.fromInt32(i32)
-//     Memory.free(WasmI32.fromGrain(i32))
-//     res
-//   } else {
-//     // fast path
-//     WasmI32.shrU(m, 1n)
-//   }
-// }
 @disableGC
 let numberToWasmI32 = n => {
-  let i32 = Int32.fromNumber(n)
-  let res = Conv.fromInt32(i32)
-  let ptr = WasmI32.fromGrain(i32)
-  // let (>) = Int32.gt;
-  // if (i32 > -1000l) {
-  //   Memory.free(ptr)
-  // } else {
-  //   print("yyy")
-  // }
-  res
+  let m = WasmI32.fromGrain(n)
+  if (WasmI32.eqz(WasmI32.and(m, 1n))) {
+    let i32 = Int32.fromNumber(n)
+    let res = Conv.fromInt32(i32)
+    Memory.free(WasmI32.fromGrain(i32))
+    res
+  } else {
+    // fast path
+    WasmI32.shrS(m, 1n)
+  }
 }
 
 /** Throws an exception if the index specified is out-of-bounds */
@@ -397,7 +384,6 @@ export let extend = (left: Number, right: Number, b: Bytes) => {
   WasmI32.toGrain(dst): Bytes
 }
 
-
 /**
  * Copies a range of bytes bytes from a source buffer to a given location in a destination buffer.
  * @param srcPos: Number - The starting byte index to copy bytes from
@@ -408,7 +394,7 @@ export let extend = (left: Number, right: Number, b: Bytes) => {
  * @returns Void
  */
 @disableGC
-export let blit = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst: Bytes) => {
+export let move = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst: Bytes) => {
   let (>) = WasmI32.gtS
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(src)
@@ -449,7 +435,7 @@ export let append = (a: Bytes, b: Bytes) => {
   let alen = length(a)
   let blen = length(b)
   let c = extend(0, blen, a)
-  blit(0, alen, blen, b, c)
+  move(0, alen, blen, b, c)
   c
 }
 

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -71,11 +71,11 @@ export let storeInTuple = (tuple, idx, item) => {
  * @returns {WasmI32} The pointer to the bytes
  */
 export let allocateBytes = (size) => {
-  let bytes = Memory.malloc(size + 8n)
-
+  let len = size + 8n
+  let bytes = Memory.malloc(len)
+  Memory.fill(bytes, 0n, len)
   WasmI32.store(bytes, Tags._GRAIN_BYTES_HEAP_TAG, 0n)
   WasmI32.store(bytes, size, 4n)
-
   bytes
 }
 

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -28,6 +28,21 @@ export let allocateArray = (numElts) => {
 }
 
 /**
+ * Allocates a new Grain bytes.
+ *
+ * @param {WasmI32} numElts The number of bytes to be contained in this buffer
+ * @returns {WasmI32} The pointer to the bytes
+ */
+export let allocateBytes = (numBytes) => {
+  let buf = Memory.malloc((numBytes + 2n) * 4n)
+
+  WasmI32.store(buf, Tags._GRAIN_BYTES_HEAP_TAG, 0n)
+  WasmI32.store(buf, numBytes, 4n)
+
+  buf
+}
+
+/**
  * Stores an item in a Grain array.
  *
  * @param {WasmI32} array The array to store the item in

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -28,21 +28,6 @@ export let allocateArray = (numElts) => {
 }
 
 /**
- * Allocates a new Grain bytes.
- *
- * @param {WasmI32} numElts The number of bytes to be contained in this buffer
- * @returns {WasmI32} The pointer to the bytes
- */
-export let allocateBytes = (numBytes) => {
-  let buf = Memory.malloc((numBytes + 2n) * 4n)
-
-  WasmI32.store(buf, Tags._GRAIN_BYTES_HEAP_TAG, 0n)
-  WasmI32.store(buf, numBytes, 4n)
-
-  buf
-}
-
-/**
  * Stores an item in a Grain array.
  *
  * @param {WasmI32} array The array to store the item in
@@ -77,6 +62,21 @@ export let allocateTuple = (numElts) => {
  */
 export let storeInTuple = (tuple, idx, item) => {
   WasmI32.store(tuple + idx * 4n, item, 8n)
+}
+
+/**
+ * Allocates a new Grain bytes.
+ *
+ * @param {WasmI32} size The number of bytes to be contained in this buffer
+ * @returns {WasmI32} The pointer to the bytes
+ */
+export let allocateBytes = (size) => {
+  let bytes = Memory.malloc(size + 8n)
+
+  WasmI32.store(bytes, Tags._GRAIN_BYTES_HEAP_TAG, 0n)
+  WasmI32.store(bytes, size, 4n)
+
+  bytes
 }
 
 /**

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -16,6 +16,7 @@ import WasmI64 from "runtime/unsafe/wasmi64"
 import Tags from "runtime/unsafe/tags"
 
 primitive (!) : Bool -> Bool = "@not"
+primitive (||) : (Bool, Bool) -> Bool = "@or"
 
 import { isNumber, numberEqual } from "runtime/numbers"
 
@@ -109,7 +110,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
         result
       }
     },
-    t when t == Tags._GRAIN_STRING_HEAP_TAG => {
+    t when t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 4n)
       let ylength = WasmI32.load(yptr, 4n)
 

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -179,7 +179,7 @@ let get_DIGITS = () => {
 // Lookup table for pairwise char codes in range [0x00-0xFF]
 let mut _HEX_DIGITS = -1n
 
-let get_HEX_DIGITS = () => {
+export let get_HEX_DIGITS = () => {
   if (_HEX_DIGITS == -1n) {
     _HEX_DIGITS = Memory.malloc(512n)
     WasmI32.store16(_HEX_DIGITS, 0x3030n, 0n) // 00

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -205,14 +205,14 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
     },
     t when t == Tags._GRAIN_BYTES_HEAP_TAG => {
       let mut numBytes = WasmI32.load(ptr, 4n)
-      let mut longBoi = false
+      let mut needsEllipsis = false
       if (numBytes > 32n) {
         numBytes = 32n
-        longBoi = true
+        needsEllipsis = true
       }
       let headBytes = 8n // <bytes: 
       let hexBytes = numBytes * 3n
-      let tailBytes = if (longBoi) { 
+      let tailBytes = if (needsEllipsis) { 
         5n // ...>
       } else {
         1n // >
@@ -233,7 +233,7 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         WasmI32.store16(strOffset, WasmI32.load16U(hex, k), j)
       }
 
-      if (longBoi) {
+      if (needsEllipsis) {
         WasmI32.store(strOffset + hexBytes, 0x3e2e2e2en, 0n) // ...>
       } else {
         WasmI32.store8(strOffset + hexBytes, 0x3en, 0n) // >

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -204,11 +204,41 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       }
     },
     t when t == Tags._GRAIN_BYTES_HEAP_TAG => {
-      let numBytes = WasmI32.load(ptr, 4n)
-      let str = allocateString(numBytes + 2n)
-      WasmI32.store8(str, 0x3cn, 8n) // <
-      Memory.copy(str + 9n, ptr + 8n, numBytes)
-      WasmI32.store8(str + numBytes, 0x3en, 9n) // >
+      let mut numBytes = WasmI32.load(ptr, 4n)
+      let mut longBoi = false
+      if (numBytes > 32n) {
+        numBytes = 32n
+        longBoi = true
+      }
+      let headBytes = 8n // <bytes: 
+      let hexBytes = numBytes * 3n
+      let tailBytes = if (longBoi) { 
+        5n // ...>
+      } else {
+        1n // >
+      }
+      let strLen = headBytes + hexBytes + tailBytes
+      let str = allocateString(strLen)
+      let bytesOffset = ptr + 8n
+      let strOffset = str + 16n
+      let hex = NumberUtils.get_HEX_DIGITS()
+
+      Memory.fill(str + 8n, 0x20n, strLen)
+      WasmI64.store(str, 0x203a73657479623cN, 8n) // <bytes: 
+      
+      for (let mut i = 0n; i < numBytes; i += 1n) {
+        let n = WasmI32.load8U(bytesOffset, i)
+        let j = i * 3n
+        let k = n * 2n
+        WasmI32.store16(strOffset, WasmI32.load16U(hex, k), j)
+      }
+
+      if (longBoi) {
+        WasmI32.store(strOffset + hexBytes, 0x3e2e2e2en, 0n) // ...>
+      } else {
+        WasmI32.store8(strOffset + hexBytes, 0x3en, 0n) // >
+      }
+
       WasmI32.toGrain(str): String
     },
     t when t == Tags._GRAIN_CHAR_HEAP_TAG => {

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -203,6 +203,14 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         WasmI32.toGrain(str): String
       }
     },
+    t when t == Tags._GRAIN_BYTES_HEAP_TAG => {
+      let numBytes = WasmI32.load(ptr, 4n)
+      let str = allocateString(numBytes + 2n)
+      WasmI32.store8(str, 0x3cn, 8n) // <
+      Memory.copy(str + 9n, ptr + 8n, numBytes)
+      WasmI32.store8(str + numBytes, 0x3en, 9n) // >
+      WasmI32.toGrain(str): String
+    },
     t when t == Tags._GRAIN_CHAR_HEAP_TAG => {
       let byte = WasmI32.load8U(ptr, 4n)
       let numBytes = if ((byte & 0x80n) == 0x00n) {

--- a/stdlib/runtime/unsafe/tags.gr
+++ b/stdlib/runtime/unsafe/tags.gr
@@ -16,6 +16,8 @@ export let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
 export let _GRAIN_LAMBDA_HEAP_TAG = 7n
 export let _GRAIN_TUPLE_HEAP_TAG = 8n
 
+export let _GRAIN_BYTES_HEAP_TAG = 9n
+
 // Boxed number types
 export let _GRAIN_FLOAT32_BOXED_NUM_TAG = 1n
 export let _GRAIN_FLOAT64_BOXED_NUM_TAG = 2n

--- a/stdlib/runtime/unsafe/tags.gr
+++ b/stdlib/runtime/unsafe/tags.gr
@@ -15,7 +15,6 @@ export let _GRAIN_ARRAY_HEAP_TAG = 5n
 export let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
 export let _GRAIN_LAMBDA_HEAP_TAG = 7n
 export let _GRAIN_TUPLE_HEAP_TAG = 8n
-
 export let _GRAIN_BYTES_HEAP_TAG = 9n
 
 // Boxed number types


### PR DESCRIPTION
# Summary
Add a new standard lib `Bytes` module

## API
```reason
// Sets a signed 8-bit integer starting at the given byte index.
setInt8: (Number, Int32, Bytes) -> Void

// Gets a signed 8-bit integer starting at the given byte index.
getInt8S: (Number, Bytes) -> Int32

// Gets an unsigned 8-bit integer starting at the given byte index.
getInt8U: (Number, Bytes) -> Int32

// Sets a signed 16-bit integer starting at the given byte index.
setInt16: (Number, Int32, Bytes) -> Void

// Gets a signed 16-bit integer starting at the given byte index.
getInt16S: (Number, Bytes) -> Int32

// Gets an unsigned 16-bit integer starting at the given byte index.
getInt16U: (Number, Bytes) -> Int32

// Sets a signed 32-bit integer starting at the given byte index.
setInt32: (Number, Int32, Bytes) -> Void

// Gets a signed 32-bit integer starting at the given byte index.
getInt32: (Number, Bytes) -> Int32

// Sets a 32-bit float starting at the given byte index.
setFloat32: (Number, Float32, Bytes) -> Void

// Gets a signed 32-bit float starting at the given byte index.
getFloat32: (Number, Bytes) -> Float32

// Sets a signed 64-bit integer starting at the given byte index.
setInt64: (Number, Int64, Bytes) -> Void

// Gets a signed 64-bit integer starting at the given byte index.
getInt64: (Number, Bytes) -> Int64

// Sets a 64-bit float starting at the given byte index.
setFloat64: (Number, Float64, Bytes) -> Void

// Gets a signed 64-bit float starting at the given byte index.
getFloat64: (Number, Bytes) -> Float64

// Return a new Bytes buffer that contains the same bytes as the argument.
copy: (Bytes) -> Bytes

// Returns a new Bytes buffer containing a subset of the original Bytes buffer.
slice: (Number, Number, Bytes) -> Bytes

// Add or remove bytes from the start and/or end of a byte sequence.
// A positive number represents bytes to add, while a negative number represents bytes to remove.appended.
resize: (Number, Number, Bytes) -> Bytes

// Copies a range of bytes from a source buffer to a given location in a destination buffer.
move: (Number, Number, Number, Bytes, Bytes) -> Void

// Get the byte length of a Bytes buffer.
length: (Bytes) -> Number

// Creates a new Bytes buffer that contains the bytes of both buffers a and b.
append: (Bytes, Bytes) -> Bytes

// Creates a new String from a Bytes buffer.
toString: (Bytes) -> String

// Creates a new byte sequence from a String.
fromString: (String) -> Bytes

// Fills a byte sequence with a given value.
fill: (Int32, Bytes) -> Void

// Make a new Bytes buffer of n-bytes size.
make: (Number) -> Bytes

// An empty Bytes buffer
empty: Bytes
```

## Things to look for

- [ ] Memory leaks
- [ ] Test coverage
- [ ] Documentation
- [ ] Exception throwing
- [ ] Performance
- [ ] Anything else I might have missed! 😅 
