### PR TITLE
chore: Remove bootstrap-sha & set release-as for 0.3.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap-sha": "620298225faf35265e7285fe3d4d2c8dee72dba3",
+  "release-as": "0.3.1",
   "bump-minor-pre-major": true,
   "packages": {
     ".": {


### PR DESCRIPTION
This is needed because we had a breaking change merged and then reverted it but the bot doesn't know how to undo that...

From the ReleasePlease docs:
> manually set next version to be "x.x.x" ignoring conventional commits.
> absence defaults to conventional commits derived next version.
> Note: once the release PR is merged you should either remove this or
> update it to a higher version. Otherwise subsequent `manifest-pr` runs
> will continue to use this version even though it was already set in the
> last release.

Basically: we need to be super careful with this, and then remove it once we cut the release.