### PR TITLE
fix: Workaround for Windows drive letters with jsoo & pkg

### DIFF
--- a/compiler/grainc/jsoo_hacks.js
+++ b/compiler/grainc/jsoo_hacks.js
@@ -1,6 +1,12 @@
 //Provides: caml_make_path
 //Requires: caml_current_dir
 //Requires: caml_jsstring_of_string
+//Requires: caml_root, jsoo_mount_point, MlNodeDevice
+if (caml_root.charCodeAt(1) == 58 && caml_root[0] != 'C') {
+  // This ensure we can find our C:/snapshot/ stuff even when running in a diff drive
+  // Not the ideal place to do this but it is the easiest to avoid free variables
+  jsoo_mount_point.push({ path: 'C:/', device: new MlNodeDevice('C:/') });
+}
 function caml_make_path(name) {
   name = caml_jsstring_of_string(name);
   // We needed to provide our own `caml_make_path` because it doesn't check


### PR DESCRIPTION
I believe this fixes #621 

I did a ton of logging and it seems that js_of_ocaml only makes a `jsoo_mount_point` for the drive letter of the `process.cwd()`; however, our `pkg` tool's virtual snapshot adds `C:` to all of the paths included in it. This checks to see if the caml_root is not `C:` and adds it as a `jsoo_mount_point` if not (only on Windows).

This is definitely not the best place for this to go, but it is really just a temporary solution.