### PR TITLE
chore(releaser): Remove release-as & allow features in patch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,14 @@
 {
-  "release-as": "0.3.1",
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "plugins": [
+    "node-workspace"
+  ],
   "packages": {
     ".": {
-      "package-name": "grain",
       "release-type": "node"
     },
     "cli": {
-      "package-name": "@grain/cli",
       "release-type": "node"
     },
     "compiler": {
@@ -15,11 +16,9 @@
       "release-type": "ocaml"
     },
     "runtime": {
-      "package-name": "@grain/runtime",
       "release-type": "node"
     },
     "stdlib": {
-      "package-name": "@grain/stdlib",
       "release-type": "node"
     }
   }


### PR DESCRIPTION
I removed the release-as for 0.3.1 - closes #637 

Since we want to be more conscious with breaking changes and only want to batch them into the next minor, I think we should allow new non-breaking features in patches. This will allow us to merge changes like #635 that add new things while deprecating old for the next breaking release.

Additionally, I tried adding the `node-workspace` plugin now that it works with monorepos to keep our `@grain/cli` in sync with version bumps happening in stdlib & runtime.

And finally, I removed the package names for the node releasers because they aren't actually used.

H/T @joeldodge79 for all the tips.