### PR TITLE
Fix: Passing an absolute path to the file to compiler on Windows systems fails

### DIFF
--- a/compiler/grainc/jsoo_hacks.js
+++ b/compiler/grainc/jsoo_hacks.js
@@ -13,6 +13,10 @@ function caml_make_path(name) {
   // for Windows drives as root
   if (name.charCodeAt(0) != 47 && name.charCodeAt(1) != 58)
     name = caml_current_dir + name;
+
+  // clean up any Windows separators that made it through
+  name = name.replace(/\\/g,'/');
+
   var comp = name.split("/");
   var ncomp = []
   for (var i = 0; i < comp.length; i++) {


### PR DESCRIPTION
Passing an absolute path fails to compile:

PS C:\Users\Marcus\Grain\grain> pkg\grain C:\Users\Marcus\Grain\hello.gr
C:\snapshot\grain\cli\bin\grainc.js: internal error, uncaught exception:
                                     TypeError: Cannot read property 'device' of undefined

The file path that arrives in caml_make_path  still has Windows separators.

Make a sanity clean up of any filename arriving here to make sure subsequent parsing works