### PR TITLE
Fix: Normalise Windows paths in the JS components otherwise JSOO fails

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -149,7 +149,6 @@ program
   .description("compile a grain program into wasm")
   .action(function (file) {
     var normalised_file = file.replace(/\\/g,'/');
-
     actions.compile(normalised_file, program);
   });
 
@@ -158,7 +157,6 @@ program
   .description("check a grain file for LSP")
   .action(function (file) {
     var normalised_file = file.replace(/\\/g,'/');
-
     actions.lsp(normalised_file, program);
   });
 

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -140,28 +140,34 @@ program
   // The root command that compiles & runs
   .arguments("<file>")
   .action(function (file) {
-    actions.run(actions.compile(file, program), program.opts());
+    var normalised_file = file.replace(/\\/g,'/');
+    actions.run(actions.compile(normalised_file, program), program.opts());
   });
 
 program
   .command("compile <file>")
   .description("compile a grain program into wasm")
   .action(function (file) {
-    actions.compile(file, program);
+    var normalised_file = file.replace(/\\/g,'/');
+
+    actions.compile(normalised_file, program);
   });
 
 program
   .command("lsp <file>")
   .description("check a grain file for LSP")
   .action(function (file) {
-    actions.lsp(file, program);
+    var normalised_file = file.replace(/\\/g,'/');
+
+    actions.lsp(normalised_file, program);
   });
 
 program
   .command("run <file>")
   .description("run a wasm file with the grain runtime")
   .action(function (wasmFile) {
-    actions.run(wasmFile, program.opts());
+    var normalised_wasm_file = wasmFile.replace(/\\/g,'/');
+    actions.run(normalised_wasm_file, program.opts());
   });
 
 program.parse(process.argv);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -140,7 +140,7 @@ program
   // The root command that compiles & runs
   .arguments("<file>")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g,'/');
+    var normalised_file = file.replace(/\\/g, "/");
     actions.run(actions.compile(normalised_file, program), program.opts());
   });
 
@@ -148,7 +148,7 @@ program
   .command("compile <file>")
   .description("compile a grain program into wasm")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g,'/');
+    var normalised_file = file.replace(/\\/g, "/");
     actions.compile(normalised_file, program);
   });
 
@@ -156,7 +156,7 @@ program
   .command("lsp <file>")
   .description("check a grain file for LSP")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g,'/');
+    var normalised_file = file.replace(/\\/g, "/");
     actions.lsp(normalised_file, program);
   });
 
@@ -164,7 +164,7 @@ program
   .command("run <file>")
   .description("run a wasm file with the grain runtime")
   .action(function (wasmFile) {
-    var normalised_wasm_file = wasmFile.replace(/\\/g,'/');
+    var normalised_wasm_file = wasmFile.replace(/\\/g, "/");
     actions.run(normalised_wasm_file, program.opts());
   });
 

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -156,8 +156,8 @@ program
   .command("lsp <file>")
   .description("check a grain file for LSP")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g, "/");
-    actions.lsp(normalised_file, program);
+    const normalisedFile = file.replace(/\\/g, "/");
+    actions.lsp(normalisedFile, program);
   });
 
 program

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -148,8 +148,8 @@ program
   .command("compile <file>")
   .description("compile a grain program into wasm")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g, "/");
-    actions.compile(normalised_file, program);
+    const normalisedFile = file.replace(/\\/g, "/");
+    actions.compile(normalisedFile, program);
   });
 
 program

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -164,8 +164,8 @@ program
   .command("run <file>")
   .description("run a wasm file with the grain runtime")
   .action(function (wasmFile) {
-    var normalised_wasm_file = wasmFile.replace(/\\/g, "/");
-    actions.run(normalised_wasm_file, program.opts());
+    const normalisedWasmFile = wasmFile.replace(/\\/g, "/");
+    actions.run(normalisedWasmFile, program.opts());
   });
 
 program.parse(process.argv);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -140,8 +140,8 @@ program
   // The root command that compiles & runs
   .arguments("<file>")
   .action(function (file) {
-    var normalised_file = file.replace(/\\/g, "/");
-    actions.run(actions.compile(normalised_file, program), program.opts());
+    const normalisedFile = file.replace(/\\/g, "/");
+    actions.run(actions.compile(normalisedFile, program), program.opts());
   });
 
 program


### PR DESCRIPTION
PKGed Windows binaries fail because the specified file to compile/run is still in Windows separator style when it is parsed by the JSOO compiled component.

This fixes #640 by normalising the filename from the CLI before it is parsed
