### PR TITLE
fix(grainc): Apply separator normalization before cmdliner util

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -154,12 +154,22 @@ let output_file_conv = {
   (parse, Format.pp_print_string);
 };
 
+let input_file_conv = {
+  open Arg;
+  let (prsr, prntr) = non_dir_file;
+
+  (
+    filename => prsr(Grain_utils.Files.normalize_separators(filename)),
+    prntr,
+  );
+};
+
 let input_filename = {
   let doc = sprintf("Grain source file to compile");
   let docv = "FILE";
   Arg.(
     required
-    & pos(~rev=true, 0, some(non_dir_file), None)
+    & pos(~rev=true, 0, some(input_file_conv), None)
     & info([], ~docv, ~doc)
   );
 };


### PR DESCRIPTION
This is an alternative fix for #640 

As I mentioned in #641, I wanted to understand the fundamental issue, which came from our usage of the `Arg.non_dir_file` utility of cmdliner. This utility tries to use `Sys.exists` to see if a file exists, but we hadn't normalized the paths for our system yet.

This fix applies our path normalization inside `grainc` instead of in the JS CLI.

Closes #640 
Closes #641 