### PR TITLE
fix(compiler): Correct reporting of locations for CRLF files

### DIFF
--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -2218,6 +2218,16 @@ let comment_tests = {
       "//comment\n//comment\n5 + 5L",
       "line 3, characters 4-6",
     ),
+    te(
+      "comment_line_numbers_2",
+      "//comment\r\n//comment\r\n5 + 5L",
+      "line 3, characters 4-6",
+    ),
+    te(
+      "comment_line_numbers_3",
+      "//comment\n//comment\r\n5 + 5L",
+      "line 3, characters 4-6",
+    ),
     t("comment_lone_//", "//\nlet x = 10\nx", "10"),
     t("comment_block", "/* block 1 */let x = 10/* block 2 */\nx", "10"),
     t("comment_doc", "/** doc 1 */let x = 10/** doc 2 */\nx", "10"),


### PR DESCRIPTION
Ref https://github.com/grain-lang/grain-language-server/issues/46

We don't really have a great way to test locations right now, so I just added some tests that the locations are correct when using comments.

I also dropped support for the single `CR` and `LFCR` line endings since a single `CR` hasn't been used since Mac OS 9 and I don't think `LFCR` was ever a thing (I did find one guy on Stack Overflow who memed about it, but that's it). I didn't count this as a breaking change because I'm _fairly_ sure Grain doesn't work on Mac OS 9. If anyone feels like we should mark it as breaking though, we can mark it as such.