### PR TITLE
feat(compiler)!: Universal WebAssembly initial and maximum pages flags

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -91,10 +91,15 @@ program
     null,
     stdlibPath
   )
-  .option("--limitMemory <size>", "maximum allowed heap size", num, -1)
-  .option(
-    "--init-memory-pages <size>",
-    "number of pages used to initialize the grain runtime"
+  .graincOption(
+    "--initial-memory-pages <size>",
+    "initial number of WebAssembly memory pages",
+    num
+  )
+  .graincOption(
+    "--maximum-memory-pages <size>",
+    "maximum number of WebAssembly memory pages",
+    num
   )
   .graincOption(
     "--compilation-mode <mode>",

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -139,10 +139,6 @@ program
     "--verbose",
     "print critical information at various stages of compilation"
   )
-  .on("option:init-memory-pages", (pages) => {
-    // Workaround for the runtime's memory being initialized statically on module load
-    process.env.GRAIN_INIT_MEMORY_PAGES = parseInt(pages, 10);
-  })
   // The root command that compiles & runs
   .arguments("<file>")
   .action(function (file) {

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -9,7 +9,10 @@ module.exports = async function run(filename, options) {
     let basePath = path.dirname(filename);
     let includeDirs = [basePath, ...options.includeDirs, options.stdlib];
     let locator = runtime.defaultFileLocator(includeDirs);
-    let GrainRunner = runtime.buildGrainRunner(locator);
+    let GrainRunner = runtime.buildGrainRunner(locator, {
+      initialMemoryPages: options.initialMemoryPages,
+      maximumMemoryPages: options.maximumMemoryPages,
+    });
     if (options.printOutput) {
       let result = await GrainRunner.runFileUnboxed(filename);
       await GrainRunner.ensureStringModule();

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -1,6 +1,7 @@
 open Grain_codegen;
 open Compmod;
 open Grain_typed;
+open Grain_utils;
 open Cmi_format;
 open Binaryen;
 open Graph;
@@ -575,7 +576,22 @@ let link_all = (linked_mod, dependencies, signature) => {
   };
   List.iter(link_one, dependencies);
   ignore @@ Table.add_table(linked_mod, function_table, table_offset^, -1);
-  Memory.set_memory(linked_mod, 64, Memory.unlimited, "memory", [], false);
+  let (initial_memory, maximum_memory) =
+    switch (Config.initial_memory_pages^, Config.maximum_memory_pages^) {
+    | (initial_memory, Some(maximum_memory)) => (
+        initial_memory,
+        maximum_memory,
+      )
+    | (initial_memory, None) => (initial_memory, Memory.unlimited)
+    };
+  Memory.set_memory(
+    linked_mod,
+    initial_memory,
+    maximum_memory,
+    "memory",
+    [],
+    false,
+  );
 
   let starts =
     List.map(

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -333,6 +333,22 @@ let color_enabled =
 // TODO: (#612) Add compiler flag when feature is complete or remove entirely
 let principal = ref(false);
 
+let initial_memory_pages =
+  opt(
+    ~names=["initial-memory-pages"],
+    ~conv=Cmdliner.Arg.int,
+    ~doc="Initial number of WebAssembly memory pages",
+    64,
+  );
+
+let maximum_memory_pages =
+  opt(
+    ~names=["maximum-memory-pages"],
+    ~conv=option_conv(Cmdliner.Arg.int),
+    ~doc="Maximum number of WebAssembly memory pages",
+    None,
+  );
+
 let compilation_mode =
   opt(
     ~names=["compilation-mode"],

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -50,6 +50,14 @@ let color_enabled: ref(bool);
 
 let principal: ref(bool);
 
+/** Initial number of WebAssembly memory pages */
+
+let initial_memory_pages: ref(int);
+
+/** Maximum number of WebAssembly memory pages */
+
+let maximum_memory_pages: ref(option(int));
+
 /** Compilation mode to use when compiling */
 
 let compilation_mode: ref(option(string));

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -44,7 +44,6 @@
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "fast-text-encoding": "^1.0.0",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.16",
     "wasm-sourcemap": "^1.0.0",

--- a/runtime/src/core/closures.js
+++ b/runtime/src/core/closures.js
@@ -1,17 +1,16 @@
-import { managedMemory, grainModule } from "../runtime";
 import { grainToJSVal, JSToGrainVal } from "../utils/utils";
 
 export class GrainClosure {
   constructor(loc, runtime) {
-    const view = managedMemory.view;
+    const view = runtime.managedMemory.view;
 
     this.loc = loc;
     this.runtime = runtime;
-    this.arity = view[loc];
-    this.ptr = view[loc + 1];
-    this.closureSize = view[loc + 2];
-    this.closureElts = view.slice(loc + 3, loc + 3 + this.closureSize);
-    this.func = grainModule.instance.exports["GRAIN$LAM_" + this.ptr];
+    this.arity = view[loc + 1];
+    this.ptr = view[loc + 2];
+    this.closureSize = view[loc + 3];
+    this.closureElts = view.slice(loc + 4, loc + 4 + this.closureSize);
+    this.func = runtime.table.get(this.ptr);
   }
 
   jsFunc(...args) {
@@ -22,7 +21,7 @@ export class GrainClosure {
 }
 
 export function printClosure(c) {
-  const view = managedMemory.view;
+  const view = runtime.managedMemory.view;
 
   c /= 4;
   let arity = view[c];

--- a/runtime/src/core/memory.js
+++ b/runtime/src/core/memory.js
@@ -1,11 +1,14 @@
 export class ManagedMemory {
-  constructor(memory) {
-    this._memory = memory;
-    this._view = new Int32Array(memory.buffer);
-    this._uview = new Uint32Array(memory.buffer);
-    this._u8view = new Uint8Array(memory.buffer);
-    this._f32view = new Float32Array(memory.buffer);
-    this._f64view = new Float64Array(memory.buffer);
+  constructor({ initialMemoryPages, maximumMemoryPages }) {
+    this._memory = new WebAssembly.Memory({
+      initial: initialMemoryPages || 64,
+      maximum: maximumMemoryPages,
+    });
+    this._view = new Int32Array(this._memory.buffer);
+    this._uview = new Uint32Array(this._memory.buffer);
+    this._u8view = new Uint8Array(this._memory.buffer);
+    this._f32view = new Float32Array(this._memory.buffer);
+    this._f64view = new Float64Array(this._memory.buffer);
     this._runtime = null;
   }
 

--- a/runtime/src/core/runner.js
+++ b/runtime/src/core/runner.js
@@ -20,6 +20,10 @@ export class GrainRunner {
       relocBase: 0,
       moduleRuntimeId: 0,
     };
+    this.table = new WebAssembly.Table({
+      element: "anyfunc",
+      initial: 1024,
+    });
   }
 
   get memoryManager() {

--- a/runtime/src/core/tags.js
+++ b/runtime/src/core/tags.js
@@ -1,5 +1,3 @@
-import { memory, managedMemory } from "../runtime";
-
 import { GRAIN_TRUE, GRAIN_FALSE, GRAIN_VOID } from "./primitives";
 
 export const GRAIN_NUMBER_TAG_MASK = 0b0001;

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -1,5 +1,3 @@
-import "fast-text-encoding";
-
 import { printClosure } from "./core/closures";
 import { ManagedMemory } from "./core/memory";
 import { GrainRunner } from "./core/runner";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,11 +1533,6 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-text-encoding@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
-  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
-
 fastq@^1.6.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"


### PR DESCRIPTION
feat(compiler): Add --initial-memory-pages and --maximum-memory-pages to set module memory limits
feat(runtime)!: Removed --limitMemory, GRAIN_INIT_MEMORY_PAGES, and GRAIN_MAX_MEMORY_PAGES in favor of --initial-memory-pages and --maximum-memory-pages
feat(runtime)!: Removed `managedMemory`, `memory`, and `table` exports. These can be accessed via `runner.managedMemory`, `runner.managedMemory._memory`, and `runner.table` respectively.
feat(runtime)!: Removed `encoder` and `decoder` exports.

The important takeaway from this PR is that it adds two new flags, `--initial-memory-pages` and `--maximum-memory-pages`, which work in both linked and non-linked mode (versus the fragmented way it was done before).