### PR TITLE
fix: Properly initialize malloc free list

### DIFF
--- a/compiler/test/input/mallocTight.gr
+++ b/compiler/test/input/mallocTight.gr
@@ -1,0 +1,30 @@
+/* grainc-flags --compilation-mode=runtime */
+
+import Malloc from "runtime/malloc"
+import WasmI32, { add as (+), sub as (-), mul as (*), eq as (==), ne as (!=) } from "runtime/unsafe/wasmi32"
+
+primitive assert : Bool -> Void = "@assert"
+primitive ignore : a -> Void = "@ignore"
+
+// Because we're in runtime mode, malloc has yet to be called
+// This provides us with a clean slate to test malloc
+
+// allow malloc to initialize
+ignore(Malloc.malloc(8n))
+
+// The free list should be pointing at the base
+let base = Malloc.getFreePtr()
+assert base == Malloc._RESERVED_RUNTIME_SPACE
+
+// grab the next (and only) block in the free list
+let block = WasmI32.load(Malloc.getFreePtr(), 0n)
+assert WasmI32.load(block, 0n) == base
+
+// When we allocate, an extra 8 bytes is reserved for the block header
+let remainingMemory = WasmI32.load(block, 4n) - 8n
+
+let firstPtr = Malloc.malloc(remainingMemory)
+let secondPtr = Malloc.malloc(remainingMemory)
+
+// These two pointers should (obviously) be different
+assert firstPtr != secondPtr

--- a/compiler/test/test_end_to_end.re
+++ b/compiler/test/test_end_to_end.re
@@ -1117,6 +1117,7 @@ let gc = [
   /* I've manually tested this test, but see TODO for automated testing */
   /* tgcfile ~todo:"Need to figure out how to disable dead assignment elimination to make sure this test is actually checking what we want" "sinister_gc" 3072 "sinister-tail-call-gc" "true"; */
   tgcfile("long_lists", 20000, "long_lists", "true"),
+  tfile("malloc_tight", "mallocTight", "void"),
   tfile("memory_grow1", "memoryGrow", "1000000000000\nvoid"),
 ];
 

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -76,6 +76,17 @@ let mut heapSize = 0n
 
 export let _RESERVED_RUNTIME_SPACE = 16384n
 
+/**
+ * The base the heap. The block at this address will be size 0 and
+ * serve as the root of the free list.
+ */
+let _BASE = _RESERVED_RUNTIME_SPACE
+
+/**
+ * The start pointer of the heap.
+ */
+let _HEAP_START = _BASE + mallocHeaderSize
+
 let _NEXT_OFFSET = 0n
 let _SIZE_OFFSET = 4n
 
@@ -113,7 +124,7 @@ let growHeap = (nbytes: WasmI32) => {
 
   // If the size has not been initialized, do so.
   if (heapSize == 0n) {
-    heapSize = memorySize() * _PAGE_SIZE - _RESERVED_RUNTIME_SPACE
+    heapSize = memorySize() * _PAGE_SIZE - _HEAP_START
     if (nbytes > heapSize) {
       // More bytes requested than the initial heap size,
       // so we need to request more anyway.
@@ -125,10 +136,10 @@ let growHeap = (nbytes: WasmI32) => {
         -1n
       } else {
         heapSize += reqSize << 16n
-        _RESERVED_RUNTIME_SPACE
+        _HEAP_START
       }
     } else {
-      _RESERVED_RUNTIME_SPACE
+      _HEAP_START
     }
   } else {
     // The size has already been initialized, so call the external function.
@@ -231,10 +242,10 @@ export let malloc = (nb: WasmI32) => {
 
   // Handle initialization
   if (heapSize == 0n) {
-    WasmI32.store(_RESERVED_RUNTIME_SPACE, _RESERVED_RUNTIME_SPACE, 0n)
-    freePtr = _RESERVED_RUNTIME_SPACE
-    prevp = _RESERVED_RUNTIME_SPACE
-    WasmI32.store(_RESERVED_RUNTIME_SPACE, 0n, 4n)
+    WasmI32.store(_BASE, _BASE, _NEXT_OFFSET)
+    freePtr = _BASE
+    prevp = _BASE
+    WasmI32.store(_BASE, 0n, _SIZE_OFFSET)
   }
 
   let mut ret = -1n


### PR DESCRIPTION
This PR fixes a pesky bug that only appears under absolutely perfect™️ conditions.

Currently, if the free list only contains one block and it's exactly the same size as the amount of requested memory, it will not be released from the free list. As such, further requests for that same size will result in the same pointer being allocated over and over again.

We hadn't noticed this because the stars really have to align to hit this case! In the case of [this run](https://github.com/grain-lang/grain/pull/698/checks?check_run_id=2750176540), it was the addition of a closure that happened to be just the right size that later calls to malloc would be perfectly sized to trigger the bug.

I reviewed the reference implementation and realized this was because we weren't setting up the free list correctly, though I don't fault us for it because it's one of the few changes that needed to be made for the C -> Wasm port. I also added a regression test for this.