### PR TITLE
fix(stdlib): return proper values from getClockTime for Sys/Time

### DIFF
--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -12,7 +12,7 @@ import { allocateInt64, tagSimpleNumber } from "runtime/dataStructures"
 
 let getClockTime = (clockid, precision) => {
   let int64Ptr = allocateInt64()
-  let timePtr = int64Ptr + 4n
+  let timePtr = int64Ptr + 8n
   let err = Wasi.clock_time_get(clockid, precision, timePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(int64Ptr)


### PR DESCRIPTION
The getClockTime function was overwriting the number tag and thus returning invalid instances of Int64.