### PR TITLE
feat (stdlib): coerceNumberToWasmI32

### DIFF
--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -7,6 +7,7 @@ import Conv from "runtime/unsafe/conv"
 import { tagSimpleNumber, allocateBytes, allocateString } from "runtime/dataStructures"
 import Exception from "runtime/exception"
 import Int32 from "int32"
+import { coerceNumberToWasmI32 as numberToWasmI32 } from "runtime/numbers"
 
 let _SIZE_OFFSET = 4n;
 let _VALUE_OFFSET = 8n;
@@ -16,21 +17,6 @@ let _INT32_BYTE_SIZE = 4n;
 let _FLOAT32_BYTE_SIZE = 4n;
 let _INT64_BYTE_SIZE = 8n;
 let _FLOAT64_BYTE_SIZE = 8n;
-
-/** Converts Number to WasmI32 */
-@disableGC
-let numberToWasmI32 = n => {
-  let m = WasmI32.fromGrain(n)
-  if (WasmI32.eqz(WasmI32.and(m, 1n))) {
-    let i32 = Int32.fromNumber(n)
-    let res = Conv.fromInt32(i32)
-    Memory.free(WasmI32.fromGrain(i32))
-    res
-  } else {
-    // fast path
-    WasmI32.shrS(m, 1n)
-  }
-}
 
 /** Throws an exception if the index specified is out-of-bounds */
 @disableGC

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -7,7 +7,7 @@ import Conv from "runtime/unsafe/conv"
 import { tagSimpleNumber, allocateBytes, allocateString } from "runtime/dataStructures"
 import Exception from "runtime/exception"
 import Int32 from "int32"
-import { coerceNumberToWasmI32 as numberToWasmI32 } from "runtime/numbers"
+import { coerceNumberToWasmI32 } from "runtime/numbers"
 
 let _SIZE_OFFSET = 4n;
 let _VALUE_OFFSET = 8n;
@@ -47,7 +47,7 @@ export let setInt8 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store8(ptr + offset, value, _VALUE_OFFSET)
@@ -64,7 +64,7 @@ export let getInt8S = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let n = WasmI32.load8S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
@@ -81,7 +81,7 @@ export let getInt8U = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT8_BYTE_SIZE, size)
   let n = WasmI32.load8U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
@@ -99,7 +99,7 @@ export let setInt16 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store16(ptr + offset, value, _VALUE_OFFSET)
@@ -116,7 +116,7 @@ export let getInt16S = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let n = WasmI32.load16S(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
@@ -133,7 +133,7 @@ export let getInt16U = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT16_BYTE_SIZE, size)
   let n = WasmI32.load16U(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
@@ -151,7 +151,7 @@ export let setInt32 = (i: Number, v: Int32, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromInt32(v)
   WasmI32.store(ptr + offset, value, _VALUE_OFFSET)
@@ -168,7 +168,7 @@ export let getInt32 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let n = WasmI32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt32(n)
@@ -186,7 +186,7 @@ export let setFloat32 = (i: Number, v: Float32, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let value = Conv.fromFloat32(v)
   WasmF32.store(ptr + offset, value, _VALUE_OFFSET)
@@ -203,7 +203,7 @@ export let getFloat32 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT32_BYTE_SIZE, size)
   let n = WasmF32.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat32(n)
@@ -221,7 +221,7 @@ export let setInt64 = (i: Number, v: Int64, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
   let value = Conv.fromInt64(v)
   WasmI64.store(ptr + offset, value, _VALUE_OFFSET)
@@ -238,7 +238,7 @@ export let getInt64 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _INT64_BYTE_SIZE, size)
   let n = WasmI64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toInt64(n)
@@ -256,7 +256,7 @@ export let setFloat64 = (i: Number, v: Float64, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
   let value = Conv.fromFloat64(v)
   WasmF64.store(ptr + offset, value, _VALUE_OFFSET)
@@ -273,7 +273,7 @@ export let getFloat64 = (i: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let ptr = WasmI32.fromGrain(b)
   let size = getSize(ptr)
-  let offset = numberToWasmI32(i)
+  let offset = coerceNumberToWasmI32(i)
   checkIndexIsInBounds(offset, _FLOAT64_BYTE_SIZE, size)
   let n = WasmF64.load(ptr + offset, _VALUE_OFFSET)
   Conv.toFloat64(n)
@@ -307,8 +307,8 @@ export let slice = (i: Number, len: Number, b: Bytes) => {
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(b)
   let size = getSize(src)
-  let i = numberToWasmI32(i)
-  let len = numberToWasmI32(len)
+  let i = coerceNumberToWasmI32(i)
+  let len = coerceNumberToWasmI32(len)
   if ((i + len) > size) {
     throw Exception.InvalidArgument("The given index and length do not specify a valid range of bytes")
   }
@@ -336,8 +336,8 @@ export let resize = (left: Number, right: Number, b: Bytes) => {
   let (*) = WasmI32.mul
   let src = WasmI32.fromGrain(b)
   let size = getSize(src)
-  let left = numberToWasmI32(left)
-  let right = numberToWasmI32(right)
+  let left = coerceNumberToWasmI32(left)
+  let right = coerceNumberToWasmI32(right)
   let newSize = size + left + right
   if (newSize < 0n) {
     throw Exception.InvalidArgument("The resulting length is less than 0")
@@ -379,11 +379,11 @@ export let move = (srcPos: Number, dstPos: Number, len: Number, src: Bytes, dst:
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(src)
   let srcSize = getSize(src)
-  let srcPos = numberToWasmI32(srcPos)
+  let srcPos = coerceNumberToWasmI32(srcPos)
   let dst = WasmI32.fromGrain(dst)
   let dstSize = getSize(dst)
-  let dstPos = numberToWasmI32(dstPos)
-  let len = numberToWasmI32(len)
+  let dstPos = coerceNumberToWasmI32(dstPos)
+  let len = coerceNumberToWasmI32(len)
   if ((srcPos + len) > srcSize) {
     throw Exception.InvalidArgument("Invalid source bytes range")
   }
@@ -470,7 +470,7 @@ export let fill = (v: Int32, b: Bytes) => {
  */
 @disableGC
 export let make = (n: Number) => {
-  let bytes = allocateBytes(numberToWasmI32(n))
+  let bytes = allocateBytes(coerceNumberToWasmI32(n))
   WasmI32.toGrain(bytes): Bytes
 }
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -2,7 +2,7 @@ import WasmI32 from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF64 from "runtime/unsafe/wasmf64"
 import {
-  coerceFloat64,
+  coerceNumberToWasmF64,
   reducedInteger,
   isFloat
 } from "runtime/numbers"
@@ -49,7 +49,7 @@ export let div = (/)
 @disableGC
 export let sqrt = (x: Number) => {
   let x = WasmI32.fromGrain(x)
-  let xval = coerceFloat64(x)
+  let xval = coerceNumberToWasmF64(WasmI32.toGrain(x) : Number)
   let sqrtd = WasmF64.sqrt(xval)
   if (!isFloat(x) && WasmF64.eq(sqrtd, WasmF64.trunc(sqrtd))) {
     WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(sqrtd))): Number
@@ -81,8 +81,7 @@ export let max = (x: Number, y: Number) => if (x > y) x else y
  */
 @disableGC
 export let ceil = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let xval = coerceFloat64(x)
+  let xval = coerceNumberToWasmF64(x)
   let ceiling = WasmI64.truncF64S(WasmF64.ceil(xval))
   WasmI32.toGrain(reducedInteger(ceiling)): Number
 }
@@ -94,8 +93,7 @@ export let ceil = (x: Number) => {
  */
 @disableGC
 export let floor = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let xval = coerceFloat64(x)
+  let xval = coerceNumberToWasmF64(x)
   let floored = WasmI64.truncF64S(WasmF64.floor(xval))
   WasmI32.toGrain(reducedInteger(floored)): Number
 }
@@ -107,8 +105,7 @@ export let floor = (x: Number) => {
  */
 @disableGC
 export let trunc = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let xval = coerceFloat64(x)
+  let xval = coerceNumberToWasmF64(x)
   let trunced = WasmI64.truncF64S(xval)
   WasmI32.toGrain(reducedInteger(trunced)): Number
 }
@@ -120,8 +117,7 @@ export let trunc = (x: Number) => {
  */
 @disableGC
 export let round = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let xval = coerceFloat64(x)
+  let xval = coerceNumberToWasmF64(x)
   let rounded = WasmI64.truncF64S(WasmF64.nearest(xval))
   WasmI32.toGrain(reducedInteger(rounded)): Number
 }

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -48,8 +48,8 @@ export let div = (/)
  */
 @disableGC
 export let sqrt = (x: Number) => {
+  let xval = coerceNumberToWasmF64(x)
   let x = WasmI32.fromGrain(x)
-  let xval = coerceNumberToWasmF64(WasmI32.toGrain(x) : Number)
   let sqrtd = WasmF64.sqrt(xval)
   if (!isFloat(x) && WasmF64.eq(sqrtd, WasmF64.trunc(sqrtd))) {
     WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(sqrtd))): Number

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -255,7 +255,8 @@ export let boxedRationalDenominator = (xptr) => {
 
 
 
-let coerceFloat32 = (x) => {
+export let coerceNumberToWasmF32 = (x: Number) => {
+  let x = WasmI32.fromGrain(x)
   if (isSimpleNumber(x)) {
     WasmF32.convertI32S(untagSimple(x))
   } else {
@@ -289,7 +290,8 @@ let coerceFloat32 = (x) => {
   }
 }
 
-export let coerceFloat64 = (x) => {
+export let coerceNumberToWasmF64 = (x: Number) => {
+  let x = WasmI32.fromGrain(x)
   if (isSimpleNumber(x)) {
     WasmF64.convertI32S(untagSimple(x))
   } else {
@@ -317,7 +319,12 @@ export let coerceFloat64 = (x) => {
   }
 }
 
-let coerceInt64 = (x) => {
+export let coerceFloat64 = (x) => {
+  coerceNumberToWasmF64(WasmI32.toGrain(x) : Number)
+}
+
+export let coerceNumberToWasmI64 = (x: Number) => {
+  let x = WasmI32.fromGrain(x)
   if (isSimpleNumber(x)) {
     WasmI64.extendI32S(untagSimple(x))
   } else {
@@ -338,7 +345,7 @@ let coerceInt64 = (x) => {
 }
 
 export let coerceNumberToWasmI32 = (x: Number) => {
-  let asInt64 = coerceInt64(WasmI32.fromGrain(x))
+  let asInt64 = coerceNumberToWasmI64(x)
   if (WasmI64.gtS(asInt64, _I32_MAX) || WasmI64.ltS(asInt64, _I32_MIN)) {
     throw Exception.Overflow
   }
@@ -702,14 +709,14 @@ let numberAddSubFloat32Help = (xval, y, isSub) => {
     let result = if (isSub) WasmF64.sub(xval, yval) else WasmF64.add(xval, yval)
     newFloat64(result)
   } else {
-    let yval = coerceFloat32(y)
+    let yval = coerceNumberToWasmF32(WasmI32.toGrain(y) : Number)
     let result = if (isSub) WasmF32.sub(xval, yval) else WasmF32.add(xval, yval)
     newFloat32(result)
   }
 }
 
 let numberAddSubFloat64Help = (xval, y, isSub) => {
-  let yval = coerceFloat64(y)
+  let yval = coerceNumberToWasmF64(WasmI32.toGrain(y) : Number)
   let result = if (isSub) WasmF64.sub(xval, yval) else WasmF64.add(xval, yval)
   newFloat64(result)
 }
@@ -953,7 +960,7 @@ let numberTimesDivideRationalHelp = (x, y, isDivide) => {
 }
 
 let numberTimesDivideFloat64Help = (x, y, isDivide) => {
-  let yAsFloat = coerceFloat64(y)
+  let yAsFloat = coerceNumberToWasmF64(WasmI32.toGrain(y) : Number)
   if (isDivide) {
     newFloat64(WasmF64.div(x, yAsFloat))
   } else {
@@ -970,7 +977,7 @@ let numberTimesDivideFloat32Help = (x, y, isDivide) => {
       newFloat64(WasmF64.mul(WasmF64.promoteF32(x), boxedFloat64Number(y)))
     }
   } else {
-    let yAsFloat = coerceFloat32(y)
+    let yAsFloat = coerceNumberToWasmF32(WasmI32.toGrain(y) : Number)
     if (isDivide) {
       newFloat32(WasmF32.div(x, yAsFloat))
     } else {
@@ -1023,8 +1030,8 @@ let numberDivide = (x, y) => {
 let i64abs = (x) => if (WasmI64.geS(x, 0N)) x else WasmI64.sub(0N, x)
 
 let numberMod = (x, y) => {
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(WasmI32.toGrain(x) : Number)
+  let yval = coerceNumberToWasmI64(WasmI32.toGrain(y) : Number)
   if (WasmI64.eqz(yval)) {
     throw Exception.ModuloByZero
   }
@@ -1045,10 +1052,8 @@ let numberMod = (x, y) => {
  */
 // TODO: (#305) is this safe? I think it's safe?
 export let (<) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceFloat64(x)
-  let yval = coerceFloat64(y)
+  let xval = coerceNumberToWasmF64(x)
+  let yval = coerceNumberToWasmF64(y)
   WasmF64.lt(xval, yval)
 }
 
@@ -1058,10 +1063,8 @@ export let (<) = (x: Number, y: Number) => {
 export let numberLess = (<);
 
 export let (>) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceFloat64(x)
-  let yval = coerceFloat64(y)
+  let xval = coerceNumberToWasmF64(x)
+  let yval = coerceNumberToWasmF64(y)
   WasmF64.gt(xval, yval)
 }
 
@@ -1071,14 +1074,14 @@ export let (>) = (x: Number, y: Number) => {
 export let numberGreater = (>);
 
 export let (<=) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
   // Equality is finicky, so delegate
-  let xval = coerceFloat64(x)
-  let yval = coerceFloat64(y)
+  let xval = coerceNumberToWasmF64(x)
+  let yval = coerceNumberToWasmF64(y)
   if (WasmF64.lt(xval, yval)) {
     true
   } else {
+    let x = WasmI32.fromGrain(x)
+    let y = WasmI32.fromGrain(y)
     numberEqual(x, y)
   }
 }
@@ -1089,14 +1092,14 @@ export let (<=) = (x: Number, y: Number) => {
 export let numberLessEqual = (<=);
 
 export let (>=) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
   // Equality is finicky, so delegate
-  let xval = coerceFloat64(x)
-  let yval = coerceFloat64(y)
+  let xval = coerceNumberToWasmF64(x)
+  let yval = coerceNumberToWasmF64(y)
   if (WasmF64.gt(xval, yval)) {
     true
   } else {
+    let x = WasmI32.fromGrain(x)
+    let y = WasmI32.fromGrain(y)
     numberEqual(x, y)
   }
 }
@@ -1123,8 +1126,7 @@ export let numberEq = (x: Number, y: Number) => {
 // TODO: (#306) Semantics around when things should stay i32/i64
 
 export let lnot = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let xval = coerceInt64(x)
+  let xval = coerceNumberToWasmI64(x)
   WasmI32.toGrain(reducedInteger(i64not(xval))): Number
 }
 
@@ -1134,10 +1136,8 @@ export let lnot = (x: Number) => {
 export let numberLnot = lnot;
 
 export let (<<) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.shl(xval, yval))): Number
 }
 
@@ -1147,10 +1147,8 @@ export let (<<) = (x: Number, y: Number) => {
 export let numberLsl = (<<);
 
 export let (>>>) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.shrU(xval, yval))): Number
 }
 
@@ -1160,10 +1158,8 @@ export let (>>>) = (x: Number, y: Number) => {
 export let numberLsr = (>>>);
 
 export let (&) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.and(xval, yval))): Number
 }
 
@@ -1173,10 +1169,8 @@ export let (&) = (x: Number, y: Number) => {
 export let numberLand = (&);
 
 export let (|) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.or(xval, yval))): Number
 }
 
@@ -1186,10 +1180,8 @@ export let (|) = (x: Number, y: Number) => {
 export let numberLor = (|);
 
 export let (^) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.xor(xval, yval))): Number
 }
 
@@ -1199,10 +1191,8 @@ export let (^) = (x: Number, y: Number) => {
 export let numberLxor = (^);
 
 export let (>>) = (x: Number, y: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let y = WasmI32.fromGrain(y)
-  let xval = coerceInt64(x)
-  let yval = coerceInt64(y)
+  let xval = coerceNumberToWasmI64(x)
+  let yval = coerceNumberToWasmI64(y)
   WasmI32.toGrain(reducedInteger(WasmI64.shrS(xval, yval))): Number
 }
 
@@ -1235,7 +1225,7 @@ export let coerceNumberToInt64 = (x: Number) => {
     // avoid extra malloc
     x
   } else {
-    newInt64(coerceInt64(x))
+    newInt64(coerceNumberToWasmI64(WasmI32.toGrain(x) : Number))
   }
   WasmI32.toGrain(result): Int64
 }
@@ -1265,7 +1255,7 @@ export let coerceNumberToFloat32 = (x: Number) => {
     // avoid extra malloc
     x
   } else {
-    newFloat32(coerceFloat32(x))
+    newFloat32(coerceNumberToWasmF32(WasmI32.toGrain(x) : Number))
   }
   WasmI32.toGrain(result): Float32
 }
@@ -1276,7 +1266,7 @@ export let coerceNumberToFloat64 = (x: Number) => {
     // avoid extra malloc
     x
   } else {
-    newFloat64(coerceFloat64(x))
+    newFloat64(coerceNumberToWasmF64(WasmI32.toGrain(x) : Number))
   }
   WasmI32.toGrain(result): Float64
 }

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1218,13 +1218,13 @@ export let numberAsr = (>>);
 //         we will fail if attempting to coerce to an int!
 
 export let coerceNumberToInt32 = (x: Number) => {
-  let y = WasmI32.fromGrain(x)
-  let result = if (!isSimpleNumber(y) && WasmI32.eq(boxedNumberTag(y), Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
+  let x = WasmI32.fromGrain(x)
+  let result = if (!isSimpleNumber(x) && WasmI32.eq(boxedNumberTag(x), Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
     // avoid extra malloc
-    y
+    x
   } else {
     // can possibly fail
-    newInt32(coerceNumberToWasmI32(x))
+    newInt32(coerceNumberToWasmI32(WasmI32.toGrain(x) : Number))
   }
   WasmI32.toGrain(result): Int32
 }
@@ -1241,17 +1241,17 @@ export let coerceNumberToInt64 = (x: Number) => {
 }
 
 export let coerceNumberToRational = (x: Number) => {
-  let y = WasmI32.fromGrain(x)
-  let result = if (isSimpleNumber(y)) {
-    newRational(untagSimple(y), 1n)
+  let x = WasmI32.fromGrain(x)
+  let result = if (isSimpleNumber(x)) {
+    newRational(untagSimple(x), 1n)
   } else {
-    let tag = boxedNumberTag(y)
+    let tag = boxedNumberTag(x)
     if (WasmI32.eq(tag, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG)) {
-      y
+      x
     } else if (WasmI32.eq(tag, Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
-      newRational(boxedInt32Number(y), 1n)
+      newRational(boxedInt32Number(x), 1n)
     } else if (WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG)) {
-      newRational(coerceNumberToWasmI32(x), 1n)
+      newRational(coerceNumberToWasmI32(WasmI32.toGrain(x) : Number), 1n)
     } else {
       throw Exception.NumberNotRational
     }

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1216,6 +1216,10 @@ export let numberAsr = (>>);
 // [NOTE]: Coercion is a *conservative* process! For example, even if a float is 1.0,
 //         we will fail if attempting to coerce to an int!
 
+export let coerceNumberToWasmI32 = (x: Number) => {
+  coerceInt32(WasmI32.fromGrain(x))
+}
+
 export let coerceNumberToInt32 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
   let result = if (!isSimpleNumber(x) && WasmI32.eq(boxedNumberTag(x), Tags._GRAIN_INT32_BOXED_NUM_TAG)) {

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -337,13 +337,14 @@ let coerceInt64 = (x) => {
   }
 }
 
-let coerceInt32 = (x) => {
-  let asInt64 = coerceInt64(x)
+export let coerceNumberToWasmI32 = (x: Number) => {
+  let asInt64 = coerceInt64(WasmI32.fromGrain(x))
   if (WasmI64.gtS(asInt64, _I32_MAX) || WasmI64.ltS(asInt64, _I32_MIN)) {
     throw Exception.Overflow
   }
   WasmI32.wrapI64(asInt64)
 }
+
 
 let isIntegerF32 = (value) => {
   WasmF32.eq(value, WasmF32.trunc(value))
@@ -1216,18 +1217,14 @@ export let numberAsr = (>>);
 // [NOTE]: Coercion is a *conservative* process! For example, even if a float is 1.0,
 //         we will fail if attempting to coerce to an int!
 
-export let coerceNumberToWasmI32 = (x: Number) => {
-  coerceInt32(WasmI32.fromGrain(x))
-}
-
 export let coerceNumberToInt32 = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let result = if (!isSimpleNumber(x) && WasmI32.eq(boxedNumberTag(x), Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
+  let y = WasmI32.fromGrain(x)
+  let result = if (!isSimpleNumber(y) && WasmI32.eq(boxedNumberTag(y), Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
     // avoid extra malloc
-    x
+    y
   } else {
     // can possibly fail
-    newInt32(coerceInt32(x))
+    newInt32(coerceNumberToWasmI32(x))
   }
   WasmI32.toGrain(result): Int32
 }
@@ -1244,17 +1241,17 @@ export let coerceNumberToInt64 = (x: Number) => {
 }
 
 export let coerceNumberToRational = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let result = if (isSimpleNumber(x)) {
-    newRational(untagSimple(x), 1n)
+  let y = WasmI32.fromGrain(x)
+  let result = if (isSimpleNumber(y)) {
+    newRational(untagSimple(y), 1n)
   } else {
-    let tag = boxedNumberTag(x)
+    let tag = boxedNumberTag(y)
     if (WasmI32.eq(tag, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG)) {
-      x
+      y
     } else if (WasmI32.eq(tag, Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
-      newRational(boxedInt32Number(x), 1n)
+      newRational(boxedInt32Number(y), 1n)
     } else if (WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG)) {
-      newRational(coerceInt32(x), 1n)
+      newRational(coerceNumberToWasmI32(x), 1n)
     } else {
       throw Exception.NumberNotRational
     }

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -319,10 +319,6 @@ export let coerceNumberToWasmF64 = (x: Number) => {
   }
 }
 
-export let coerceFloat64 = (x) => {
-  coerceNumberToWasmF64(WasmI32.toGrain(x) : Number)
-}
-
 export let coerceNumberToWasmI64 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
   if (isSimpleNumber(x)) {


### PR DESCRIPTION
This PR adds a simple function for Number to WasmI32 conversion that just wraps an existing one. The new function adds a bit of type safety instead of just exposing coerceInt32. It also replaces the duplicate function in Bytes module, which is replicated in the Buffer module currently proposed in PR #710 as well.

@ospencer briefly mentioned on Discord the possibility of just exporting coerceInt32 directly instead of a wrapper function, so if that is preferable I don't mind changing it.