### PR TITLE
chore(deps): Update esy & ocaml-lsp

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@opam/js_of_ocaml-compiler": ">= 3.6.0",
-    "@opam/ocaml-lsp-server": "1.4.0",
+    "@opam/ocaml-lsp-server": "1.4.1",
     "@reason-native/rely": "^3.2.1"
   },
   "resolutions": {

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "263f13dafbac6c3858d5a73544aa5186",
+  "checksum": "7cc2eff314c5979c146dc8015838e6ce",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -785,20 +785,20 @@
         "ocaml@4.11.0@d41d8cd9", "@opam/dune@opam:2.8.5@01003f12"
       ]
     },
-    "@opam/ocaml-lsp-server@opam:1.4.0@c9583433": {
-      "id": "@opam/ocaml-lsp-server@opam:1.4.0@c9583433",
+    "@opam/ocaml-lsp-server@opam:1.4.1@cd85c376": {
+      "id": "@opam/ocaml-lsp-server@opam:1.4.1@cd85c376",
       "name": "@opam/ocaml-lsp-server",
-      "version": "opam:1.4.0",
+      "version": "opam:1.4.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/fd/fd138e6c4fcff32c6d15eb66cc9391b7e1183717a6d1a47c688c7f6d320a159f#sha256:fd138e6c4fcff32c6d15eb66cc9391b7e1183717a6d1a47c688c7f6d320a159f",
-          "archive:https://github.com/ocaml/ocaml-lsp/releases/download/1.4.0/jsonrpc-1.4.0.tbz#sha256:fd138e6c4fcff32c6d15eb66cc9391b7e1183717a6d1a47c688c7f6d320a159f"
+          "archive:https://opam.ocaml.org/cache/sha256/ce/cee8371e7048e24c90e916c373ef6f3aba6f474d8a5fcf507ab6650fd8575eeb#sha256:cee8371e7048e24c90e916c373ef6f3aba6f474d8a5fcf507ab6650fd8575eeb",
+          "archive:https://github.com/ocaml/ocaml-lsp/releases/download/1.4.1/jsonrpc-1.4.1.tbz#sha256:cee8371e7048e24c90e916c373ef6f3aba6f474d8a5fcf507ab6650fd8575eeb"
         ],
         "opam": {
           "name": "ocaml-lsp-server",
-          "version": "1.4.0",
-          "path": "esy.lock/opam/ocaml-lsp-server.1.4.0"
+          "version": "1.4.1",
+          "path": "esy.lock/opam/ocaml-lsp-server.1.4.1"
         }
       },
       "overrides": [],
@@ -1538,7 +1538,7 @@
       ],
       "devDependencies": [
         "@reason-native/rely@3.2.1@d41d8cd9",
-        "@opam/ocaml-lsp-server@opam:1.4.0@c9583433",
+        "@opam/ocaml-lsp-server@opam:1.4.1@cd85c376",
         "@opam/js_of_ocaml-compiler@opam:3.9.1@19f5797f"
       ],
       "installConfig": { "pnp": false }

--- a/compiler/esy.lock/opam/ocaml-lsp-server.1.4.1/opam
+++ b/compiler/esy.lock/opam/ocaml-lsp-server.1.4.1/opam
@@ -40,12 +40,12 @@ build: [
     "--release"
   ]
 ]
-x-commit-hash: "92924b6e36a91ce323b7f8eddfe20def4173e6e5"
+x-commit-hash: "154ccd7142651807d40eb851969f318b873b7fb4"
 url {
   src:
-    "https://github.com/ocaml/ocaml-lsp/releases/download/1.4.0/jsonrpc-1.4.0.tbz"
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.4.1/jsonrpc-1.4.1.tbz"
   checksum: [
-    "sha256=fd138e6c4fcff32c6d15eb66cc9391b7e1183717a6d1a47c688c7f6d320a159f"
-    "sha512=567a73b3c10bb59c5a4d4e8291d1aeefdfd34438a95313fba8a485638294ca5fb8034334719631243c304d3328c27afa90dfd564fdb1e7390507a06db3a4ad03"
+    "sha256=cee8371e7048e24c90e916c373ef6f3aba6f474d8a5fcf507ab6650fd8575eeb"
+    "sha512=150ebf71d3484d3beec1a145877cf30d84581bd072dd20159e878ed07cc4fc647b019b98bb0c9fede839b87f7bd13de4a64b534c0760a2ec57d0e4a4deac6f0f"
   ]
 }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -9,7 +9,7 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "esy": "0.6.7"
+    "esy": "0.6.10"
   },
   "scripts": {
     "link": "yarn link",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,17 +1422,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-esy-solve-cudf@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/esy-solve-cudf/-/esy-solve-cudf-0.1.10.tgz#2cd48af78183ae8f06c035a398beb65673c2d77d"
-  integrity sha512-/MrZOBH0wuJndvZN8pl+S3Mg3zJaK70PH9ZZwqDeJHulghEWROEZxpmenNiS9pqAaxyUVhTZJBt2/vL9jKCJbg==
-
-esy@0.6.7:
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/esy/-/esy-0.6.7.tgz#a04f5c469280115f39364e5f51927d9e74180236"
-  integrity sha512-G/C0wXDQy19eDqlFNmPg2kHmrllUez9deZd1OOIk/VTKtc75STdeE/Nl1NusVY+La/+eCtovNqk0/ZAb4Mg8gw==
-  dependencies:
-    esy-solve-cudf "^0.1.10"
+esy@0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/esy/-/esy-0.6.10.tgz#918de2ad7e40793978c63b8216563408527cc25e"
+  integrity sha512-O+mWNPB9NJqDr3CA1PUbWUO1ZSy53ksZWivGrvbquATR5INlp3CYguwkq4BzZACg1s1bVYyhr7byjB/l1nuGRA==
 
 events@^3.0.0:
   version "3.3.0"


### PR DESCRIPTION
I tried to jump back into the project and the ocaml-lsp was really angry. I made these changes and it is working again.

Note: we are on a "really" old version of ocaml-lsp because 1.5.0 dropped support for ocaml <4.12 but they backported some merlin fixes to 1.4.1