### PR TITLE
chore(tests): Add dune files to configure tests properly

### DIFF
--- a/compiler/test/dune
+++ b/compiler/test/dune
@@ -1,17 +1,16 @@
-(include_subdirs unqualified)
+(dirs :standard suites utils)
 
 (library
  (name Grain_tests)
- (public_name grain-tests.test)
- (flags
-  (:standard -linkall -g -w -40))
+ (public_name grain-tests.framework)
  (libraries grain rely.lib)
- (modules
-  (:standard \ test)))
+ (modules TestFramework runner))
 
 (executable
  (name test)
  (public_name test)
  (package grain-tests)
- (libraries grain-tests.test)
+ (flags
+  (:standard -linkall -g -w -40))
+ (libraries grain grain-tests.framework grain-tests.suites grain-tests.utils)
  (modules test))

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("arrays", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("basic functionality", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/boxes.re
+++ b/compiler/test/suites/boxes.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("boxes", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/chars.re
+++ b/compiler/test/suites/chars.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("chars", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/comments.re
+++ b/compiler/test/suites/comments.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 open Grain_parsing;
 open Ast_helper;
 

--- a/compiler/test/suites/dune
+++ b/compiler/test/suites/dune
@@ -1,0 +1,5 @@
+(library
+ (name Grain_tests_suites)
+ (public_name grain-tests.suites)
+ (libraries grain grain-tests.framework)
+ (modules (:standard)))

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("enums", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/exceptions.re
+++ b/compiler/test/suites/exceptions.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("exceptions", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/exports.re
+++ b/compiler/test/suites/exports.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("exports", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("functions", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 let makeGcProgram = (program, heap_size) => {
   Printf.sprintf(

--- a/compiler/test/suites/imports.re
+++ b/compiler/test/suites/imports.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("imports", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/let_mut.re
+++ b/compiler/test/suites/let_mut.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("let mut", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/linking.re
+++ b/compiler/test/suites/linking.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("linking", ({test}) => {
   let assertRun = makeRunner(test);

--- a/compiler/test/suites/lists.re
+++ b/compiler/test/suites/lists.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("lists", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/loops.re
+++ b/compiler/test/suites/loops.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("loops", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("numbers", ({test}) => {
   let assertRun = makeRunner(test);

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 open Grain_middle_end.Anftree;
 open Grain_middle_end.Anf_helper;
 

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("pattern matching", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/print.re
+++ b/compiler/test/suites/print.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("print", ({test}) => {
   let assertRun = makeRunner(test);

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("records", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("stdlib", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 open Grain_middle_end.Anftree;
 open Grain_middle_end.Anf_helper;
 

--- a/compiler/test/suites/tuples.re
+++ b/compiler/test/suites/tuples.re
@@ -1,5 +1,5 @@
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 describe("tuples", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);

--- a/compiler/test/utils/concatlist.re
+++ b/compiler/test/utils/concatlist.re
@@ -2,8 +2,8 @@
 open Grain_codegen;
 open Concatlist;
 
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 let l1 = append(snoc(cons(1, empty), 2), cons(3, snoc(empty, 4)));
 

--- a/compiler/test/utils/dune
+++ b/compiler/test/utils/dune
@@ -1,0 +1,5 @@
+(library
+ (name Grain_tests_utils)
+ (public_name grain-tests.utils)
+ (libraries grain grain-tests.framework)
+ (modules (:standard)))

--- a/compiler/test/utils/wasm_utils.re
+++ b/compiler/test/utils/wasm_utils.re
@@ -1,8 +1,8 @@
 open Grain_utils;
 open Wasm_utils;
 
-open TestFramework;
-open Runner;
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
 
 let iter_bytes = bytes => {
   let bytes = ref(bytes);


### PR DESCRIPTION
My understanding is that `(include_subdirs unqualified)` is a bad stanza and we shouldn't be using it, so I dove into setting up the tests repository more correctly. This required adding dune files for the suites and utils and setting up the framework/runner library differently, but things seem to be working.