### PR TITLE
chore(stdlib): Update clean command to delete new files

### DIFF
--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "clean": "del-cli '**/*.wasm' '**/*.wasm.*' '**/*.gr.mashtree' '!stdlib-external/**'"
+    "clean": "del-cli '**/*.wasm' '**/*.wat' '**/*.modsig'"
   },
   "pkg": {
     "assets": "**/*.gr"


### PR DESCRIPTION
When the CLI changes landed, it looks like this didn't get updated. I'm unsure if I should have kept the mashtree glob.