### PR TITLE
chore(tests): Fix test name that created directory

### DIFF
--- a/compiler/test/__snapshots__/comments.573e549e.0.snapshot
+++ b/compiler/test/__snapshots__/comments.573e549e.0.snapshot
@@ -1,4 +1,4 @@
-comments › comment_lone_//
+comments › comment_alone
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))

--- a/compiler/test/suites/comments.re
+++ b/compiler/test/suites/comments.re
@@ -85,7 +85,7 @@ describe("comments", ({test}) => {
     "//comment\n//comment\r\n5 + 5L",
     "line 3, characters 4-6",
   );
-  assertSnapshot("comment_lone_//", "//\nlet x = 10\nx");
+  assertSnapshot("comment_alone", "//\nlet x = 10\nx");
   assertSnapshot("comment_block", "/* block 1 */let x = 10/* block 2 */\nx");
   assertSnapshot("comment_doc", "/** doc 1 */let x = 10/** doc 2 */\nx");
   assertSnapshot("comment_shebang", "#!/bin/grain\nlet x = 10\nx");


### PR DESCRIPTION
The `//` in the name of this test caused a directory called `comment_lone_` to be created in the `test/output` directory and then it wrote files named **just** `.gr.wasm`, `.gr.wat`, and `.gr.modsig` into it.

This just renames the test and updates the snapshot so that doesn't happen.