### PR TITLE
feat(stdlib): Add Array.zip function

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -373,3 +373,14 @@ export let unique = (array) => {
     array
   )
 }
+
+export let zip = (a, b) => {
+  let len = length(a)
+  if (len != length(b)) {
+    fail "arguments to zip must be same length"
+  } else {
+    init(len, n => {
+      (a[n], b[n])
+    })
+  }
+}


### PR DESCRIPTION
In the spirit of #711 - I've begun splitting out the changes from the "misc" section of #680

I started with `Array.zip` in order to land #699

I attributed the commit to @peblair but I also made a change to explicitly guard on the array lengths since a longer `b` wouldn't error. I'm not sure how much I like this API being a "fail" API but I think it is fine for now.

I didn't add tests since they are added in #699 