### PR TITLE
fix!: Adjust Number equality, thus that 5 == 5.0

### DIFF
--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -50,6 +50,7 @@ describe("numbers", ({test}) => {
   );
   assertRun("nan_equality3", {|print(0.0 / 0.0 == 0.0 / 0.0)|}, "false\n");
   assertRun("number_equality", {|print(5.0 == 5)|}, "true\n");
+  assertRun("number_equality2", {|print(5 == 5.0)|}, "true\n");
   // syntax errors
   assertCompileError(
     "number_syntax_err1",

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -49,6 +49,7 @@ describe("numbers", ({test}) => {
     "false\n",
   );
   assertRun("nan_equality3", {|print(0.0 / 0.0 == 0.0 / 0.0)|}, "false\n");
+  assertRun("number_equality", {|print(5.0 == 5)|}, "true\n");
   // syntax errors
   assertCompileError(
     "number_syntax_err1",

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -17,6 +17,7 @@ import Tags from "runtime/unsafe/tags"
 
 primitive (!) : Bool -> Bool = "@not"
 primitive (||) : (Bool, Bool) -> Bool = "@or"
+primitive (&&) : (Bool, Bool) -> Bool = "@and"
 
 import { isNumber, numberEqual } from "runtime/numbers"
 
@@ -186,12 +187,12 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
     }
   }
 }, equalHelp = (x, y) => {
-  if ((x & Tags._GRAIN_GENERIC_TAG_MASK) != 0n) {
+  if (((x & Tags._GRAIN_GENERIC_TAG_MASK) != 0n) && ((y & Tags._GRAIN_GENERIC_TAG_MASK) != 0n)) {
     // Short circuit for non-pointer values
     x == y
   } else if (isNumber(x)) {
     // Numbers have special equality rules, e.g. NaN != NaN
-    numberEqual(x, y)
+    isNumber(y) && numberEqual(x, y)
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -192,7 +192,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
     x == y
   } else if (isNumber(x)) {
     // Numbers have special equality rules, e.g. NaN != NaN
-    isNumber(y) && numberEqual(x, y)
+    numberEqual(x, y)
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -192,7 +192,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
     x == y
   } else if (isNumber(x)) {
     // Numbers have special equality rules, e.g. NaN != NaN
-    numberEqual(x, y)
+    isNumber(y) && numberEqual(x, y)
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -264,16 +264,16 @@ export let coerceNumberToWasmF32 = (x: Number) => {
     match (xtag) {
       t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
         WasmF32.convertI32S(boxedInt32Number(x))
-      }, 
+      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         WasmF32.convertI64S(boxedInt64Number(x))
-      }, 
+      },
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         WasmF32.div(WasmF32.convertI32S(boxedRationalNumerator(x)), WasmF32.convertI32S(boxedRationalDenominator(x)))
-      }, 
+      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
         boxedFloat32Number(x)
-      }, 
+      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = boxedFloat64Number(x)
         if (WasmF64.gt(xval, _F32_MAX) || WasmF64.lt(xval, _F32_MIN)) {

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -537,7 +537,7 @@ let numberEqualFloat32Help = (x, y) => {
   let xIsInteger = isIntegerF32(x)
   // Basic number:
   if (isSimpleNumber(y)) {
-    xIsInteger && WasmF64.eq(WasmF64.promoteF32(x), WasmF64.convertI32S(untagSimple(y)))
+    xIsInteger && WasmF32.eq(x, WasmF32.convertI32S(untagSimple(y)))
   } else {
     // Boxed number
     let yBoxedNumberTag = boxedNumberTag(y)

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -534,7 +534,23 @@ let numberEqualFloat64Help = (x, y) => {
 }
 
 let numberEqualFloat32Help = (x, y) => {
-  numberEqualFloat64Help(WasmF64.promoteF32(x), y)
+  let xIsInteger = isIntegerF32(x)
+  // Basic number:
+  if (isSimpleNumber(y)) {
+    xIsInteger && WasmF64.eq(WasmF64.promoteF32(x), WasmF64.convertI32S(untagSimple(y)))
+  } else {
+    // Boxed number
+    let yBoxedNumberTag = boxedNumberTag(y)
+    match (yBoxedNumberTag) {
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+        // Special case: f32/f32 equality (need to handle here without promotion)
+        WasmF32.eq(x, boxedFloat32Number(y))
+      },
+      _ => {
+        numberEqualFloat64Help(WasmF64.promoteF32(x), y)
+      }
+    }
+  }
 }
 
 export let numberEqual = (x, y) => {


### PR DESCRIPTION
In the spirit of #711 - I've begun splitting out the changes from the "misc" section of #680

(I'm pretty sure this commit name will need to be changed)

I split out the change for Number equality and labeled it as a breaking fix. However, when writing tests for this, I noticed that `5 == 5.0` is false but `5.0 == 5` is true. Need someone's help to fix that, but it highlights the importance of writing tests for all our changes.