### PR TITLE
feat(stdlib): Add Array.slice function

### DIFF
--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -269,3 +269,20 @@ assert Array.unique([>]) == [>]
 // Array.join
 assert Array.join(", ", [> "a", "b", "c"]) == "a, b, c"
 assert Array.join(", ", [>]) == ""
+
+// Array.slice
+let  testChars = [> 'a', 'b', 'c']
+
+assert Array.slice(0, 1, testChars) == [> 'a']
+assert Array.slice(1, Array.length(testChars), testChars) == [> 'b', 'c']
+assert Array.slice(0, 0, testChars) == [>]
+// Purposefully huge number
+assert Array.slice(1, 10000, testChars) == [> 'b', 'c']
+// Negative indexing
+assert Array.slice(1, -1, testChars) == [> 'b']
+assert Array.slice(-2, -1, testChars) == [> 'b']
+// Bad order
+assert Array.slice(2, 1, testChars) == [>]
+assert Array.slice(-1, -2, testChars) == [>]
+// Empty
+assert Array.slice(1, 4, [>]) == [>]

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -420,7 +420,7 @@ export let join = (separator: String, items: Array<String>) => {
  * at the end index will not be included in the result.
  *
  * If either index is a negative number, it will be treated as a reverse index from
- * the end of the array. e.g. slice(1, -1, [> 'a', 'b', 'c']) === 'b'].
+ * the end of the array. e.g. slice(1, -1, [> 'a', 'b', 'c']) == [> 'b'].
  *
  * @param startIndex: Number The index of the array where the slice will begin (inclusive)
  * @param endIndex: Number The index of the array where the slice will end (exclusive)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -416,7 +416,7 @@ export let join = (separator: String, items: Array<String>) => {
 }
 
 /**
- * Slices an array given zero-based start and end indexes. The character
+ * Slices an array given zero-based start and end indexes. The value
  * at the end index will not be included in the result.
  *
  * If either index is a negative number, it will be treated as a reverse index from

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -414,3 +414,47 @@ export let join = (separator: String, items: Array<String>) => {
     Some(s) => s,
   }
 }
+
+/**
+ * Slices an array given zero-based start and end indexes. The character
+ * at the end index will not be included in the result.
+ *
+ * If either index is a negative number, it will be treated as a reverse index from
+ * the end of the array. e.g. slice(1, -1, [> 'a', 'b', 'c']) === 'b'].
+ *
+ * @param startIndex: Number The index of the array where the slice will begin (inclusive)
+ * @param endIndex: Number The index of the array where the slice will end (exclusive)
+ * @param array: Array<a> The array to be sliced
+ * @returns Array<a> The subset of the array that was sliced
+ */
+export let slice = (startIndex, endIndex, array) => {
+  // Note(blaine): Implementation taken directly from the String.slice method
+  // I wrote in Reason for Grain_utils.String
+  let arrayLength = length(array)
+
+  let wrapNegativeIndex = idx => {
+    if (idx >= 0) {
+      idx
+    } else {
+      arrayLength + idx
+    }
+  }
+
+  let startIndex = wrapNegativeIndex(startIndex)
+  let endIndex = wrapNegativeIndex(endIndex)
+  // Ensure we aren't working with an `end` value that is too big
+  let endIndex = if (endIndex > arrayLength) {
+    arrayLength
+  } else {
+    endIndex
+  }
+
+  let newLength = endIndex - startIndex;
+  if (newLength < 0) {
+    [>]
+  } else if (newLength > arrayLength) {
+    array
+  } else {
+    init(newLength, n => array[startIndex + n])
+  }
+}

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -428,8 +428,6 @@ export let join = (separator: String, items: Array<String>) => {
  * @returns Array<a> The subset of the array that was sliced
  */
 export let slice = (startIndex, endIndex, array) => {
-  // Note(blaine): Implementation taken directly from the String.slice method
-  // I wrote in Reason for Grain_utils.String
   let arrayLength = length(array)
 
   let wrapNegativeIndex = idx => {


### PR DESCRIPTION
In the spirit of #711 - I've begun splitting out the changes from the "misc" section of #680

This adds `slice` to the Array stdlib. I actually rewrote the function because I believe our guiding principals on the stdlib is to be graceful where possible. This change is likely to be a bit controversial for the team so I'd like feedback if anyone doesn't think we should handle indexes too large or negative indexing from the end.