### PR TITLE
chore(compiler): Attach comments to the typed_program

### DIFF
--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -504,11 +504,28 @@ type toplevel_stmt = {
   ttop_env: [@sexp.opaque] Env.t,
 };
 
+[@deriving (sexp, yojson)]
+type comment_desc =
+  Parsetree.comment_desc = {
+    cmt_content: string,
+    cmt_source: string,
+    cmt_loc: Location.t,
+  };
+
+[@deriving (sexp, yojson)]
+type comment =
+  Parsetree.comment =
+    | Line(comment_desc)
+    | Shebang(comment_desc)
+    | Block(comment_desc)
+    | Doc(comment_desc);
+
 [@deriving sexp]
 type typed_program = {
   statements: list(toplevel_stmt),
   env: [@sexp.opaque] Env.t,
   signature: Cmi_format.cmi_infos,
+  comments: list(comment),
 };
 
 let iter_pattern_desc = (f, patt) =>

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -468,11 +468,28 @@ type toplevel_stmt = {
   ttop_env: Env.t,
 };
 
+[@deriving (sexp, yojson)]
+type comment_desc =
+  Parsetree.comment_desc = {
+    cmt_content: string,
+    cmt_source: string,
+    cmt_loc: Location.t,
+  };
+
+[@deriving (sexp, yojson)]
+type comment =
+  Parsetree.comment =
+    | Line(comment_desc)
+    | Shebang(comment_desc)
+    | Block(comment_desc)
+    | Doc(comment_desc);
+
 [@deriving sexp]
 type typed_program = {
   statements: list(toplevel_stmt),
   env: Env.t,
   signature: Cmi_format.cmi_infos,
+  comments: list(comment),
 };
 
 /* Auxiliary functions over the AST */

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -967,7 +967,7 @@ let type_implementation = prog => {
   let normalized_sig = normalize_signature(finalenv, simple_sg);
   let signature = Env.build_signature(normalized_sig, modulename, filename);
   ignore(coercion);
-  {statements, env, signature};
+  {statements, env, signature, comments: prog.comments};
 };
 
 /* Error report */


### PR DESCRIPTION
In preparation of "graindoc", I need to submit a few cleanup PRs.

This attaches the comments from the `parsed_program` to the `typed_program` because the documentation generator runs the compiler until typechecking is complete and then combines the type signatures with the comments.

I'm not sure this needs to be tested because it is typechecked and doesn't actually modify the comments at all. We already test the comments are parsed correctly in the Parsetree.