### PR TITLE
chore(compiler): Trim each line of a block or doc comment

### DIFF
--- a/compiler/src/parsing/parser_header.re
+++ b/compiler/src/parsing/parser_header.re
@@ -37,12 +37,16 @@ let make_shebang_comment = (source, loc) => {
 };
 
 let make_block_comment = (source, loc) => {
-  let content = String_utils.slice(~first=2, ~last=-2, source) |> String.trim;
+  let content =
+    String_utils.slice(~first=2, ~last=-2, source)
+    |> String_utils.trim_each_line;
   Block({cmt_content: content, cmt_source: source, cmt_loc: loc});
 };
 
 let make_doc_comment = (source, loc) => {
-  let content = String_utils.slice(~first=3, ~last=-2, source) |> String.trim;
+  let content =
+    String_utils.slice(~first=3, ~last=-2, source)
+    |> String_utils.trim_each_line;
   Doc({cmt_content: content, cmt_source: source, cmt_loc: loc});
 };
 

--- a/compiler/src/utils/string_utils.re
+++ b/compiler/src/utils/string_utils.re
@@ -13,6 +13,13 @@ let starts_with = (string, prefix) => {
   };
 };
 
+let trim_each_line = str => {
+  str
+  |> Str.split(Str.regexp("[\n\r]"))
+  |> List.map(String.trim)
+  |> String.concat("\n");
+};
+
 /**
 Slices a string given optional zero-based [~first] and [~last] indexes. The character
 at the [~last] index will not be included in the result.

--- a/compiler/src/utils/string_utils.re
+++ b/compiler/src/utils/string_utils.re
@@ -15,7 +15,7 @@ let starts_with = (string, prefix) => {
 
 let trim_each_line = str => {
   str
-  |> Str.split(Str.regexp("[\n\r]"))
+  |> Str.split(Str.regexp("\\(\r\n\\|\n\\)"))
   |> List.map(String.trim)
   |> String.concat("\n");
 };

--- a/compiler/test/suites/comments.re
+++ b/compiler/test/suites/comments.re
@@ -41,6 +41,21 @@ describe("comments", ({test}) => {
     },
   );
   assertParse(
+    "comment_parse_block_multiline_trim",
+    "/* Test\n    Weird indent\n  Normal indent */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Block({
+          cmt_content: "Test\nWeird indent\nNormal indent",
+          cmt_source: "/* Test\n    Weird indent\n  Normal indent */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
     "comment_parse_3",
     "/** Test */\"foo\"",
     {
@@ -49,6 +64,21 @@ describe("comments", ({test}) => {
         Parsetree.Doc({
           cmt_content: "Test",
           cmt_source: "/** Test */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "comment_parse_doc_multiline_trim",
+    "/** Test\n    Weird indent\n  Normal indent */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Doc({
+          cmt_content: "Test\nWeird indent\nNormal indent",
+          cmt_source: "/** Test\n    Weird indent\n  Normal indent */",
           cmt_loc: Location.dummy_loc,
         }),
       ],

--- a/compiler/test/suites/comments.re
+++ b/compiler/test/suites/comments.re
@@ -56,6 +56,21 @@ describe("comments", ({test}) => {
     },
   );
   assertParse(
+    "comment_parse_block_multiline_trim2",
+    "/* Test\r\n    Weird indent\r\n  Normal indent */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Block({
+          cmt_content: "Test\nWeird indent\nNormal indent",
+          cmt_source: "/* Test\r\n    Weird indent\r\n  Normal indent */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
     "comment_parse_3",
     "/** Test */\"foo\"",
     {
@@ -79,6 +94,21 @@ describe("comments", ({test}) => {
         Parsetree.Doc({
           cmt_content: "Test\nWeird indent\nNormal indent",
           cmt_source: "/** Test\n    Weird indent\n  Normal indent */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "comment_parse_doc_multiline_trim2",
+    "/** Test\r\n    Weird indent\r\n  Normal indent */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Doc({
+          cmt_content: "Test\nWeird indent\nNormal indent",
+          cmt_source: "/** Test\r\n    Weird indent\r\n  Normal indent */",
           cmt_loc: Location.dummy_loc,
         }),
       ],


### PR DESCRIPTION
In preparation of "graindoc", I need to submit a few cleanup PRs.

This improves our comment string trimming to trim each line of a Doc or Block comment which allows for a more precise regexp in the documentation attribute parser (so each attribute line will start with an `@`-symbol).