### PR TITLE
fix(compiler): Strip leading line asterisks in block and doc comments

### DIFF
--- a/compiler/src/parsing/parser_header.re
+++ b/compiler/src/parsing/parser_header.re
@@ -39,6 +39,7 @@ let make_shebang_comment = (source, loc) => {
 let make_block_comment = (source, loc) => {
   let content =
     String_utils.slice(~first=2, ~last=-2, source)
+    |> String_utils.deasterisk_each_line
     |> String_utils.trim_each_line;
   Block({cmt_content: content, cmt_source: source, cmt_loc: loc});
 };
@@ -46,6 +47,7 @@ let make_block_comment = (source, loc) => {
 let make_doc_comment = (source, loc) => {
   let content =
     String_utils.slice(~first=3, ~last=-2, source)
+    |> String_utils.deasterisk_each_line
     |> String_utils.trim_each_line;
   Doc({cmt_content: content, cmt_source: source, cmt_loc: loc});
 };

--- a/compiler/src/utils/string_utils.re
+++ b/compiler/src/utils/string_utils.re
@@ -20,6 +20,10 @@ let trim_each_line = str => {
   |> String.concat("\n");
 };
 
+let deasterisk_each_line = str => {
+  Str.global_replace(Str.regexp("^[ \t]*\\*"), "", str);
+};
+
 /**
 Slices a string given optional zero-based [~first] and [~last] indexes. The character
 at the [~last] index will not be included in the result.

--- a/compiler/test/suites/comments.re
+++ b/compiler/test/suites/comments.re
@@ -130,6 +130,36 @@ describe("comments", ({test}) => {
       prog_loc: Location.dummy_loc,
     },
   );
+  assertParse(
+    "comment_parse_block_deasterisk",
+    "/* Test\n* no space before\n * space before\n  * tab before\n *no space after */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Block({
+          cmt_content: "Test\nno space before\nspace before\ntab before\nno space after",
+          cmt_source: "/* Test\n* no space before\n * space before\n  * tab before\n *no space after */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "comment_parse_doc_deasterisk",
+    "/** Test\n* no space before\n * space before\n  * tab before\n *no space after */\"foo\"",
+    {
+      statements: [str("foo")],
+      comments: [
+        Parsetree.Doc({
+          cmt_content: "Test\nno space before\nspace before\ntab before\nno space after",
+          cmt_source: "/** Test\n* no space before\n * space before\n  * tab before\n *no space after */",
+          cmt_loc: Location.dummy_loc,
+        }),
+      ],
+      prog_loc: Location.dummy_loc,
+    },
+  );
   assertCompileError(
     "comment_line_numbers_1",
     "//comment\n//comment\n5 + 5L",

--- a/stdlib/range.gr
+++ b/stdlib/range.gr
@@ -1,34 +1,34 @@
 /**
-  @module Range: Utilities for working with ranges. A range represents an interval—a set of values with a beginning and an end.
-  @example import Range from "range"
-*/
+ * @module Range: Utilities for working with ranges. A range represents an interval—a set of values with a beginning and an end.
+ * @example import Range from "range"
+ */
 
 /**
-  @section Types: Type declarations included in the Range module.
-*/
+ * @section Types: Type declarations included in the Range module.
+ */
 
 /**
-  Ranges can be inclusive or exclusive. When `Inclusive`, the end value will be included in operations. When `Exclusive`, the end value will be excluded from operations.
-*/
+ * Ranges can be inclusive or exclusive. When `Inclusive`, the end value will be included in operations. When `Exclusive`, the end value will be excluded from operations.
+ */
 export enum Range {
   Inclusive(Number, Number),
   Exclusive(Number, Number),
 }
 
 /**
-  @section Values: Functions and constants included in the Range module.
-*/
+ * @section Values: Functions and constants included in the Range module.
+ */
 
 /**
-  Checks if the given number is within the range.
-
-  @param value: The number being checked
-  @param range: The range to check within
-  @returns Whether or not the value is within range
-
-  @example Range.inRange(1, Range.Inclusive(0, 2)) == true
-  @example Range.inRange(10, Range.Inclusive(0, 2)) == false
-*/
+ * Checks if the given number is within the range.
+ *
+ * @param value: The number being checked
+ * @param range: The range to check within
+ * @returns Whether or not the value is within range
+ *
+ * @example Range.inRange(1, Range.Inclusive(0, 2)) == true
+ * @example Range.inRange(10, Range.Inclusive(0, 2)) == false
+ */
 export let inRange = (value, range) => {
   match (range) {
     Inclusive(lower, upper) when value >= lower && value <= upper => true,
@@ -40,13 +40,13 @@ export let inRange = (value, range) => {
 }
 
 /**
-  Calls the given function with each number in the range. For increasing ranges, the value is increased by `1` in each iteration, and for decreasing ranges, the value is decreased by `1`. The value is always changed by `1`, even if non-integer values were provided in the range.
-
-  @param fn: The function to be executed on each number in the range
-  @param range: The range to iterate
-
-  @example Range.forEach(val => print(val), Range.Exclusive(0, 2))
-*/
+ * Calls the given function with each number in the range. For increasing ranges, the value is increased by `1` in each iteration, and for decreasing ranges, the value is decreased by `1`. The value is always changed by `1`, even if non-integer values were provided in the range.
+ *
+ * @param fn: The function to be executed on each number in the range
+ * @param range: The range to iterate
+ *
+ * @example Range.forEach(val => print(val), Range.Exclusive(0, 2))
+ */
 export let forEach = (fn: (Number) -> Void, range) => {
   match (range) {
     Inclusive(lower, upper) when lower <= upper => {
@@ -81,14 +81,14 @@ export let forEach = (fn: (Number) -> Void, range) => {
 }
 
 /**
-  Produces a list by calling the given function on each number included in the range. For increasing ranges, the value is increased by `1` in each iteration, and for decreasing ranges, the value is decreased by `1`. The value is always changed by `1`, even if non-integer values were provided in the range.
-
-  @param fn: The function called on each number in the range that returns the value for the output list
-  @param range: The range to iterate
-  @returns A list containing all values returned from the `fn`
-
-  @example Range.map(val => val * 2, Range.Inclusive(0, 2)) == [0, 2, 4]
-*/
+ * Produces a list by calling the given function on each number included in the range. For increasing ranges, the value is increased by `1` in each iteration, and for decreasing ranges, the value is decreased by `1`. The value is always changed by `1`, even if non-integer values were provided in the range.
+ *
+ * @param fn: The function called on each number in the range that returns the value for the output list
+ * @param range: The range to iterate
+ * @returns A list containing all values returned from the `fn`
+ *
+ * @example Range.map(val => val * 2, Range.Inclusive(0, 2)) == [0, 2, 4]
+ */
 export let map = (fn, range) => {
   let mut result = []
   match (range) {


### PR DESCRIPTION
This was the intended behavior of how `cmt_content` would work (and why we have both `cmt_source` and `cmt_content` in the first place 🤦). Added bonus: this makes writing `* @param` work with Graindoc 😄 