### PR TITLE
feat(compiler): Emit a warning when using Pervasives.(==) with unsafe Wasm types

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -58,7 +58,11 @@ let compile_string = name => {
     ignore(
       {
         let compile_state =
-          Compile.compile_string(~hook=stop_after_typed, ~name, program_str^);
+          Compile.compile_string(
+            ~hook=stop_after_typed_well_formed,
+            ~name,
+            program_str^,
+          );
 
         switch (compile_state.cstate_desc) {
         | TypeChecked(typed_program) =>

--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -125,7 +125,12 @@ let next_state = ({cstate_desc, cstate_filename} as cs) => {
       apply_inline_flags(p);
       Well_formedness.check_well_formedness(p);
       WellFormed(p);
-    | WellFormed(p) => TypeChecked(Typemod.type_implementation(p))
+    | WellFormed(p) =>
+      let typed_mod = Typemod.type_implementation(p);
+      // This just emits warnings, so it's in the same step in the state machine.
+      // If there's a reason, this can be split out into a separate step.
+      Typed_well_formedness.check_well_formedness(typed_mod);
+      TypeChecked(typed_mod);
     | TypeChecked(typed_mod) =>
       Linearized(Linearize.transl_anf_module(typed_mod))
     | Linearized(anfed) =>

--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -14,6 +14,7 @@ type compilation_state_desc =
   | Parsed(Parsetree.parsed_program)
   | WellFormed(Parsetree.parsed_program)
   | TypeChecked(Typedtree.typed_program)
+  | TypedWellFormed(Typedtree.typed_program)
   | Linearized(Anftree.anf_program)
   | Optimized(Anftree.anf_program)
   | Mashed(Mashtree.mash_program)
@@ -60,6 +61,8 @@ let log_state = state =>
     | TypeChecked(typed_mod) =>
       prerr_string("\nTyped program:\n");
       prerr_sexp(Grain_typed.Typedtree.sexp_of_typed_program, typed_mod);
+    | TypedWellFormed(typed_mod) =>
+      prerr_string("\nTyped well-formedness passed")
     | Linearized(anfed) =>
       prerr_string("\nANFed program:\n");
       prerr_sexp(Anftree.sexp_of_anf_program, anfed);
@@ -125,13 +128,11 @@ let next_state = ({cstate_desc, cstate_filename} as cs) => {
       apply_inline_flags(p);
       Well_formedness.check_well_formedness(p);
       WellFormed(p);
-    | WellFormed(p) =>
-      let typed_mod = Typemod.type_implementation(p);
-      // This just emits warnings, so it's in the same step in the state machine.
-      // If there's a reason, this can be split out into a separate step.
-      Typed_well_formedness.check_well_formedness(typed_mod);
-      TypeChecked(typed_mod);
+    | WellFormed(p) => TypeChecked(Typemod.type_implementation(p))
     | TypeChecked(typed_mod) =>
+      Typed_well_formedness.check_well_formedness(typed_mod);
+      TypedWellFormed(typed_mod);
+    | TypedWellFormed(typed_mod) =>
       Linearized(Linearize.transl_anf_module(typed_mod))
     | Linearized(anfed) =>
       if (Grain_utils.Config.optimizations_enabled^) {
@@ -225,6 +226,11 @@ let stop_after_well_formed =
 let stop_after_typed =
   fun
   | {cstate_desc: TypeChecked(_)} => Stop
+  | s => Continue(s);
+
+let stop_after_typed_well_formed =
+  fun
+  | {cstate_desc: TypedWellFormed(_)} => Stop
   | s => Continue(s);
 
 let stop_after_anf =

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -1,0 +1,44 @@
+open Grain_parsing;
+open Types;
+open Typedtree;
+open TypedtreeIter;
+
+/*
+ * This module provides well-formedness checks which are type/value resolution-dependent.
+ * For the moment, this is just a warning on (==), but feel free to refactor once more checks
+ * are desired.
+ */
+
+let wasm_unsafe_types = ["WasmI32", "WasmI64", "WasmF32", "WasmF64"];
+
+let exp_is_wasm_unsafe = ({exp_type: {desc}}) => {
+  switch (desc) {
+  | TTyConstr(path, [], _) => List.mem(Path.name(path), wasm_unsafe_types)
+  | _ => false
+  };
+};
+
+module WellFormednessArg: TypedtreeIter.IteratorArgument = {
+  include TypedtreeIter.DefaultIteratorArgument;
+
+  let enter_expression: expression => unit =
+    ({exp_desc, exp_loc}) => {
+      switch (exp_desc) {
+      | TExpApp({exp_desc: TExpIdent(val_fullpath, _, _)}, args)
+          when Path.name(val_fullpath) == "Pervasives.==" =>
+        if (List.exists(exp_is_wasm_unsafe, args)) {
+          let warning = Grain_utils.Warnings.EqualWasmUnsafe;
+          if (Grain_utils.Warnings.is_active(warning)) {
+            Grain_parsing.Location.prerr_warning(exp_loc, warning);
+          };
+        }
+      | _ => ()
+      };
+    };
+};
+
+module WellFormednessIterator = TypedtreeIter.MakeIterator(WellFormednessArg);
+
+let check_well_formedness = ({statements}) => {
+  List.iter(WellFormednessIterator.iter_toplevel_stmt, statements);
+};

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -5,8 +5,6 @@ open TypedtreeIter;
 
 /*
  * This module provides well-formedness checks which are type/value resolution-dependent.
- * For the moment, this is just a warning on (==), but feel free to refactor once more checks
- * are desired.
  */
 
 let wasm_unsafe_types = [

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -30,7 +30,11 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
       | TExpApp(
           {
             exp_desc:
-              TExpIdent(Path.PExternal(Path.PIdent({name: "Pervasives"}), "==", _), _, _),
+              TExpIdent(
+                Path.PExternal(Path.PIdent({name: "Pervasives"}), "==", _),
+                _,
+                _,
+              ),
           },
           args,
         ) =>

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -30,11 +30,10 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
       | TExpApp(
           {
             exp_desc:
-              TExpIdent(Path.PExternal(Path.PIdent(mod_), fnc, _), _, _),
+              TExpIdent(Path.PExternal(Path.PIdent({name: "Pervasives"}), "==", _), _, _),
           },
           args,
-        )
-          when Ident.name(mod_) == "Pervasives" && fnc == "==" =>
+        ) =>
         if (List.exists(exp_is_wasm_unsafe, args)) {
           let warning = Grain_utils.Warnings.EqualWasmUnsafe;
           if (Grain_utils.Warnings.is_active(warning)) {

--- a/compiler/src/typed/typed_well_formedness.rei
+++ b/compiler/src/typed/typed_well_formedness.rei
@@ -1,0 +1,5 @@
+/**
+ * Performs well-formedness checks on the given typed program.
+ * These checks are distinct from those defined in Grain_parsing.Well_formedness.
+ */
+let check_well_formedness: Typedtree.typed_program => unit;

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -22,7 +22,8 @@ type t =
   | NonClosedRecordPattern(string)
   | UnreachableCase
   | ShadowConstructor(string)
-  | NoCmiFile(string, option(string));
+  | NoCmiFile(string, option(string))
+  | EqualWasmUnsafe;
 
 let number =
   fun
@@ -41,9 +42,10 @@ let number =
   | ShadowConstructor(_) => 13
   | NoCmiFile(_) => 14
   | NonClosedRecordPattern(_) => 15
-  | UnusedExtension => 16;
+  | UnusedExtension => 16
+  | EqualWasmUnsafe => 17;
 
-let last_warning_number = 16;
+let last_warning_number = 17;
 
 let message =
   fun
@@ -102,7 +104,8 @@ let message =
       msg,
     )
   | NonClosedRecordPattern(s) =>
-    "the following fields are missing from the record pattern: " ++ s;
+    "the following fields are missing from the record pattern: " ++ s
+  | EqualWasmUnsafe => "it looks like you are using (==) on two unsafe WASM values here.\nPlease ensure that this is intentional.";
 
 let sub_locs =
   fun
@@ -143,6 +146,7 @@ let defaults = [
   UnreachableCase,
   ShadowConstructor(""),
   NoCmiFile("", None),
+  EqualWasmUnsafe,
 ];
 
 let _ = List.iter(x => current^.active[number(x)] = true, defaults);

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -105,7 +105,7 @@ let message =
     )
   | NonClosedRecordPattern(s) =>
     "the following fields are missing from the record pattern: " ++ s
-  | EqualWasmUnsafe => "it looks like you are using (==) on two unsafe WASM values here.\nPlease ensure that this is intentional.";
+  | EqualWasmUnsafe => "it looks like you are using Pervasives.(==) on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use `WasmI32.eq`, `WasmI64.eq`, `WasmF32.eq`, or `WasmF64.eq` instead.";
 
 let sub_locs =
   fun

--- a/compiler/src/utils/warnings.rei
+++ b/compiler/src/utils/warnings.rei
@@ -36,7 +36,8 @@ type t =
   | NonClosedRecordPattern(string)
   | UnreachableCase
   | ShadowConstructor(string)
-  | NoCmiFile(string, option(string));
+  | NoCmiFile(string, option(string))
+  | EqualWasmUnsafe;
 
 let is_active: t => bool;
 let is_error: t => bool;


### PR DESCRIPTION
Closes #738.

This pull request adds a QOL improvement for low-level standard WASM development by emitting a warning when `Pervasives.(==)` is used to compare any of the following types: `WasmI32`, `WasmI64`, `WasmF32`, and `WasmF64`. This is accomplished by a new well-formedness pass on the Typed AST, which we can add things to in the future. To illustrate, consider the following `tst.gr` file:
```grain
import WasmI32 from "runtime/unsafe/wasmi32"
assert 9n == WasmI32.fromGrain(4)
assert WasmI32.toGrain(9n) == 4
let (==) = WasmI32.eq
// safe, since we have shadowed (==) with the WasmI32 variant
assert 9n == WasmI32.fromGrain(4)
```
The compiler now emits the following:
```
 λ grain git:(warn-wasm-unsafe-equal) > grain tst.gr                             
File "tst.gr", line 2, characters 7-33:
Warning 17: it looks like you are using (==) on two unsafe WASM values here.
Please ensure that this is intentional.
```

I've verified that backing out the change from #735 causes the warning to be emitted when running the test:
```
 λ grain git:(warn-wasm-unsafe-equal) ✗ > grain compiler/test/stdlib/string.test.gr
File "/Users/pblair/views/grain/stdlib/string.gr", line 1176, characters 6-22:
Warning 17: it looks like you are using (==) on two WasmI32 values here.
Please ensure that this is intentional.
```
I haven't found any warnings emitted by the standard library, which is good news in general, but bad news for #726 .