### PR TITLE
Reduce reduntant memory loads in Malloc.free.

### DIFF
--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -172,7 +172,7 @@ export let free = (ap: WasmI32) => {
   // is actually already pointing to this node, so we don't do anything.
   if (blockPtr != freePtr) {
     // Find the location to insert this block into the free list
-    for ( ; ; ) {
+    while (true) {
       let nextp = getNext(p)
       if ( ((blockPtr > p) && (blockPtr < nextp)) || ((p >= nextp) && ((blockPtr > p) || (blockPtr < nextp))) ) {
         break

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -172,23 +172,27 @@ export let free = (ap: WasmI32) => {
   // is actually already pointing to this node, so we don't do anything.
   if (blockPtr != freePtr) {
     // Find the location to insert this block into the free list
-    for ( ; !((blockPtr > p) && (blockPtr < getNext(p))); p = getNext(p) ) {
-      if ((p >= getNext(p)) && ((blockPtr > p) || (blockPtr < getNext(p)))) {
+    for ( ; ; ) {
+      let nextp = getNext(p)
+      if ( ((blockPtr > p) && (blockPtr < nextp)) || ((p >= nextp) && ((blockPtr > p) || (blockPtr < nextp))) ) {
         break
       }
+      p = nextp
     }
 
     // Merge the block into the adjacent free list entry above, if needed
-    if (blockPtr + getSize(blockPtr) == getNext(p)) {
-      let next = getNext(p)
-      setSize(blockPtr, getSize(blockPtr) + getSize(next))
+    let blockPtrSize = getSize(blockPtr)
+    let next = getNext(p)
+    if (blockPtr + blockPtrSize == next) {
+      setSize(blockPtr, blockPtrSize + getSize(next))
       setNext(blockPtr, getNext(next))
     } else {
-      setNext(blockPtr, getNext(p))
+      setNext(blockPtr, next)
     }
     // Merge the previous (adjacent) free list entry into this block, if needed
-    if (p + getSize(p) == blockPtr) {
-      setSize(p, getSize(p) + getSize(blockPtr))
+    let pSize = getSize(p)
+    if (p + pSize == blockPtr) {
+      setSize(p, pSize + getSize(blockPtr))
       setNext(p, getNext(blockPtr))
     } else {
       setNext(p, blockPtr)


### PR DESCRIPTION
This PR should speed up all grain programs at least a little bit by avoiding redundant memory accesses in Malloc.free.

I hope someone can carefully triple check this change so we can feel a little bit greener 💚

Synthetic test:
just allocate and free 1000000 strings  of 10 bytes each in a loop (with @disableGC).
207ms-216ms unoptimized
198ms-207ms optimized

Slightly less synthetic test:
Emit 15KiB json.
127ms-132ms unoptimized
74ms-81ms optimized

Emit 150KiB json.
5969ms-6364ms unoptimized
2955ms-3188ms optimized

Side note: Emit json time seems to grow exponentially with input size, but its not the case. It's because of a memory leak in GC (#745) so my benchmark results are heavily skewed with each iteration of the same being slower. 1.5MiB json takes 14 minutes (compare that to 5ms for the same in node.js, not exactly a fair comparison, but still 🐢). The synthetic test instead uses @disableGC to only test malloc. Sorry for side-tracking.

```
starting benchmark emit example json
iteration 0
iteration time: 3896ms
iteration 1
iteration time: 4438ms
iteration 2
iteration time: 5207ms
iteration 3
iteration time: 5742ms
iteration 4
iteration time: 5648ms
iteration 5
iteration time: 6961ms
iteration 6
iteration time: 7296ms
iteration 7
iteration time: 7985ms
iteration 8
iteration time: 7983ms
iteration 9
iteration time: 8478ms
emit example json: 6364ms
```

