### PR TITLE
feat(graindoc): Add support for deprecated attribute

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -123,6 +123,28 @@ let signature_item_in_range =
 let to_markdown = docblock => {
   let buf = Buffer.create(0);
   Buffer.add_string(buf, Markdown.heading(~level=3, docblock.name));
+  let deprecations =
+    docblock.attributes
+    |> List.filter(Comments.Attribute.is_deprecated)
+    |> List.map((attr: Comments.Attribute.t) => {
+         switch (attr) {
+         | Deprecated({attr_desc}) => attr_desc
+         | _ =>
+           failwith(
+             "Unreachable: Non-`deprecated` attribute can't exist here.",
+           )
+         }
+       });
+  if (List.length(deprecations) > 0) {
+    List.iter(
+      msg =>
+        Buffer.add_string(
+          buf,
+          Markdown.blockquote(Markdown.bold("Deprecated:") ++ " " ++ msg),
+        ),
+      deprecations,
+    );
+  };
   Buffer.add_string(buf, Markdown.code_block(docblock.type_sig));
   if (String.length(docblock.description) > 0) {
     Buffer.add_string(buf, Markdown.paragraph(docblock.description));

--- a/compiler/src/diagnostics/comments.re
+++ b/compiler/src/diagnostics/comments.re
@@ -30,7 +30,8 @@ module Attribute = {
     | Section({
         attr_name,
         attr_desc,
-      });
+      })
+    | Deprecated({attr_desc});
 
   let try_or_malformed = (~attr, ~hint, fn) =>
     try(fn()) {
@@ -97,6 +98,15 @@ module Attribute = {
                 attrs := [Section({attr_name, attr_desc}), ...attrs^];
               },
             )
+          | "deprecated" =>
+            try_or_malformed(
+              ~attr,
+              ~hint="@deprecated Description of deprecation",
+              () => {
+                let attr_desc = Str.matched_group(4, comment);
+                attrs := [Deprecated({attr_desc: attr_desc}), ...attrs^];
+              },
+            )
           | _ => raise(InvalidAttribute(attr))
           };
 
@@ -140,6 +150,13 @@ module Attribute = {
   let is_section = (attr: t) => {
     switch (attr) {
     | Section(_) => true
+    | _ => false
+    };
+  };
+
+  let is_deprecated = (attr: t) => {
+    switch (attr) {
+    | Deprecated(_) => true
     | _ => false
     };
   };

--- a/compiler/src/utils/markdown.re
+++ b/compiler/src/utils/markdown.re
@@ -49,3 +49,11 @@ let frontmatter = rows => {
   |> String.concat("\n")
   |> Format.sprintf("---\n%s\n---\n\n");
 };
+
+let bold = str => {
+  Format.sprintf("**%s**", str);
+};
+
+let blockquote = str => {
+  Format.sprintf("> %s\n\n", str);
+};

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -1,13 +1,40 @@
+/**
+ * @module Stack: An immutable stack implementation. A stack is a LIFO (last-in-first-out) data structure where new values are added, retrieved, and removed from the end.
+ * @example import Stack from "stack"
+ */
+
 import List from "list"
 
+/**
+ * @section Types: Type declarations included in the Stack module.
+ */
+
+/**
+ * Stacks are immutable data structures that store their data in a List.
+ */
 record Stack<a> {
     data: List<a>
 }
 
+/**
+ * @section Values: Functions and constants included in the Stack module.
+ */
+
+/**
+ * Creates a new stack.
+ *
+ * @returns An empty stack
+ */
 export let make = () => {
     { data: [] }
 }
 
+/**
+ * Checks if the given stack contains no items.
+ *
+ * @param stack: The stack to check
+ * @returns `true` if the stack has no items, and `false` otherwise
+ */
 export let isEmpty = (stack) => {
     match (stack) {
         { data: [] } => true,
@@ -15,6 +42,12 @@ export let isEmpty = (stack) => {
     }
 }
 
+/**
+ * Returns `Some(item)` where `item` is the value at the top of the stack, and `None` otherwise.
+ *
+ * @param stack: The stack to inspect
+ * @returns The value at the top of the stack, if it exists
+ */
 export let peek = (stack) => {
     match (stack) {
         { data: [] } => None,
@@ -23,10 +56,22 @@ export let peek = (stack) => {
 }
 
 /**
-  @deprecated Please use `Stack.peek` instead. `Stack.head` will be removed in v0.4.0.
-*/
+ * Returns `Some(item)` where `item` is the value at the top of the stack, and `None` otherwise.
+ *
+ * @param stack: The stack to inspect
+ * @returns The value at the top of the stack, if it exists
+ *
+ * @deprecated Please use `Stack.peek` instead. `Stack.head` will be removed in v0.4.0.
+ */
 export let head = peek;
 
+/**
+ * Adds a new item to the top of the stack.
+ *
+ * @param value: The item to be added
+ * @param stack: The stack being updated
+ * @returns A new stack with the item added to the end
+ */
 export let push = (value, stack) => {
     match (stack) {
         { data: [] } => { data: [value] },
@@ -34,6 +79,12 @@ export let push = (value, stack) => {
     }
 }
 
+/**
+ * Removes the item at the top of the stack.
+ *
+ * @param stack: The stack being updated
+ * @returns A new stack with the last item removed
+ */
 export let pop = (stack) => {
     match (stack) {
         { data: [] } => stack,
@@ -41,6 +92,12 @@ export let pop = (stack) => {
     }
 }
 
+/**
+ * Computes the size of the input stack.
+ *
+ * @param stack: The stack to inspect
+ * @returns The count of the items in the stack
+ */
 export let size = (stack) => {
     match (stack) {
         { data: [] } => 0,


### PR DESCRIPTION
This adds support in GrainDoc for the `@deprecated` attribute. I decided to generate this markdown when the attribute is encountered:
```md
> **Deprecated:** Message for deprecation
```
(This currently doesn't style well on the website, but we can fix that.)

The deprecation markdown is inserted after the function name but before the type signature or any other documentation.

I also added my Stack documentation to this PR so y'all can test the generation to see if you like it. If you'd like me to split that documentation out before merge, let me know.