### PR TITLE
feat(compiler)!: Remove semantic meaning of semicolons

### DIFF
--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -503,7 +503,7 @@ block_body_expr :
   | expr  { $1 }
 
 block_body_stmt :
-  | block_body_expr SEMI eols? { Exp.ignore $1 }
+  | block_body_expr SEMI eols? { $1 }
   | block_body_expr eols { $1 }
 
 tuple_exprs :
@@ -532,7 +532,7 @@ record_exprs :
   | [record_field | record_pun] [comma [record_field | record_pun] {$2}]* trailing_comma? {$1::$2}
 
 block_body :
-  | block_body_stmt* block_body_expr SEMI { $1 @ [Exp.ignore $2] }
+  | block_body_stmt* block_body_expr SEMI { $1 @ [$2] }
   | block_body_stmt* block_body_expr { $1 @ [$2] }
 
 file_path :

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -8,7 +8,7 @@ basic functionality › orshort2
  (import \"grainRuntime\" \"relocBase\" (global $import_grainRuntime_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1140_print_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1139_print_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -18,28 +18,19 @@ basic functionality › orshort2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
+    (local.tee $0
      (tuple.extract 0
       (tuple.make
        (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1140_print_1141)
-            (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1140_print_1141)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+        (drop
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1139_print_1140)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1139_print_1140)
           )
          )
         )
@@ -54,10 +45,10 @@ basic functionality › orshort2
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $0)
+    (i32.const 0)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › void
  (import \"grainRuntime\" \"relocBase\" (global $import_grainRuntime_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,7 +16,6 @@ basic functionality › void
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -26,59 +23,34 @@ basic functionality › void
      (tuple.extract 0
       (tuple.make
        (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
-              )
-             )
-             (i32.const 1)
+        (i32.store
+         (local.tee $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+             (i32.const 16)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
             (i32.const 0)
            )
           )
          )
+         (i32.const 1)
         )
-        (drop
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $1)
-         )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.const 3)
         )
-        (i32.const 1879048190)
+        (i64.store offset=8
+         (local.get $0)
+         (i64.const 7303014)
+        )
+        (local.get $0)
        )
        (local.get $0)
       )
      )
     )
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -8,7 +8,7 @@ basic functionality › andshort1
  (import \"grainRuntime\" \"relocBase\" (global $import_grainRuntime_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1140_print_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1139_print_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -18,28 +18,19 @@ basic functionality › andshort1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
+    (local.tee $0
      (tuple.extract 0
       (tuple.make
        (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1140_print_1141)
-            (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1140_print_1141)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+        (drop
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1139_print_1140)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1139_print_1140)
           )
          )
         )
@@ -54,10 +45,10 @@ basic functionality › andshort1
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $0)
+    (i32.const 0)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -29,7 +29,6 @@ loops › loop2
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   (local.set $1
    (tuple.extract 0
     (tuple.make
@@ -140,7 +139,7 @@ loops › loop2
          )
         )
        )
-       (local.set $7
+       (local.set $6
         (tuple.extract 0
          (tuple.make
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -168,7 +167,7 @@ loops › loop2
           )
           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-           (local.get $7)
+           (local.get $6)
           )
          )
         )
@@ -208,43 +207,21 @@ loops › loop2
          )
         )
        )
-       (local.set $6
+       (i32.store offset=8
+        (local.get $2)
         (tuple.extract 0
          (tuple.make
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (block (result i32)
-            (i32.store offset=8
-             (local.get $2)
-             (tuple.extract 0
-              (tuple.make
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $5)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.load offset=8
-                 (local.get $2)
-                )
-               )
-              )
-             )
-            )
-            (i32.const 1879048190)
-           )
+           (local.get $5)
           )
           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-           (local.get $6)
+           (i32.load offset=8
+            (local.get $2)
+           )
           )
          )
-        )
-       )
-       (drop
-        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-         (local.get $6)
         )
        )
        (br $MFor_loop.6)

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -144,7 +144,7 @@ describe("basic functionality", ({test}) => {
   assertSnapshot("if_one_sided6", "let mut x = 1; if (3 < 4) x = 2 + 3; x");
   assertCompileError(
     "if_one_sided_type_err",
-    "let foo = (if (false) { 5; }); let bar = foo + 5; bar",
+    "let foo = (if (false) { ignore(5) }); let bar = foo + 5; bar",
     "has type Void but",
   );
   assertSnapshot("int32_1", "42l");

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -31,6 +31,7 @@ import WasmI32, {
 primitive (&&) : (Bool, Bool) -> Bool = "@and"
 primitive (||) : (Bool, Bool) -> Bool = "@or"
 primitive throw : Exception -> a = "@throw"
+primitive ignore : a -> Void = "@ignore"
 
 exception DecRefError
 
@@ -98,28 +99,28 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
       let arity = WasmI32.load(userPtr, 16n)
       let maxOffset = arity * 4n
       for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i = i + 4n) {
-        decRef(WasmI32.load(userPtr + i, 20n), false);
+        ignore(decRef(WasmI32.load(userPtr + i, 20n), false))
       }
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
       let arity = WasmI32.load(userPtr, 12n)
       let maxOffset = arity * 4n
       for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i = i + 4n) {
-        decRef(WasmI32.load(userPtr + i, 16n), false);
+        ignore(decRef(WasmI32.load(userPtr + i, 16n), false))
       }
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG || t == Tags._GRAIN_TUPLE_HEAP_TAG => {
       let arity = WasmI32.load(userPtr, 4n)
       let maxOffset = arity * 4n
       for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i = i + 4n) {
-        decRef(WasmI32.load(userPtr + i, 8n), false);
+        ignore(decRef(WasmI32.load(userPtr + i, 8n), false))
       }
     },
     t when t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
       let arity = WasmI32.load(userPtr, 12n)
       let maxOffset = arity * 4n
       for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i = i + 4n) {
-        decRef(WasmI32.load(userPtr + i, 16n), false);
+        ignore(decRef(WasmI32.load(userPtr + i, 16n), false))
       }
     },
     _ => {


### PR DESCRIPTION
Up until this PR, ending a statement with a semicolon had the same effect as calling `ignore` on that statement. We found this feature to be too subtle, often causing more confusion than the feature was worth. This PR removes that behavior.