### PR TITLE
chore(stdlib): Implement Map.toArray without intermediate list

### DIFF
--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -291,7 +291,7 @@ let setInArray = (array) => {
 @disableGC
 export let toArray = (map) => {
   let length = WasmI32.shrS(WasmI32.fromGrain(map.size), 1n)
-  // TODO: Removing parens around Array<a> causes a parse error
+  // TODO(#783): Removing parens around Array<a> causes a parse error
   let array = WasmI32.toGrain(allocateArray(length)): (Array<a>)
   let setInArray = setInArray(array)
   reduce(setInArray, 0, map)

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -277,9 +277,15 @@ export let fromList = (list) => {
   map
 }
 
-let setInArray = (array) => (i, key, value) => {
-  array[i] = (key, value)
-  i + 1
+let setInArray = (array) => {
+  @disableGC
+  let iter = (i, key, value) => {
+    Memory.incRef(WasmI32.fromGrain(key))
+    Memory.incRef(WasmI32.fromGrain(value))
+    array[i] = (key, value)
+    i + 1
+  }
+  iter
 }
 
 @disableGC

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -3,6 +3,9 @@
 import List from "list"
 import Array from "array"
 import { hash } from "hash"
+import Memory from "runtime/unsafe/memory"
+import WasmI32 from "runtime/unsafe/wasmi32"
+import { allocateArray } from "runtime/dataStructures"
 
 // TODO: Consider implementing this as List<(Box<k>, Box<v>)>
 record Bucket<k, v> {
@@ -274,8 +277,20 @@ export let fromList = (list) => {
   map
 }
 
+let setInArray = (array) => (i, key, value) => {
+  array[i] = (key, value)
+  i + 1
+}
+
+@disableGC
 export let toArray = (map) => {
-  Array.fromList(toList(map))
+  let length = WasmI32.shrS(WasmI32.fromGrain(map.size), 1n)
+  // TODO: Removing parens around Array<a> causes a parse error
+  let array = WasmI32.toGrain(allocateArray(length)): (Array<a>)
+  let setInArray = setInArray(array)
+  reduce(setInArray, 0, map)
+  Memory.decRef(WasmI32.fromGrain(setInArray))
+  array
 }
 
 export let fromArray = (array) => {


### PR DESCRIPTION
This implements Map.toArray without converting it to an intermediate list. This avoids blowing the stack on huge Maps when you don't have experimental tail calls, and it increases performance by 25%.

Closes #187 (which this implementation inspired, and proves that we can allocate an array without items in it).