### PR TITLE
feat(compiler): Emit a warning when using Pervasives.(!=) with unsafe Wasm types

### DIFF
--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -37,9 +37,13 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
               ),
           },
           args,
-        ) when func == "==" || func == "!=" =>
+        )
+          when func == "==" || func == "!=" =>
         if (List.exists(exp_is_wasm_unsafe, args)) {
-          let warning = Grain_utils.Warnings.FuncWasmUnsafe(Printf.sprintf("Pervasives.(%s)", func));
+          let warning =
+            Grain_utils.Warnings.FuncWasmUnsafe(
+              Printf.sprintf("Pervasives.(%s)", func),
+            );
           if (Grain_utils.Warnings.is_active(warning)) {
             Grain_parsing.Location.prerr_warning(exp_loc, warning);
           };

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -31,13 +31,13 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           {
             exp_desc:
               TExpIdent(
-                Path.PExternal(Path.PIdent({name: "Pervasives"}), "==", _),
+                Path.PExternal(Path.PIdent({name: "Pervasives"}), func, _),
                 _,
                 _,
               ),
           },
           args,
-        ) =>
+        ) when func == "==" || func == "!=" =>
         if (List.exists(exp_is_wasm_unsafe, args)) {
           let warning = Grain_utils.Warnings.EqualWasmUnsafe;
           if (Grain_utils.Warnings.is_active(warning)) {

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -39,7 +39,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           args,
         ) when func == "==" || func == "!=" =>
         if (List.exists(exp_is_wasm_unsafe, args)) {
-          let warning = Grain_utils.Warnings.EqualWasmUnsafe;
+          let warning = Grain_utils.Warnings.FuncWasmUnsafe(Printf.sprintf("Pervasives.(%s)", func));
           if (Grain_utils.Warnings.is_active(warning)) {
             Grain_parsing.Location.prerr_warning(exp_loc, warning);
           };

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -105,7 +105,10 @@ let message =
     )
   | NonClosedRecordPattern(s) =>
     "the following fields are missing from the record pattern: " ++ s
-  | FuncWasmUnsafe(func) => "it looks like you are using " ++ func ++ " on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use one of the equivalent functions in `WasmI32`, `WasmI64`, `WasmF32`, or `WasmF64` instead.";
+  | FuncWasmUnsafe(func) =>
+    "it looks like you are using "
+    ++ func
+    ++ " on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use one of the equivalent functions in `WasmI32`, `WasmI64`, `WasmF32`, or `WasmF64` instead.";
 
 let sub_locs =
   fun

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -23,7 +23,7 @@ type t =
   | UnreachableCase
   | ShadowConstructor(string)
   | NoCmiFile(string, option(string))
-  | EqualWasmUnsafe;
+  | FuncWasmUnsafe(string);
 
 let number =
   fun
@@ -43,7 +43,7 @@ let number =
   | NoCmiFile(_) => 14
   | NonClosedRecordPattern(_) => 15
   | UnusedExtension => 16
-  | EqualWasmUnsafe => 17;
+  | FuncWasmUnsafe(_) => 17;
 
 let last_warning_number = 17;
 
@@ -105,7 +105,7 @@ let message =
     )
   | NonClosedRecordPattern(s) =>
     "the following fields are missing from the record pattern: " ++ s
-  | EqualWasmUnsafe => "it looks like you are using Pervasives.(==) on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use `WasmI32.eq`, `WasmI64.eq`, `WasmF32.eq`, or `WasmF64.eq` instead.";
+  | FuncWasmUnsafe(func) => "it looks like you are using " ++ func ++ " on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use `WasmI32.eq`, `WasmI64.eq`, `WasmF32.eq`, or `WasmF64.eq` instead.";
 
 let sub_locs =
   fun
@@ -146,7 +146,7 @@ let defaults = [
   UnreachableCase,
   ShadowConstructor(""),
   NoCmiFile("", None),
-  EqualWasmUnsafe,
+  FuncWasmUnsafe(""),
 ];
 
 let _ = List.iter(x => current^.active[number(x)] = true, defaults);

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -105,7 +105,7 @@ let message =
     )
   | NonClosedRecordPattern(s) =>
     "the following fields are missing from the record pattern: " ++ s
-  | FuncWasmUnsafe(func) => "it looks like you are using " ++ func ++ " on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use `WasmI32.eq`, `WasmI64.eq`, `WasmF32.eq`, or `WasmF64.eq` instead.";
+  | FuncWasmUnsafe(func) => "it looks like you are using " ++ func ++ " on two unsafe Wasm values here.\nThis is generally unsafe and will cause errors. Use one of the equivalent functions in `WasmI32`, `WasmI64`, `WasmF32`, or `WasmF64` instead.";
 
 let sub_locs =
   fun

--- a/compiler/src/utils/warnings.rei
+++ b/compiler/src/utils/warnings.rei
@@ -37,7 +37,7 @@ type t =
   | UnreachableCase
   | ShadowConstructor(string)
   | NoCmiFile(string, option(string))
-  | EqualWasmUnsafe;
+  | FuncWasmUnsafe(string);
 
 let is_active: t => bool;
 let is_error: t => bool;


### PR DESCRIPTION
Fixes issue found by @phated .