### PR TITLE
fix(stdlib): Correct usages of `==` and `!=` on WasmI32 values

### DIFF
--- a/compiler/test/stdlib/wasmi32.test.gr
+++ b/compiler/test/stdlib/wasmi32.test.gr
@@ -67,7 +67,7 @@ let test = () => {
   assert WasmI32.eq(WasmI32.fromGrain(true), 0xfffffffen)
   assert (WasmI32.toGrain(0xfffffffen): Bool)
   assert Conv.toInt32(45n) == 45l
-  assert Conv.fromInt32(45l) == 45n
+  assert WasmI32.eq(Conv.fromInt32(45l), 45n)
 }
 
 test()

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -192,7 +192,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
     x == y
   } else if (isNumber(x)) {
     // Numbers have special equality rules, e.g. NaN != NaN
-    isNumber(y) && numberEqual(x, y)
+    numberEqual(x, y)
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -447,6 +447,7 @@ export let contains = (p: String, s: String) => {
   let (+) = WasmI32.add
   let (-) = WasmI32.sub
   let (==) = WasmI32.eq
+  let (!=) = WasmI32.ne
   let (<) = WasmI32.ltU
   let (<=) = WasmI32.leU
   let (>) = WasmI32.gtU
@@ -978,6 +979,7 @@ let decodedLength = (bytes: Bytes, encoding: Encoding, start: WasmI32, size: Was
   let (+) = WasmI32.add
   let (-) = WasmI32.sub
   let (==) = WasmI32.eq
+  let (!=) = WasmI32.ne
   let (<) = WasmI32.ltU
   let (>) = WasmI32.gtU
   let (|) = WasmI32.or


### PR DESCRIPTION
Closes #746

The new warnings helped catch some more references to `Pervasives.(==)` and `Pervasives.(!=)` in the stdlib and tests. This fixes those issues and then removes the `isNumber(y)` workaround.

Probably should land after #758 