### PR TITLE
chore(compiler): Remove extra space when printing tuples

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -380,7 +380,7 @@ and print_out_type_2 = ppf =>
       fprintf(
         ppf,
         "@[<0>%a@]",
-        print_typlist(print_simple_out_type, ", "),
+        print_typlist(print_simple_out_type, ","),
         tyl,
       );
       pp_print_char(ppf, ')');


### PR DESCRIPTION
While working on some docs, I noticed an extra space in tuples when being printed. This updates oprint to remove where I believe it was coming from.