### PR TITLE
fix(compiler): Refactor function return value incRef logic

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -395,6 +395,7 @@ and instr_desc =
   | MStore(list((binding, instr))) /* Items in the same list have their backpatching delayed until the end of that list */
   | MSet(binding, instr)
   | MDrop(instr) /* Ignore the result of an expression. Used for sequences. */
+  | MIncRef(instr) /* Apply a GC incRef to the value */
   | MTracepoint(int) /* Prints a message to the console; for compiler debugging */
 
 [@deriving sexp]

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -241,6 +241,7 @@ module RegisterAllocation = {
         MSet(apply_allocation_to_bind(b), apply_allocations(ty, allocs, i))
       | MAllocate(x) => MAllocate(x)
       | MDrop(i) => MDrop(apply_allocations(ty, allocs, i))
+      | MIncRef(i) => MDrop(apply_allocations(ty, allocs, i))
       | MTracepoint(x) => MTracepoint(x)
       };
     {...instr, instr_desc: desc};
@@ -271,6 +272,7 @@ let run_register_allocation = (instrs: list(Mashtree.instr)) => {
 
   let rec live_locals = instr =>
     switch (instr.instr_desc) {
+    | MIncRef(i)
     | MDrop(i) => live_locals(i)
     | MImmediate(imm)
     | MTagOp(_, _, imm)

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -23,12 +23,64 @@ arrays › array_access
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (block (result i32)
         (if
          (i32.lt_s
@@ -36,58 +88,7 @@ arrays › array_access
           (i32.sub
            (i32.const 0)
            (i32.load offset=4
-            (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                     (i32.const 20)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 5)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i32.store offset=8
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=12
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 5)
-                 )
-                )
-                (i32.store offset=16
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 7)
-                 )
-                )
-                (local.get $0)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.const 0)
-               )
-              )
-             )
-            )
+            (local.get $1)
            )
           )
          )
@@ -104,9 +105,9 @@ arrays › array_access
         (if
          (i32.le_s
           (i32.load offset=4
-           (local.get $2)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $2)
          )
          (block
           (drop
@@ -123,33 +124,33 @@ arrays › array_access
           (i32.shl
            (if (result i32)
             (i32.lt_u
-             (local.get $1)
+             (local.get $2)
              (i32.const 0)
             )
             (i32.add
-             (local.get $1)
+             (local.get $2)
              (i32.load offset=4
-              (local.get $2)
+              (local.get $1)
              )
             )
-            (local.get $1)
+            (local.get $2)
            )
            (i32.const 2)
           )
-          (local.get $2)
+          (local.get $1)
          )
         )
        )
-       (local.get $0)
       )
      )
+     (local.get $0)
     )
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
@@ -16,61 +16,53 @@ arrays › array1_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
          )
-         (i32.const 5)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 3)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 5)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 7)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 5)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 3)
       )
      )
+     (i32.store offset=12
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 7)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -23,73 +23,74 @@ arrays › array_access4
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (block (result i32)
         (if
          (i32.lt_s
-          (local.tee $1
+          (local.tee $2
            (i32.const -2)
           )
           (i32.sub
            (i32.const 0)
            (i32.load offset=4
-            (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                     (i32.const 20)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 5)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i32.store offset=8
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=12
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 5)
-                 )
-                )
-                (i32.store offset=16
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 7)
-                 )
-                )
-                (local.get $0)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.const 0)
-               )
-              )
-             )
-            )
+            (local.get $1)
            )
           )
          )
@@ -106,9 +107,9 @@ arrays › array_access4
         (if
          (i32.le_s
           (i32.load offset=4
-           (local.get $2)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $2)
          )
          (block
           (drop
@@ -125,33 +126,33 @@ arrays › array_access4
           (i32.shl
            (if (result i32)
             (i32.lt_s
-             (local.get $1)
+             (local.get $2)
              (i32.const 0)
             )
             (i32.add
-             (local.get $1)
+             (local.get $2)
              (i32.load offset=4
-              (local.get $2)
+              (local.get $1)
              )
             )
-            (local.get $1)
+            (local.get $2)
            )
            (i32.const 2)
           )
-          (local.get $2)
+          (local.get $1)
          )
         )
        )
-       (local.get $0)
       )
      )
+     (local.get $0)
     )
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -23,73 +23,74 @@ arrays › array_access2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (block (result i32)
         (if
          (i32.lt_s
-          (local.tee $1
+          (local.tee $2
            (i32.const 1)
           )
           (i32.sub
            (i32.const 0)
            (i32.load offset=4
-            (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                     (i32.const 20)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 5)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i32.store offset=8
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=12
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 5)
-                 )
-                )
-                (i32.store offset=16
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 7)
-                 )
-                )
-                (local.get $0)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.const 0)
-               )
-              )
-             )
-            )
+            (local.get $1)
            )
           )
          )
@@ -106,9 +107,9 @@ arrays › array_access2
         (if
          (i32.le_s
           (i32.load offset=4
-           (local.get $2)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $2)
          )
          (block
           (drop
@@ -125,33 +126,33 @@ arrays › array_access2
           (i32.shl
            (if (result i32)
             (i32.lt_u
-             (local.get $1)
+             (local.get $2)
              (i32.const 0)
             )
             (i32.add
-             (local.get $1)
+             (local.get $2)
              (i32.load offset=4
-              (local.get $2)
+              (local.get $1)
              )
             )
-            (local.get $1)
+            (local.get $2)
            )
            (i32.const 2)
           )
-          (local.get $2)
+          (local.get $1)
          )
         )
        )
-       (local.get $0)
       )
      )
+     (local.get $0)
     )
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -23,73 +23,74 @@ arrays › array_access3
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (block (result i32)
         (if
          (i32.lt_s
-          (local.tee $1
+          (local.tee $2
            (i32.const 2)
           )
           (i32.sub
            (i32.const 0)
            (i32.load offset=4
-            (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                     (i32.const 20)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 5)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i32.store offset=8
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=12
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 5)
-                 )
-                )
-                (i32.store offset=16
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 7)
-                 )
-                )
-                (local.get $0)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.const 0)
-               )
-              )
-             )
-            )
+            (local.get $1)
            )
           )
          )
@@ -106,9 +107,9 @@ arrays › array_access3
         (if
          (i32.le_s
           (i32.load offset=4
-           (local.get $2)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $2)
          )
          (block
           (drop
@@ -125,33 +126,33 @@ arrays › array_access3
           (i32.shl
            (if (result i32)
             (i32.lt_u
-             (local.get $1)
+             (local.get $2)
              (i32.const 0)
             )
             (i32.add
-             (local.get $1)
+             (local.get $2)
              (i32.load offset=4
-              (local.get $2)
+              (local.get $1)
              )
             )
-            (local.get $1)
+            (local.get $2)
            )
            (i32.const 2)
           )
-          (local.get $2)
+          (local.get $1)
          )
         )
        )
-       (local.get $0)
       )
      )
+     (local.get $0)
     )
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -23,73 +23,74 @@ arrays › array_access5
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (block (result i32)
         (if
          (i32.lt_s
-          (local.tee $1
+          (local.tee $2
            (i32.const -3)
           )
           (i32.sub
            (i32.const 0)
            (i32.load offset=4
-            (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                     (i32.const 20)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                 (i32.const 5)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i32.store offset=8
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 3)
-                 )
-                )
-                (i32.store offset=12
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 5)
-                 )
-                )
-                (i32.store offset=16
-                 (local.get $0)
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (i32.const 7)
-                 )
-                )
-                (local.get $0)
-               )
-               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                (i32.const 0)
-               )
-              )
-             )
-            )
+            (local.get $1)
            )
           )
          )
@@ -106,9 +107,9 @@ arrays › array_access5
         (if
          (i32.le_s
           (i32.load offset=4
-           (local.get $2)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $2)
          )
          (block
           (drop
@@ -125,33 +126,33 @@ arrays › array_access5
           (i32.shl
            (if (result i32)
             (i32.lt_s
-             (local.get $1)
+             (local.get $2)
              (i32.const 0)
             )
             (i32.add
-             (local.get $1)
+             (local.get $2)
              (i32.load offset=4
-              (local.get $2)
+              (local.get $1)
              )
             )
-            (local.get $1)
+            (local.get $2)
            )
            (i32.const 2)
           )
-          (local.get $2)
+          (local.get $1)
          )
         )
        )
-       (local.get $0)
       )
      )
+     (local.get $0)
     )
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
@@ -16,61 +16,53 @@ arrays › array3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
          )
-         (i32.const 5)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 3)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 5)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 7)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 5)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 3)
       )
      )
+     (i32.store offset=12
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 7)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
@@ -16,61 +16,53 @@ arrays › array1_trailing_space
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
          )
-         (i32.const 5)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 3)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 5)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 7)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 5)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 3)
       )
      )
+     (i32.store offset=12
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 7)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop2.4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -3)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -3)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
@@ -1,13 +1,11 @@
 basic functionality › neg
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt32\" (global $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt32\" (func $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -15,24 +13,15 @@ basic functionality › neg
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0
-        (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0)
-        (i32.const -1073741824)
-       )
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0
+     (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0)
+     (i32.const -1073741824)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp5
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 9)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 9)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › precedence1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 55)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 55)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 953
 )

--- a/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp16
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 11)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 11)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › orshadow
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 7)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 7)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 950
 )

--- a/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › precedence2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 55)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 55)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 953
 )

--- a/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 13)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 13)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -6,10 +6,8 @@ basic functionality › orshort2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1139_print_1140 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -18,27 +16,22 @@ basic functionality › orshort2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1139_print_1140)
-          (i32.const 3)
-          (i32.load offset=8
-           (global.get $import_pervasives_1139_print_1140)
-          )
-         )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1139_print_1140)
+        (i32.const 3)
+        (i32.load offset=8
+         (global.get $import_pervasives_1139_print_1140)
         )
-        (i32.const 2147483646)
        )
-       (i32.const 0)
       )
+      (i32.const 2147483646)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 11)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 11)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › forty
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 81)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 81)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › assert2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1879048190)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1879048190)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 949
 )

--- a/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › and2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 946
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › fals
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 946
 )

--- a/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › oct_neg
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -125)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -125)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 949
 )

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -2,13 +2,10 @@ basic functionality › int64_1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt64\" (global $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt64_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt64\" (func $import_GRAIN$MODULE$runtime/dataStructures_0_newInt64_0 (param i32 i64) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -16,24 +13,15 @@ basic functionality › int64_1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt64_0
-        (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt64_0)
-        (i64.const 99999999999999999)
-       )
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt64_0
+     (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt64_0)
+     (i64.const 99999999999999999)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › orshort1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 950
 )

--- a/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop5
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 5)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 5)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › precedence5
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 953
 )

--- a/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › if4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 7)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 7)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › hex_neg
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -509)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -509)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 949
 )

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -17,45 +17,44 @@ basic functionality › if_one_sided6
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 3)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 3)
          )
-        )
-        (local.tee $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 11)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 11)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › and3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 946
 )

--- a/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › or4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -1,7 +1,7 @@
 basic functionality › block_no_expression
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
@@ -9,10 +9,8 @@ basic functionality › block_no_expression
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $func_0)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 1))
  (export \"memory\" (memory $0))
@@ -20,15 +18,7 @@ basic functionality › block_no_expression
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1879048190)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1879048190)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -17,46 +17,41 @@ basic functionality › if_one_sided5
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 3)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 3)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 11)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 11)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -3)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -3)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop2.2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › or1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › assert1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1879048190)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1879048190)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 949
 )

--- a/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › tru
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › or3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › and4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 946
 )

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -2,13 +2,10 @@ basic functionality › division1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newRational\" (global $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"newRational\" (func $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0 (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -16,25 +13,16 @@ basic functionality › division1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
-        (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
-        (i32.const 5)
-        (i32.const 2)
-       )
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
+     (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
+     (i32.const 5)
+     (i32.const 2)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › if_one_sided2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1879048190)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1879048190)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 955
 )

--- a/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › bin_neg
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -19)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -19)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 949
 )

--- a/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp13
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › andshadow
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 7)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 7)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 951
 )

--- a/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop2.3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -3)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -3)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
@@ -1,14 +1,12 @@
 basic functionality › void
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,44 +14,36 @@ basic functionality › void
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 16)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 16)
          )
-         (i32.const 1)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i64.store offset=8
-         (local.get $0)
-         (i64.const 7303014)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 1)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 7303014)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -17,46 +17,41 @@ basic functionality › if_one_sided3
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 3)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 3)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 5)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 5)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › and1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 946
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 9)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 9)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › hex
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 511)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 511)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp9
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › andshort2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 951
 )

--- a/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp8
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp7
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 17)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 17)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -6,10 +6,8 @@ basic functionality › complex1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1154_print_1155 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -18,27 +16,22 @@ basic functionality › complex1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1154_print_1155)
-          (i32.const 7)
-          (i32.load offset=8
-           (global.get $import_pervasives_1154_print_1155)
-          )
-         )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1154_print_1155)
+        (i32.const 7)
+        (i32.load offset=8
+         (global.get $import_pervasives_1154_print_1155)
         )
-        (i32.const -5)
        )
-       (i32.const 0)
       )
+      (i32.const -5)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › oct
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 127)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 127)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › or2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -7,11 +7,9 @@ basic functionality › toplevel_statements
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1151_print_1152 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -20,85 +18,80 @@ basic functionality › toplevel_statements
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1151_print_1152)
-          (i32.const 3)
-          (i32.load offset=8
-           (global.get $import_pervasives_1151_print_1152)
-          )
-         )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1151_print_1152)
+        (i32.const 3)
+        (i32.load offset=8
+         (global.get $import_pervasives_1151_print_1152)
         )
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1151_print_1152)
-          (i32.const 5)
-          (i32.load offset=8
-           (global.get $import_pervasives_1151_print_1152)
-          )
-         )
-        )
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1151_print_1152)
-          (i32.const 7)
-          (i32.load offset=8
-           (global.get $import_pervasives_1151_print_1152)
-          )
-         )
-        )
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1151_print_1152)
-          (i32.const 9)
-          (i32.load offset=8
-           (global.get $import_pervasives_1151_print_1152)
-          )
-         )
-        )
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1151_print_1152)
-          (i32.const 11)
-          (i32.load offset=8
-           (global.get $import_pervasives_1151_print_1152)
-          )
-         )
-        )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 16)
-            )
-            (i32.const 0)
-           )
-          )
-         )
-         (i32.const 1)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i64.store offset=8
-         (local.get $0)
-         (i64.const 7303014)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1151_print_1152)
+        (i32.const 5)
+        (i32.load offset=8
+         (global.get $import_pervasives_1151_print_1152)
+        )
+       )
+      )
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1151_print_1152)
+        (i32.const 7)
+        (i32.load offset=8
+         (global.get $import_pervasives_1151_print_1152)
+        )
+       )
+      )
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1151_print_1152)
+        (i32.const 9)
+        (i32.load offset=8
+         (global.get $import_pervasives_1151_print_1152)
+        )
+       )
+      )
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1151_print_1152)
+        (i32.const 11)
+        (i32.load offset=8
+         (global.get $import_pervasives_1151_print_1152)
+        )
+       )
+      )
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+           (i32.const 16)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.const 1)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i64.store offset=8
+       (local.get $0)
+       (i64.const 7303014)
+      )
+      (local.get $0)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp14
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › bin
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 945
 )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -6,10 +6,8 @@ basic functionality › andshort1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1139_print_1140 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -18,27 +16,22 @@ basic functionality › andshort1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (drop
-         (call_indirect (type $i32_i32_=>_i32)
-          (global.get $import_pervasives_1139_print_1140)
-          (i32.const 3)
-          (i32.load offset=8
-           (global.get $import_pervasives_1139_print_1140)
-          )
-         )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (drop
+       (call_indirect (type $i32_i32_=>_i32)
+        (global.get $import_pervasives_1139_print_1140)
+        (i32.const 3)
+        (i32.load offset=8
+         (global.get $import_pervasives_1139_print_1140)
         )
-        (i32.const 2147483646)
        )
-       (i32.const 0)
       )
+      (i32.const 2147483646)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp15
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp10
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -17,45 +17,44 @@ basic functionality › if_one_sided4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 3)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 3)
          )
-        )
-        (local.tee $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 5)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 5)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › comp6
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 19)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 19)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 947
 )

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -1,13 +1,11 @@
 basic functionality › int32_1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt32\" (global $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt32\" (func $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -15,24 +13,15 @@ basic functionality › int32_1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0
-        (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0)
-        (i32.const 42)
-       )
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/dataStructures_0_newInt32_0
+     (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newInt32_0)
+     (i32.const 42)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
@@ -2,32 +2,18 @@ basic functionality › binop2.1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 1)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 1)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 948
 )

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -24,87 +24,82 @@ boxes › box_subtraction1
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1150_box_1151)
-            (i32.const 9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1150_box_1151)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1150_box_1151)
+          (i32.const 9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1150_box_1151)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_unbox_1147)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_unbox_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1148_-_1149)
-            (local.get $1)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1148_-_1149)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_unbox_1147)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_unbox_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1148_-_1149)
+          (local.get $1)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1148_-_1149)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $2)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -24,87 +24,82 @@ boxes › box_division1
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1150_box_1151)
-            (i32.const 153)
-            (i32.load offset=8
-             (global.get $import_pervasives_1150_box_1151)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1150_box_1151)
+          (i32.const 153)
+          (i32.load offset=8
+           (global.get $import_pervasives_1150_box_1151)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_unbox_1147)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_unbox_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1148_/_1149)
-            (local.get $1)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1148_/_1149)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_unbox_1147)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_unbox_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1148_/_1149)
+          (local.get $1)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1148_/_1149)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $2)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -24,87 +24,82 @@ boxes › box_addition1
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1150_box_1151)
-            (i32.const 9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1150_box_1151)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1150_box_1151)
+          (i32.const 9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1150_box_1151)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_unbox_1147)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_unbox_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1148_+_1149)
-            (local.get $1)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1148_+_1149)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_unbox_1147)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_unbox_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1148_+_1149)
+          (local.get $1)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1148_+_1149)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $2)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -24,87 +24,82 @@ boxes › box_multiplication1
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1150_box_1151)
-            (i32.const 9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1150_box_1151)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1150_box_1151)
+          (i32.const 9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1150_box_1151)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_unbox_1147)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_unbox_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1148_*_1149)
-            (local.get $1)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1148_*_1149)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_unbox_1147)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_unbox_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1148_*_1149)
+          (local.get $1)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1148_*_1149)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $2)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -19,51 +19,46 @@ boxes › test_set_extra1
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store offset=8
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call_indirect (type $i32_i32_=>_i32)
-             (global.get $import_pervasives_1142_box_1143)
-             (i32.const 3)
-             (i32.load offset=8
-              (global.get $import_pervasives_1142_box_1143)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store offset=8
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call_indirect (type $i32_i32_=>_i32)
+           (global.get $import_pervasives_1142_box_1143)
+           (i32.const 3)
+           (i32.load offset=8
+            (global.get $import_pervasives_1142_box_1143)
            )
           )
-         )
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 5)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
+          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+           (i32.const 0)
           )
          )
         )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 5)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+        )
+       )
       )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
+++ b/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
@@ -1,14 +1,12 @@
 chars › char4
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 65)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 65)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/chars.259e330c.0.snapshot
+++ b/compiler/test/__snapshots__/chars.259e330c.0.snapshot
@@ -1,14 +1,12 @@
 chars › char2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 65)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 65)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/chars.51010573.0.snapshot
+++ b/compiler/test/__snapshots__/chars.51010573.0.snapshot
@@ -1,14 +1,12 @@
 chars › char7
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char7
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const -1098080272)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const -1098080272)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
+++ b/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
@@ -1,14 +1,12 @@
 chars › char6
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char6
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const -1349345296)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const -1349345296)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
+++ b/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
@@ -1,14 +1,12 @@
 chars › char5
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char5
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 65)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 65)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
+++ b/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
@@ -1,14 +1,12 @@
 chars › char3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,40 +14,32 @@ chars › char3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 8)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
          )
-         (i32.const 2)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 65)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 2)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 65)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/comments.573e549e.0.snapshot
+++ b/compiler/test/__snapshots__/comments.573e549e.0.snapshot
@@ -2,32 +2,18 @@ comments › comment_alone
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 955
 )

--- a/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
+++ b/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
@@ -2,32 +2,18 @@ comments › comment_block
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 955
 )

--- a/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
+++ b/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
@@ -2,32 +2,18 @@ comments › comment_shebang
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 957
 )

--- a/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
+++ b/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
@@ -2,32 +2,18 @@ comments › comment_doc
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 21)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 21)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 953
 )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -24,254 +24,241 @@ enums › adt_trailing
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
          )
-         (i32.const 3)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 3)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
       )
      )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 80)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 85899347057)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 25769803776)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 111546296789059)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 4294967324)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 8102087123911311369)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 452824363621)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
           )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (global.set $global_0
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (global.get $import__grainEnv_0_relocBase_0)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (global.get $global_0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (global.get $global_0)
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 68)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 240518168577)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 85899347057)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 25769803776)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 111546296789059)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 4294967324)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 8102087123911311369)
+          )
+          (i64.store offset=64
+           (local.get $0)
+           (i64.const 452824363621)
+          )
+          (i64.store offset=72
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
+         (local.get $0)
         )
-        (global.set $global_1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 3)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (global.get $global_1)
-           )
-          )
-         )
-        )
-        (global.get $global_1)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 7)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $import__grainEnv_0_relocBase_0)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+              (i32.const 20)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 3)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.shl
+           (global.get $import__grainEnv_0_moduleRuntimeId_0)
+           (i32.const 1)
+          )
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 2275)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $global_1)
+     )
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -30,134 +30,118 @@ enums › enum_recursive_data_definition
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_5))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 28)
          )
-         (i32.const 3)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2277)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $2)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 3)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
       )
      )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2277)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
+      )
+     )
+     (i32.store offset=24
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $2)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $func_1 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 28)
          )
-         (i32.const 3)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $2)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 3)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
       )
      )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
+      )
+     )
+     (i32.store offset=24
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $2)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -25,257 +25,244 @@ exceptions › exception_4
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 28)
          )
-         (i32.const 3)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 5)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $2)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 3)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
       )
      )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 5)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
+      )
+     )
+     (i32.store offset=24
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $2)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 72)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 72)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 60)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 206158430209)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 85899345922)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 12884903025)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 7302982)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 4891967750164)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 32195083440750595)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
           )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (global.set $global_0
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (global.get $import__grainEnv_0_relocBase_0)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (global.get $global_0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (global.get $global_0)
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 60)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 206158430209)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 85899345922)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 12884903025)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 7302982)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 4891967750164)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 32195083440750595)
+          )
+          (i64.store offset=64
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
+         (local.get $0)
         )
-        (global.set $global_1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 3)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 5)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 2279)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (global.get $global_1)
-           )
-          )
-         )
-        )
-        (global.get $global_1)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 7)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $import__grainEnv_0_relocBase_0)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+              (i32.const 20)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 3)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.shl
+           (global.get $import__grainEnv_0_moduleRuntimeId_0)
+           (i32.const 1)
+          )
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 5)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 2279)
+         )
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $global_1)
+     )
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -21,132 +21,127 @@ exceptions › exception_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 40)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 120259084289)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 85899345922)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 12884903025)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 7302982)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 40)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 120259084289)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 85899345922)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 12884903025)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 7302982)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (global.set $global_0
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 3)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 5)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (global.get $global_0)
-           )
-          )
-         )
-        )
-        (global.get $global_0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+              (i32.const 20)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 3)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.shl
+           (global.get $import__grainEnv_0_moduleRuntimeId_0)
+           (i32.const 1)
+          )
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 5)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 2275)
+         )
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $global_0)
+     )
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
+++ b/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
@@ -14,21 +14,15 @@ exports › export7
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
@@ -14,21 +14,15 @@ exports › export4
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_onlyXExported_1141_x_1142)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_onlyXExported_1141_x_1142)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -1,7 +1,7 @@
 functions › dup_func
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
@@ -9,10 +9,8 @@ functions › dup_func
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $func_0)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 1))
  (export \"memory\" (memory $0))
@@ -20,15 +18,7 @@ functions › dup_func
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 19)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 19)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -19,20 +19,15 @@ functions › shorthand_1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (local.get $1)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -8,10 +8,8 @@ functions › lambda_pat_any
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $func_0)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 1))
  (export \"memory\" (memory $0))
@@ -19,15 +17,7 @@ functions › lambda_pat_any
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 11)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 11)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -22,67 +22,59 @@ functions › curried_func
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $2
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
          )
-         (i32.const 7)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $2)
-         (i32.const 2)
-        )
-        (i32.store offset=8
-         (local.get $2)
-         (i32.add
-          (global.get $import__grainEnv_0_relocBase_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=12
-         (local.get $2)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $2)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=16
-           (local.get $0)
-          )
-         )
-        )
-        (i32.store offset=20
-         (local.get $2)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (local.get $2)
        )
-       (local.get $2)
+      )
+      (i32.const 7)
+     )
+     (i32.store offset=4
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.store offset=8
+      (local.get $2)
+      (i32.add
+       (global.get $import__grainEnv_0_relocBase_0)
+       (i32.const 1)
       )
      )
+     (i32.store offset=12
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $2)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $0)
+       )
+      )
+     )
+     (i32.store offset=20
+      (local.get $2)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
+      )
+     )
+     (local.get $2)
     )
+    (local.get $2)
    )
   )
-  (local.get $0)
  )
  (func $func_1 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (return_call_indirect (type $i32_i32_i32_=>_i32)

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -19,20 +19,15 @@ functions › app_1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (local.get $1)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -19,20 +19,15 @@ functions › shorthand_3
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (local.get $1)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -8,10 +8,8 @@ functions › lam_destructure_1
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $func_0)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 1))
  (export \"memory\" (memory $0))
@@ -19,15 +17,7 @@ functions › lam_destructure_1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 11)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 11)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -8,10 +8,8 @@ functions › lam_destructure_2
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $func_0)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 1))
  (export \"memory\" (memory $0))
@@ -19,15 +17,7 @@ functions › lam_destructure_2
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 11)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 11)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
@@ -2,32 +2,18 @@ functions › multi_bind2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 7)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 7)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 953
 )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -22,15 +22,7 @@ functions › func_record_associativity2
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -22,15 +22,7 @@ functions › func_record_associativity1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
@@ -14,21 +14,15 @@ imports › import_some
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
@@ -14,21 +14,15 @@ imports › import_all_except_multiple
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_exportStar_1147_z_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_exportStar_1147_z_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.45beae05.0.snapshot
+++ b/compiler/test/__snapshots__/imports.45beae05.0.snapshot
@@ -14,21 +14,15 @@ imports › annotation_across_import
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_tlists_1146_Empty_1147)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_tlists_1146_Empty_1147)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
@@ -14,21 +14,15 @@ imports › import_alias
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
@@ -14,21 +14,15 @@ imports › import_all_except_constructor
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_tlists_1145_Empty_1146)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_tlists_1145_Empty_1146)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.8955ad85.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8955ad85.0.snapshot
@@ -14,21 +14,15 @@ imports › import_relative_path
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_./exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_./exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
@@ -14,21 +14,15 @@ imports › import_module
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.e295854d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e295854d.0.snapshot
@@ -14,21 +14,15 @@ imports › import_relative_path2
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_../test-libs/exportStar_1147_x_1148)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_../test-libs/exportStar_1147_x_1148)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
@@ -14,21 +14,15 @@ imports › import_relative_path3
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $import_nested/nested_1141_j_1142)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (global.get $import_nested/nested_1141_j_1142)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -21,64 +21,59 @@ let mut › let-mut_division1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 153)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 153)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1145_/_1146)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1145_/_1146)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1145_/_1146)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1145_/_1146)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_multiplication2
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_*_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_*_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_*_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_*_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_division3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 153)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 153)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_/_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_/_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_/_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_/_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut5
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_-_1147)
-            (local.get $0)
-            (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_-_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_-_1147)
+          (local.get $0)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_-_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -21,121 +21,120 @@ let mut › let-mut2
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
           )
-         )
-        )
-        (local.tee $3
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 11)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 13)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $2)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $3)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -21,64 +21,59 @@ let mut › let-mut_multiplication1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1145_*_1146)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1145_*_1146)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1145_*_1146)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1145_*_1146)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_multiplication3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_*_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_*_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_*_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_*_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -18,62 +18,60 @@ let mut › let-mut4
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.const 7)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.const 7)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -21,64 +21,59 @@ let mut › let-mut_subtraction1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1145_-_1146)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1145_-_1146)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1145_-_1146)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1145_-_1146)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_subtraction2
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_-_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_-_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_-_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_-_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_addition2
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_+_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_+_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_+_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_+_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -21,64 +21,59 @@ let mut › let-mut_addition1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1145_+_1146)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1145_+_1146)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
-       (i32.const 0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1145_+_1146)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1145_+_1146)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_subtraction3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_-_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_-_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_-_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_-_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_addition3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 9)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_+_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_+_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_+_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_+_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -22,80 +22,78 @@ let mut › let-mut_division2
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $3
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 153)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 153)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_/_1147)
-            (local.get $0)
-            (i32.const 39)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_/_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_/_1147)
+          (local.get $0)
+          (i32.const 39)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_/_1147)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $0)
-                )
-               )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $1)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
               )
              )
-             (i32.const 1879048190)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1879048190)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -17,29 +17,30 @@ let mut › let-mut1
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $1
-     (tuple.extract 0
-      (tuple.make
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (i32.const 9)
-          )
-          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-           (i32.const 0)
-          )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 9)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -25,162 +25,160 @@ loops › loop5
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $4
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 25)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 25)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (loop $MFor_loop.6 (result i32)
-             (block $MFor.5 (result i32)
-              (local.set $0
-               (tuple.extract 0
-                (tuple.make
-                 (call_indirect (type $i32_i32_i32_=>_i32)
-                  (global.get $import_pervasives_1160_-_1161)
-                  (local.get $1)
-                  (i32.const 3)
-                  (i32.load offset=8
-                   (global.get $import_pervasives_1160_-_1161)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $0)
-                 )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (loop $MFor_loop.6 (result i32)
+           (block $MFor.5 (result i32)
+            (local.set $0
+             (tuple.extract 0
+              (tuple.make
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (global.get $import_pervasives_1160_-_1161)
+                (local.get $1)
+                (i32.const 3)
+                (i32.load offset=8
+                 (global.get $import_pervasives_1160_-_1161)
                 )
                )
-              )
-              (local.set $3
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (block (result i32)
-                   (local.set $1
-                    (tuple.extract 0
-                     (tuple.make
-                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                       (local.get $0)
-                      )
-                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                       (local.get $1)
-                      )
-                     )
-                    )
-                   )
-                   (i32.const 1879048190)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $3)
-                 )
-                )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $0)
                )
               )
-              (drop
-               (br_if $MFor.5
-                (i32.const 1879048190)
-                (i32.eqz
-                 (i32.shr_u
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1158_>=_1159)
-                   (local.get $1)
-                   (i32.const 1)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1158_>=_1159)
-                   )
-                  )
-                  (i32.const 31)
-                 )
-                )
-               )
-              )
-              (local.set $0
-               (tuple.extract 0
-                (tuple.make
-                 (call_indirect (type $i32_i32_i32_=>_i32)
-                  (global.get $import_pervasives_1162_+_1163)
-                  (local.get $2)
-                  (i32.const 3)
-                  (i32.load offset=8
-                   (global.get $import_pervasives_1162_+_1163)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $0)
-                 )
-                )
-               )
-              )
-              (local.set $2
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $0)
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $2)
-                 )
-                )
-               )
-              )
-              (br $MFor_loop.6)
              )
             )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $0)
+            (local.set $3
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (block (result i32)
+                 (local.set $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (local.get $0)
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (local.get $1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $3)
+               )
+              )
+             )
+            )
+            (drop
+             (br_if $MFor.5
+              (i32.const 1879048190)
+              (i32.eqz
+               (i32.shr_u
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1158_>=_1159)
+                 (local.get $1)
+                 (i32.const 1)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1158_>=_1159)
+                 )
+                )
+                (i32.const 31)
+               )
+              )
+             )
+            )
+            (local.set $0
+             (tuple.extract 0
+              (tuple.make
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (global.get $import_pervasives_1162_+_1163)
+                (local.get $2)
+                (i32.const 3)
+                (i32.load offset=8
+                 (global.get $import_pervasives_1162_+_1163)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (local.set $2
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (local.get $0)
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (br $MFor_loop.6)
            )
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $0)
+         )
         )
-        (local.get $2)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $2)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -22,100 +22,98 @@ loops › loop3
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 7)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 7)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (loop $MFor_loop.4 (result i32)
-             (block $MFor.3 (result i32)
-              (drop
-               (br_if $MFor.3
-                (i32.const 1879048190)
-                (i32.eqz
-                 (i32.shr_u
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1150_>_1151)
-                   (local.get $0)
-                   (i32.const 1)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1150_>_1151)
-                   )
-                  )
-                  (i32.const 31)
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (loop $MFor_loop.4 (result i32)
+           (block $MFor.3 (result i32)
+            (drop
+             (br_if $MFor.3
+              (i32.const 1879048190)
+              (i32.eqz
+               (i32.shr_u
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1150_>_1151)
+                 (local.get $0)
+                 (i32.const 1)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1150_>_1151)
                  )
                 )
+                (i32.const 31)
                )
               )
-              (local.set $1
-               (tuple.extract 0
-                (tuple.make
-                 (call_indirect (type $i32_i32_i32_=>_i32)
-                  (global.get $import_pervasives_1152_-_1153)
-                  (local.get $0)
-                  (i32.const 3)
-                  (i32.load offset=8
-                   (global.get $import_pervasives_1152_-_1153)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $1)
-                 )
-                )
-               )
-              )
-              (local.set $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $0)
-                 )
-                )
-               )
-              )
-              (br $MFor_loop.4)
              )
             )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $1)
+            (local.set $1
+             (tuple.extract 0
+              (tuple.make
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (global.get $import_pervasives_1152_-_1153)
+                (local.get $0)
+                (i32.const 3)
+                (i32.load offset=8
+                 (global.get $import_pervasives_1152_-_1153)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (local.set $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (local.get $1)
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $0)
+               )
+              )
+             )
+            )
+            (br $MFor_loop.4)
            )
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $1)
+         )
         )
-        (local.get $0)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $0)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -26,162 +26,160 @@ loops › loop4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $5
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 25)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 25)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.const 1)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.const 1)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (loop $MFor_loop.6 (result i32)
-             (block $MFor.5 (result i32)
-              (drop
-               (br_if $MFor.5
-                (i32.const 1879048190)
-                (i32.eqz
-                 (i32.shr_u
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1158_>_1159)
-                   (local.get $0)
-                   (i32.const 1)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1158_>_1159)
-                   )
-                  )
-                  (i32.const 31)
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (loop $MFor_loop.6 (result i32)
+           (block $MFor.5 (result i32)
+            (drop
+             (br_if $MFor.5
+              (i32.const 1879048190)
+              (i32.eqz
+               (i32.shr_u
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1158_>_1159)
+                 (local.get $0)
+                 (i32.const 1)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1158_>_1159)
                  )
                 )
+                (i32.const 31)
                )
               )
-              (local.set $2
-               (tuple.extract 0
-                (tuple.make
-                 (call_indirect (type $i32_i32_i32_=>_i32)
-                  (global.get $import_pervasives_1162_-_1163)
-                  (local.get $0)
-                  (i32.const 3)
-                  (i32.load offset=8
-                   (global.get $import_pervasives_1162_-_1163)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $2)
-                 )
-                )
-               )
-              )
-              (local.set $4
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (block (result i32)
-                   (local.set $0
-                    (tuple.extract 0
-                     (tuple.make
-                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                       (local.get $2)
-                      )
-                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                       (local.get $0)
-                      )
-                     )
-                    )
-                   )
-                   (i32.const 1879048190)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $4)
-                 )
-                )
-               )
-              )
-              (local.set $3
-               (tuple.extract 0
-                (tuple.make
-                 (call_indirect (type $i32_i32_i32_=>_i32)
-                  (global.get $import_pervasives_1160_+_1161)
-                  (local.get $1)
-                  (i32.const 3)
-                  (i32.load offset=8
-                   (global.get $import_pervasives_1160_+_1161)
-                  )
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $3)
-                 )
-                )
-               )
-              )
-              (local.set $1
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $3)
-                 )
-                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                  (local.get $1)
-                 )
-                )
-               )
-              )
-              (br $MFor_loop.6)
              )
             )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (local.get $2)
+            (local.set $2
+             (tuple.extract 0
+              (tuple.make
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (global.get $import_pervasives_1162_-_1163)
+                (local.get $0)
+                (i32.const 3)
+                (i32.load offset=8
+                 (global.get $import_pervasives_1162_-_1163)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $2)
+               )
+              )
+             )
+            )
+            (local.set $4
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (block (result i32)
+                 (local.set $0
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (local.get $2)
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $4)
+               )
+              )
+             )
+            )
+            (local.set $3
+             (tuple.extract 0
+              (tuple.make
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (global.get $import_pervasives_1160_+_1161)
+                (local.get $1)
+                (i32.const 3)
+                (i32.load offset=8
+                 (global.get $import_pervasives_1160_+_1161)
+                )
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $3)
+               )
+              )
+             )
+            )
+            (local.set $1
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (local.get $3)
+               )
+               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                (local.get $1)
+               )
+              )
+             )
+            )
+            (br $MFor_loop.6)
            )
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $2)
+         )
         )
-        (local.get $1)
        )
-       (i32.const 0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (local.get $1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -20,82 +20,72 @@ optimizations › trs1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $func_0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (i32.const 0)
-      )
-     )
+  (tuple.extract 0
+   (tuple.make
+    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+     (local.get $1)
     )
+    (i32.const 0)
    )
   )
-  (local.get $0)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
-              )
-             )
-             (i32.const 7)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (global.get $import__grainEnv_0_relocBase_0)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.const 3)
-        (i32.const 5)
-        (i32.load offset=8
-         (local.get $1)
-        )
-       )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
        (tuple.extract 0
         (tuple.make
-         (local.get $1)
-         (local.get $0)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $import__grainEnv_0_relocBase_0)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
        )
+      )
+      (i32.const 3)
+      (i32.const 5)
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
       )
      )
     )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -27,159 +27,154 @@ optimizations › test_dead_branch_elimination_5
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1159_box_1160)
-            (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1159_box_1160)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1159_box_1160)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1159_box_1160)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1159_box_1160)
-            (i32.const 5)
-            (i32.load offset=8
-             (global.get $import_pervasives_1159_box_1160)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (i32.store offset=8
-              (local.get $0)
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.const 7)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.load offset=8
-                  (local.get $0)
-                 )
-                )
-               )
-              )
-             )
-             (i32.const 1879048190)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (i32.store offset=8
-              (local.get $1)
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.const 9)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.load offset=8
-                  (local.get $1)
-                 )
-                )
-               )
-              )
-             )
-             (i32.const 1879048190)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1155_unbox_1156)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1155_unbox_1156)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1155_unbox_1156)
-            (local.get $1)
-            (i32.load offset=8
-             (global.get $import_pervasives_1155_unbox_1156)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1157_+_1158)
-         (local.get $2)
-         (local.get $3)
-         (i32.load offset=8
-          (global.get $import_pervasives_1157_+_1158)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1159_box_1160)
+          (i32.const 5)
+          (i32.load offset=8
+           (global.get $import_pervasives_1159_box_1160)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (i32.store offset=8
+            (local.get $0)
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.const 7)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (i32.load offset=8
+                (local.get $0)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 1879048190)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (i32.store offset=8
+            (local.get $1)
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.const 9)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (i32.load offset=8
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 1879048190)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1155_unbox_1156)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1155_unbox_1156)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1155_unbox_1156)
+          (local.get $1)
+          (i32.load offset=8
+           (global.get $import_pervasives_1155_unbox_1156)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1157_+_1158)
+       (local.get $2)
+       (local.get $3)
+       (i32.load offset=8
+        (global.get $import_pervasives_1157_+_1158)
+       )
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -25,200 +25,195 @@ pattern matching › record_match_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=20
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1150_+_1151)
-         (local.get $3)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1150_+_1151)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 13)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=20
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1150_+_1151)
+       (local.get $3)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1150_+_1151)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -29,279 +29,278 @@ pattern matching › adt_match_deep
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 48)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 36)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 103079215105)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1158_[...]_1159)
-            (local.get $4)
-            (global.get $import_pervasives_1156_[]_1157)
-            (i32.load offset=8
-             (global.get $import_pervasives_1158_[...]_1159)
+       )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
+       (local.get $0)
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 11)
            )
           )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $2)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1158_[...]_1159)
+          (local.get $4)
+          (global.get $import_pervasives_1156_[]_1157)
+          (i32.load offset=8
+           (global.get $import_pervasives_1158_[...]_1159)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.20_outer (result i32)
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $2)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.20_outer (result i32)
+       (drop
+        (block $switch.20_branch_1 (result i32)
          (drop
-          (block $switch.20_branch_1 (result i32)
+          (block $switch.20_branch_2 (result i32)
            (drop
-            (block $switch.20_branch_2 (result i32)
-             (drop
-              (block $switch.20_default (result i32)
-               (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
-                (i32.const 0)
-                (i32.shr_s
-                 (local.tee $3
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (if (result i32)
-                      (i32.shr_u
-                       (local.get $5)
-                       (i32.const 31)
-                      )
-                      (i32.const 3)
-                      (if (result i32)
-                       (i32.shr_u
-                        (local.tee $3
-                         (tuple.extract 0
-                          (tuple.make
-                           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $2)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
+            (block $switch.20_default (result i32)
+             (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
+              (i32.const 0)
+              (i32.shr_s
+               (local.tee $3
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (if (result i32)
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
+                    )
+                    (i32.const 3)
+                    (if (result i32)
+                     (i32.shr_u
+                      (local.tee $3
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (local.get $2)
+                             (i32.const 1)
                             )
+                            (i32.const 31)
                            )
-                           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                            (i32.const 0)
-                           )
+                           (i32.const 2147483646)
                           )
                          )
+                         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                          (i32.const 0)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 1)
-                       (unreachable)
                       )
+                      (i32.const 31)
                      )
-                    )
-                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                     (local.get $3)
+                     (i32.const 1)
+                     (unreachable)
                     )
                    )
                   )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (local.get $3)
+                  )
                  )
-                 (i32.const 1)
                 )
                )
+               (i32.const 1)
               )
              )
-             (unreachable)
             )
            )
-           (br $switch.20_outer
-            (i32.load offset=16
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (local.get $1)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
+           (unreachable)
+          )
+         )
+         (local.set $6
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $1)
              )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (i32.const 0)
             )
            )
           )
          )
-         (i32.const 1999)
+         (br $switch.20_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=16
+            (local.get $6)
+           )
+          )
+         )
         )
        )
-       (local.get $0)
+       (i32.const 1999)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -38,165 +38,203 @@ pattern matching › tuple_match_deep4
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1219_[...]_1220)
-            (i32.const 5)
-            (global.get $import_pervasives_1217_[]_1218)
-            (i32.load offset=8
-             (global.get $import_pervasives_1219_[...]_1220)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1219_[...]_1220)
+          (i32.const 5)
+          (global.get $import_pervasives_1217_[]_1218)
+          (i32.load offset=8
+           (global.get $import_pervasives_1219_[...]_1220)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $6
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $6)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $13)
-             )
-            )
-            (local.get $6)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $6)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $13)
            )
           )
+          (local.get $6)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $14
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $12)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.52_outer (result i32)
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $12)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.52_outer (result i32)
+       (drop
+        (block $switch.52_branch_1 (result i32)
          (drop
-          (block $switch.52_branch_1 (result i32)
+          (block $switch.52_branch_2 (result i32)
            (drop
-            (block $switch.52_branch_2 (result i32)
+            (block $switch.52_branch_3 (result i32)
              (drop
-              (block $switch.52_branch_3 (result i32)
+              (block $switch.52_branch_4 (result i32)
                (drop
-                (block $switch.52_branch_4 (result i32)
+                (block $switch.52_branch_5 (result i32)
                  (drop
-                  (block $switch.52_branch_5 (result i32)
-                   (drop
-                    (block $switch.52_default (result i32)
-                     (br_table $switch.52_branch_1 $switch.52_branch_2 $switch.52_branch_3 $switch.52_branch_4 $switch.52_branch_5 $switch.52_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $8
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.52_default (result i32)
+                   (br_table $switch.52_branch_1 $switch.52_branch_2 $switch.52_branch_3 $switch.52_branch_4 $switch.52_branch_5 $switch.52_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $8
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $14)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $8
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $11)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $8)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $14)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $8
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $11)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -206,13 +244,32 @@ pattern matching › tuple_match_deep4
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $8)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -224,7 +281,7 @@ pattern matching › tuple_match_deep4
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -232,7 +289,7 @@ pattern matching › tuple_match_deep4
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -250,28 +307,12 @@ pattern matching › tuple_match_deep4
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -282,9 +323,27 @@ pattern matching › tuple_match_deep4
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -292,8 +351,8 @@ pattern matching › tuple_match_deep4
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -309,107 +368,13 @@ pattern matching › tuple_match_deep4
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -417,7 +382,7 @@ pattern matching › tuple_match_deep4
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -437,9 +402,11 @@ pattern matching › tuple_match_deep4
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $8
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -447,7 +414,7 @@ pattern matching › tuple_match_deep4
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $12)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -464,188 +431,58 @@ pattern matching › tuple_match_deep4
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $8)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $12)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $8)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.52_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=12
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $1)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $9
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=8
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $9)
-                  )
-                 )
-                )
-               )
-               (local.set $10
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1215_+_1216)
-                   (local.get $9)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1215_+_1216)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $10)
-                  )
-                 )
-                )
-               )
-               (local.set $15
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1215_+_1216)
-                   (local.get $10)
-                   (local.get $7)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1215_+_1216)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.52_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1215_+_1216)
-                 (local.get $15)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1215_+_1216)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -686,7 +523,7 @@ pattern matching › tuple_match_deep4
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $2)
                  )
                 )
@@ -703,7 +540,7 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -718,8 +555,8 @@ pattern matching › tuple_match_deep4
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=8
-                  (local.get $3)
+                 (i32.load offset=20
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -732,12 +569,10 @@ pattern matching › tuple_match_deep4
              (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1215_+_1216)
-                 (local.get $7)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1215_+_1216)
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -747,11 +582,63 @@ pattern matching › tuple_match_deep4
                )
               )
              )
+             (local.set $9
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=8
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $9)
+                )
+               )
+              )
+             )
+             (local.set $10
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1215_+_1216)
+                 (local.get $9)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1215_+_1216)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $10)
+                )
+               )
+              )
+             )
+             (local.set $15
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1215_+_1216)
+                 (local.get $10)
+                 (local.get $7)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1215_+_1216)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
              (br $switch.52_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1215_+_1216)
-               (local.get $5)
-               (local.get $1)
+               (local.get $15)
+               (local.get $4)
                (i32.load offset=8
                 (global.get $import_pervasives_1215_+_1216)
                )
@@ -780,7 +667,7 @@ pattern matching › tuple_match_deep4
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
+               (i32.load offset=24
                 (local.get $0)
                )
               )
@@ -796,8 +683,8 @@ pattern matching › tuple_match_deep4
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=8
-                (local.get $3)
+               (i32.load offset=20
+                (local.get $2)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -807,11 +694,61 @@ pattern matching › tuple_match_deep4
              )
             )
            )
+           (local.set $4
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $4)
+              )
+             )
+            )
+           )
+           (local.set $7
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=8
+                (local.get $3)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $7)
+              )
+             )
+            )
+           )
+           (local.set $5
+            (tuple.extract 0
+             (tuple.make
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (global.get $import_pervasives_1215_+_1216)
+               (local.get $7)
+               (local.get $4)
+               (i32.load offset=8
+                (global.get $import_pervasives_1215_+_1216)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $5)
+              )
+             )
+            )
+           )
            (br $switch.52_outer
             (call_indirect (type $i32_i32_i32_=>_i32)
              (global.get $import_pervasives_1215_+_1216)
+             (local.get $5)
              (local.get $1)
-             (local.get $2)
              (i32.load offset=8
               (global.get $import_pervasives_1215_+_1216)
              )
@@ -819,14 +756,75 @@ pattern matching › tuple_match_deep4
            )
           )
          )
-         (i32.load offset=8
-          (local.get $3)
+         (local.set $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=12
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $2
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (local.set $1
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=8
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $1)
+            )
+           )
+          )
+         )
+         (br $switch.52_outer
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (global.get $import_pervasives_1215_+_1216)
+           (local.get $1)
+           (local.get $2)
+           (i32.load offset=8
+            (global.get $import_pervasives_1215_+_1216)
+           )
+          )
          )
         )
        )
-       (local.get $6)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.load offset=8
+         (local.get $3)
+        )
+       )
       )
      )
+     (local.get $6)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -35,140 +35,178 @@ pattern matching › adt_match_4
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $14
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1200_[...]_1201)
-            (i32.const 13)
-            (global.get $import_pervasives_1198_[]_1199)
-            (i32.load offset=8
-             (global.get $import_pervasives_1200_[...]_1201)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $14
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1200_[...]_1201)
+          (i32.const 13)
+          (global.get $import_pervasives_1198_[]_1199)
+          (i32.load offset=8
+           (global.get $import_pervasives_1200_[...]_1201)
           )
          )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1200_[...]_1201)
-            (i32.const 11)
-            (local.get $9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1200_[...]_1201)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1200_[...]_1201)
-            (i32.const 9)
-            (local.get $10)
-            (i32.load offset=8
-             (global.get $import_pervasives_1200_[...]_1201)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1200_[...]_1201)
+          (i32.const 11)
+          (local.get $9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1200_[...]_1201)
           )
          )
-        )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $8)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1200_[...]_1201)
+          (i32.const 9)
+          (local.get $10)
+          (i32.load offset=8
+           (global.get $import_pervasives_1200_[...]_1201)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.51_outer (result i32)
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $8)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.51_outer (result i32)
+       (drop
+        (block $switch.51_branch_1 (result i32)
          (drop
-          (block $switch.51_branch_1 (result i32)
+          (block $switch.51_branch_2 (result i32)
            (drop
-            (block $switch.51_branch_2 (result i32)
+            (block $switch.51_branch_3 (result i32)
              (drop
-              (block $switch.51_branch_3 (result i32)
+              (block $switch.51_branch_4 (result i32)
                (drop
-                (block $switch.51_branch_4 (result i32)
+                (block $switch.51_branch_5 (result i32)
                  (drop
-                  (block $switch.51_branch_5 (result i32)
-                   (drop
-                    (block $switch.51_default (result i32)
-                     (br_table $switch.51_branch_1 $switch.51_branch_2 $switch.51_branch_3 $switch.51_branch_4 $switch.51_branch_5 $switch.51_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $4
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.51_default (result i32)
+                   (br_table $switch.51_branch_1 $switch.51_branch_2 $switch.51_branch_3 $switch.51_branch_4 $switch.51_branch_5 $switch.51_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $4
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $11)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $4)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $11)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $4
+                             (local.tee $3
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $2)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -178,13 +216,32 @@ pattern matching › adt_match_4
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $4)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $5
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $4)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -196,7 +253,7 @@ pattern matching › adt_match_4
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $3
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -204,7 +261,7 @@ pattern matching › adt_match_4
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $5)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -222,28 +279,12 @@ pattern matching › adt_match_4
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $6
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $4)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $5
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -254,9 +295,27 @@ pattern matching › adt_match_4
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $12
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $6)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $13
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -264,8 +323,8 @@ pattern matching › adt_match_4
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $5)
-                                        (i32.const 3)
+                                        (local.get $12)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -281,107 +340,13 @@ pattern matching › adt_match_4
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $6
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $12
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $6)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $13
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $12)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $6
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $5)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $6
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -389,7 +354,7 @@ pattern matching › adt_match_4
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $5)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -409,9 +374,11 @@ pattern matching › adt_match_4
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $4
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -419,7 +386,7 @@ pattern matching › adt_match_4
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $8)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -436,138 +403,58 @@ pattern matching › adt_match_4
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $4)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $8)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $4)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.51_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $3
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1196_+_1197)
-                   (local.get $7)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1196_+_1197)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $6)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.51_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1196_+_1197)
-                 (local.get $6)
-                 (local.get $1)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1196_+_1197)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -592,7 +479,7 @@ pattern matching › adt_match_4
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $0)
                  )
                 )
@@ -609,7 +496,7 @@ pattern matching › adt_match_4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $2)
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -619,11 +506,61 @@ pattern matching › adt_match_4
                )
               )
              )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1196_+_1197)
+                 (local.get $7)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1196_+_1197)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
+                )
+               )
+              )
+             )
              (br $switch.51_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1196_+_1197)
+               (local.get $6)
                (local.get $1)
-               (local.get $3)
                (i32.load offset=8
                 (global.get $import_pervasives_1196_+_1197)
                )
@@ -631,19 +568,80 @@ pattern matching › adt_match_4
              )
             )
            )
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=24
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
+              )
+             )
+            )
+           )
            (br $switch.51_outer
-            (i32.load offset=20
-             (local.get $2)
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (global.get $import_pervasives_1196_+_1197)
+             (local.get $1)
+             (local.get $3)
+             (i32.load offset=8
+              (global.get $import_pervasives_1196_+_1197)
+             )
             )
            )
           )
          )
-         (i32.const 1)
+         (br $switch.51_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=20
+            (local.get $2)
+           )
+          )
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -21,197 +21,196 @@ pattern matching › record_match_2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-          )
-         )
-        )
-        (i32.load offset=20
-         (local.tee $2
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 28)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 4)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.shl
-               (global.get $import__grainEnv_0_moduleRuntimeId_0)
-               (i32.const 1)
-              )
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (i32.const 2275)
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (i32.const 3)
-             )
-             (i32.store offset=16
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const 9)
-              )
-             )
-             (i32.store offset=20
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
-             )
-             (i32.store offset=24
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const -2)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=20
+        (local.get $2)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -28,261 +28,256 @@ pattern matching › constant_match_3
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-             (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-             (local.get $2)
-             (local.get $5)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (select
-             (i32.const 2147483646)
-             (local.get $3)
-             (i32.shr_u
-              (local.get $3)
-              (i32.const 31)
+              (local.get $0)
              )
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+           (local.get $2)
+           (local.get $5)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $6
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (select
+           (i32.const 2147483646)
+           (local.get $3)
+           (i32.shr_u
+            (local.get $3)
+            (i32.const 31)
            )
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.28_outer (result i32)
+       )
+      )
+      (block $switch.28_outer (result i32)
+       (drop
+        (block $switch.28_branch_1 (result i32)
          (drop
-          (block $switch.28_branch_1 (result i32)
+          (block $switch.28_branch_2 (result i32)
            (drop
-            (block $switch.28_branch_2 (result i32)
+            (block $switch.28_branch_3 (result i32)
              (drop
-              (block $switch.28_branch_3 (result i32)
-               (drop
-                (block $switch.28_default (result i32)
-                 (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_branch_3 $switch.28_default
-                  (i32.const 0)
-                  (i32.shr_s
-                   (local.tee $1
-                    (tuple.extract 0
-                     (tuple.make
-                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.get $6)
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (block (result i32)
-                         (local.set $1
-                          (tuple.extract 0
-                           (tuple.make
-                            (block (result i32)
-                             (i32.store
-                              (local.tee $0
-                               (tuple.extract 0
-                                (tuple.make
-                                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                                  (i32.const 16)
-                                 )
-                                 (local.get $0)
-                                )
+              (block $switch.28_default (result i32)
+               (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_branch_3 $switch.28_default
+                (i32.const 0)
+                (i32.shr_s
+                 (local.tee $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (if (result i32)
+                      (i32.shr_u
+                       (local.get $6)
+                       (i32.const 31)
+                      )
+                      (i32.const 1)
+                      (block (result i32)
+                       (local.set $1
+                        (tuple.extract 0
+                         (tuple.make
+                          (block (result i32)
+                           (i32.store
+                            (local.tee $0
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                                (i32.const 16)
                                )
+                               (local.get $0)
                               )
-                              (i32.const 1)
                              )
-                             (i32.store offset=4
-                              (local.get $0)
-                              (i32.const 3)
-                             )
-                             (i64.store offset=8
-                              (local.get $0)
-                              (i64.const 7303014)
-                             )
-                             (local.get $0)
                             )
-                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                             (i32.const 0)
-                            )
+                            (i32.const 1)
                            )
+                           (i32.store offset=4
+                            (local.get $0)
+                            (i32.const 3)
+                           )
+                           (i64.store offset=8
+                            (local.get $0)
+                            (i64.const 7303014)
+                           )
+                           (local.get $0)
                           )
-                         )
-                         (local.set $4
-                          (tuple.extract 0
-                           (tuple.make
-                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                             (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                              (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                              (local.get $2)
-                              (local.get $1)
-                             )
-                            )
-                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                         )
-                         (select
-                          (i32.const 3)
-                          (i32.const 5)
-                          (i32.shr_u
-                           (local.tee $7
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                               (select
-                                (i32.const -2)
-                                (local.get $4)
-                                (i32.shr_u
-                                 (local.get $4)
-                                 (i32.const 31)
-                                )
-                               )
-                              )
-                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                           )
-                           (i32.const 31)
+                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                           (i32.const 0)
                           )
                          )
                         )
                        )
-                      )
-                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                       (local.get $1)
+                       (local.set $4
+                        (tuple.extract 0
+                         (tuple.make
+                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                           (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                            (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                            (local.get $2)
+                            (local.get $1)
+                           )
+                          )
+                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                       )
+                       (select
+                        (i32.const 3)
+                        (i32.const 5)
+                        (i32.shr_u
+                         (local.tee $7
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (select
+                              (i32.const -2)
+                              (local.get $4)
+                              (i32.shr_u
+                               (local.get $4)
+                               (i32.const 31)
+                              )
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 31)
+                        )
+                       )
                       )
                      )
                     )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (local.get $1)
+                    )
                    )
-                   (i32.const 1)
                   )
                  )
+                 (i32.const 1)
                 )
                )
-               (unreachable)
               )
              )
-             (br $switch.28_outer
-              (i32.const 2147483646)
-             )
+             (unreachable)
             )
            )
            (br $switch.28_outer
-            (i32.const -2)
+            (i32.const 2147483646)
            )
           )
          )
-         (i32.const 2147483646)
+         (br $switch.28_outer
+          (i32.const -2)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 2147483646)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -25,149 +25,144 @@ pattern matching › guarded_match_2
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 5)
            )
           )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1158_==_1159)
-            (local.get $2)
-            (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1158_==_1159)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
            )
           )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.12_outer (result i32)
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1158_==_1159)
+          (local.get $2)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1158_==_1159)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.12_outer (result i32)
+       (drop
+        (block $switch.12_branch_1 (result i32)
          (drop
-          (block $switch.12_branch_1 (result i32)
+          (block $switch.12_branch_2 (result i32)
            (drop
-            (block $switch.12_branch_2 (result i32)
-             (drop
-              (block $switch.12_default (result i32)
-               (br_table $switch.12_branch_1 $switch.12_branch_2 $switch.12_default
-                (i32.const 0)
-                (i32.shr_s
-                 (local.tee $4
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (select
-                      (i32.const 1)
-                      (i32.const 3)
-                      (i32.shr_u
-                       (local.get $3)
-                       (i32.const 31)
-                      )
-                     )
-                    )
-                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                     (i32.const 0)
+            (block $switch.12_default (result i32)
+             (br_table $switch.12_branch_1 $switch.12_branch_2 $switch.12_default
+              (i32.const 0)
+              (i32.shr_s
+               (local.tee $4
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (select
+                    (i32.const 1)
+                    (i32.const 3)
+                    (i32.shr_u
+                     (local.get $3)
+                     (i32.const 31)
                     )
                    )
                   )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
                  )
-                 (i32.const 1)
                 )
                )
+               (i32.const 1)
               )
              )
-             (unreachable)
             )
            )
-           (br $switch.12_outer
-            (i32.const 199)
-           )
+           (unreachable)
           )
          )
-         (i32.const 85)
+         (br $switch.12_outer
+          (i32.const 199)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 85)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -30,238 +30,233 @@ pattern matching › tuple_match_deep
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
           )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 9)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 11)
            )
           )
+          (local.get $0)
          )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1158_+_1159)
-            (local.get $7)
-            (local.get $4)
-            (i32.load offset=8
-             (global.get $import_pervasives_1158_+_1159)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1158_+_1159)
-            (local.get $8)
-            (local.get $6)
-            (i32.load offset=8
-             (global.get $import_pervasives_1158_+_1159)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1158_+_1159)
-         (local.get $9)
-         (local.get $5)
-         (i32.load offset=8
-          (global.get $import_pervasives_1158_+_1159)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $3)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $6
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $7
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1158_+_1159)
+          (local.get $7)
+          (local.get $4)
+          (i32.load offset=8
+           (global.get $import_pervasives_1158_+_1159)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1158_+_1159)
+          (local.get $8)
+          (local.get $6)
+          (i32.load offset=8
+           (global.get $import_pervasives_1158_+_1159)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1158_+_1159)
+       (local.get $9)
+       (local.get $5)
+       (i32.load offset=8
+        (global.get $import_pervasives_1158_+_1159)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -21,197 +21,196 @@ pattern matching › record_match_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-          )
-         )
-        )
-        (i32.load offset=16
-         (local.tee $2
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 28)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 4)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.shl
-               (global.get $import__grainEnv_0_moduleRuntimeId_0)
-               (i32.const 1)
-              )
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (i32.const 2275)
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (i32.const 3)
-             )
-             (i32.store offset=16
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const 9)
-              )
-             )
-             (i32.store offset=20
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
-             )
-             (i32.store offset=24
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const -2)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $2)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -36,284 +36,404 @@ pattern matching › constant_match_2
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $9)
+              (local.get $0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 2147483646)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $9)
            )
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 11)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=16
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 2147483646)
            )
           )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $10)
-               (i32.const 2147483646)
-              )
-              (i32.const 31)
-             )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $6
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $10)
              (i32.const 2147483646)
             )
+            (i32.const 31)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 2147483646)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (if (result i32)
-             (i32.shr_u
-              (local.get $6)
-              (i32.const 31)
-             )
-             (if (result i32)
-              (i32.shr_u
-               (local.tee $3
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                    (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                    (local.get $11)
-                    (i32.const 11)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
-               (i32.const 31)
-              )
-              (block (result i32)
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (block (result i32)
-                   (i32.store
-                    (local.tee $0
-                     (tuple.extract 0
-                      (tuple.make
-                       (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                        (i32.const 16)
-                       )
-                       (local.get $0)
-                      )
-                     )
-                    )
-                    (i32.const 1)
-                   )
-                   (i32.store offset=4
-                    (local.get $0)
-                    (i32.const 3)
-                   )
-                   (i64.store offset=8
-                    (local.get $0)
-                    (i64.const 7496034)
-                   )
-                   (local.get $0)
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
-               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                (local.get $12)
-                (local.get $2)
-               )
-              )
-              (local.get $3)
-             )
-             (local.get $6)
-            )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (if (result i32)
+           (i32.shr_u
+            (local.get $6)
+            (i32.const 31)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+           (if (result i32)
+            (i32.shr_u
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                  (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                  (local.get $11)
+                  (i32.const 11)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
+             (i32.const 31)
+            )
+            (block (result i32)
+             (local.set $2
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 16)
+                     )
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (i32.const 1)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i64.store offset=8
+                  (local.get $0)
+                  (i64.const 7496034)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+              (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+              (local.get $12)
+              (local.get $2)
+             )
+            )
             (local.get $3)
            )
+           (local.get $6)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (local.get $3)
+         )
         )
-        (block $switch.60_outer (result i32)
+       )
+      )
+      (block $switch.60_outer (result i32)
+       (drop
+        (block $switch.60_branch_1 (result i32)
          (drop
-          (block $switch.60_branch_1 (result i32)
+          (block $switch.60_branch_2 (result i32)
            (drop
-            (block $switch.60_branch_2 (result i32)
+            (block $switch.60_branch_3 (result i32)
              (drop
-              (block $switch.60_branch_3 (result i32)
+              (block $switch.60_branch_4 (result i32)
                (drop
-                (block $switch.60_branch_4 (result i32)
-                 (drop
-                  (block $switch.60_default (result i32)
-                   (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
-                    (i32.const 0)
-                    (i32.shr_s
-                     (local.tee $2
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (block $switch.60_default (result i32)
+                 (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
+                  (i32.const 0)
+                  (i32.shr_s
+                   (local.tee $2
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (if (result i32)
+                        (i32.shr_u
+                         (local.get $3)
+                         (i32.const 31)
+                        )
+                        (i32.const 1)
+                        (block (result i32)
+                         (local.set $2
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (i32.load offset=16
+                              (local.get $1)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (local.get $2)
+                            )
+                           )
+                          )
+                         )
+                         (local.set $13
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (i32.load offset=8
+                              (local.get $1)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                         (local.set $7
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (i32.or
+                              (i32.shl
+                               (i32.eq
+                                (local.get $2)
+                                (i32.const -2)
+                               )
+                               (i32.const 31)
+                              )
+                              (i32.const 2147483646)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
                          (if (result i32)
                           (i32.shr_u
-                           (local.get $3)
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (if (result i32)
+                                (i32.shr_u
+                                 (local.get $7)
+                                 (i32.const 31)
+                                )
+                                (block (result i32)
+                                 (local.set $4
+                                  (tuple.extract 0
+                                   (tuple.make
+                                    (block (result i32)
+                                     (i32.store
+                                      (local.tee $0
+                                       (tuple.extract 0
+                                        (tuple.make
+                                         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                                          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                                          (i32.const 16)
+                                         )
+                                         (local.get $0)
+                                        )
+                                       )
+                                      )
+                                      (i32.const 1)
+                                     )
+                                     (i32.store offset=4
+                                      (local.get $0)
+                                      (i32.const 3)
+                                     )
+                                     (i64.store offset=8
+                                      (local.get $0)
+                                      (i64.const 7303014)
+                                     )
+                                     (local.get $0)
+                                    )
+                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                     (i32.const 0)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                                  (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                                  (local.get $13)
+                                  (local.get $4)
+                                 )
+                                )
+                                (local.get $7)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (local.get $4)
+                              )
+                             )
+                            )
+                           )
                            (i32.const 31)
                           )
-                          (i32.const 1)
+                          (i32.const 3)
                           (block (result i32)
-                           (local.set $2
+                           (local.set $14
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -324,12 +444,12 @@ pattern matching › constant_match_2
                               )
                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                               (local.get $2)
+                               (i32.const 0)
                               )
                              )
                             )
                            )
-                           (local.set $13
+                           (local.set $15
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -345,7 +465,7 @@ pattern matching › constant_match_2
                              )
                             )
                            )
-                           (local.set $7
+                           (local.set $8
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -353,8 +473,8 @@ pattern matching › constant_match_2
                                (i32.or
                                 (i32.shl
                                  (i32.eq
-                                  (local.get $2)
-                                  (i32.const -2)
+                                  (local.get $14)
+                                  (i32.const 2147483646)
                                  )
                                  (i32.const 31)
                                 )
@@ -368,20 +488,22 @@ pattern matching › constant_match_2
                              )
                             )
                            )
-                           (if (result i32)
+                           (select
+                            (i32.const 5)
+                            (i32.const 7)
                             (i32.shr_u
-                             (local.tee $4
+                             (local.tee $5
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (if (result i32)
                                   (i32.shr_u
-                                   (local.get $7)
+                                   (local.get $8)
                                    (i32.const 31)
                                   )
                                   (block (result i32)
-                                   (local.set $4
+                                   (local.set $5
                                     (tuple.extract 0
                                      (tuple.make
                                       (block (result i32)
@@ -418,189 +540,62 @@ pattern matching › constant_match_2
                                    )
                                    (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
                                     (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                    (local.get $13)
-                                    (local.get $4)
+                                    (local.get $15)
+                                    (local.get $5)
                                    )
                                   )
-                                  (local.get $7)
+                                  (local.get $8)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (local.get $4)
+                                 (local.get $5)
                                 )
                                )
                               )
                              )
                              (i32.const 31)
                             )
-                            (i32.const 3)
-                            (block (result i32)
-                             (local.set $14
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=16
-                                  (local.get $1)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (local.set $15
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=8
-                                  (local.get $1)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (local.set $8
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.or
-                                  (i32.shl
-                                   (i32.eq
-                                    (local.get $14)
-                                    (i32.const 2147483646)
-                                   )
-                                   (i32.const 31)
-                                  )
-                                  (i32.const 2147483646)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (select
-                              (i32.const 5)
-                              (i32.const 7)
-                              (i32.shr_u
-                               (local.tee $5
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (if (result i32)
-                                    (i32.shr_u
-                                     (local.get $8)
-                                     (i32.const 31)
-                                    )
-                                    (block (result i32)
-                                     (local.set $5
-                                      (tuple.extract 0
-                                       (tuple.make
-                                        (block (result i32)
-                                         (i32.store
-                                          (local.tee $0
-                                           (tuple.extract 0
-                                            (tuple.make
-                                             (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                                              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                                              (i32.const 16)
-                                             )
-                                             (local.get $0)
-                                            )
-                                           )
-                                          )
-                                          (i32.const 1)
-                                         )
-                                         (i32.store offset=4
-                                          (local.get $0)
-                                          (i32.const 3)
-                                         )
-                                         (i64.store offset=8
-                                          (local.get $0)
-                                          (i64.const 7303014)
-                                         )
-                                         (local.get $0)
-                                        )
-                                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                         (i32.const 0)
-                                        )
-                                       )
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                                      (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                      (local.get $15)
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (local.get $5)
-                                  )
-                                 )
-                                )
-                               )
-                               (i32.const 31)
-                              )
-                             )
-                            )
                            )
                           )
                          )
                         )
-                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                         (local.get $2)
-                        )
                        )
                       )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (local.get $2)
+                      )
                      )
-                     (i32.const 1)
                     )
                    )
+                   (i32.const 1)
                   )
                  )
-                 (unreachable)
                 )
                )
-               (br $switch.60_outer
-                (i32.const 2147483646)
-               )
+               (unreachable)
               )
              )
              (br $switch.60_outer
-              (i32.const -2)
+              (i32.const 2147483646)
              )
             )
            )
            (br $switch.60_outer
-            (i32.const 2147483646)
+            (i32.const -2)
            )
           )
          )
-         (i32.const 2147483646)
+         (br $switch.60_outer
+          (i32.const 2147483646)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 2147483646)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -27,234 +27,229 @@ pattern matching › record_match_4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
            )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=24
-             (local.get $1)
-            )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
            )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=20
-             (local.get $1)
-            )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
            )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1153_+_1154)
-            (local.get $4)
-            (local.get $3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1153_+_1154)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1153_+_1154)
-         (local.get $5)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1153_+_1154)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 13)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=24
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=20
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1153_+_1154)
+          (local.get $4)
+          (local.get $3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1153_+_1154)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1153_+_1154)
+       (local.get $5)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1153_+_1154)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -25,77 +25,96 @@ pattern matching › constant_match_1
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $4
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
-            (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
-            (i32.const 1)
-            (i32.const 3)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
+          (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
+          (i32.const 1)
+          (i32.const 3)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-             (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-             (local.get $1)
-             (i32.const 11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+           (local.get $1)
+           (i32.const 11)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.15_outer (result i32)
+       )
+      )
+      (block $switch.15_outer (result i32)
+       (drop
+        (block $switch.15_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_1 (result i32)
+          (block $switch.15_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_2 (result i32)
+            (block $switch.15_branch_3 (result i32)
              (drop
-              (block $switch.15_branch_3 (result i32)
-               (drop
-                (block $switch.15_default (result i32)
-                 (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_default
-                  (i32.const 0)
-                  (i32.shr_s
-                   (local.tee $0
-                    (tuple.extract 0
-                     (tuple.make
-                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.get $2)
-                         (i32.const 31)
+              (block $switch.15_default (result i32)
+               (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_default
+                (i32.const 0)
+                (i32.shr_s
+                 (local.tee $0
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (if (result i32)
+                      (i32.shr_u
+                       (local.get $2)
+                       (i32.const 31)
+                      )
+                      (i32.const 1)
+                      (block (result i32)
+                       (local.set $0
+                        (tuple.extract 0
+                         (tuple.make
+                          (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
+                           (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
+                           (i32.const 1)
+                           (i32.const 3)
+                          )
+                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                           (i32.const 0)
+                          )
+                         )
                         )
-                        (i32.const 1)
-                        (block (result i32)
-                         (local.set $0
+                       )
+                       (select
+                        (i32.const 3)
+                        (i32.const 5)
+                        (i32.shr_u
+                         (local.tee $3
                           (tuple.extract 0
                            (tuple.make
-                            (call $import_GRAIN$MODULE$runtime/dataStructures_0_newRational_0
-                             (global.get $import_GRAIN$MODULE$runtime/dataStructures_0_GRAIN$EXPORT$newRational_0)
-                             (i32.const 1)
-                             (i32.const 3)
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                              (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                              (local.get $1)
+                              (local.get $0)
+                             )
                             )
                             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
@@ -104,65 +123,41 @@ pattern matching › constant_match_1
                            )
                           )
                          )
-                         (select
-                          (i32.const 3)
-                          (i32.const 5)
-                          (i32.shr_u
-                           (local.tee $3
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                (local.get $1)
-                                (local.get $0)
-                               )
-                              )
-                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
+                         (i32.const 31)
                         )
                        )
                       )
-                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                       (local.get $0)
-                      )
                      )
                     )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (local.get $0)
+                    )
                    )
-                   (i32.const 1)
                   )
                  )
+                 (i32.const 1)
                 )
                )
-               (unreachable)
               )
              )
-             (br $switch.15_outer
-              (i32.const 2147483646)
-             )
+             (unreachable)
             )
            )
            (br $switch.15_outer
-            (i32.const -2)
+            (i32.const 2147483646)
            )
           )
          )
-         (i32.const 2147483646)
+         (br $switch.15_outer
+          (i32.const -2)
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 2147483646)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -40,201 +40,239 @@ pattern matching › tuple_match_deep6
   (local $15 i32)
   (local $16 i32)
   (local $17 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1223_[...]_1224)
-            (i32.const 13)
-            (global.get $import_pervasives_1221_[]_1222)
-            (i32.load offset=8
-             (global.get $import_pervasives_1223_[...]_1224)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1223_[...]_1224)
+          (i32.const 13)
+          (global.get $import_pervasives_1221_[]_1222)
+          (i32.load offset=8
+           (global.get $import_pervasives_1223_[...]_1224)
           )
          )
-        )
-        (local.set $14
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1223_[...]_1224)
-            (i32.const 11)
-            (local.get $13)
-            (i32.load offset=8
-             (global.get $import_pervasives_1223_[...]_1224)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $15
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1223_[...]_1224)
-            (i32.const 9)
-            (local.get $14)
-            (i32.load offset=8
-             (global.get $import_pervasives_1223_[...]_1224)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1223_[...]_1224)
+          (i32.const 11)
+          (local.get $13)
+          (i32.load offset=8
+           (global.get $import_pervasives_1223_[...]_1224)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+       )
+      )
+      (local.set $15
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1223_[...]_1224)
+          (i32.const 9)
+          (local.get $14)
+          (i32.load offset=8
+           (global.get $import_pervasives_1223_[...]_1224)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $6
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $6)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $15)
-             )
-            )
-            (local.get $6)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $6)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $15)
            )
           )
+          (local.get $6)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $16
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $12)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.56_outer (result i32)
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $16
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $12)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.56_outer (result i32)
+       (drop
+        (block $switch.56_branch_1 (result i32)
          (drop
-          (block $switch.56_branch_1 (result i32)
+          (block $switch.56_branch_2 (result i32)
            (drop
-            (block $switch.56_branch_2 (result i32)
+            (block $switch.56_branch_3 (result i32)
              (drop
-              (block $switch.56_branch_3 (result i32)
+              (block $switch.56_branch_4 (result i32)
                (drop
-                (block $switch.56_branch_4 (result i32)
+                (block $switch.56_branch_5 (result i32)
                  (drop
-                  (block $switch.56_branch_5 (result i32)
-                   (drop
-                    (block $switch.56_default (result i32)
-                     (br_table $switch.56_branch_1 $switch.56_branch_2 $switch.56_branch_3 $switch.56_branch_4 $switch.56_branch_5 $switch.56_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $8
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.56_default (result i32)
+                   (br_table $switch.56_branch_1 $switch.56_branch_2 $switch.56_branch_3 $switch.56_branch_4 $switch.56_branch_5 $switch.56_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $8
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $16)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $8
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $11)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $8)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $16)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $8
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $11)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -244,13 +282,32 @@ pattern matching › tuple_match_deep6
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $8)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -262,7 +319,7 @@ pattern matching › tuple_match_deep6
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -270,7 +327,7 @@ pattern matching › tuple_match_deep6
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -288,28 +345,12 @@ pattern matching › tuple_match_deep6
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -320,9 +361,27 @@ pattern matching › tuple_match_deep6
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -330,8 +389,8 @@ pattern matching › tuple_match_deep6
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -347,107 +406,13 @@ pattern matching › tuple_match_deep6
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -455,7 +420,7 @@ pattern matching › tuple_match_deep6
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -475,9 +440,11 @@ pattern matching › tuple_match_deep6
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $8
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -485,7 +452,7 @@ pattern matching › tuple_match_deep6
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $12)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -502,188 +469,58 @@ pattern matching › tuple_match_deep6
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $8)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $12)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $8)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.56_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=12
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $1)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $9
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=8
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $9)
-                  )
-                 )
-                )
-               )
-               (local.set $10
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1219_+_1220)
-                   (local.get $9)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1219_+_1220)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $10)
-                  )
-                 )
-                )
-               )
-               (local.set $17
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1219_+_1220)
-                   (local.get $10)
-                   (local.get $7)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1219_+_1220)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.56_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1219_+_1220)
-                 (local.get $17)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1219_+_1220)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -724,7 +561,7 @@ pattern matching › tuple_match_deep6
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $2)
                  )
                 )
@@ -741,7 +578,7 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -756,8 +593,8 @@ pattern matching › tuple_match_deep6
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=8
-                  (local.get $3)
+                 (i32.load offset=20
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -770,12 +607,10 @@ pattern matching › tuple_match_deep6
              (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1219_+_1220)
-                 (local.get $7)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1219_+_1220)
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -785,11 +620,63 @@ pattern matching › tuple_match_deep6
                )
               )
              )
+             (local.set $9
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=8
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $9)
+                )
+               )
+              )
+             )
+             (local.set $10
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1219_+_1220)
+                 (local.get $9)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1219_+_1220)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $10)
+                )
+               )
+              )
+             )
+             (local.set $17
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1219_+_1220)
+                 (local.get $10)
+                 (local.get $7)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1219_+_1220)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
              (br $switch.56_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1219_+_1220)
-               (local.get $5)
-               (local.get $1)
+               (local.get $17)
+               (local.get $4)
                (i32.load offset=8
                 (global.get $import_pervasives_1219_+_1220)
                )
@@ -818,7 +705,7 @@ pattern matching › tuple_match_deep6
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
+               (i32.load offset=24
                 (local.get $0)
                )
               )
@@ -834,8 +721,8 @@ pattern matching › tuple_match_deep6
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=8
-                (local.get $3)
+               (i32.load offset=20
+                (local.get $2)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -845,11 +732,61 @@ pattern matching › tuple_match_deep6
              )
             )
            )
+           (local.set $4
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $4)
+              )
+             )
+            )
+           )
+           (local.set $7
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=8
+                (local.get $3)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $7)
+              )
+             )
+            )
+           )
+           (local.set $5
+            (tuple.extract 0
+             (tuple.make
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (global.get $import_pervasives_1219_+_1220)
+               (local.get $7)
+               (local.get $4)
+               (i32.load offset=8
+                (global.get $import_pervasives_1219_+_1220)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $5)
+              )
+             )
+            )
+           )
            (br $switch.56_outer
             (call_indirect (type $i32_i32_i32_=>_i32)
              (global.get $import_pervasives_1219_+_1220)
+             (local.get $5)
              (local.get $1)
-             (local.get $2)
              (i32.load offset=8
               (global.get $import_pervasives_1219_+_1220)
              )
@@ -857,14 +794,75 @@ pattern matching › tuple_match_deep6
            )
           )
          )
-         (i32.load offset=8
-          (local.get $3)
+         (local.set $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=12
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $2
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (local.set $1
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=8
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $1)
+            )
+           )
+          )
+         )
+         (br $switch.56_outer
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (global.get $import_pervasives_1219_+_1220)
+           (local.get $1)
+           (local.get $2)
+           (i32.load offset=8
+            (global.get $import_pervasives_1219_+_1220)
+           )
+          )
          )
         )
        )
-       (local.get $6)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.load offset=8
+         (local.get $3)
+        )
+       )
       )
      )
+     (local.get $6)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -23,192 +23,187 @@ pattern matching › tuple_match_3
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 4)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 1886351202)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $2)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 2147483646)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 4)
           )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 1886351202)
           )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 8)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $4)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $3)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $2)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 2147483646)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+           (i32.const 20)
+          )
+          (local.get $0)
+         )
+        )
+       )
+       (i32.const 8)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $5)
+       )
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $4)
+       )
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $3)
+       )
+      )
+      (local.get $0)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -36,147 +36,185 @@ pattern matching › tuple_match_deep3
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $6
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $6)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1214_[]_1215)
-             )
-            )
-            (local.get $6)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $6)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (global.get $import_pervasives_1214_[]_1215)
            )
           )
+          (local.get $6)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $12)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.50_outer (result i32)
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $12)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.50_outer (result i32)
+       (drop
+        (block $switch.50_branch_1 (result i32)
          (drop
-          (block $switch.50_branch_1 (result i32)
+          (block $switch.50_branch_2 (result i32)
            (drop
-            (block $switch.50_branch_2 (result i32)
+            (block $switch.50_branch_3 (result i32)
              (drop
-              (block $switch.50_branch_3 (result i32)
+              (block $switch.50_branch_4 (result i32)
                (drop
-                (block $switch.50_branch_4 (result i32)
+                (block $switch.50_branch_5 (result i32)
                  (drop
-                  (block $switch.50_branch_5 (result i32)
-                   (drop
-                    (block $switch.50_default (result i32)
-                     (br_table $switch.50_branch_1 $switch.50_branch_2 $switch.50_branch_3 $switch.50_branch_4 $switch.50_branch_5 $switch.50_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $8
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.50_default (result i32)
+                   (br_table $switch.50_branch_1 $switch.50_branch_2 $switch.50_branch_3 $switch.50_branch_4 $switch.50_branch_5 $switch.50_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $8
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $13)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $8
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $11)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $8)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $13)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $8
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $11)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -186,13 +224,32 @@ pattern matching › tuple_match_deep3
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $8)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -204,7 +261,7 @@ pattern matching › tuple_match_deep3
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -212,7 +269,7 @@ pattern matching › tuple_match_deep3
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -230,28 +287,12 @@ pattern matching › tuple_match_deep3
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -262,9 +303,27 @@ pattern matching › tuple_match_deep3
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -272,8 +331,8 @@ pattern matching › tuple_match_deep3
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -289,107 +348,13 @@ pattern matching › tuple_match_deep3
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -397,7 +362,7 @@ pattern matching › tuple_match_deep3
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -417,9 +382,11 @@ pattern matching › tuple_match_deep3
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $8
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -427,7 +394,7 @@ pattern matching › tuple_match_deep3
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $12)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -444,188 +411,58 @@ pattern matching › tuple_match_deep3
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $8)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $12)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $8)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.50_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=12
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $1)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $9
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=8
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $9)
-                  )
-                 )
-                )
-               )
-               (local.set $10
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1212_+_1213)
-                   (local.get $9)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1212_+_1213)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $10)
-                  )
-                 )
-                )
-               )
-               (local.set $14
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1212_+_1213)
-                   (local.get $10)
-                   (local.get $7)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1212_+_1213)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.50_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1212_+_1213)
-                 (local.get $14)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1212_+_1213)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -666,7 +503,7 @@ pattern matching › tuple_match_deep3
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $2)
                  )
                 )
@@ -683,7 +520,7 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -698,8 +535,8 @@ pattern matching › tuple_match_deep3
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=8
-                  (local.get $3)
+                 (i32.load offset=20
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -712,12 +549,10 @@ pattern matching › tuple_match_deep3
              (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1212_+_1213)
-                 (local.get $7)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1212_+_1213)
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -727,11 +562,63 @@ pattern matching › tuple_match_deep3
                )
               )
              )
+             (local.set $9
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=8
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $9)
+                )
+               )
+              )
+             )
+             (local.set $10
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1212_+_1213)
+                 (local.get $9)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1212_+_1213)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $10)
+                )
+               )
+              )
+             )
+             (local.set $14
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1212_+_1213)
+                 (local.get $10)
+                 (local.get $7)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1212_+_1213)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
              (br $switch.50_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1212_+_1213)
-               (local.get $5)
-               (local.get $1)
+               (local.get $14)
+               (local.get $4)
                (i32.load offset=8
                 (global.get $import_pervasives_1212_+_1213)
                )
@@ -760,7 +647,7 @@ pattern matching › tuple_match_deep3
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
+               (i32.load offset=24
                 (local.get $0)
                )
               )
@@ -776,8 +663,8 @@ pattern matching › tuple_match_deep3
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=8
-                (local.get $3)
+               (i32.load offset=20
+                (local.get $2)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -787,11 +674,61 @@ pattern matching › tuple_match_deep3
              )
             )
            )
+           (local.set $4
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $4)
+              )
+             )
+            )
+           )
+           (local.set $7
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=8
+                (local.get $3)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $7)
+              )
+             )
+            )
+           )
+           (local.set $5
+            (tuple.extract 0
+             (tuple.make
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (global.get $import_pervasives_1212_+_1213)
+               (local.get $7)
+               (local.get $4)
+               (i32.load offset=8
+                (global.get $import_pervasives_1212_+_1213)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $5)
+              )
+             )
+            )
+           )
            (br $switch.50_outer
             (call_indirect (type $i32_i32_i32_=>_i32)
              (global.get $import_pervasives_1212_+_1213)
+             (local.get $5)
              (local.get $1)
-             (local.get $2)
              (i32.load offset=8
               (global.get $import_pervasives_1212_+_1213)
              )
@@ -799,14 +736,75 @@ pattern matching › tuple_match_deep3
            )
           )
          )
-         (i32.load offset=8
-          (local.get $3)
+         (local.set $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=12
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $2
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (local.set $1
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=8
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $1)
+            )
+           )
+          )
+         )
+         (br $switch.50_outer
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (global.get $import_pervasives_1212_+_1213)
+           (local.get $1)
+           (local.get $2)
+           (i32.load offset=8
+            (global.get $import_pervasives_1212_+_1213)
+           )
+          )
          )
         )
        )
-       (local.get $6)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.load offset=8
+         (local.get $3)
+        )
+       )
       )
      )
+     (local.get $6)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -31,86 +31,124 @@ pattern matching › adt_match_1
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $11
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (global.get $import_pervasives_1191_[]_1192)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $7
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (global.get $import_pervasives_1191_[]_1192)
           )
          )
-        )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $7)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.45_outer (result i32)
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $7)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.45_outer (result i32)
+       (drop
+        (block $switch.45_branch_1 (result i32)
          (drop
-          (block $switch.45_branch_1 (result i32)
+          (block $switch.45_branch_2 (result i32)
            (drop
-            (block $switch.45_branch_2 (result i32)
+            (block $switch.45_branch_3 (result i32)
              (drop
-              (block $switch.45_branch_3 (result i32)
+              (block $switch.45_branch_4 (result i32)
                (drop
-                (block $switch.45_branch_4 (result i32)
+                (block $switch.45_branch_5 (result i32)
                  (drop
-                  (block $switch.45_branch_5 (result i32)
-                   (drop
-                    (block $switch.45_default (result i32)
-                     (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_branch_5 $switch.45_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $3
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.45_default (result i32)
+                   (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_branch_5 $switch.45_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $3
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $8)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (global.get $import_pervasives_1191_[]_1192)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $3)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $8)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $3
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (global.get $import_pervasives_1191_[]_1192)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -120,13 +158,32 @@ pattern matching › adt_match_1
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $3)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -138,7 +195,7 @@ pattern matching › adt_match_1
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $6
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -146,7 +203,7 @@ pattern matching › adt_match_1
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -164,28 +221,12 @@ pattern matching › adt_match_1
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $3)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -196,9 +237,27 @@ pattern matching › adt_match_1
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $6
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -206,8 +265,8 @@ pattern matching › adt_match_1
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -223,107 +282,13 @@ pattern matching › adt_match_1
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -331,7 +296,7 @@ pattern matching › adt_match_1
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -351,9 +316,11 @@ pattern matching › adt_match_1
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $3
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -361,7 +328,7 @@ pattern matching › adt_match_1
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $7)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -378,138 +345,58 @@ pattern matching › adt_match_1
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $3)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $3
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $7)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $3)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.45_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (global.get $import_pervasives_1191_[]_1192)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (global.get $import_pervasives_1191_[]_1192)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $6)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1189_+_1190)
-                   (local.get $6)
-                   (local.get $4)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1189_+_1190)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.45_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1189_+_1190)
-                 (local.get $5)
-                 (local.get $1)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1189_+_1190)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -534,7 +421,7 @@ pattern matching › adt_match_1
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $0)
                  )
                 )
@@ -551,7 +438,7 @@ pattern matching › adt_match_1
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (global.get $import_pervasives_1191_[]_1192)
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -561,11 +448,61 @@ pattern matching › adt_match_1
                )
               )
              )
+             (local.set $4
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $4)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (global.get $import_pervasives_1191_[]_1192)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1189_+_1190)
+                 (local.get $6)
+                 (local.get $4)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1189_+_1190)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
              (br $switch.45_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1189_+_1190)
+               (local.get $5)
                (local.get $1)
-               (local.get $2)
                (i32.load offset=8
                 (global.get $import_pervasives_1189_+_1190)
                )
@@ -573,19 +510,80 @@ pattern matching › adt_match_1
              )
             )
            )
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=24
+                (global.get $import_pervasives_1191_[]_1192)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $2
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $2)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (global.get $import_pervasives_1191_[]_1192)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
+              )
+             )
+            )
+           )
            (br $switch.45_outer
-            (i32.load offset=20
-             (global.get $import_pervasives_1191_[]_1192)
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (global.get $import_pervasives_1189_+_1190)
+             (local.get $1)
+             (local.get $2)
+             (i32.load offset=8
+              (global.get $import_pervasives_1189_+_1190)
+             )
             )
            )
           )
          )
-         (i32.const 1)
+         (br $switch.45_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=20
+            (global.get $import_pervasives_1191_[]_1192)
+           )
+          )
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -42,523 +42,518 @@ pattern matching › tuple_match_deep2
   (local $19 i32)
   (local $20 i32)
   (local $21 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $6
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 15)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $6)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
           )
-         )
-        )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $8)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $9)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 13)
            )
           )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 15)
            )
           )
+          (local.get $0)
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $5)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $5)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $14
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $4)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $15
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $16
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $17
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1179_+_1180)
-            (local.get $16)
-            (local.get $15)
-            (i32.load offset=8
-             (global.get $import_pervasives_1179_+_1180)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $18
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1179_+_1180)
-            (local.get $17)
-            (local.get $14)
-            (i32.load offset=8
-             (global.get $import_pervasives_1179_+_1180)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $19
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1179_+_1180)
-            (local.get $18)
-            (local.get $13)
-            (i32.load offset=8
-             (global.get $import_pervasives_1179_+_1180)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $20
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1179_+_1180)
-            (local.get $19)
-            (local.get $12)
-            (i32.load offset=8
-             (global.get $import_pervasives_1179_+_1180)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $21
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1179_+_1180)
-            (local.get $20)
-            (local.get $11)
-            (i32.load offset=8
-             (global.get $import_pervasives_1179_+_1180)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1179_+_1180)
-         (local.get $21)
-         (local.get $10)
-         (i32.load offset=8
-          (global.get $import_pervasives_1179_+_1180)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $7
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $6)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $8)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $4)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $5)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $5)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $4)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $15
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $3)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $16
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $17
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1179_+_1180)
+          (local.get $16)
+          (local.get $15)
+          (i32.load offset=8
+           (global.get $import_pervasives_1179_+_1180)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $18
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1179_+_1180)
+          (local.get $17)
+          (local.get $14)
+          (i32.load offset=8
+           (global.get $import_pervasives_1179_+_1180)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $19
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1179_+_1180)
+          (local.get $18)
+          (local.get $13)
+          (i32.load offset=8
+           (global.get $import_pervasives_1179_+_1180)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $20
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1179_+_1180)
+          (local.get $19)
+          (local.get $12)
+          (i32.load offset=8
+           (global.get $import_pervasives_1179_+_1180)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $21
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1179_+_1180)
+          (local.get $20)
+          (local.get $11)
+          (i32.load offset=8
+           (global.get $import_pervasives_1179_+_1180)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1179_+_1180)
+       (local.get $21)
+       (local.get $10)
+       (i32.load offset=8
+        (global.get $import_pervasives_1179_+_1180)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -22,209 +22,208 @@ pattern matching › record_match_deep
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 72)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 72)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 60)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215106)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 103079215104)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 68719477874)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 60)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2277)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 103079215106)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 103079215104)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 68719477874)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (i32.load offset=16
-         (local.tee $3
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (i32.load offset=16
-              (local.get $2)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2277)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $3)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -27,193 +27,188 @@ pattern matching › guarded_match_4
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 17)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 17)
            )
           )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 5)
            )
           )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1160_==_1161)
+          (local.get $4)
+          (i32.const 5)
+          (i32.load offset=8
+           (global.get $import_pervasives_1160_==_1161)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (if (result i32)
+           (i32.shr_u
+            (local.get $2)
+            (i32.const 31)
+           )
            (call_indirect (type $i32_i32_i32_=>_i32)
             (global.get $import_pervasives_1160_==_1161)
-            (local.get $4)
-            (i32.const 5)
+            (local.get $3)
+            (i32.const 7)
             (i32.load offset=8
              (global.get $import_pervasives_1160_==_1161)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (local.get $2)
           )
          )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (if (result i32)
-             (i32.shr_u
-              (local.get $2)
-              (i32.const 31)
-             )
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (global.get $import_pervasives_1160_==_1161)
-              (local.get $3)
-              (i32.const 7)
-              (i32.load offset=8
-               (global.get $import_pervasives_1160_==_1161)
-              )
-             )
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.18_outer (result i32)
+       )
+      )
+      (block $switch.18_outer (result i32)
+       (drop
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.18_branch_1 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.18_branch_2 (result i32)
-             (drop
-              (block $switch.18_default (result i32)
-               (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_default
-                (i32.const 0)
-                (i32.shr_s
-                 (local.tee $6
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (select
-                      (i32.const 1)
-                      (i32.const 3)
-                      (i32.shr_u
-                       (local.get $5)
-                       (i32.const 31)
-                      )
-                     )
-                    )
-                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                     (i32.const 0)
+            (block $switch.18_default (result i32)
+             (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_default
+              (i32.const 0)
+              (i32.shr_s
+               (local.tee $6
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (select
+                    (i32.const 1)
+                    (i32.const 3)
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
                     )
                    )
                   )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
                  )
-                 (i32.const 1)
                 )
                )
+               (i32.const 1)
               )
              )
-             (unreachable)
             )
            )
-           (br $switch.18_outer
-            (i32.const 199)
-           )
+           (unreachable)
           )
          )
-         (i32.const 85)
+         (br $switch.18_outer
+          (i32.const 199)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 85)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -25,149 +25,144 @@ pattern matching › guarded_match_1
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1158_==_1159)
-            (local.get $2)
             (i32.const 3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1158_==_1159)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.12_outer (result i32)
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1158_==_1159)
+          (local.get $2)
+          (i32.const 3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1158_==_1159)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.12_outer (result i32)
+       (drop
+        (block $switch.12_branch_1 (result i32)
          (drop
-          (block $switch.12_branch_1 (result i32)
+          (block $switch.12_branch_2 (result i32)
            (drop
-            (block $switch.12_branch_2 (result i32)
-             (drop
-              (block $switch.12_default (result i32)
-               (br_table $switch.12_branch_1 $switch.12_branch_2 $switch.12_default
-                (i32.const 0)
-                (i32.shr_s
-                 (local.tee $4
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (select
-                      (i32.const 1)
-                      (i32.const 3)
-                      (i32.shr_u
-                       (local.get $3)
-                       (i32.const 31)
-                      )
-                     )
-                    )
-                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                     (i32.const 0)
+            (block $switch.12_default (result i32)
+             (br_table $switch.12_branch_1 $switch.12_branch_2 $switch.12_default
+              (i32.const 0)
+              (i32.shr_s
+               (local.tee $4
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (select
+                    (i32.const 1)
+                    (i32.const 3)
+                    (i32.shr_u
+                     (local.get $3)
+                     (i32.const 31)
                     )
                    )
                   )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
                  )
-                 (i32.const 1)
                 )
                )
+               (i32.const 1)
               )
              )
-             (unreachable)
             )
            )
-           (br $switch.12_outer
-            (i32.const 199)
-           )
+           (unreachable)
           )
          )
-         (i32.const 85)
+         (br $switch.12_outer
+          (i32.const 199)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 85)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -33,104 +33,142 @@ pattern matching › adt_match_2
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $12
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1196_[...]_1197)
-            (i32.const 5)
-            (global.get $import_pervasives_1194_[]_1195)
-            (i32.load offset=8
-             (global.get $import_pervasives_1196_[...]_1197)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1196_[...]_1197)
+          (i32.const 5)
+          (global.get $import_pervasives_1194_[]_1195)
+          (i32.load offset=8
+           (global.get $import_pervasives_1196_[...]_1197)
           )
          )
-        )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $8)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.47_outer (result i32)
+       )
+      )
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $8)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.47_outer (result i32)
+       (drop
+        (block $switch.47_branch_1 (result i32)
          (drop
-          (block $switch.47_branch_1 (result i32)
+          (block $switch.47_branch_2 (result i32)
            (drop
-            (block $switch.47_branch_2 (result i32)
+            (block $switch.47_branch_3 (result i32)
              (drop
-              (block $switch.47_branch_3 (result i32)
+              (block $switch.47_branch_4 (result i32)
                (drop
-                (block $switch.47_branch_4 (result i32)
+                (block $switch.47_branch_5 (result i32)
                  (drop
-                  (block $switch.47_branch_5 (result i32)
-                   (drop
-                    (block $switch.47_default (result i32)
-                     (br_table $switch.47_branch_1 $switch.47_branch_2 $switch.47_branch_3 $switch.47_branch_4 $switch.47_branch_5 $switch.47_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $4
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.47_default (result i32)
+                   (br_table $switch.47_branch_1 $switch.47_branch_2 $switch.47_branch_3 $switch.47_branch_4 $switch.47_branch_5 $switch.47_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $4
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $9)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $4)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $9)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $4
+                             (local.tee $3
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $2)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -140,13 +178,32 @@ pattern matching › adt_match_2
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $4)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $5
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $4)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -158,7 +215,7 @@ pattern matching › adt_match_2
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $3
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -166,7 +223,7 @@ pattern matching › adt_match_2
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $5)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -184,28 +241,12 @@ pattern matching › adt_match_2
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $6
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $4)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $5
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -216,9 +257,27 @@ pattern matching › adt_match_2
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $10
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $6)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $11
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -226,8 +285,8 @@ pattern matching › adt_match_2
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $5)
-                                        (i32.const 3)
+                                        (local.get $10)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -243,107 +302,13 @@ pattern matching › adt_match_2
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $6
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $10
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $6)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $11
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $10)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $6
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $5)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $6
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -351,7 +316,7 @@ pattern matching › adt_match_2
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $5)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -371,9 +336,11 @@ pattern matching › adt_match_2
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $4
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -381,7 +348,7 @@ pattern matching › adt_match_2
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $8)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -398,138 +365,58 @@ pattern matching › adt_match_2
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $4)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $8)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $4)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.47_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $3
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1192_+_1193)
-                   (local.get $7)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1192_+_1193)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $6)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.47_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1192_+_1193)
-                 (local.get $6)
-                 (local.get $1)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1192_+_1193)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -554,7 +441,7 @@ pattern matching › adt_match_2
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $0)
                  )
                 )
@@ -571,7 +458,7 @@ pattern matching › adt_match_2
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $2)
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -581,11 +468,61 @@ pattern matching › adt_match_2
                )
               )
              )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1192_+_1193)
+                 (local.get $7)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1192_+_1193)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
+                )
+               )
+              )
+             )
              (br $switch.47_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1192_+_1193)
+               (local.get $6)
                (local.get $1)
-               (local.get $3)
                (i32.load offset=8
                 (global.get $import_pervasives_1192_+_1193)
                )
@@ -593,19 +530,80 @@ pattern matching › adt_match_2
              )
             )
            )
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=24
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
+              )
+             )
+            )
+           )
            (br $switch.47_outer
-            (i32.load offset=20
-             (local.get $2)
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (global.get $import_pervasives_1192_+_1193)
+             (local.get $1)
+             (local.get $3)
+             (i32.load offset=8
+              (global.get $import_pervasives_1192_+_1193)
+             )
             )
            )
           )
          )
-         (i32.const 1)
+         (br $switch.47_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=20
+            (local.get $2)
+           )
+          )
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -27,193 +27,188 @@ pattern matching › guarded_match_3
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 5)
            )
           )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=8
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 5)
            )
           )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1160_==_1161)
+          (local.get $4)
+          (i32.const 5)
+          (i32.load offset=8
+           (global.get $import_pervasives_1160_==_1161)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (if (result i32)
+           (i32.shr_u
+            (local.get $2)
+            (i32.const 31)
+           )
            (call_indirect (type $i32_i32_i32_=>_i32)
             (global.get $import_pervasives_1160_==_1161)
-            (local.get $4)
-            (i32.const 5)
+            (local.get $3)
+            (i32.const 7)
             (i32.load offset=8
              (global.get $import_pervasives_1160_==_1161)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (local.get $2)
           )
          )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (if (result i32)
-             (i32.shr_u
-              (local.get $2)
-              (i32.const 31)
-             )
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (global.get $import_pervasives_1160_==_1161)
-              (local.get $3)
-              (i32.const 7)
-              (i32.load offset=8
-               (global.get $import_pervasives_1160_==_1161)
-              )
-             )
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.18_outer (result i32)
+       )
+      )
+      (block $switch.18_outer (result i32)
+       (drop
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.18_branch_1 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.18_branch_2 (result i32)
-             (drop
-              (block $switch.18_default (result i32)
-               (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_default
-                (i32.const 0)
-                (i32.shr_s
-                 (local.tee $6
-                  (tuple.extract 0
-                   (tuple.make
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (select
-                      (i32.const 1)
-                      (i32.const 3)
-                      (i32.shr_u
-                       (local.get $5)
-                       (i32.const 31)
-                      )
-                     )
-                    )
-                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                     (i32.const 0)
+            (block $switch.18_default (result i32)
+             (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_default
+              (i32.const 0)
+              (i32.shr_s
+               (local.tee $6
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (select
+                    (i32.const 1)
+                    (i32.const 3)
+                    (i32.shr_u
+                     (local.get $5)
+                     (i32.const 31)
                     )
                    )
                   )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
                  )
-                 (i32.const 1)
                 )
                )
+               (i32.const 1)
               )
              )
-             (unreachable)
             )
            )
-           (br $switch.18_outer
-            (i32.const 199)
-           )
+           (unreachable)
           )
          )
-         (i32.const 85)
+         (br $switch.18_outer
+          (i32.const 199)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 85)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -34,122 +34,160 @@ pattern matching › adt_match_3
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $13
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1198_[...]_1199)
-            (i32.const 11)
-            (global.get $import_pervasives_1196_[]_1197)
-            (i32.load offset=8
-             (global.get $import_pervasives_1198_[...]_1199)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1198_[...]_1199)
+          (i32.const 11)
+          (global.get $import_pervasives_1196_[]_1197)
+          (i32.load offset=8
+           (global.get $import_pervasives_1198_[...]_1199)
           )
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1198_[...]_1199)
-            (i32.const 9)
-            (local.get $9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1198_[...]_1199)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1198_[...]_1199)
+          (i32.const 9)
+          (local.get $9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1198_[...]_1199)
           )
          )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $8)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.49_outer (result i32)
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $8)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.49_outer (result i32)
+       (drop
+        (block $switch.49_branch_1 (result i32)
          (drop
-          (block $switch.49_branch_1 (result i32)
+          (block $switch.49_branch_2 (result i32)
            (drop
-            (block $switch.49_branch_2 (result i32)
+            (block $switch.49_branch_3 (result i32)
              (drop
-              (block $switch.49_branch_3 (result i32)
+              (block $switch.49_branch_4 (result i32)
                (drop
-                (block $switch.49_branch_4 (result i32)
+                (block $switch.49_branch_5 (result i32)
                  (drop
-                  (block $switch.49_branch_5 (result i32)
-                   (drop
-                    (block $switch.49_default (result i32)
-                     (br_table $switch.49_branch_1 $switch.49_branch_2 $switch.49_branch_3 $switch.49_branch_4 $switch.49_branch_5 $switch.49_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $4
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.49_default (result i32)
+                   (br_table $switch.49_branch_1 $switch.49_branch_2 $switch.49_branch_3 $switch.49_branch_4 $switch.49_branch_5 $switch.49_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $4
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $10)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $4)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $10)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $4
+                             (local.tee $3
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $2)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -159,13 +197,32 @@ pattern matching › adt_match_3
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $4)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $5
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $4)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -177,7 +234,7 @@ pattern matching › adt_match_3
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $3
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -185,7 +242,7 @@ pattern matching › adt_match_3
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $5)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -203,28 +260,12 @@ pattern matching › adt_match_3
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $6
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $4)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $5
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -235,9 +276,27 @@ pattern matching › adt_match_3
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $11
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $6)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $12
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -245,8 +304,8 @@ pattern matching › adt_match_3
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $5)
-                                        (i32.const 3)
+                                        (local.get $11)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -262,107 +321,13 @@ pattern matching › adt_match_3
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $6
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $11
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $6)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $12
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $11)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $6
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $5)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $6
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -370,7 +335,7 @@ pattern matching › adt_match_3
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $5)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -390,9 +355,11 @@ pattern matching › adt_match_3
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $4
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -400,7 +367,7 @@ pattern matching › adt_match_3
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $8)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -417,138 +384,58 @@ pattern matching › adt_match_3
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $4)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $8)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $4)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.49_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $3
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1194_+_1195)
-                   (local.get $7)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1194_+_1195)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $6)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.49_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1194_+_1195)
-                 (local.get $6)
-                 (local.get $1)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1194_+_1195)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -573,7 +460,7 @@ pattern matching › adt_match_3
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $0)
                  )
                 )
@@ -590,7 +477,7 @@ pattern matching › adt_match_3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $2)
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -600,11 +487,61 @@ pattern matching › adt_match_3
                )
               )
              )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1194_+_1195)
+                 (local.get $7)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1194_+_1195)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
+                )
+               )
+              )
+             )
              (br $switch.49_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1194_+_1195)
+               (local.get $6)
                (local.get $1)
-               (local.get $3)
                (i32.load offset=8
                 (global.get $import_pervasives_1194_+_1195)
                )
@@ -612,19 +549,80 @@ pattern matching › adt_match_3
              )
             )
            )
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=24
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
+              )
+             )
+            )
+           )
            (br $switch.49_outer
-            (i32.load offset=20
-             (local.get $2)
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (global.get $import_pervasives_1194_+_1195)
+             (local.get $1)
+             (local.get $3)
+             (i32.load offset=8
+              (global.get $import_pervasives_1194_+_1195)
+             )
             )
            )
           )
          )
-         (i32.const 1)
+         (br $switch.49_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=20
+            (local.get $2)
+           )
+          )
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -36,158 +36,196 @@ pattern matching › adt_match_5
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $15
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1202_[...]_1203)
-            (i32.const 15)
-            (global.get $import_pervasives_1200_[]_1201)
-            (i32.load offset=8
-             (global.get $import_pervasives_1202_[...]_1203)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $15
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1202_[...]_1203)
+          (i32.const 15)
+          (global.get $import_pervasives_1200_[]_1201)
+          (i32.load offset=8
+           (global.get $import_pervasives_1202_[...]_1203)
           )
          )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1202_[...]_1203)
-            (i32.const 13)
-            (local.get $9)
-            (i32.load offset=8
-             (global.get $import_pervasives_1202_[...]_1203)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1202_[...]_1203)
-            (i32.const 11)
-            (local.get $10)
-            (i32.load offset=8
-             (global.get $import_pervasives_1202_[...]_1203)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1202_[...]_1203)
+          (i32.const 13)
+          (local.get $9)
+          (i32.load offset=8
+           (global.get $import_pervasives_1202_[...]_1203)
           )
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1202_[...]_1203)
-            (i32.const 9)
-            (local.get $11)
-            (i32.load offset=8
-             (global.get $import_pervasives_1202_[...]_1203)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $2)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1202_[...]_1203)
+          (i32.const 11)
+          (local.get $10)
+          (i32.load offset=8
+           (global.get $import_pervasives_1202_[...]_1203)
           )
          )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $8)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (block $switch.53_outer (result i32)
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1202_[...]_1203)
+          (i32.const 9)
+          (local.get $11)
+          (i32.load offset=8
+           (global.get $import_pervasives_1202_[...]_1203)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $8)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.53_outer (result i32)
+       (drop
+        (block $switch.53_branch_1 (result i32)
          (drop
-          (block $switch.53_branch_1 (result i32)
+          (block $switch.53_branch_2 (result i32)
            (drop
-            (block $switch.53_branch_2 (result i32)
+            (block $switch.53_branch_3 (result i32)
              (drop
-              (block $switch.53_branch_3 (result i32)
+              (block $switch.53_branch_4 (result i32)
                (drop
-                (block $switch.53_branch_4 (result i32)
+                (block $switch.53_branch_5 (result i32)
                  (drop
-                  (block $switch.53_branch_5 (result i32)
-                   (drop
-                    (block $switch.53_default (result i32)
-                     (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_branch_3 $switch.53_branch_4 $switch.53_branch_5 $switch.53_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $4
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.53_default (result i32)
+                   (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_branch_3 $switch.53_branch_4 $switch.53_branch_5 $switch.53_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $4
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $12)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $4)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $12)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $4
+                             (local.tee $3
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $2)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -197,13 +235,32 @@ pattern matching › adt_match_5
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $4)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $5
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $4)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -215,7 +272,7 @@ pattern matching › adt_match_5
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $3
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -223,7 +280,7 @@ pattern matching › adt_match_5
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $5)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -241,28 +298,12 @@ pattern matching › adt_match_5
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $6
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $4)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $5
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -273,9 +314,27 @@ pattern matching › adt_match_5
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $13
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $6)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $14
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -283,8 +342,8 @@ pattern matching › adt_match_5
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $5)
-                                        (i32.const 3)
+                                        (local.get $13)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -300,107 +359,13 @@ pattern matching › adt_match_5
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $6
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $13
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $6)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $14
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $13)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $6
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $5)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $6
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -408,7 +373,7 @@ pattern matching › adt_match_5
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $5)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -428,9 +393,11 @@ pattern matching › adt_match_5
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $4
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -438,7 +405,7 @@ pattern matching › adt_match_5
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $8)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -455,138 +422,58 @@ pattern matching › adt_match_5
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $4)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $8)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $4)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.53_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $3
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1198_+_1199)
-                   (local.get $7)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1198_+_1199)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $6)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.53_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1198_+_1199)
-                 (local.get $6)
-                 (local.get $1)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1198_+_1199)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -611,7 +498,7 @@ pattern matching › adt_match_5
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $0)
                  )
                 )
@@ -628,7 +515,7 @@ pattern matching › adt_match_5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $2)
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -638,11 +525,61 @@ pattern matching › adt_match_5
                )
               )
              )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1198_+_1199)
+                 (local.get $7)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1198_+_1199)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
+                )
+               )
+              )
+             )
              (br $switch.53_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1198_+_1199)
+               (local.get $6)
                (local.get $1)
-               (local.get $3)
                (i32.load offset=8
                 (global.get $import_pervasives_1198_+_1199)
                )
@@ -650,19 +587,80 @@ pattern matching › adt_match_5
              )
             )
            )
+           (local.set $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=24
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $2)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
+              )
+             )
+            )
+           )
            (br $switch.53_outer
-            (i32.load offset=20
-             (local.get $2)
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (global.get $import_pervasives_1198_+_1199)
+             (local.get $1)
+             (local.get $3)
+             (i32.load offset=8
+              (global.get $import_pervasives_1198_+_1199)
+             )
             )
            )
           )
          )
-         (i32.const 1)
+         (br $switch.53_outer
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (i32.load offset=20
+            (local.get $2)
+           )
+          )
+         )
         )
        )
-       (i32.const 0)
+       (i32.const 1)
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -39,183 +39,221 @@ pattern matching › tuple_match_deep5
   (local $14 i32)
   (local $15 i32)
   (local $16 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1221_[...]_1222)
-            (i32.const 11)
-            (global.get $import_pervasives_1219_[]_1220)
-            (i32.load offset=8
-             (global.get $import_pervasives_1221_[...]_1222)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1221_[...]_1222)
+          (i32.const 11)
+          (global.get $import_pervasives_1219_[]_1220)
+          (i32.load offset=8
+           (global.get $import_pervasives_1221_[...]_1222)
           )
          )
-        )
-        (local.set $14
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1221_[...]_1222)
-            (i32.const 9)
-            (local.get $13)
-            (i32.load offset=8
-             (global.get $import_pervasives_1221_[...]_1222)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1221_[...]_1222)
+          (i32.const 9)
+          (local.get $13)
+          (i32.load offset=8
+           (global.get $import_pervasives_1221_[...]_1222)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $6
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $6)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $14)
-             )
-            )
-            (local.get $6)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $6)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $14)
            )
           )
+          (local.get $6)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $15
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $12)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.54_outer (result i32)
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $15
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $12)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.54_outer (result i32)
+       (drop
+        (block $switch.54_branch_1 (result i32)
          (drop
-          (block $switch.54_branch_1 (result i32)
+          (block $switch.54_branch_2 (result i32)
            (drop
-            (block $switch.54_branch_2 (result i32)
+            (block $switch.54_branch_3 (result i32)
              (drop
-              (block $switch.54_branch_3 (result i32)
+              (block $switch.54_branch_4 (result i32)
                (drop
-                (block $switch.54_branch_4 (result i32)
+                (block $switch.54_branch_5 (result i32)
                  (drop
-                  (block $switch.54_branch_5 (result i32)
-                   (drop
-                    (block $switch.54_default (result i32)
-                     (br_table $switch.54_branch_1 $switch.54_branch_2 $switch.54_branch_3 $switch.54_branch_4 $switch.54_branch_5 $switch.54_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $8
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.54_default (result i32)
+                   (br_table $switch.54_branch_1 $switch.54_branch_2 $switch.54_branch_3 $switch.54_branch_4 $switch.54_branch_5 $switch.54_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $8
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $15)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $8
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $11)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $8)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $15)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $8
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $11)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -225,13 +263,32 @@ pattern matching › tuple_match_deep5
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $8)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -243,7 +300,7 @@ pattern matching › tuple_match_deep5
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -251,7 +308,7 @@ pattern matching › tuple_match_deep5
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -269,28 +326,12 @@ pattern matching › tuple_match_deep5
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -301,9 +342,27 @@ pattern matching › tuple_match_deep5
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -311,8 +370,8 @@ pattern matching › tuple_match_deep5
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -328,107 +387,13 @@ pattern matching › tuple_match_deep5
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -436,7 +401,7 @@ pattern matching › tuple_match_deep5
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -456,9 +421,11 @@ pattern matching › tuple_match_deep5
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $8
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -466,7 +433,7 @@ pattern matching › tuple_match_deep5
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $12)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -483,188 +450,58 @@ pattern matching › tuple_match_deep5
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $8)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $12)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $8)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.54_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=12
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $1)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $9
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=8
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $9)
-                  )
-                 )
-                )
-               )
-               (local.set $10
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1217_+_1218)
-                   (local.get $9)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1217_+_1218)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $10)
-                  )
-                 )
-                )
-               )
-               (local.set $16
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1217_+_1218)
-                   (local.get $10)
-                   (local.get $7)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1217_+_1218)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.54_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1217_+_1218)
-                 (local.get $16)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1217_+_1218)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -705,7 +542,7 @@ pattern matching › tuple_match_deep5
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $2)
                  )
                 )
@@ -722,7 +559,7 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -737,8 +574,8 @@ pattern matching › tuple_match_deep5
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=8
-                  (local.get $3)
+                 (i32.load offset=20
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -751,12 +588,10 @@ pattern matching › tuple_match_deep5
              (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1217_+_1218)
-                 (local.get $7)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1217_+_1218)
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -766,11 +601,63 @@ pattern matching › tuple_match_deep5
                )
               )
              )
+             (local.set $9
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=8
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $9)
+                )
+               )
+              )
+             )
+             (local.set $10
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1217_+_1218)
+                 (local.get $9)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1217_+_1218)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $10)
+                )
+               )
+              )
+             )
+             (local.set $16
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1217_+_1218)
+                 (local.get $10)
+                 (local.get $7)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1217_+_1218)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
              (br $switch.54_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1217_+_1218)
-               (local.get $5)
-               (local.get $1)
+               (local.get $16)
+               (local.get $4)
                (i32.load offset=8
                 (global.get $import_pervasives_1217_+_1218)
                )
@@ -799,7 +686,7 @@ pattern matching › tuple_match_deep5
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
+               (i32.load offset=24
                 (local.get $0)
                )
               )
@@ -815,8 +702,8 @@ pattern matching › tuple_match_deep5
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=8
-                (local.get $3)
+               (i32.load offset=20
+                (local.get $2)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -826,11 +713,61 @@ pattern matching › tuple_match_deep5
              )
             )
            )
+           (local.set $4
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $4)
+              )
+             )
+            )
+           )
+           (local.set $7
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=8
+                (local.get $3)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $7)
+              )
+             )
+            )
+           )
+           (local.set $5
+            (tuple.extract 0
+             (tuple.make
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (global.get $import_pervasives_1217_+_1218)
+               (local.get $7)
+               (local.get $4)
+               (i32.load offset=8
+                (global.get $import_pervasives_1217_+_1218)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $5)
+              )
+             )
+            )
+           )
            (br $switch.54_outer
             (call_indirect (type $i32_i32_i32_=>_i32)
              (global.get $import_pervasives_1217_+_1218)
+             (local.get $5)
              (local.get $1)
-             (local.get $2)
              (i32.load offset=8
               (global.get $import_pervasives_1217_+_1218)
              )
@@ -838,14 +775,75 @@ pattern matching › tuple_match_deep5
            )
           )
          )
-         (i32.load offset=8
-          (local.get $3)
+         (local.set $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=12
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $2
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (local.set $1
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=8
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $1)
+            )
+           )
+          )
+         )
+         (br $switch.54_outer
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (global.get $import_pervasives_1217_+_1218)
+           (local.get $1)
+           (local.get $2)
+           (i32.load offset=8
+            (global.get $import_pervasives_1217_+_1218)
+           )
+          )
          )
         )
        )
-       (local.get $6)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.load offset=8
+         (local.get $3)
+        )
+       )
       )
      )
+     (local.get $6)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -39,233 +39,368 @@ pattern matching › constant_match_4
   (local $14 i32)
   (local $15 i32)
   (local $16 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $8
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $8
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $8)
+              (local.get $0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $9
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $8)
            )
           )
-         )
-        )
-        (local.set $10
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $9
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $10
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=8
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+           (local.get $10)
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (if (result i32)
+           (i32.shr_u
+            (local.get $5)
+            (i32.const 31)
+           )
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (global.get $import_pervasives_1186_==_1187)
+            (local.get $9)
+            (i32.const 15)
             (i32.load offset=8
-             (local.get $1)
+             (global.get $import_pervasives_1186_==_1187)
             )
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (local.get $5)
           )
          )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-             (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-             (local.get $10)
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (if (result i32)
-             (i32.shr_u
-              (local.get $5)
-              (i32.const 31)
-             )
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (global.get $import_pervasives_1186_==_1187)
-              (local.get $9)
-              (i32.const 15)
-              (i32.load offset=8
-               (global.get $import_pervasives_1186_==_1187)
-              )
-             )
-             (local.get $5)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (block $switch.58_outer (result i32)
+       )
+      )
+      (block $switch.58_outer (result i32)
+       (drop
+        (block $switch.58_branch_1 (result i32)
          (drop
-          (block $switch.58_branch_1 (result i32)
+          (block $switch.58_branch_2 (result i32)
            (drop
-            (block $switch.58_branch_2 (result i32)
+            (block $switch.58_branch_3 (result i32)
              (drop
-              (block $switch.58_branch_3 (result i32)
+              (block $switch.58_branch_4 (result i32)
                (drop
-                (block $switch.58_branch_4 (result i32)
-                 (drop
-                  (block $switch.58_default (result i32)
-                   (br_table $switch.58_branch_1 $switch.58_branch_2 $switch.58_branch_3 $switch.58_branch_4 $switch.58_default
-                    (i32.const 0)
-                    (i32.shr_s
-                     (local.tee $3
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (block $switch.58_default (result i32)
+                 (br_table $switch.58_branch_1 $switch.58_branch_2 $switch.58_branch_3 $switch.58_branch_4 $switch.58_default
+                  (i32.const 0)
+                  (i32.shr_s
+                   (local.tee $3
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (if (result i32)
+                        (i32.shr_u
+                         (local.get $12)
+                         (i32.const 31)
+                        )
+                        (i32.const 1)
+                        (block (result i32)
+                         (local.set $3
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (i32.load offset=12
+                              (local.get $1)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                         (local.set $13
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (i32.load offset=8
+                              (local.get $1)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                         (local.set $6
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                             (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                              (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                              (local.get $3)
+                              (i32.const 19)
+                             )
+                            )
+                            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
                          (if (result i32)
                           (i32.shr_u
-                           (local.get $12)
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (if (result i32)
+                                (i32.shr_u
+                                 (local.get $6)
+                                 (i32.const 31)
+                                )
+                                (block (result i32)
+                                 (local.set $4
+                                  (tuple.extract 0
+                                   (tuple.make
+                                    (block (result i32)
+                                     (i32.store
+                                      (local.tee $0
+                                       (tuple.extract 0
+                                        (tuple.make
+                                         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                                          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                                          (i32.const 16)
+                                         )
+                                         (local.get $0)
+                                        )
+                                       )
+                                      )
+                                      (i32.const 1)
+                                     )
+                                     (i32.store offset=4
+                                      (local.get $0)
+                                      (i32.const 3)
+                                     )
+                                     (i64.store offset=8
+                                      (local.get $0)
+                                      (i64.const 7303014)
+                                     )
+                                     (local.get $0)
+                                    )
+                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                     (i32.const 0)
+                                    )
+                                   )
+                                  )
+                                 )
+                                 (select
+                                  (i32.const -2)
+                                  (local.tee $2
+                                   (tuple.extract 0
+                                    (tuple.make
+                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                      (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
+                                       (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                                       (local.get $13)
+                                       (local.get $4)
+                                      )
+                                     )
+                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                      (i32.const 0)
+                                     )
+                                    )
+                                   )
+                                  )
+                                  (i32.shr_u
+                                   (local.get $2)
+                                   (i32.const 31)
+                                  )
+                                 )
+                                )
+                                (local.get $6)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (local.get $4)
+                              )
+                             )
+                            )
+                           )
                            (i32.const 31)
                           )
-                          (i32.const 1)
+                          (i32.const 3)
                           (block (result i32)
-                           (local.set $3
+                           (local.set $2
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -276,12 +411,12 @@ pattern matching › constant_match_4
                               )
                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                               (i32.const 0)
+                               (local.get $2)
                               )
                              )
                             )
                            )
-                           (local.set $13
+                           (local.set $14
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -297,15 +432,50 @@ pattern matching › constant_match_4
                              )
                             )
                            )
-                           (local.set $6
+                           (local.set $15
+                            (tuple.extract 0
+                             (tuple.make
+                              (block (result i32)
+                               (i32.store
+                                (local.tee $0
+                                 (tuple.extract 0
+                                  (tuple.make
+                                   (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                                    (i32.const 16)
+                                   )
+                                   (local.get $0)
+                                  )
+                                 )
+                                )
+                                (i32.const 1)
+                               )
+                               (i32.store offset=4
+                                (local.get $0)
+                                (i32.const 3)
+                               )
+                               (i64.store offset=8
+                                (local.get $0)
+                                (i64.const 7303014)
+                               )
+                               (local.get $0)
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $7
                             (tuple.extract 0
                              (tuple.make
                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
                                 (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                (local.get $3)
-                                (i32.const 19)
+                                (local.get $14)
+                                (local.get $15)
                                )
                               )
                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -315,255 +485,80 @@ pattern matching › constant_match_4
                              )
                             )
                            )
-                           (if (result i32)
+                           (select
+                            (i32.const 5)
+                            (i32.const 7)
                             (i32.shr_u
-                             (local.tee $4
+                             (local.tee $16
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (if (result i32)
                                   (i32.shr_u
-                                   (local.get $6)
+                                   (local.get $7)
                                    (i32.const 31)
                                   )
-                                  (block (result i32)
-                                   (local.set $4
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (block (result i32)
-                                       (i32.store
-                                        (local.tee $0
-                                         (tuple.extract 0
-                                          (tuple.make
-                                           (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                                            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                                            (i32.const 16)
-                                           )
-                                           (local.get $0)
-                                          )
-                                         )
-                                        )
-                                        (i32.const 1)
-                                       )
-                                       (i32.store offset=4
-                                        (local.get $0)
-                                        (i32.const 3)
-                                       )
-                                       (i64.store offset=8
-                                        (local.get $0)
-                                        (i64.const 7303014)
-                                       )
-                                       (local.get $0)
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (select
-                                    (i32.const -2)
-                                    (local.tee $2
-                                     (tuple.extract 0
-                                      (tuple.make
-                                       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                        (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                                         (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                         (local.get $13)
-                                         (local.get $4)
-                                        )
-                                       )
-                                       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                        (i32.const 0)
-                                       )
-                                      )
-                                     )
-                                    )
-                                    (i32.shr_u
-                                     (local.get $2)
-                                     (i32.const 31)
-                                    )
+                                  (call_indirect (type $i32_i32_i32_=>_i32)
+                                   (global.get $import_pervasives_1186_==_1187)
+                                   (local.get $2)
+                                   (i32.const 11)
+                                   (i32.load offset=8
+                                    (global.get $import_pervasives_1186_==_1187)
                                    )
                                   )
-                                  (local.get $6)
+                                  (local.get $7)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (local.get $4)
+                                 (i32.const 0)
                                 )
                                )
                               )
                              )
                              (i32.const 31)
                             )
-                            (i32.const 3)
-                            (block (result i32)
-                             (local.set $2
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=12
-                                  (local.get $1)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (local.get $2)
-                                )
-                               )
-                              )
-                             )
-                             (local.set $14
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=8
-                                  (local.get $1)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (local.set $15
-                              (tuple.extract 0
-                               (tuple.make
-                                (block (result i32)
-                                 (i32.store
-                                  (local.tee $0
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                                      (i32.const 16)
-                                     )
-                                     (local.get $0)
-                                    )
-                                   )
-                                  )
-                                  (i32.const 1)
-                                 )
-                                 (i32.store offset=4
-                                  (local.get $0)
-                                  (i32.const 3)
-                                 )
-                                 (i64.store offset=8
-                                  (local.get $0)
-                                  (i64.const 7303014)
-                                 )
-                                 (local.get $0)
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (local.set $7
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                                  (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
-                                  (local.get $14)
-                                  (local.get $15)
-                                 )
-                                )
-                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                             )
-                             (select
-                              (i32.const 5)
-                              (i32.const 7)
-                              (i32.shr_u
-                               (local.tee $16
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (if (result i32)
-                                    (i32.shr_u
-                                     (local.get $7)
-                                     (i32.const 31)
-                                    )
-                                    (call_indirect (type $i32_i32_i32_=>_i32)
-                                     (global.get $import_pervasives_1186_==_1187)
-                                     (local.get $2)
-                                     (i32.const 11)
-                                     (i32.load offset=8
-                                      (global.get $import_pervasives_1186_==_1187)
-                                     )
-                                    )
-                                    (local.get $7)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (i32.const 31)
-                              )
-                             )
-                            )
                            )
                           )
                          )
                         )
-                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                         (local.get $3)
-                        )
                        )
                       )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (local.get $3)
+                      )
                      )
-                     (i32.const 1)
                     )
                    )
+                   (i32.const 1)
                   )
                  )
-                 (unreachable)
                 )
                )
-               (br $switch.58_outer
-                (i32.const 2147483646)
-               )
+               (unreachable)
               )
              )
              (br $switch.58_outer
-              (i32.const -2)
+              (i32.const 2147483646)
              )
             )
            )
            (br $switch.58_outer
-            (i32.const 2147483646)
+            (i32.const -2)
            )
           )
          )
-         (i32.const 2147483646)
+         (br $switch.58_outer
+          (i32.const 2147483646)
+         )
         )
        )
-       (local.get $0)
+       (i32.const 2147483646)
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -41,219 +41,257 @@ pattern matching › tuple_match_deep7
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $13
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1225_[...]_1226)
-            (i32.const 15)
-            (global.get $import_pervasives_1223_[]_1224)
-            (i32.load offset=8
-             (global.get $import_pervasives_1225_[...]_1226)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $13
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1225_[...]_1226)
+          (i32.const 15)
+          (global.get $import_pervasives_1223_[]_1224)
+          (i32.load offset=8
+           (global.get $import_pervasives_1225_[...]_1226)
           )
          )
-        )
-        (local.set $14
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1225_[...]_1226)
-            (i32.const 13)
-            (local.get $13)
-            (i32.load offset=8
-             (global.get $import_pervasives_1225_[...]_1226)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $15
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1225_[...]_1226)
-            (i32.const 11)
-            (local.get $14)
-            (i32.load offset=8
-             (global.get $import_pervasives_1225_[...]_1226)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1225_[...]_1226)
+          (i32.const 13)
+          (local.get $13)
+          (i32.load offset=8
+           (global.get $import_pervasives_1225_[...]_1226)
           )
          )
-        )
-        (local.set $16
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1225_[...]_1226)
-            (i32.const 9)
-            (local.get $15)
-            (i32.load offset=8
-             (global.get $import_pervasives_1225_[...]_1226)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $6
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+       )
+      )
+      (local.set $15
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1225_[...]_1226)
+          (i32.const 11)
+          (local.get $14)
+          (i32.load offset=8
+           (global.get $import_pervasives_1225_[...]_1226)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $16
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1225_[...]_1226)
+          (i32.const 9)
+          (local.get $15)
+          (i32.load offset=8
+           (global.get $import_pervasives_1225_[...]_1226)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $6
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $6)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $6)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $16)
-             )
-            )
-            (local.get $6)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 8)
           )
-         )
-        )
-        (local.set $11
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=4
+           (local.get $6)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $3)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $12
-         (tuple.extract 0
-          (tuple.make
+          (i32.store offset=12
+           (local.get $6)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=12
-             (local.get $11)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+            (local.get $16)
            )
           )
+          (local.get $6)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
-        (local.set $17
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.or
-             (i32.shl
-              (i32.eq
-               (local.get $12)
-               (i32.const 3)
-              )
-              (i32.const 31)
-             )
-             (i32.const 2147483646)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+       )
+      )
+      (local.set $11
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
           )
          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
         )
-        (block $switch.58_outer (result i32)
+       )
+      )
+      (local.set $12
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $11)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $17
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.or
+           (i32.shl
+            (i32.eq
+             (local.get $12)
+             (i32.const 3)
+            )
+            (i32.const 31)
+           )
+           (i32.const 2147483646)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (block $switch.58_outer (result i32)
+       (drop
+        (block $switch.58_branch_1 (result i32)
          (drop
-          (block $switch.58_branch_1 (result i32)
+          (block $switch.58_branch_2 (result i32)
            (drop
-            (block $switch.58_branch_2 (result i32)
+            (block $switch.58_branch_3 (result i32)
              (drop
-              (block $switch.58_branch_3 (result i32)
+              (block $switch.58_branch_4 (result i32)
                (drop
-                (block $switch.58_branch_4 (result i32)
+                (block $switch.58_branch_5 (result i32)
                  (drop
-                  (block $switch.58_branch_5 (result i32)
-                   (drop
-                    (block $switch.58_default (result i32)
-                     (br_table $switch.58_branch_1 $switch.58_branch_2 $switch.58_branch_3 $switch.58_branch_4 $switch.58_branch_5 $switch.58_default
-                      (i32.const 0)
-                      (i32.shr_s
-                       (local.tee $8
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (block $switch.58_default (result i32)
+                   (br_table $switch.58_branch_1 $switch.58_branch_2 $switch.58_branch_3 $switch.58_branch_4 $switch.58_branch_5 $switch.58_default
+                    (i32.const 0)
+                    (i32.shr_s
+                     (local.tee $8
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                         (if (result i32)
+                          (i32.shr_u
+                           (local.get $17)
+                           (i32.const 31)
+                          )
+                          (block (result i32)
+                           (local.set $8
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=24
+                                (local.get $11)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                           (local.set $0
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                               (i32.load offset=12
+                                (local.get $8)
+                               )
+                              )
+                              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
                            (if (result i32)
                             (i32.shr_u
-                             (local.get $17)
-                             (i32.const 31)
-                            )
-                            (block (result i32)
-                             (local.set $8
+                             (local.tee $2
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                 (i32.load offset=24
-                                  (local.get $11)
+                                 (i32.or
+                                  (i32.shl
+                                   (i32.eq
+                                    (local.get $0)
+                                    (i32.const 3)
+                                   )
+                                   (i32.const 31)
+                                  )
+                                  (i32.const 2147483646)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -263,13 +301,32 @@ pattern matching › tuple_match_deep7
                                )
                               )
                              )
-                             (local.set $0
+                             (i32.const 31)
+                            )
+                            (block (result i32)
+                             (local.set $1
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                 (i32.const 0)
+                                )
+                               )
+                              )
+                             )
+                             (local.set $4
                               (tuple.extract 0
                                (tuple.make
                                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                  (i32.load offset=12
-                                  (local.get $8)
+                                  (local.get $1)
                                  )
                                 )
                                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -281,7 +338,7 @@ pattern matching › tuple_match_deep7
                              )
                              (if (result i32)
                               (i32.shr_u
-                               (local.tee $2
+                               (local.tee $7
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -289,7 +346,7 @@ pattern matching › tuple_match_deep7
                                    (i32.or
                                     (i32.shl
                                      (i32.eq
-                                      (local.get $0)
+                                      (local.get $4)
                                       (i32.const 3)
                                      )
                                      (i32.const 31)
@@ -307,28 +364,12 @@ pattern matching › tuple_match_deep7
                                (i32.const 31)
                               )
                               (block (result i32)
-                               (local.set $1
+                               (local.set $5
                                 (tuple.extract 0
                                  (tuple.make
                                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                                    (i32.load offset=24
-                                    (local.get $8)
-                                   )
-                                  )
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                   (i32.const 0)
-                                  )
-                                 )
-                                )
-                               )
-                               (local.set $4
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                   (i32.load offset=12
                                     (local.get $1)
                                    )
                                   )
@@ -339,9 +380,27 @@ pattern matching › tuple_match_deep7
                                  )
                                 )
                                )
-                               (if (result i32)
+                               (local.set $9
+                                (tuple.extract 0
+                                 (tuple.make
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                   (i32.load offset=12
+                                    (local.get $5)
+                                   )
+                                  )
+                                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                   (i32.const 0)
+                                  )
+                                 )
+                                )
+                               )
+                               (select
+                                (i32.const 7)
+                                (i32.const 9)
                                 (i32.shr_u
-                                 (local.tee $7
+                                 (local.tee $10
                                   (tuple.extract 0
                                    (tuple.make
                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -349,8 +408,8 @@ pattern matching › tuple_match_deep7
                                      (i32.or
                                       (i32.shl
                                        (i32.eq
-                                        (local.get $4)
-                                        (i32.const 3)
+                                        (local.get $9)
+                                        (i32.const 1)
                                        )
                                        (i32.const 31)
                                       )
@@ -366,107 +425,13 @@ pattern matching › tuple_match_deep7
                                  )
                                  (i32.const 31)
                                 )
-                                (block (result i32)
-                                 (local.set $5
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=24
-                                      (local.get $1)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (local.set $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                     (i32.load offset=12
-                                      (local.get $5)
-                                     )
-                                    )
-                                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (select
-                                  (i32.const 7)
-                                  (i32.const 9)
-                                  (i32.shr_u
-                                   (local.tee $10
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                       (i32.or
-                                        (i32.shl
-                                         (i32.eq
-                                          (local.get $9)
-                                          (i32.const 1)
-                                         )
-                                         (i32.const 31)
-                                        )
-                                        (i32.const 2147483646)
-                                       )
-                                      )
-                                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                   (i32.const 31)
-                                  )
-                                 )
-                                )
-                                (select
-                                 (i32.const 5)
-                                 (i32.const 9)
-                                 (i32.shr_u
-                                  (local.tee $5
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                                      (i32.or
-                                       (i32.shl
-                                        (i32.eq
-                                         (local.get $4)
-                                         (i32.const 1)
-                                        )
-                                        (i32.const 31)
-                                       )
-                                       (i32.const 2147483646)
-                                      )
-                                     )
-                                     (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 31)
-                                 )
-                                )
                                )
                               )
                               (select
-                               (i32.const 3)
+                               (i32.const 5)
                                (i32.const 9)
                                (i32.shr_u
-                                (local.tee $1
+                                (local.tee $5
                                  (tuple.extract 0
                                   (tuple.make
                                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -474,7 +439,7 @@ pattern matching › tuple_match_deep7
                                     (i32.or
                                      (i32.shl
                                       (i32.eq
-                                       (local.get $0)
+                                       (local.get $4)
                                        (i32.const 1)
                                       )
                                       (i32.const 31)
@@ -494,9 +459,11 @@ pattern matching › tuple_match_deep7
                               )
                              )
                             )
-                            (if (result i32)
+                            (select
+                             (i32.const 3)
+                             (i32.const 9)
                              (i32.shr_u
-                              (local.tee $8
+                              (local.tee $1
                                (tuple.extract 0
                                 (tuple.make
                                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -504,7 +471,7 @@ pattern matching › tuple_match_deep7
                                   (i32.or
                                    (i32.shl
                                     (i32.eq
-                                     (local.get $12)
+                                     (local.get $0)
                                      (i32.const 1)
                                     )
                                     (i32.const 31)
@@ -521,188 +488,58 @@ pattern matching › tuple_match_deep7
                               )
                               (i32.const 31)
                              )
-                             (i32.const 1)
-                             (unreachable)
                             )
                            )
                           )
-                          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                           (local.get $8)
+                          (if (result i32)
+                           (i32.shr_u
+                            (local.tee $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                                (i32.or
+                                 (i32.shl
+                                  (i32.eq
+                                   (local.get $12)
+                                   (i32.const 1)
+                                  )
+                                  (i32.const 31)
+                                 )
+                                 (i32.const 2147483646)
+                                )
+                               )
+                               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                                (i32.const 0)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 1)
+                           (unreachable)
                           )
                          )
                         )
+                        (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                         (local.get $8)
+                        )
                        )
-                       (i32.const 1)
                       )
                      )
+                     (i32.const 1)
                     )
                    )
-                   (unreachable)
                   )
                  )
-                 (br $switch.58_outer
-                  (i32.const 1999)
-                 )
-                )
-               )
-               (local.set $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=12
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $0)
-                  )
-                 )
-                )
-               )
-               (local.set $2
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-               )
-               (local.set $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-               )
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $1)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-               )
-               (local.set $7
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $2)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $7)
-                  )
-                 )
-                )
-               )
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=20
-                    (local.get $0)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $5)
-                  )
-                 )
-                )
-               )
-               (local.set $9
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=8
-                    (local.get $3)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $9)
-                  )
-                 )
-                )
-               )
-               (local.set $10
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1221_+_1222)
-                   (local.get $9)
-                   (local.get $5)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1221_+_1222)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (local.get $10)
-                  )
-                 )
-                )
-               )
-               (local.set $18
-                (tuple.extract 0
-                 (tuple.make
-                  (call_indirect (type $i32_i32_i32_=>_i32)
-                   (global.get $import_pervasives_1221_+_1222)
-                   (local.get $10)
-                   (local.get $7)
-                   (i32.load offset=8
-                    (global.get $import_pervasives_1221_+_1222)
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
+                 (unreachable)
                 )
                )
                (br $switch.58_outer
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1221_+_1222)
-                 (local.get $18)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1221_+_1222)
-                 )
-                )
+                (i32.const 1999)
                )
               )
              )
@@ -743,7 +580,7 @@ pattern matching › tuple_match_deep7
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
+                 (i32.load offset=24
                   (local.get $2)
                  )
                 )
@@ -760,7 +597,7 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -775,8 +612,8 @@ pattern matching › tuple_match_deep7
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=8
-                  (local.get $3)
+                 (i32.load offset=20
+                  (local.get $2)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -789,12 +626,10 @@ pattern matching › tuple_match_deep7
              (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call_indirect (type $i32_i32_i32_=>_i32)
-                 (global.get $import_pervasives_1221_+_1222)
-                 (local.get $7)
-                 (local.get $4)
-                 (i32.load offset=8
-                  (global.get $import_pervasives_1221_+_1222)
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -804,11 +639,63 @@ pattern matching › tuple_match_deep7
                )
               )
              )
+             (local.set $9
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=8
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $9)
+                )
+               )
+              )
+             )
+             (local.set $10
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1221_+_1222)
+                 (local.get $9)
+                 (local.get $5)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1221_+_1222)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $10)
+                )
+               )
+              )
+             )
+             (local.set $18
+              (tuple.extract 0
+               (tuple.make
+                (call_indirect (type $i32_i32_i32_=>_i32)
+                 (global.get $import_pervasives_1221_+_1222)
+                 (local.get $10)
+                 (local.get $7)
+                 (i32.load offset=8
+                  (global.get $import_pervasives_1221_+_1222)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
+             )
              (br $switch.58_outer
               (call_indirect (type $i32_i32_i32_=>_i32)
                (global.get $import_pervasives_1221_+_1222)
-               (local.get $5)
-               (local.get $1)
+               (local.get $18)
+               (local.get $4)
                (i32.load offset=8
                 (global.get $import_pervasives_1221_+_1222)
                )
@@ -837,7 +724,7 @@ pattern matching › tuple_match_deep7
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
+               (i32.load offset=24
                 (local.get $0)
                )
               )
@@ -853,8 +740,8 @@ pattern matching › tuple_match_deep7
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=8
-                (local.get $3)
+               (i32.load offset=20
+                (local.get $2)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -864,11 +751,61 @@ pattern matching › tuple_match_deep7
              )
             )
            )
+           (local.set $4
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $4)
+              )
+             )
+            )
+           )
+           (local.set $7
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=8
+                (local.get $3)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $7)
+              )
+             )
+            )
+           )
+           (local.set $5
+            (tuple.extract 0
+             (tuple.make
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (global.get $import_pervasives_1221_+_1222)
+               (local.get $7)
+               (local.get $4)
+               (i32.load offset=8
+                (global.get $import_pervasives_1221_+_1222)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $5)
+              )
+             )
+            )
+           )
            (br $switch.58_outer
             (call_indirect (type $i32_i32_i32_=>_i32)
              (global.get $import_pervasives_1221_+_1222)
+             (local.get $5)
              (local.get $1)
-             (local.get $2)
              (i32.load offset=8
               (global.get $import_pervasives_1221_+_1222)
              )
@@ -876,14 +813,75 @@ pattern matching › tuple_match_deep7
            )
           )
          )
-         (i32.load offset=8
-          (local.get $3)
+         (local.set $0
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=12
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $0)
+            )
+           )
+          )
+         )
+         (local.set $2
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=20
+              (local.get $0)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $2)
+            )
+           )
+          )
+         )
+         (local.set $1
+          (tuple.extract 0
+           (tuple.make
+            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+             (i32.load offset=8
+              (local.get $3)
+             )
+            )
+            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+             (local.get $1)
+            )
+           )
+          )
+         )
+         (br $switch.58_outer
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (global.get $import_pervasives_1221_+_1222)
+           (local.get $1)
+           (local.get $2)
+           (i32.load offset=8
+            (global.get $import_pervasives_1221_+_1222)
+           )
+          )
          )
         )
        )
-       (local.get $6)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.load offset=8
+         (local.get $3)
+        )
+       )
       )
      )
+     (local.get $6)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -25,185 +25,180 @@ records › record_get_multiple
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 64)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 24)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 19)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 52)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
            )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 171798691841)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
            )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=20
-             (local.get $1)
-            )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_+_1147)
-         (local.get $2)
-         (local.get $3)
-         (i32.load offset=8
-          (global.get $import_pervasives_1146_+_1147)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 24)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 19)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=20
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_+_1147)
+       (local.get $2)
+       (local.get $3)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_+_1147)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -17,122 +17,114 @@ records › record_definition_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 36)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 103079215105)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -17,122 +17,114 @@ records › record_pun
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 36)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 103079215105)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -21,197 +21,196 @@ records › record_destruct_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-          )
-         )
-        )
-        (i32.load offset=16
-         (local.tee $2
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 28)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 4)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.shl
-               (global.get $import__grainEnv_0_moduleRuntimeId_0)
-               (i32.const 1)
-              )
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (i32.const 2275)
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (i32.const 3)
-             )
-             (i32.store offset=16
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const 9)
-              )
-             )
-             (i32.store offset=20
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
-             )
-             (i32.store offset=24
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const -2)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $2)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -27,234 +27,229 @@ records › record_destruct_4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
            )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
            )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=20
-             (local.get $1)
-            )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
            )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=24
-             (local.get $1)
-            )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1150_+_1151)
-            (local.get $2)
-            (local.get $3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1150_+_1151)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1150_+_1151)
-         (local.get $5)
-         (local.get $4)
-         (i32.load offset=8
-          (global.get $import_pervasives_1150_+_1151)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 13)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=20
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=24
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1150_+_1151)
+          (local.get $2)
+          (local.get $3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1150_+_1151)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1150_+_1151)
+       (local.get $5)
+       (local.get $4)
+       (i32.load offset=8
+        (global.get $import_pervasives_1150_+_1151)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -17,122 +17,114 @@ records › record_value_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 36)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 103079215105)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -27,276 +27,271 @@ records › record_recursive_data_definition
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 72)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 72)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 60)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215106)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477874)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 103079215104)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 60)
            )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2277)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1153_None_1154)
-             )
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1153_None_1154)
-             )
-            )
+           (i64.store offset=16
             (local.get $0)
+            (i64.const 103079215106)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477874)
            )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1151_Some_1152)
-            (local.get $2)
-            (i32.load offset=8
-             (global.get $import_pervasives_1151_Some_1152)
-            )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 32195220879704067)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 103079215104)
            )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (block (result i32)
-             (i32.store offset=16
-              (local.get $1)
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.load offset=16
-                  (local.get $1)
-                 )
-                )
-               )
-              )
-             )
-             (i32.const 1879048190)
-            )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 68719477873)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_=>_i32)
-            (global.get $import_pervasives_1151_Some_1152)
-            (local.get $1)
-            (i32.load offset=8
-             (global.get $import_pervasives_1151_Some_1152)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.store offset=16
-         (local.get $2)
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $4)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.load offset=16
-             (local.get $2)
-            )
-           )
-          )
-         )
-        )
-        (i32.const 1879048190)
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2277)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1153_None_1154)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1153_None_1154)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1151_Some_1152)
+          (local.get $2)
+          (i32.load offset=8
+           (global.get $import_pervasives_1151_Some_1152)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (block (result i32)
+           (i32.store offset=16
+            (local.get $1)
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $3)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (i32.load offset=16
+                (local.get $1)
+               )
+              )
+             )
+            )
+           )
+           (i32.const 1879048190)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (global.get $import_pervasives_1151_Some_1152)
+          (local.get $1)
+          (i32.load offset=8
+           (global.get $import_pervasives_1151_Some_1152)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=16
+       (local.get $2)
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (local.get $4)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.load offset=16
+           (local.get $2)
+          )
+         )
+        )
+       )
+      )
+      (i32.const 1879048190)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_mixed_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -21,197 +21,196 @@ records › record_destruct_2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
            )
-          )
-         )
-        )
-        (i32.load offset=20
-         (local.tee $2
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 28)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 4)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.shl
-               (global.get $import__grainEnv_0_moduleRuntimeId_0)
-               (i32.const 1)
-              )
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (i32.const 2275)
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (i32.const 3)
-             )
-             (i32.store offset=16
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const 9)
-              )
-             )
-             (i32.store offset=20
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
-             )
-             (i32.store offset=24
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const -2)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=20
+        (local.get $2)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -17,122 +17,114 @@ records › record_pun_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 36)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 103079215105)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -22,209 +22,208 @@ records › record_destruct_deep
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 72)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 72)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 60)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215106)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 103079215104)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 68719477874)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 60)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2277)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 103079215106)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 103079215104)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 68719477874)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (i32.load offset=16
-         (local.tee $3
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (i32.load offset=16
-              (local.get $2)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2277)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $3)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -25,200 +25,195 @@ records › record_destruct_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 11)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 13)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 68)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=16
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (i32.load offset=20
-             (local.get $1)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1148_+_1149)
-         (local.get $2)
-         (local.get $3)
-         (i32.load offset=8
-          (global.get $import_pervasives_1148_+_1149)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 11)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 13)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=20
+           (local.get $1)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1148_+_1149)
+       (local.get $2)
+       (local.get $3)
+       (i32.load offset=8
+        (global.get $import_pervasives_1148_+_1149)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -22,224 +22,223 @@ records › record_get_multilevel
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 88)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 88)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 76)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691842)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 103079215104)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 68719477874)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=80
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 24)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 4)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 19)
-             )
-            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 76)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 20)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2277)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
+           (i64.store offset=8
             (local.get $0)
+            (i64.const 0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 171798691842)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 103079215104)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 68719477874)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=80
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (i32.load offset=20
-         (local.tee $3
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (i32.load offset=16
-              (local.get $2)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 24)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 19)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2277)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=16
+           (local.get $2)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=20
+        (local.get $3)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -20,183 +20,178 @@ records › record_multiple_fields_definition_trailing
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const -2)
-         )
-        )
-        (local.get $0)
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+           (i32.const 28)
+          )
+          (local.get $0)
+         )
+        )
+       )
+       (i32.const 4)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.shl
+        (global.get $import__grainEnv_0_moduleRuntimeId_0)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 2275)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const 9)
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $1)
+       )
+      )
+      (i32.store offset=24
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const -2)
+       )
+      )
+      (local.get $0)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -20,132 +20,131 @@ records › record_get_2
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 48)
                )
+               (i32.const 0)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
              )
             )
+            (i32.const 1)
+           )
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 36)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 103079215105)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (i32.load offset=16
-         (local.tee $1
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 20)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 4)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.shl
-               (global.get $import__grainEnv_0_moduleRuntimeId_0)
-               (i32.const 1)
-              )
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (i32.const 2275)
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (i32.const 1)
-             )
-             (i32.store offset=16
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.const 9)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $1)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_mixed
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_mixed_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -20,183 +20,178 @@ records › record_multiple_fields_both_trailing
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const -2)
-         )
-        )
-        (local.get $0)
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+           (i32.const 28)
+          )
+          (local.get $0)
+         )
+        )
+       )
+       (i32.const 4)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.shl
+        (global.get $import__grainEnv_0_moduleRuntimeId_0)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 2275)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const 9)
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $1)
+       )
+      )
+      (i32.store offset=24
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const -2)
+       )
+      )
+      (local.get $0)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -17,122 +17,114 @@ records › record_both_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 48)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 48)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 36)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 103079215105)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 36)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 103079215105)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 1)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 1)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_multiple_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -20,183 +20,178 @@ records › record_multiple_fields_value_trailing
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
+          (local.get $0)
          )
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 28)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-        )
-        (i32.store offset=24
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const -2)
-         )
-        )
-        (local.get $0)
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+           (i32.const 28)
+          )
+          (local.get $0)
+         )
+        )
+       )
+       (i32.const 4)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.shl
+        (global.get $import__grainEnv_0_moduleRuntimeId_0)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 2275)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const 9)
+       )
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (local.get $1)
+       )
+      )
+      (i32.store offset=24
+       (local.get $0)
+       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+        (i32.const -2)
+       )
+      )
+      (local.get $0)
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -17,137 +17,129 @@ records › record_pun_mixed_2_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 64)
-                 )
-                 (i32.const 0)
-                )
-               )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 52)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 171798691841)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 52)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i64.store offset=16
+           (local.get $0)
+           (i64.const 171798691841)
+          )
+          (i64.store offset=24
+           (local.get $0)
+           (i64.const 68719477873)
+          )
+          (i64.store offset=32
+           (local.get $0)
+           (i64.const 31366206292230147)
+          )
+          (i64.store offset=40
+           (local.get $0)
+           (i64.const 68719476736)
+          )
+          (i64.store offset=48
+           (local.get $0)
+           (i64.const 32195220879704067)
+          )
+          (i64.store offset=56
+           (local.get $0)
+           (i64.const 0)
+          )
+          (i32.add
+           (local.get $0)
+           (i32.const 8)
           )
          )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
          (local.get $0)
         )
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 24)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.const 4)
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.shl
-          (global.get $import__grainEnv_0_moduleRuntimeId_0)
-          (i32.const 1)
-         )
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (i32.const 2275)
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (i32.const 2)
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 9)
-         )
-        )
-        (i32.store offset=20
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 2147483646)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.load
+       (i32.const 1032)
       )
      )
+     (i32.store offset=4
+      (local.get $0)
+      (global.get $import__grainEnv_0_moduleRuntimeId_0)
+     )
+     (i32.store
+      (i32.const 1032)
+      (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+         (local.get $0)
+        )
+       )
+      )
+      (i32.const 4)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.shl
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+       (i32.const 1)
+      )
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2275)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 9)
+      )
+     )
+     (i32.store offset=20
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 2147483646)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
@@ -2,32 +2,18 @@ stdlib › stdlib_equal_4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 1000
 )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -26,301 +26,296 @@ stdlib › stdlib_equal_20
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7496034)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_==_1147)
-         (local.get $2)
-         (local.get $4)
-         (i32.load offset=8
-          (global.get $import_pervasives_1146_==_1147)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7496034)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $3)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_==_1147)
+       (local.get $2)
+       (local.get $4)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_==_1147)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_18
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,95 +21,90 @@ stdlib › stdlib_equal_18
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 8)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const -9036296798633758874)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 8)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const -8891900135581192346)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 8)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const -9036296798633758874)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 8)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const -8891900135581192346)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -23,115 +23,110 @@ stdlib › stdlib_equal_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
            )
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1252_is_1253)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1252_is_1253)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1252_is_1253)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1252_is_1253)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -1,17 +1,15 @@
 stdlib › stdlib_cons
 (module
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $import_pervasives_1144_[]_1145 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $import_pervasives_1146_[...]_1147 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -22,61 +20,56 @@ stdlib › stdlib_cons
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $2
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_[...]_1147)
-            (i32.const 7)
-            (global.get $import_pervasives_1144_[]_1145)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_[...]_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1146_[...]_1147)
-            (i32.const 5)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1146_[...]_1147)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_[...]_1147)
-         (i32.const 3)
-         (local.get $1)
-         (i32.load offset=8
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
           (global.get $import_pervasives_1146_[...]_1147)
+          (i32.const 7)
+          (global.get $import_pervasives_1144_[]_1145)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_[...]_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1146_[...]_1147)
+          (i32.const 5)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1146_[...]_1147)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_[...]_1147)
+       (i32.const 3)
+       (local.get $1)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_[...]_1147)
+       )
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -26,301 +26,296 @@ stdlib › stdlib_equal_19
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_==_1147)
-         (local.get $2)
-         (local.get $4)
-         (i32.load offset=8
-          (global.get $import_pervasives_1146_==_1147)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $3)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_==_1147)
+       (local.get $2)
+       (local.get $4)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_==_1147)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_16
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,95 +21,90 @@ stdlib › stdlib_equal_16
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -23,143 +23,138 @@ stdlib › stdlib_equal_12
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 24)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 24)
               )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 4)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 4)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 24)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 4)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
            )
           )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1256_==_1257)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1256_==_1257)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 24)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 4)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1256_==_1257)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1256_==_1257)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -26,301 +26,296 @@ stdlib › stdlib_equal_21
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 157)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_==_1147)
-         (local.get $2)
-         (local.get $4)
-         (i32.load offset=8
-          (global.get $import_pervasives_1146_==_1147)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 157)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $3)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_==_1147)
+       (local.get $2)
+       (local.get $4)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_==_1147)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_15
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,91 +21,86 @@ stdlib › stdlib_equal_15
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 102)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 102)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_14
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,91 +21,86 @@ stdlib › stdlib_equal_14
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 32)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 32)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -1,18 +1,16 @@
 stdlib › stdlib_equal_3
 (module
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $import_pervasives_1260_[]_1261 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $import_pervasives_1262_[...]_1263 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1264_==_1265 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -27,133 +25,128 @@ stdlib › stdlib_equal_3
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $6
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $0
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 7)
-            (global.get $import_pervasives_1260_[]_1261)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 7)
+          (global.get $import_pervasives_1260_[]_1261)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
           )
          )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 5)
-            (local.get $0)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 3)
-            (local.get $1)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 7)
-            (global.get $import_pervasives_1260_[]_1261)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 5)
-            (local.get $3)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (global.get $import_pervasives_1262_[...]_1263)
-            (i32.const 3)
-            (local.get $4)
-            (i32.load offset=8
-             (global.get $import_pervasives_1262_[...]_1263)
-            )
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1264_==_1265)
-         (local.get $2)
-         (local.get $5)
-         (i32.load offset=8
-          (global.get $import_pervasives_1264_==_1265)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (i32.const 0)
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 5)
+          (local.get $0)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 3)
+          (local.get $1)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 7)
+          (global.get $import_pervasives_1260_[]_1261)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 5)
+          (local.get $3)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $5
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (global.get $import_pervasives_1262_[...]_1263)
+          (i32.const 3)
+          (local.get $4)
+          (i32.load offset=8
+           (global.get $import_pervasives_1262_[...]_1263)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1264_==_1265)
+       (local.get $2)
+       (local.get $5)
+       (i32.load offset=8
+        (global.get $import_pervasives_1264_==_1265)
+       )
       )
      )
+     (i32.const 0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -23,108 +23,103 @@ stdlib › stdlib_equal_11
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 12)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
            )
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1251_==_1252)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1251_==_1252)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 12)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1251_==_1252)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1251_==_1252)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -23,94 +23,89 @@ stdlib › stdlib_equal_9
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
               )
+              (i32.const 0)
              )
-             (i32.const 5)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 5)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 12)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1249_==_1250)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1249_==_1250)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 12)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1249_==_1250)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1249_==_1250)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -23,115 +23,110 @@ stdlib › stdlib_equal_2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
            )
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1180_==_1181)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1180_==_1181)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1180_==_1181)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1180_==_1181)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
@@ -2,32 +2,18 @@ stdlib › stdlib_equal_6
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const -2)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const -2)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 1000
 )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -26,301 +26,296 @@ stdlib › stdlib_equal_22
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 80)
-                 )
-                 (i32.const 0)
-                )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                (i32.const 80)
                )
-              )
-              (i32.const 1)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 68)
-             )
-             (i64.store offset=8
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i64.store offset=16
-              (local.get $0)
-              (i64.const 240518168577)
-             )
-             (i64.store offset=24
-              (local.get $0)
-              (i64.const 68719477873)
-             )
-             (i64.store offset=32
-              (local.get $0)
-              (i64.const 31366206292230147)
-             )
-             (i64.store offset=40
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=48
-              (local.get $0)
-              (i64.const 32195220879704067)
-             )
-             (i64.store offset=56
-              (local.get $0)
-              (i64.const 68719476736)
-             )
-             (i64.store offset=64
-              (local.get $0)
-              (i64.const 34447020693389315)
-             )
-             (i64.store offset=72
-              (local.get $0)
-              (i64.const 0)
-             )
-             (i32.add
-              (local.get $0)
-              (i32.const 8)
-             )
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load
-          (i32.const 1032)
-         )
-        )
-        (i32.store offset=4
-         (local.get $0)
-         (global.get $import__grainEnv_0_moduleRuntimeId_0)
-        )
-        (i32.store
-         (i32.const 1032)
-         (local.get $0)
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
+               (i32.const 0)
               )
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
+            (i32.const 1)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 68)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i64.store offset=16
+            (local.get $0)
+            (i64.const 240518168577)
+           )
+           (i64.store offset=24
+            (local.get $0)
+            (i64.const 68719477873)
+           )
+           (i64.store offset=32
+            (local.get $0)
+            (i64.const 31366206292230147)
+           )
+           (i64.store offset=40
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=48
+            (local.get $0)
+            (i64.const 32195220879704067)
+           )
+           (i64.store offset=56
+            (local.get $0)
+            (i64.const 68719476736)
+           )
+           (i64.store offset=64
+            (local.get $0)
+            (i64.const 34447020693389315)
+           )
+           (i64.store offset=72
+            (local.get $0)
+            (i64.const 0)
+           )
+           (i32.add
+            (local.get $0)
+            (i32.const 8)
            )
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const -2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303010)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 28)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 4)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.shl
-              (global.get $import__grainEnv_0_moduleRuntimeId_0)
-              (i32.const 1)
-             )
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (i32.const 2275)
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
-             )
-            )
-            (i32.store offset=24
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 2147483646)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1146_==_1147)
-         (local.get $2)
-         (local.get $4)
-         (i32.load offset=8
-          (global.get $import_pervasives_1146_==_1147)
+          (local.get $0)
          )
         )
        )
+       (i32.load
+        (i32.const 1032)
+       )
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (global.get $import__grainEnv_0_moduleRuntimeId_0)
+      )
+      (i32.store
+       (i32.const 1032)
        (local.get $0)
       )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const -2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303010)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 28)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 4)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.shl
+            (global.get $import__grainEnv_0_moduleRuntimeId_0)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 2275)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $3)
+           )
+          )
+          (i32.store offset=24
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 2147483646)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1146_==_1147)
+       (local.get $2)
+       (local.get $4)
+       (i32.load offset=8
+        (global.get $import_pervasives_1146_==_1147)
+       )
+      )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -23,101 +23,96 @@ stdlib › stdlib_equal_10
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 12)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 12)
               )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
+          (local.get $0)
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 12)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 1)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1250_==_1251)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1250_==_1251)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 12)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1250_==_1251)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1250_==_1251)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_13
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,87 +21,82 @@ stdlib › stdlib_equal_13
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
@@ -2,32 +2,18 @@ stdlib › stdlib_equal_7
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 1000
 )

--- a/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
@@ -2,32 +2,18 @@ stdlib › stdlib_equal_5
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 2147483646)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 1000
 )

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_8
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,87 +21,82 @@ stdlib › stdlib_equal_8
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
               )
+              (i32.const 0)
              )
-             (i32.const 5)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 5)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 8)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 5)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 0)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
           )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 8)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 5)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 0)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -8,11 +8,9 @@ stdlib › stdlib_equal_17
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1248_==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,95 +21,90 @@ stdlib › stdlib_equal_17
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 8)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const -9036296798633758874)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 8)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const -9036296798633758874)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 8)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const -9036296798633758874)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1248_==_1249)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1248_==_1249)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 8)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const -9036296798633758874)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1248_==_1249)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1248_==_1249)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/strings.434adad0.0.snapshot
+++ b/compiler/test/__snapshots__/strings.434adad0.0.snapshot
@@ -1,14 +1,12 @@
 strings › string2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,44 +14,36 @@ strings › string2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 16)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 16)
          )
-         (i32.const 1)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 4)
-        )
-        (i64.store offset=8
-         (local.get $0)
-         (i64.const 2945622000)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 1)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 4)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 2945622000)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.a67428df.0.snapshot
+++ b/compiler/test/__snapshots__/strings.a67428df.0.snapshot
@@ -1,14 +1,12 @@
 strings › string1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,44 +14,36 @@ strings › string1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 16)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 16)
          )
-         (i32.const 1)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i64.store offset=8
-         (local.get $0)
-         (i64.const 7303014)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 1)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 7303014)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
+++ b/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
@@ -1,14 +1,12 @@
 strings › string3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -16,60 +14,52 @@ strings › string3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 48)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 48)
          )
-         (i32.const 1)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 36)
-        )
-        (i64.store offset=8
-         (local.get $0)
-         (i64.const 7863398673301594477)
-        )
-        (i64.store offset=16
-         (local.get $0)
-         (i64.const 8026576141579395193)
-        )
-        (i64.store offset=24
-         (local.get $0)
-         (i64.const 2318349367439027831)
-        )
-        (i64.store offset=32
-         (local.get $0)
-         (i64.const 2334956330867777911)
-        )
-        (i64.store offset=40
-         (local.get $0)
-         (i64.const 1953718630)
-        )
-        (local.get $0)
        )
-       (local.get $0)
       )
+      (i32.const 1)
      )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 36)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 7863398673301594477)
+     )
+     (i64.store offset=16
+      (local.get $0)
+      (i64.const 8026576141579395193)
+     )
+     (i64.store offset=24
+      (local.get $0)
+      (i64.const 2318349367439027831)
+     )
+     (i64.store offset=32
+      (local.get $0)
+      (i64.const 2334956330867777911)
+     )
+     (i64.store offset=40
+      (local.get $0)
+      (i64.const 1953718630)
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -8,11 +8,9 @@ strings › concat
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$++\" (global $import_pervasives_1140_++_1141 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,95 +21,90 @@ strings › concat
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
+              (i32.const 0)
              )
-             (i32.const 1)
             )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7303014)
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+           (i32.const 1)
           )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 1)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 3)
-            )
-            (i64.store offset=8
-             (local.get $0)
-             (i64.const 7496034)
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
           )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7303014)
+          )
+          (local.get $0)
          )
-        )
-        (call_indirect (type $i32_i32_i32_=>_i32)
-         (global.get $import_pervasives_1140_++_1141)
-         (local.get $1)
-         (local.get $2)
-         (i32.load offset=8
-          (global.get $import_pervasives_1140_++_1141)
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 1)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i64.store offset=8
+           (local.get $0)
+           (i64.const 7496034)
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (global.get $import_pervasives_1140_++_1141)
+       (local.get $1)
+       (local.get $2)
+       (i32.load offset=8
+        (global.get $import_pervasives_1140_++_1141)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -22,170 +22,169 @@ tuples › nested_tup_3
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (local.get $0)
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.load offset=8
-         (local.tee $4
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (i32.load offset=12
-              (local.get $3)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=8
+        (local.get $4)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -21,154 +21,153 @@ tuples › nested_tup_1
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (local.get $0)
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.load offset=8
-         (local.tee $3
-          (tuple.extract 0
-           (tuple.make
-            (block (result i32)
-             (i32.store
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                  (i32.const 16)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (i32.const 8)
-             )
-             (i32.store offset=4
-              (local.get $0)
-              (i32.const 2)
-             )
-             (i32.store offset=8
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
-             )
-             (i32.store offset=12
-              (local.get $0)
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $2)
-              )
-             )
-             (local.get $0)
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=8
+        (local.get $3)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.4e8e882f.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.4e8e882f.0.snapshot
@@ -2,32 +2,18 @@ tuples › no_singleton_tup
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (i32.const 3)
-    )
-   )
-  )
-  (local.get $0)
+  (i32.const 3)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 958
 )

--- a/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
@@ -16,61 +16,53 @@ tuples › tup1_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
          )
-         (i32.const 8)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 3)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 5)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 7)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 8)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 3)
       )
      )
+     (i32.store offset=12
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 7)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -19,76 +19,77 @@ tuples › big_tup_access
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (i32.load offset=16
-        (local.tee $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 24)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 24)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 4)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (i32.store offset=16
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=20
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 4)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (i32.store offset=16
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=20
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=16
+        (local.get $1)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -22,170 +22,169 @@ tuples › nested_tup_2
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (i32.const 0)
-               )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
               )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 3)
+              (i32.const 0)
              )
             )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 5)
-             )
-            )
-            (local.get $0)
            )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 3)
            )
           )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 5)
+           )
+          )
+          (local.get $0)
          )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 7)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (i32.const 9)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (block (result i32)
-            (i32.store
-             (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-                 (i32.const 16)
-                )
-                (local.get $0)
-               )
-              )
-             )
-             (i32.const 8)
-            )
-            (i32.store offset=4
-             (local.get $0)
-             (i32.const 2)
-            )
-            (i32.store offset=8
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
-             )
-            )
-            (i32.store offset=12
-             (local.get $0)
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $2)
-             )
-            )
-            (local.get $0)
-           )
-           (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (i32.load offset=12
-         (local.tee $4
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (i32.load offset=12
-              (local.get $3)
-             )
-            )
-            (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-             (i32.const 0)
-            )
-           )
-          )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
          )
         )
        )
-       (local.get $0)
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 7)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (i32.const 9)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+               (i32.const 16)
+              )
+              (local.get $0)
+             )
+            )
+           )
+           (i32.const 8)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $1)
+           )
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (local.get $2)
+           )
+          )
+          (local.get $0)
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+          (i32.load offset=12
+           (local.get $3)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.load offset=12
+        (local.get $4)
+       )
       )
      )
+     (local.get $0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
@@ -16,61 +16,53 @@ tuples › tup1_trailing_space
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-    (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (block (result i32)
-        (i32.store
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-             (i32.const 20)
-            )
-            (i32.const 0)
-           )
-          )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
          )
-         (i32.const 8)
+         (i32.const 0)
         )
-        (i32.store offset=4
-         (local.get $0)
-         (i32.const 3)
-        )
-        (i32.store offset=8
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 3)
-         )
-        )
-        (i32.store offset=12
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 5)
-         )
-        )
-        (i32.store offset=16
-         (local.get $0)
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.const 7)
-         )
-        )
-        (local.get $0)
        )
-       (local.get $0)
+      )
+      (i32.const 8)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 3)
       )
      )
+     (i32.store offset=12
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 5)
+      )
+     )
+     (i32.store offset=16
+      (local.get $0)
+      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+       (i32.const 7)
+      )
+     )
+     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/input/loopMemoryReclaim.gr
+++ b/compiler/test/input/loopMemoryReclaim.gr
@@ -1,0 +1,12 @@
+let f = () => {
+  "this is a thirty-two byte string"
+}
+
+for (let mut i = 0; i < 1024; i += 1) {
+  // Since f uses 64 bytes of memory at runtime, calling it 1024 times
+  // spans 1 WebAssembly page of memory. As the Grain runtime uses roughly
+  // half a page of memory, this sufficiently exercises garbage collection.
+  let s = f()
+}
+
+print("OK")

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -179,17 +179,22 @@ let makeErrorRunner =
   });
 };
 
-let makeFileRunner = (test, name, filename, expected) => {
-  test(
-    name,
-    ({expect}) => {
+let makeFileRunner = (test, ~num_pages=?, name, filename, expected) => {
+  test(name, ({expect}) => {
+    Config.preserve_config(() => {
+      switch (num_pages) {
+      | Some(pages) =>
+        Config.initial_memory_pages := pages;
+        Config.maximum_memory_pages := Some(pages);
+      | None => ()
+      };
       let infile = grainfile(filename);
       let outfile = wasmfile(name);
       compile_file(infile, outfile);
       let (result, _) = run(outfile);
       expect.string(result).toEqual(expected);
-    },
-  );
+    })
+  });
 };
 
 let makeFileErrorRunner = (test, name, filename, expected) => {

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -36,6 +36,7 @@ let readWholeFile = filename => {
 
 describe("garbage collection", ({test}) => {
   let assertFileRun = makeFileRunner(test);
+  let assertMemoryLimitedFileRun = makeFileRunner(~num_pages=1, test);
   let assertRunGC = (name, heapSize, prog) =>
     makeRunner(test, name, makeGcProgram(prog, heapSize), "");
   let assertRunGCError = (name, heapSize, prog, expected) =>
@@ -91,4 +92,9 @@ describe("garbage collection", ({test}) => {
   assertFileRunGC("long_lists", 20000, "long_lists", "true");
   assertFileRun("malloc_tight", "mallocTight", "");
   assertFileRun("memory_grow1", "memoryGrow", "1000000000000\n");
+  assertMemoryLimitedFileRun(
+    "loop_memory_reclaim",
+    "loopMemoryReclaim",
+    "OK\n",
+  );
 });

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -948,6 +948,7 @@ let writeUtf8CodePoint = (ptr, codePoint) => {
   }
 }
 
+@disableGC
 let bytesHaveBom = (bytes: Bytes, encoding: Encoding, start: WasmI32) => {
   let (+) = WasmI32.add
   let (==) = WasmI32.eq


### PR DESCRIPTION
Fixes #745.

The tl;dr of the issue here was that we always would incRef the return value of a function, which could make some simple functions return a value with a ref count of +2. This PR adds some logic to insert appropriate incRefs.

Since this changes the wasm emitted for nearly all functions, nearly all of the snapshots were updated 😬 
I put all of the snapshots into a separate commit, so it should be easy to use the file filter or filter out that commit when reviewing the changes. I added a test so we can catch it if it happens again.