### PR TITLE
feat(stdlib): forEachCodePoint and forEachCodePointi

### DIFF
--- a/compiler/test/stdlib/string.test.gr
+++ b/compiler/test/stdlib/string.test.gr
@@ -234,3 +234,21 @@ assert String.decodeRange(String.encodeAtWithBom(emojis, String.UTF32_LE, Bytes.
 // BOM stripping
 assert String.decode(String.encode(emojis, String.UTF32_LE), String.UTF32_LE) == emojis
 assert String.decode(String.encode(emojis, String.UTF32_BE), String.UTF32_BE) == emojis
+
+// codepoint iteration tests
+// conveniently reussing data from explode tests
+{
+  let mut tmp = []
+  String.forEachCodePoint((codePoint) => {
+    tmp = [codePoint, ...tmp]
+  }, emojis)
+  assert Array.reverse(Array.fromList(tmp)) == codes
+}
+
+{
+  let mut tmp = []
+  String.forEachCodePointi((codePoint,idx) => {
+    tmp = [(codePoint,idx), ...tmp]
+  }, emojis)
+  assert Array.reverse(Array.fromList(tmp)) == Array.mapi((c,i) => (c,i), codes)
+}

--- a/compiler/test/stdlib/string.test.gr
+++ b/compiler/test/stdlib/string.test.gr
@@ -236,7 +236,7 @@ assert String.decode(String.encode(emojis, String.UTF32_LE), String.UTF32_LE) ==
 assert String.decode(String.encode(emojis, String.UTF32_BE), String.UTF32_BE) == emojis
 
 // codepoint iteration tests
-// conveniently reussing data from explode tests
+// conveniently reusing data from `explode` tests
 {
   let mut tmp = []
   String.forEachCodePoint((codePoint) => {

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1297,3 +1297,102 @@ export let decode = (bytes: Bytes, encoding: Encoding) => {
 export let decodeKeepBom = (bytes: Bytes, encoding: Encoding) => {
   decodeHelp(bytes, encoding, false)
 }
+
+/**
+ * Iterates over Unicode code points in this string.
+ * 
+ * @param f: (Number) -> Void - The iterator function
+ * @param s: String - The string to iterate
+ * @returns Void
+ */
+@disableGC
+export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
+  let (>>>) = WasmI32.shrU
+  let (-) = WasmI32.sub
+  let (&) = WasmI32.and
+  let (<) = WasmI32.ltU
+  let (<=) = WasmI32.leU
+  let (==) = WasmI32.eq
+  let (+) = WasmI32.add
+
+  let s = WasmI32.fromGrain(s)
+
+  let byteSize = WasmI32.load(s, 4n)
+
+  let mut ptr = s + 8n
+  let end = ptr + byteSize
+  
+  let mut idx = 0n
+  while (ptr < end) {
+    let byte = WasmI32.load8U(ptr, 0n)
+    let codePointByteCount = if ((byte & 0x80n) == 0x00n) {
+      1n
+    } else if ((byte & 0xF0n) == 0xF0n) {
+      4n
+    } else if ((byte & 0xE0n) == 0xE0n) {
+      3n
+    } else {
+      2n
+    }
+
+    // Note that even if up to 4 bytes are needed to represent Unicode
+    // codepoints, this doesn't mean 32 bits. The highest allowed code point is
+    // 0x10FFFF and it should not change in future versions of Unicode. Which
+    // means no more than 21 bits are necessary to represent a code point and
+    // thus we can use Grain's "simple" numbers that hold up to 31 bits and
+    // avoid heap allocations. I'm assuming here that getCodePoint would throw
+    // MalformedUnicode exception for values exceeding this limit.
+    let codePoint = getCodePoint(ptr)
+    f(tagSimpleNumber(codePoint))
+
+    ptr += codePointByteCount
+    idx += 1n
+  }
+}
+
+@disableGC
+export let forEachCodePointi = (f: (Number,Number) -> Void, s: String) => {
+  let (>>>) = WasmI32.shrU
+  let (-) = WasmI32.sub
+  let (&) = WasmI32.and
+  let (<) = WasmI32.ltU
+  let (<=) = WasmI32.leU
+  let (==) = WasmI32.eq
+  let (+) = WasmI32.add
+
+  let s = WasmI32.fromGrain(s)
+
+  let byteSize = WasmI32.load(s, 4n)
+
+  let mut ptr = s + 8n
+  let end = ptr + byteSize
+  
+  let mut idx = 0n
+  while (ptr < end) {
+    let byte = WasmI32.load8U(ptr, 0n)
+    let codePointByteCount = if ((byte & 0x80n) == 0x00n) {
+      1n
+    } else if ((byte & 0xF0n) == 0xF0n) {
+      4n
+    } else if ((byte & 0xE0n) == 0xE0n) {
+      3n
+    } else {
+      2n
+    }
+
+    // Note that even if up to 4 bytes are needed to represent Unicode
+    // codepoints, this doesn't mean 32 bits. The highest allowed code point is
+    // 0x10FFFF and it should not change in future versions of Unicode. Which
+    // means no more than 21 bits are necessary to represent a code point and
+    // thus we can use Grain's "simple" numbers that hold up to 31 bits and
+    // avoid heap allocations. I'm assuming here that getCodePoint would throw
+    // MalformedUnicode exception for values exceeding this limit. Idem for the
+    // index. String can never have more than 2^31 codepoints (or bytes for
+    // that matter).
+    let codePoint = getCodePoint(ptr)
+    f(tagSimpleNumber(codePoint), tagSimpleNumber(idx))
+
+    ptr += codePointByteCount
+    idx += 1n
+  }
+}

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1350,6 +1350,15 @@ export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
   }
 }
 
+/**
+ * Iterates over Unicode code points in this string. This same as the
+ * forEachCodePoint function, but with a code point index provided for
+ * convenience.
+ * 
+ * @param f: (Number,Number) -> Void - The iterator function
+ * @param s: String - The string to iterate
+ * @returns Void
+ */
 @disableGC
 export let forEachCodePointi = (f: (Number,Number) -> Void, s: String) => {
   let (>>>) = WasmI32.shrU

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1299,11 +1299,10 @@ export let decodeKeepBom = (bytes: Bytes, encoding: Encoding) => {
 }
 
 /**
- * Iterates over Unicode code points in this string.
+ * Iterates over Unicode code points in a string.
  * 
- * @param f: (Number) -> Void - The iterator function
- * @param s: String - The string to iterate
- * @returns Void
+ * @param f: The iterator function
+ * @param s: The string to iterate
  */
 @disableGC
 export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
@@ -1337,10 +1336,10 @@ export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
 
     // Note that even if up to 4 bytes are needed to represent Unicode
     // codepoints, this doesn't mean 32 bits. The highest allowed code point is
-    // 0x10FFFF and it should not change in future versions of Unicode. Which
+    // 0x10FFFF and it should not change in future versions of Unicode. This
     // means no more than 21 bits are necessary to represent a code point and
     // thus we can use Grain's "simple" numbers that hold up to 31 bits and
-    // avoid heap allocations. I'm assuming here that getCodePoint would throw
+    // avoid heap allocations. `getCodePoint` will throw
     // MalformedUnicode exception for values exceeding this limit.
     let codePoint = getCodePoint(ptr)
     f(tagSimpleNumber(codePoint))
@@ -1351,16 +1350,15 @@ export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
 }
 
 /**
- * Iterates over Unicode code points in this string. This same as the
- * forEachCodePoint function, but with a code point index provided for
- * convenience.
+ * Iterates over Unicode code points in a string. This is the same as
+ * `forEachCodePoint`, but provides the code point's index as the
+ * second argument to the iterator function.
  * 
- * @param f: (Number,Number) -> Void - The iterator function
- * @param s: String - The string to iterate
- * @returns Void
+ * @param f: The iterator function
+ * @param s: The string to iterate
  */
 @disableGC
-export let forEachCodePointi = (f: (Number,Number) -> Void, s: String) => {
+export let forEachCodePointi = (f: (Number, Number) -> Void, s: String) => {
   let (>>>) = WasmI32.shrU
   let (-) = WasmI32.sub
   let (&) = WasmI32.and
@@ -1391,13 +1389,11 @@ export let forEachCodePointi = (f: (Number,Number) -> Void, s: String) => {
 
     // Note that even if up to 4 bytes are needed to represent Unicode
     // codepoints, this doesn't mean 32 bits. The highest allowed code point is
-    // 0x10FFFF and it should not change in future versions of Unicode. Which
+    // 0x10FFFF and it should not change in future versions of Unicode. This
     // means no more than 21 bits are necessary to represent a code point and
     // thus we can use Grain's "simple" numbers that hold up to 31 bits and
-    // avoid heap allocations. I'm assuming here that getCodePoint would throw
-    // MalformedUnicode exception for values exceeding this limit. Idem for the
-    // index. String can never have more than 2^31 codepoints (or bytes for
-    // that matter).
+    // avoid heap allocations. `getCodePoint` will throw
+    // MalformedUnicode exception for values exceeding this limit.
     let codePoint = getCodePoint(ptr)
     f(tagSimpleNumber(codePoint), tagSimpleNumber(idx))
 

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1314,11 +1314,11 @@ export let forEachCodePoint = (fn: (Number) -> Void, str: String) => {
   let (==) = WasmI32.eq
   let (+) = WasmI32.add
 
-  let s = WasmI32.fromGrain(s)
+  let strPtr = WasmI32.fromGrain(str)
 
-  let byteSize = WasmI32.load(s, 4n)
+  let byteSize = WasmI32.load(strPtr, 4n)
 
-  let mut ptr = s + 8n
+  let mut ptr = strPtr + 8n
   let end = ptr + byteSize
   
   let mut idx = 0n
@@ -1342,7 +1342,7 @@ export let forEachCodePoint = (fn: (Number) -> Void, str: String) => {
     // avoid heap allocations. `getCodePoint` will throw
     // MalformedUnicode exception for values exceeding this limit.
     let codePoint = getCodePoint(ptr)
-    f(tagSimpleNumber(codePoint))
+    fn(tagSimpleNumber(codePoint))
 
     ptr += codePointByteCount
     idx += 1n
@@ -1367,11 +1367,11 @@ export let forEachCodePointi = (fn: (Number, Number) -> Void, str: String) => {
   let (==) = WasmI32.eq
   let (+) = WasmI32.add
 
-  let s = WasmI32.fromGrain(s)
+  let strPtr = WasmI32.fromGrain(str)
 
-  let byteSize = WasmI32.load(s, 4n)
+  let byteSize = WasmI32.load(strPtr, 4n)
 
-  let mut ptr = s + 8n
+  let mut ptr = strPtr + 8n
   let end = ptr + byteSize
   
   let mut idx = 0n
@@ -1395,7 +1395,7 @@ export let forEachCodePointi = (fn: (Number, Number) -> Void, str: String) => {
     // avoid heap allocations. `getCodePoint` will throw
     // MalformedUnicode exception for values exceeding this limit.
     let codePoint = getCodePoint(ptr)
-    f(tagSimpleNumber(codePoint), tagSimpleNumber(idx))
+    fn(tagSimpleNumber(codePoint), tagSimpleNumber(idx))
 
     ptr += codePointByteCount
     idx += 1n

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1301,11 +1301,11 @@ export let decodeKeepBom = (bytes: Bytes, encoding: Encoding) => {
 /**
  * Iterates over Unicode code points in a string.
  * 
- * @param f: The iterator function
- * @param s: The string to iterate
+ * @param fn: The iterator function
+ * @param str: The string to iterate
  */
 @disableGC
-export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
+export let forEachCodePoint = (fn: (Number) -> Void, str: String) => {
   let (>>>) = WasmI32.shrU
   let (-) = WasmI32.sub
   let (&) = WasmI32.and
@@ -1354,11 +1354,11 @@ export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
  * `forEachCodePoint`, but provides the code point's index in the string
  * as the second argument to the iterator function.
  * 
- * @param f: The iterator function
- * @param s: The string to iterate
+ * @param fn: The iterator function
+ * @param str: The string to iterate
  */
 @disableGC
-export let forEachCodePointi = (f: (Number, Number) -> Void, s: String) => {
+export let forEachCodePointi = (fn: (Number, Number) -> Void, str: String) => {
   let (>>>) = WasmI32.shrU
   let (-) = WasmI32.sub
   let (&) = WasmI32.and

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1351,8 +1351,8 @@ export let forEachCodePoint = (f: (Number) -> Void, s: String) => {
 
 /**
  * Iterates over Unicode code points in a string. This is the same as
- * `forEachCodePoint`, but provides the code point's index as the
- * second argument to the iterator function.
+ * `forEachCodePoint`, but provides the code point's index in the string
+ * as the second argument to the iterator function.
  * 
  * @param f: The iterator function
  * @param s: The string to iterate


### PR DESCRIPTION
This PR adds two optimized functions to iterate over Unicode code point that make up a given String. It's equivalent to calling String.explode and then converting single chars to code points, but a lot more efficient since no heap allocations are made.