### PR TITLE
chore: Document memory management in Grain

### DIFF
--- a/docs/contributor/memory_management.md
+++ b/docs/contributor/memory_management.md
@@ -1,0 +1,145 @@
+# Memory Management in Grain
+
+This guide documents Grain's memory management system. This document is aimed at those who are developing the code-generation pass of the compiler or writing low-level code inside of the Grain runtime; most users should not need to interact with the memory manager, and doing so risks corrupting the memory of your program (if the guidelines laid out here are not adhered to).
+
+We ultimately aim to replace Grain's in-house memory management with the WebAssembly GC instructions once [the proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) is implemented, but, in the meantime, Grain implements its own memory allocator and garbage collector.
+
+## Memory Allocator
+Grain uses a [memory allocator](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/malloc.gr) derived from the `malloc`/`free` example given in Kernighan and Ritchie's "The C Programming Language" (K&R C). This module exports the following values:
+
+```grain
+/**
+ * The amount of space reserved for runtime code which needs to be executed
+ * at boot before the malloc module is loaded
+ */
+export let _RESERVED_RUNTIME_SPACE: WasmI32
+
+/**
+ * Allocates the requested number of bytes, returning a pointer.
+ *
+ * @param nbytes: WasmI32 - The number of bytes to allocate
+ * @return WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
+ */
+export let malloc: (nbytes: WasmI32) => WasmI32
+
+/**
+ * Frees the given allocated pointer.
+ *
+ * @param ap: WasmI32 - The pointer to free
+ */
+export let free = (ap: WasmI32) => Void
+
+/**
+ * Returns the current free list pointer
+ * (used for debugging)
+ *
+ * @return WasmI32 - The free list pointer
+ */
+export let getFreePtr = () => WasmI32
+```
+
+These functions should be familiar to programmers who have used `malloc` and `free` in C (and C-like languages). For further reading, refer to this Wikipedia page: [C dynamic memory allocation](https://en.wikipedia.org/wiki/C_dynamic_memory_allocation). The semantics of these functions align near-identically with those of C's corresponding functions.
+
+Users should not call these functions directly in 99% of circumstances, and should instead use the `GC` module's wrappers (described below).
+
+## Garbage Collector
+
+Functional programming patterns often result in a large number of allocations, so it is imperative for developer experience that the language manages the creation and deletion of objects for users. Grain uses a reference-counting [garbage collector](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/gc.gr) in order to determine when objects are no longer in active use by the program (and therefore able to have their memory freed).
+
+At a technical level, this is represented in-memory in the following way, for an n-byte heap object:
+```
+ [ 32-bit counter ][ 32-bit padding ][ n-byte payload ]
+ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
+ {start address}                    {pointer used by Grain runtime}
+```
+Here, `{start address}` is the value returned by `Malloc.malloc` (and passed to `Malloc.free` when the object is cleaned up), and the `{pointer used by Grain runtime}` is what everything outside of the `GC` wrapper uses as the pointer to the object. In other words, we "hide" the reference count in the 8 bytes prior to the pointer.
+
+The interface provided by the `GC` module is similar (but not identical) to that which is provided by the `Malloc` module:
+```grain
+/**
+ * Allocates the requested number of bytes, returning a pointer with a reference count of 1.
+ *
+ * @param size: WasmI32 - The number of bytes to allocate
+ * @return WasmI32 - The pointer to the allocated region
+ */
+export let malloc = (size: WasmI32) => WasmI32
+
+/**
+ * Frees the given pointer. Using this pointer after it has been freed will result in undefined behavior.
+ *
+ * @param userPtr: WasmI32 - The pointer to free
+ * @return Void
+ */
+export let free = (userPtr: WasmI32) => Void
+
+/**
+ * Increments the reference count of the given pointer.
+ *
+ * @param userPtr: WasmI32 - The pointer whose reference count should be incremented
+ * @return WasmI32 - The given pointer
+ */
+export let incRef = (userPtr: WasmI32) => WasmI32
+
+/**
+ * Decrements the reference count of the given pointer if it is greater than zero
+ *
+ * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
+ * @return WasmI32 - The given pointer
+ */
+export let decRefIgnoreZeros = (userPtr: WasmI32) => WasmI32
+
+/**
+ * Decrements the reference count of the given pointer. An error is thrown if the
+ * reference count is not greater than zero.
+ *
+ * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
+ * @return WasmI32 - The given pointer
+ */
+export let decRef = (userPtr: WasmI32) => WasmI32
+```
+
+When writing code in the runtime, `decRefIgnoreZeros` should never be used. It exists solely to support the cleanup step of compiled functions.
+
+### Garbage Collection in Compiled Programs
+
+In most Grain programs, the above functions do not need to be invoked by users. Instead, the compiler automatically inserts calls to them where required. When developing in `compcore.re`, it is important to understand the conventions used by the garbage collector.
+
+**References from the local frame still count as references.** In other words, when a variable is stored inside of a WASM local, its reference count should be incremented. There is one exception to this rule: so-called "swap slots". These are special locals that Grain uses to store temporary results within a single compiled `Mashtree` instruction (similar to how CPU registers are used in native compilers). For performance reasons, we do not increment the reference counter when storing values in these slots. This is safe due to the fact that these values do not escape beyond a single `Mashtree` instruction; while they may still be physically present in the local, they are not read by later pieces of the program.
+
+For non-swap locals, this gives rise to the following pseudocode when storing a value in a local variable (this order is important to account for situations in which `val` is already in `local0`):
+```
+// We want to put `val` in `local0`
+local0 := {
+  tmp := incRef(val);
+  decRef(local0);
+  tmp
+}
+```
+In practice, this is facilitated by `Tuple` instructions Binaryen, similar to this:
+```
+// We want to put `val` in `local0`
+local0 := {
+  (incRef(val), decRef(local0))[0]
+}
+```
+
+**When a function returns a pointer, that pointer already has a reference count of at least one, which includes the reference from the local frame.** This means that, if the returned pointer does not escape the function, then a (net) single `decRef` should be invoked on that pointer in order to not leak memory.
+
+When a function is exiting, it is imperative to clean up all references to values in the local frame while preserving the return value. We do this by doing the following:
+
+- Calling `incRef` on the return value (which is in a local)
+- Calling `decRefIgnoreZeros` on all locals
+
+This should result in a net change of zero references on the return value, and a net change of -1 references on all other locals.
+
+## Disabling the Garbage Collector
+
+There are times in which the garbage collector is not desired in Grain code. The typical example of this is the implementation of the core runtime (for example the garbage collector itself), which involves working with native WebAssembly values. Consequently, Grain provides two mechanisms for disabling the garbage collector, either on a per-function or a per-file basis.
+
+First, it is possible to annotate functions with `@disableGC`. This will compile the annotated function with no garbage collection instructions. Second, it is possible to pass the `--compilation-mode=runtime` flag to the compiler (**NOTE** that this is not the only effect of this flag; see `runtime.md` for more details), which is typically done by placing this at the beginning of the file:
+```grain
+/* grainc-flags --compilation-mode=runtime */
+```
+When this flag is enabled, no functions in the file will be compiled with garbage collection instructions.
+
+Naturally, this means that it is incumbent upon the programmer to make the appropriate calls to `GC.incRef` and `GC.decRef` in order to not leak memory.

--- a/docs/contributor/memory_management.md
+++ b/docs/contributor/memory_management.md
@@ -5,6 +5,7 @@ This guide documents Grain's memory management system. This document is aimed at
 We ultimately aim to replace Grain's in-house memory management with the WebAssembly GC instructions once [the proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) is implemented, but, in the meantime, Grain implements its own memory allocator and garbage collector.
 
 ## Memory Allocator
+
 Grain uses a [memory allocator](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/malloc.gr) derived from the `malloc`/`free` example given in Kernighan and Ritchie's ["The C Programming Language"](https://kremlin.cc/k&r.pdf) (K&R C), pages 185-188 (PDF page 199). This module exports the following values:
 
 ```grain
@@ -47,14 +48,17 @@ Users should not call these functions directly in 99% of circumstances, and shou
 Functional programming patterns often result in a large number of allocations, so it is imperative for developer experience that the language manages the creation and deletion of objects for users. Grain uses a reference-counting [garbage collector](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/gc.gr) in order to determine when objects are no longer in active use by the program (and therefore able to have their memory freed).
 
 At a technical level, this is represented in-memory in the following way, for an n-byte heap object:
+
 ```
  [ 32-bit counter ][ 32-bit padding ][ n-byte payload ]
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
  {start address}                    {pointer used by Grain runtime}
 ```
+
 Here, `{start address}` is the value returned by `Malloc.malloc` (and passed to `Malloc.free` when the object is cleaned up), and the `{pointer used by Grain runtime}` is what everything outside of the `GC` wrapper uses as the pointer to the object. In other words, we "hide" the reference count in the 8 bytes prior to the pointer.
 
 The interface provided by the `GC` module is similar (but not identical) to that which is provided by the `Malloc` module:
+
 ```grain
 /**
  * Allocates the requested number of bytes, returning a pointer with a reference count of 1.
@@ -62,7 +66,7 @@ The interface provided by the `GC` module is similar (but not identical) to that
  * @param size: WasmI32 - The number of bytes to allocate
  * @return WasmI32 - The pointer to the allocated region
  */
-export let malloc = (size: WasmI32) => WasmI32
+export let malloc = (size: WasmI32) -> WasmI32
 
 /**
  * Frees the given pointer. Using this pointer after it has been freed will result in undefined behavior.
@@ -70,7 +74,7 @@ export let malloc = (size: WasmI32) => WasmI32
  * @param userPtr: WasmI32 - The pointer to free
  * @return Void
  */
-export let free = (userPtr: WasmI32) => Void
+export let free = (userPtr: WasmI32) -> Void
 
 /**
  * Increments the reference count of the given pointer.
@@ -78,7 +82,7 @@ export let free = (userPtr: WasmI32) => Void
  * @param userPtr: WasmI32 - The pointer whose reference count should be incremented
  * @return WasmI32 - The given pointer
  */
-export let incRef = (userPtr: WasmI32) => WasmI32
+export let incRef = (userPtr: WasmI32) -> WasmI32
 
 /**
  * Decrements the reference count of the given pointer if it is greater than zero
@@ -86,7 +90,7 @@ export let incRef = (userPtr: WasmI32) => WasmI32
  * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
  * @return WasmI32 - The given pointer
  */
-export let decRefIgnoreZeros = (userPtr: WasmI32) => WasmI32
+export let decRefIgnoreZeros = (userPtr: WasmI32) -> WasmI32
 
 /**
  * Decrements the reference count of the given pointer. An error is thrown if the
@@ -95,74 +99,79 @@ export let decRefIgnoreZeros = (userPtr: WasmI32) => WasmI32
  * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
  * @return WasmI32 - The given pointer
  */
-export let decRef = (userPtr: WasmI32) => WasmI32
+export let decRef = (userPtr: WasmI32) -> WasmI32
 ```
 
-When writing code in the runtime, `decRefIgnoreZeros` should never be used. It exists solely to support the cleanup step of compiled functions.
+When writing code in the runtime, `decRefIgnoreZeros` should never be used. It exists solely to support the cleanup step of compiled functions. The reference count-managing functions are safe to use with non-pointers; if a non-pointer is passed
+to them, it will be returned without any side effects. **However**, it should be noted that these functions are not safe to use with arbitrary (untagged) `WasmXX` (`WasmI32`/`WasmI64`/etc) values, which is why the use of such types is only permitted in `@disableGC` blocks (so that the compiler does not insert `incRef`/`decRef` calls).
 
 ### Garbage Collection in Compiled Programs
 
 In most Grain programs, the above functions do not need to be invoked by users. Instead, the compiler automatically inserts calls to them where required. When developing in `compcore.re`, it is important to understand the conventions used by the garbage collector.
 
-**References from the local frame still count as references.** In other words, when a variable is stored inside of a Wasm local, its reference count should be incremented. There is one exception to this rule: so-called "swap slots". These are special locals that Grain uses to store temporary results within a single compiled `Mashtree` instruction (similar to how CPU registers are used in native compilers). For performance reasons, we do not increment the reference counter when storing values in these slots. This is safe due to the fact that these values do not escape beyond a single `Mashtree` instruction; while they may still be physically present in the local, they are not read by later pieces of the program.
+**Reference counts are incremented upon access.** With some exceptions in generated code, reference counts are incremented whenever a value is accessed (loaded from storage slots such as arguments, locals, and globals). This streamlines the conventions in generated code, as function calls require no specific `incRef` invocation for arguments (see "References are callee-owned" subsection below). For clarity, a couple of notes:
 
-For non-swap locals, this gives rise to the following pseudocode when storing a value in a local variable (this order is important to account for situations in which `val` is already in `local0`):
+- If a value is stored somewhere, no `incRef`/`decRef` calls are needed (again, there are rare exceptions to this in the compiler, specifically regarding "swap slots", which are local variables used as registers).
+- If the computation no longer needs a live value (e.g. after a statement in the middle of a block), it should be `decRef`ed.
+- No special `incRef` is needed for return values, as the access of those values performs the requisite `incRef`. It should be noted that in generated WebAssembly code, the function postamble looks as follows:
+
 ```
-// We want to put `val` in `local0`
-local0 := {
-  tmp := incRef(val);
-  decRef(local0);
-  tmp
-}
-```
-In practice, this is facilitated by `Tuple` instructions Binaryen, similar to this:
-```
-// We want to put `val` in `local0`
-local0 := {
-  (incRef(val), decRef(local0))[0]
-}
+swap_slot <- return_value
+for argument in arguments:
+    decref(argument)
+for local_variable in local_variables:
+    decref(local_variable)
+return load_swap(return_value) # see note below
 ```
 
-**When a function returns a pointer, that pointer already has a reference count of at least one, which includes the reference from the local frame.** This means that, if the returned pointer does not escape the function, then a (net) single `decRef` should be invoked on that pointer in order to not leak memory.
+Note that `load_swap` is one of the aforementioned exceptions which does not `incRef` the value upon access. Swap slots are used by the compiler to temporarily store intermediate values during computation, and they do not need to have their contents `incRef`ed; i.e. since they are only used for intermediate values, any references they hold are treated as weak and do not impact the reference count.
 
-When a function is exiting, it is imperative to clean up all references to values in the local frame while preserving the return value. We do this by doing the following:
+**References are callee-owned.** This has a couple of implications:
 
-- Calling `incRef` on the return value (which is in a local)
-- Calling `decRefIgnoreZeros` on all locals
+- If a function is called with an argument, it is the responsibility of that function to `decRef` that argument
+- If a value is passed to a function with a reference count of `n`, when it returns, it will have the a reference count of `n-1` (unless it was stored in an external location, in which case the reference count may be higher).
 
-This should result in a net change of zero references on the return value, and a net change of -1 references on all other locals.
-
-**References are caller-owned.** This has a few implications:
-- If a function is called with an argument, it is the responsibility of whoever called that function to `decRef` that argument
-- If a value is passed to a function, when it returns, it will have the same reference count as when the function was called (unless it was stored in an external location, in which case the reference count may be higher).
-
-Moreover, the Grain compiler is designed to minimize the overall number of calls to `incRef` and `decRef` calls in its produced code. This means that, rather than the following (pseudocode):
-```grain
-let f = x => {
-  incRef(x)
-  foo(x)
-  decRef(x)
-  incRef(x)
-  bar(x)
-  decRef(x)
-}
-```
-Grain's compiler will emit something more like this (again, note that `x` is an argument, so it is incumbent upon `f`'s caller to `decRef` it):
-```grain
-let f = x => {
-  foo(x)
-  bar(x)
-}
-```
+**Functions contain references to themselves.** In order to support closures, Grain's compiler emits code which passes the current closure to each function as an extra argument. With respect to the calling convention, this extra argument is the same as normal arguments, so it follows the same `incRef`-before-function-call pattern as standard arguments (and must be `decRef`ed before functions return). This is particularly important to keep in mind when writing `@disableGC` code, as discussed below.
 
 ## Disabling the Garbage Collector
 
 There are times in which the garbage collector is not desired in Grain code. The typical example of this is the implementation of the core runtime (for example the garbage collector itself), which involves working with native WebAssembly values. Consequently, Grain provides two mechanisms for disabling the garbage collector, either on a per-function or a per-file basis.
 
 First, it is possible to annotate functions with `@disableGC`. This will compile the annotated function with no garbage collection instructions. Second, it is possible to pass the `--compilation-mode=runtime` flag to the compiler (**NOTE** that this is not the only effect of this flag; see `runtime.md` for more details), which is typically done by placing this at the beginning of the file:
+
 ```grain
 /* grainc-flags --compilation-mode=runtime */
 ```
+
 When this flag is enabled, no functions in the file will be compiled with garbage collection instructions.
 
-Naturally, this means that it is incumbent upon the programmer to make the appropriate calls to `GC.incRef` and `GC.decRef` in order to not leak memory.
+Naturally, this means that it is incumbent upon the programmer to make the appropriate calls to `GC.incRef` and `GC.decRef` in order to not leak memory. For example, because references are callee-owned, it is required to increment the reference counts of all arguments _and_ the function itself (recall from the "Functions contain references to themselves" subsection that the function will receive the closure as a "hidden" argument) before calling GC-enabled functions. Some internal functions in the runtime and standard library may be GC-disabled, in which case this is not necessary. This is typically the case for functions which accept or return a `WasmXX` (`WasmI32`/`WasmI64`/etc) type value.
+
+Here are some concrete examples.
+
+When calling function from inside a GC-disabled function:
+
+```grain
+// Taken from string.gr
+// @disableGC-safe wrapper
+@disableGC
+let wasmSafeLength = (s: String) => {
+  Memory.incRef(WasmI32.fromGrain(length)) // <- incRef closure being invoked
+  Memory.incRef(WasmI32.fromGrain(s)) // <- incRef argument before call
+  length(s)
+}
+```
+
+Before returning from a GC-disabled function which follows the Grain calling convention (i.e. one which is safe to call from GC-enabled code):
+
+```grain
+// Taken from sqrt() function in number.gr
+@disableGC
+export let rec sqrt = (x: Number) => {
+  // ...
+  let ret = ...
+  Memory.decRef(WasmI32.fromGrain(x))   // <- decrement argument
+  Memory.decRef(WasmI32.fromGrain(sqrt)) // <- decrement closure (note that this function needs to be recursive)
+  ret
+}
+```

--- a/docs/contributor/memory_management.md
+++ b/docs/contributor/memory_management.md
@@ -1,8 +1,8 @@
 # Memory Management in Grain
 
-This guide documents Grain's memory management system. This document is aimed at those who are developing the code-generation pass of the compiler or writing low-level code inside of the Grain runtime; most users should not need to interact with the memory manager, and doing so risks corrupting the memory of your program (if the guidelines laid out here are not adhered to).
+This guide documents Grain's memory management system. This document is aimed at those who are developing the code-generation pass of the compiler or writing low-level code inside of the Grain runtime; most users should not need to interact with the memory manager, and doing so risks corrupting the memory of your program if the guidelines laid out here are not adhered to.
 
-We ultimately aim to replace Grain's in-house memory management with the WebAssembly GC instructions once [the proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) is implemented, but, in the meantime, Grain implements its own memory allocator and garbage collector.
+We ultimately aim to replace Grain's bespoke memory management with the WebAssembly GC instructions once [the proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) is implemented—in the meantime, Grain implements its own memory allocator and garbage collector.
 
 ## Memory Allocator
 
@@ -18,23 +18,22 @@ export let _RESERVED_RUNTIME_SPACE: WasmI32
 /**
  * Allocates the requested number of bytes, returning a pointer.
  *
- * @param nbytes: WasmI32 - The number of bytes to allocate
- * @return WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
+ * @param nbytes: The number of bytes to allocate
+ * @returns The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
  */
 export let malloc: (nbytes: WasmI32) -> WasmI32
 
 /**
  * Frees the given allocated pointer.
  *
- * @param ap: WasmI32 - The pointer to free
+ * @param ap: The pointer to free
  */
 export let free = (ap: WasmI32) => Void
 
 /**
- * Returns the current free list pointer
- * (used for debugging)
+ * Returns the current free list pointer (used for debugging)
  *
- * @return WasmI32 - The free list pointer
+ * @returns The free list pointer
  */
 export let getFreePtr = () => WasmI32
 ```
@@ -45,7 +44,7 @@ These functions generally should not be called directly in 99% of circumstances,
 
 ## Garbage Collector
 
-Functional programming patterns often result in a large number of allocations, so it is imperative for developer experience that the language manages the creation and deletion of objects for users. Grain uses a reference-counting [garbage collector](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/gc.gr) in order to determine when objects are no longer in active use by the program (and therefore able to have their memory freed).
+Functional programming patterns often result in a large number of allocations, so it is imperative for developer experience that the language manages the creation and deletion of objects for users. Grain uses a reference-counting [garbage collector](https://github.com/grain-lang/grain/blob/main/stdlib/runtime/gc.gr) in order to determine when objects are no longer in active use by the program and therefore able to have their memory freed.
 
 At a technical level, this is represented in-memory in the following way, for an n-byte heap object:
 
@@ -63,32 +62,31 @@ The interface provided by the `GC` module is similar (but not identical) to that
 /**
  * Allocates the requested number of bytes, returning a pointer with a reference count of 1.
  *
- * @param size: WasmI32 - The number of bytes to allocate
- * @return WasmI32 - The pointer to the allocated region
+ * @param size: The number of bytes to allocate
+ * @returns The pointer to the allocated region
  */
 export let malloc = (size: WasmI32) -> WasmI32
 
 /**
  * Frees the given pointer. Using this pointer after it has been freed will result in undefined behavior.
  *
- * @param userPtr: WasmI32 - The pointer to free
- * @return Void
+ * @param userPtr: The pointer to free
  */
 export let free = (userPtr: WasmI32) -> Void
 
 /**
  * Increments the reference count of the given pointer.
  *
- * @param userPtr: WasmI32 - The pointer whose reference count should be incremented
- * @return WasmI32 - The given pointer
+ * @param userPtr: The pointer whose reference count should be incremented
+ * @returns The given pointer
  */
 export let incRef = (userPtr: WasmI32) -> WasmI32
 
 /**
  * Decrements the reference count of the given pointer if it is greater than zero
  *
- * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
- * @return WasmI32 - The given pointer
+ * @param userPtr: The pointer whose reference count should be decremented
+ * @returns The given pointer
  */
 export let decRefIgnoreZeros = (userPtr: WasmI32) -> WasmI32
 
@@ -96,24 +94,24 @@ export let decRefIgnoreZeros = (userPtr: WasmI32) -> WasmI32
  * Decrements the reference count of the given pointer. An error is thrown if the
  * reference count is not greater than zero.
  *
- * @param userPtr: WasmI32 - The pointer whose reference count should be decremented
- * @return WasmI32 - The given pointer
+ * @param userPtr: The pointer whose reference count should be decremented
+ * @returns The given pointer
  */
 export let decRef = (userPtr: WasmI32) -> WasmI32
 ```
 
 When writing code in the runtime, `decRefIgnoreZeros` should never be used. It exists solely to support the cleanup step of compiled functions. The reference count-managing functions are safe to use with non-pointers; if a non-pointer is passed
-to them, it will be returned without any side effects. **However**, it should be noted that these functions are not safe to use with arbitrary (untagged) `WasmXX` (`WasmI32`/`WasmI64`/etc) values, which is why the use of such types is only permitted in `@disableGC` blocks (so that the compiler does not insert `incRef`/`decRef` calls).
+to them, it will be returned without any side effects. **However**, it should be noted that these functions are not safe to use with arbitrary (untagged) `WasmXX` (`WasmI32`/`WasmI64`/etc) values, which is why the use of such types is only permitted in `@disableGC` blocks—so that the compiler does not insert `incRef`/`decRef` calls.
 
 ### Garbage Collection in Compiled Programs
 
-In most Grain programs, the above functions do not need to be invoked by users. Instead, the compiler automatically inserts calls to them where required. When developing in `compcore.re`, it is important to understand the conventions used by the garbage collector.
+In normal Grain programs, the above functions do not need to be invoked by users. Instead, the compiler automatically inserts calls to them where required. When developing in `compcore.re`, it is important to understand the conventions used by the garbage collector.
 
-**Functions contain references to themselves.** In order to support closures, Grain's compiler emits code which passes the current closure to each function as an extra argument. With respect to the calling convention, this extra argument is the same as normal arguments, so it follows the same `incRef`-before-function-call pattern as standard arguments (and must be `decRef`ed before functions return), as described in the following section. This is particularly important to keep in mind when writing `@disableGC` code, as discussed in "Disabling the Garbage Collector" below.
+**Functions contain references to themselves.** In order to support closures, Grain's compiler emits code which passes the current closure to each function as an extra argument. With respect to the calling convention, this extra argument is the same as normal arguments, so it follows the same `incRef`-before-function-call pattern as standard arguments and must be `decRef`ed before functions return, as described in the following section. This is particularly important to keep in mind when writing `@disableGC` code, as discussed in "Disabling the Garbage Collector" below.
 
 **Reference counts are incremented upon access.** With some exceptions in generated code, reference counts are incremented whenever a value is accessed (loaded from storage slots such as arguments, locals, and globals). This streamlines the conventions in generated code, as function calls require no specific `incRef` invocation for arguments (see "References are callee-owned" subsection below). For clarity, a couple of notes:
 
-- If a value is stored somewhere, no extra `incRef`/`decRef` calls are needed (again, there are rare exceptions to this in the compiler, specifically regarding "swap slots", which are local variables used as registers).
+- If a value is stored somewhere, no extra `incRef`/`decRef` calls are needed. There are rare exceptions to this in the compiler, specifically regarding "swap slots", which are local variables used as registers.
 - If the computation no longer needs a live value (e.g. after a statement in the middle of a block), it should be `decRef`ed.
 - No special `incRef` is needed for return values, as the access of those values performs the requisite `incRef`. It should be noted that in generated WebAssembly code, the function postamble looks as follows:
 
@@ -130,7 +128,7 @@ Note that `load_swap` is one of the aforementioned exceptions which does not `in
 
 **References are callee-owned.** This has a couple of implications:
 
-- If a function is called with an argument, it is the responsibility of that function to `decRef` that argument
+- If a function is called with an argument, it is the responsibility of that function to `decRef` that argument.
 - If a value is passed to a function with a reference count of `n`, when it returns, it will have the a reference count of `n-1` (unless it was stored in an external location, in which case the reference count may be higher).
 
 ## Disabling the Garbage Collector

--- a/docs/contributor/memory_management.md
+++ b/docs/contributor/memory_management.md
@@ -41,7 +41,7 @@ export let getFreePtr = () => WasmI32
 
 These functions should be familiar to programmers who have used `malloc` and `free` in C (and C-like languages). For further reading, refer to this Wikipedia page: [C dynamic memory allocation](https://en.wikipedia.org/wiki/C_dynamic_memory_allocation). The semantics of these functions align near-identically with those of C's corresponding functions.
 
-Users should not call these functions directly in 99% of circumstances, and should instead use the `GC` module's wrappers (described below).
+These functions generally should not be called directly in 99% of circumstances, and the `GC` module's wrappers should be used instead (described below).
 
 ## Garbage Collector
 

--- a/docs/contributor/memory_management.md
+++ b/docs/contributor/memory_management.md
@@ -21,7 +21,7 @@ export let _RESERVED_RUNTIME_SPACE: WasmI32
  * @param nbytes: WasmI32 - The number of bytes to allocate
  * @return WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
  */
-export let malloc: (nbytes: WasmI32) => WasmI32
+export let malloc: (nbytes: WasmI32) -> WasmI32
 
 /**
  * Frees the given allocated pointer.


### PR DESCRIPTION
This will probably need some revisions based on reviewer feedback, but I wanted to have a go at documenting the Grain memory system, since a lot of details are not recorded anywhere and contributors such as @cician and @jozanza are interacting with low-level runtime code on a regular basis.