### PR TITLE
fix(stdlib): Fixed memory leak in the print function.

### DIFF
--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -572,7 +572,8 @@ export let toString = (value) => {
 
 @disableGC
 export let print = (value) => {
-  let ptr = WasmI32.fromGrain(toString(value))
+  let s = toString(value)
+  let ptr = WasmI32.fromGrain(s)
   let buf = Memory.malloc(37n)
   let iov = buf
   let written = buf + 32n
@@ -584,4 +585,11 @@ export let print = (value) => {
   WasmI32.store(iov, 1n, 12n)
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
+
+  // Deallocate the temporary string created from the input value, except in
+  // case the input value is already a string, in which case toString returns
+  // the same instance passed as input.
+  if (ptr != WasmI32.fromGrain(value)) {
+    Memory.free(ptr)
+  }
 }

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -280,6 +280,10 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
   match (tag) {
     t when t == Tags._GRAIN_STRING_HEAP_TAG => {
       if (toplevel) {
+        // We can just return the pointer since its already a string and
+        // doesn't need escaping in this case, but by convention its reference
+        // count needs to be incremented.
+        Memory.incRef(ptr)
         WasmI32.toGrain(ptr): String
       } else {
         escapeString(WasmI32.toGrain(ptr))
@@ -572,6 +576,11 @@ export let toString = (value) => {
 
 @disableGC
 export let print = (value) => {
+  // First convert the value to string, if it isn't one already. Calling
+  // toString will either return value instance itself if it's already a
+  // string, or a new string with the content of value object, which will need
+  // to be deallocated. In either case it's sufficient to force decrement its
+  // reference count.
   let s = toString(value)
   let ptr = WasmI32.fromGrain(s)
   let buf = Memory.malloc(37n)
@@ -585,11 +594,6 @@ export let print = (value) => {
   WasmI32.store(iov, 1n, 12n)
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
-
-  // Deallocate the temporary string created from the input value, except in
-  // case the input value is already a string, in which case toString returns
-  // the same instance passed as input.
-  if (ptr != WasmI32.fromGrain(value)) {
-    Memory.free(ptr)
-  }
+  Memory.decRef(ptr)
+  void
 }


### PR DESCRIPTION
This PR fixes a memory leak in the print function.

The intermediate string created was not freed. I'm not entirely sure I'm using the "right" free. Or maybe I should call decRef instead?

ps: I was using print to debug memory leaks, which lead me to the memory leak in print. So then I used print to debug the memory leak in print. 🤟