### PR TITLE
feat(compiler): Emit unoptimized wat file when `--debug` and `--wat` are enabled

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3501,7 +3501,6 @@ let compile_wasm_module = (~env=?, ~name=?, prog) => {
     Bytes.to_string(serialized_cmi),
   );
   validate_module(~name?, wasm_mod);
-  Module.optimize(wasm_mod);
   wasm_mod;
 };
 

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -12,6 +12,16 @@ let emit_module = ({asm, signature}, outfile) => {
     output_string(oc, sig_string);
     close_out(oc);
   };
+  // Emit unoptimized version of module if debug and wat set:
+  if (Config.wat^ && Config.debug^) {
+    Binaryen.Settings.set_colors_enabled(Grain_utils.Config.color_enabled^);
+    let asm_string = Binaryen.Module.write_text(asm);
+    let wat_file = Files.replace_extension(outfile, "unoptimized.wat");
+    let oc = open_out(wat_file);
+    output_string(oc, asm_string);
+    close_out(oc);
+  };
+  Binaryen.Module.optimize(asm);
   if (Config.wat^) {
     Binaryen.Settings.set_colors_enabled(Grain_utils.Config.color_enabled^);
     let asm_string = Binaryen.Module.write_text(asm);


### PR DESCRIPTION
This is a QOL improvement PR which facilitates easier debugging of `compcore.re`. When `--wat` and `--debug` are passed to the compiler, it will emit an additional `<file>.unoptimized.wat` file containing the WebAssembly module _prior_ to the call to `Module.optimize` (which directly reflects the instructions emitted in `compcore.re`).