### PR TITLE
chore(docs): Add `@since` and `@history` annotations for Array

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1,6 +1,11 @@
 /**
  * @module Array: Utilities for working with arrays.
+ *
  * @example import Array from "array"
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `arrays`
+ * @history v0.2.0: Renamed to `array`
  */
 
 import WasmI32 from "runtime/unsafe/wasmi32"
@@ -32,6 +37,9 @@ let initLength = (length) => {
  * Returns the length of the input array.
  *
  * @param array: The array to inspect
+ * @returns The amount of elements in the array
+ *
+ * @since v0.1.0
  */
 @disableGC
 export let length = (array) => {
@@ -48,6 +56,8 @@ export let length = (array) => {
  * @returns The new array
  *
  * @example Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
+ *
+ * @since v0.1.0
  */
 @disableGC
 export let make : (Number, a) -> Array<a>  = (length, item) => {
@@ -70,6 +80,8 @@ export let make : (Number, a) -> Array<a>  = (length, item) => {
  * @returns The new array
  *
  * @example Array.init(5, n => n + 3) // [> 8, 9, 10, 11, 12]
+ *
+ * @since v0.1.0
  */
 @disableGC
 export let init : (Number, Number -> a) -> Array<a> = (length, fn) => {
@@ -93,6 +105,9 @@ export let init : (Number, Number -> a) -> Array<a> = (length, fn) => {
  * @param index: The index to access
  * @param array: The array to access
  * @returns The element from the array
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Argument order changed to data-last
  */
 export let get = (index, array) => {
   array[index]
@@ -107,6 +122,9 @@ export let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Argument order changed to data-last
  */
 export let set = (index, value, array) => {
   array[index] = value
@@ -119,6 +137,8 @@ export let set = (index, value, array) => {
  * @param array1: The array containing elements to appear first
  * @param array2: The array containing elements to appear second
  * @returns The new array containing elements from `array1` followed by elements from `array2`
+ *
+ * @since v0.1.0
  */
 export let append = (array1, array2) => {
   let len1 = length(array1)
@@ -139,6 +159,8 @@ export let append = (array1, array2) => {
  *
  * @param arrays: A list containing all arrays to combine
  * @returns The new array
+ *
+ * @since v0.1.0
  */
 export let concat = (arrays) => {
   // This function is slightly verbose to avoid depending on the List stdlib.
@@ -179,6 +201,8 @@ export let concat = (arrays) => {
  *
  * @param array: The array to copy
  * @returns The new array containing the elements from the input
+ *
+ * @since v0.1.0
  */
 export let copy = (array) => {
   init(length(array), n => array[n])
@@ -189,6 +213,9 @@ export let copy = (array) => {
  *
  * @param fn: The iterator function to call with each element
  * @param array: The array to iterate
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Argument order changed to data-last
  */
 export let forEach = (fn, array) => {
   let length = length(array)
@@ -205,6 +232,9 @@ export let forEach = (fn, array) => {
  *
  * @param fn: The iterator function to call with each element
  * @param array: The array to iterate
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Argument order changed to data-last
  */
 export let forEachi = (fn, array) => {
   let length = length(array)
@@ -222,6 +252,9 @@ export let forEachi = (fn, array) => {
  * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new array
  * @param array: The array to iterate
  * @returns The new array with mapped values
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Argument order changed to data-last
  */
 export let map = (fn, array) => {
   let length = length(array)
@@ -237,6 +270,8 @@ export let map = (fn, array) => {
  * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new array
  * @param array: The array to iterate
  * @returns The new array with mapped values
+ *
+ * @since v0.1.0
  */
 export let mapi = (fn, array) => {
   let length = length(array)
@@ -260,6 +295,8 @@ export let mapi = (fn, array) => {
  * @returns The final accumulator returned from `fn`
  *
  * @example Array.reduce((a, b) => a + b, 0, [> 1, 2, 3]) // 6
+ *
+ * @since v0.3.0
  */
 export let reduce = (fn, initial, array) => {
   let mut acc = initial
@@ -281,6 +318,8 @@ export let reduce = (fn, initial, array) => {
  * @param initial: The initial value to use for the accumulator on the first iteration
  * @param array: The array to iterate
  * @returns The final accumulator returned from `fn`
+ *
+ * @since v0.3.0
  */
 export let reducei = (fn, initial, array) => {
   let mut acc = initial
@@ -297,6 +336,8 @@ export let reducei = (fn, initial, array) => {
  * @param fn: The function to be called on each element, where the value returned will be an array that gets appended to the new array
  * @param array: The array to iterate
  * @returns The new array
+ *
+ * @since v0.3.0
  */
 export let flatMap = (fn, array) => {
   reduce((result, value) => append(result, fn(value)), [>], array)
@@ -309,6 +350,8 @@ export let flatMap = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to check
  * @returns `true` if all elements satify the condition, otherwise `false`
+ *
+ * @since v0.3.0
  */
 export let every = (fn, array) => {
   reduce((acc, value) => { acc && fn(value) }, true, array)
@@ -321,6 +364,8 @@ export let every = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns `true` if one or more elements satify the condition, otherwise `false`
+ *
+ * @since v0.3.0
  */
 export let some = (fn, array) => {
   reduce((acc, value) => { acc || fn(value) }, false, array)
@@ -331,6 +376,8 @@ export let some = (fn, array) => {
  *
  * @param value: The value replacing each element
  * @param array: The array to update
+ *
+ * @since v0.2.0
  */
 export let fill = (value, array) => {
   let length = length(array)
@@ -348,6 +395,8 @@ export let fill = (value, array) => {
  * @param start: The index to begin replacement
  * @param stop: The (exclusive) index to end replacement
  * @param array: The array to update
+ *
+ * @since v0.2.0
  */
 export let fillRange = (value, start, stop, array) => {
   let length = length(array)
@@ -374,6 +423,8 @@ export let fillRange = (value, start, stop, array) => {
  *
  * @param array: The array to reverse
  * @returns The new array
+ *
+ * @since v0.4.0
  */
 export let reverse = (array) => {
   let len = length(array)
@@ -388,6 +439,8 @@ export let reverse = (array) => {
  *
  * @param array: The array to convert
  * @returns The list containing all elements from the array
+ *
+ * @since v0.1.0
  */
 export let toList = (array) => {
   let rec buildList = (acc, index) => {
@@ -406,6 +459,8 @@ export let toList = (array) => {
  *
  * @param list: The list to convert
  * @returns The array containing all elements from the list
+ *
+ * @since v0.1.0
  */
 export let fromList = (list) => {
   let rec listLength = (list, acc) => {
@@ -435,6 +490,8 @@ export let fromList = (list) => {
  * @param search: The value to compare
  * @param array: The array to iterate
  * @returns `true` if the value exists in the array, otherwise `false`
+ *
+ * @since v0.2.0
  */
 export let contains = (search, array) => {
   // TODO: This should use recursion when we can pattern match arrays
@@ -454,6 +511,8 @@ export let contains = (search, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to search
  * @returns `Some(element)` containing the first value found and `None` otherwise
+ *
+ * @since v0.2.0
  */
 export let find = (fn, array) => {
   let length = length(array)
@@ -486,6 +545,8 @@ export let find = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to search
  * @returns `Some(index)` containing the index of the first element found and `None` otherwise
+ *
+ * @since v0.2.0
  */
 export let findIndex = (fn, array) => {
   let length = length(array)
@@ -519,6 +580,8 @@ export let findIndex = (fn, array) => {
  * @param array1: The array to provide values for the first tuple element
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing all pairs of `(a, b)`
+ *
+ * @since v0.2.0
  */
 export let product = (array1, array2) => {
   let lenA = length(array1)
@@ -541,6 +604,8 @@ export let product = (array1, array2) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
+ *
+ * @since v0.2.0
  */
 export let count = (fn, array) => {
   let length = length(array)
@@ -564,6 +629,8 @@ export let count = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
+ *
+ * @since v0.3.0
  */
 export let counti = (fn, array) => {
   let length = length(array)
@@ -588,6 +655,8 @@ export let counti = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
+ *
+ * @since v0.3.0
  */
 export let filter = (fn, array) => {
   let filtered = copy(array)
@@ -611,6 +680,8 @@ export let filter = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
+ *
+ * @since v0.3.0
  */
 export let filteri = (fn, array) => {
   let filtered = copy(array)
@@ -632,6 +703,8 @@ export let filteri = (fn, array) => {
  *
  * @param array: The array to filter
  * @returns The new array with only unique values
+ *
+ * @since v0.3.0
  */
 export let unique = (array) => {
   filteri(
@@ -650,6 +723,8 @@ export let unique = (array) => {
  * @param array1: The array to provide values for the first tuple element
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing indexed pairs of `(a, b)`
+ *
+ * @since v0.4.0
  */
 export let zip = (array1, array2) => {
   let len = length(array1)
@@ -667,6 +742,8 @@ export let zip = (array1, array2) => {
  *
  * @param array: The array of tuples to split
  * @returns An array containing all elements from the first tuple element, and an array containing all elements from the second tuple element
+ *
+ * @since v0.4.0
  */
 export let unzip = (array) => {
   let lenArr = length(array)
@@ -688,6 +765,8 @@ export let unzip = (array) => {
  * @param separator: The separator to insert between items in the string
  * @param items: The input strings
  * @returns The concatenated string
+ *
+ * @since v0.4.0
  */
 export let join = (separator: String, items: Array<String>) => {
   let iter = (acc, str) => {
@@ -713,6 +792,8 @@ export let join = (separator: String, items: Array<String>) => {
  * @param endIndex: The index of the array where the slice will end (exclusive)
  * @param array: The array to be sliced
  * @returns The subset of the array that was sliced
+ *
+ * @since v0.4.0
  */
 export let slice = (startIndex, endIndex, array) => {
   let arrayLength = length(array)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -37,7 +37,7 @@ let initLength = (length) => {
  * Returns the length of the input array.
  *
  * @param array: The array to inspect
- * @returns The amount of elements in the array
+ * @returns The number of elements in the array
  *
  * @since v0.1.0
  */

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -1,0 +1,1008 @@
+---
+title: Array
+---
+
+Utilities for working with arrays.
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `arrays`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `array`</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+import Array from "array"
+```
+
+## Values
+
+Functions for working with the Array data type.
+
+### Array.**length**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+length : Array<a> -> Number
+```
+
+Returns the length of the input array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<a>`|The array to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The amount of elements in the array|
+
+### Array.**make**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+make : (Number, a) -> Array<a>
+```
+
+Creates a new array of the specified length with each element being
+initialized with the given value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The length of the new array|
+|`item`|`a`|The value to store at each index|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array|
+
+Examples:
+
+```grain
+Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
+```
+
+### Array.**init**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+init : (Number, (Number -> a)) -> Array<a>
+```
+
+Creates a new array of the specified length where each element is
+initialized with the result of an initializer function. The initializer
+is called with the index of each array element.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The length of the new array|
+|`fn`|`Number -> a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array|
+
+Examples:
+
+```grain
+Array.init(5, n => n + 3) // [> 8, 9, 10, 11, 12]
+```
+
+### Array.**get**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Argument order changed to data-last</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+get : (Number, Array<a>) -> a
+```
+
+An alias for normal syntactic array access, i.e. `array[n]`.
+
+Retrieves the element from the array at the specified index.
+A negative index is treated as an offset from the end of the array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`index`|`Number`|The index to access|
+|`array`|`Array<a>`|The array to access|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`a`|The element from the array|
+
+### Array.**set**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Argument order changed to data-last</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+set : (Number, a, Array<a>) -> Void
+```
+
+An alias for normal syntactic array set, i.e. `array[n] = value`.
+
+Sets the element at the specified index in the array to the new value.
+A negative index is treated as an offset from the end of the array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`index`|`Number`|The index to update|
+|`value`|`a`|The value to store|
+|`array`|`Array<a>`|The array to update|
+
+### Array.**append**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+append : (Array<a>, Array<a>) -> Array<a>
+```
+
+Creates a new array with the items the first array, followed by
+the items of the second array. This does not modify the arguments.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array1`|`Array<a>`|The array containing elements to appear first|
+|`array2`|`Array<a>`|The array containing elements to appear second|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array containing elements from `array1` followed by elements from `array2`|
+
+### Array.**concat**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+concat : List<Array<a>> -> Array<a>
+```
+
+Creates a single array containing the elements of all arrays in the
+provided list. Does not modify any of the input arguments.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`arrays`|`List<Array<a>>`|A list containing all arrays to combine|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array|
+
+### Array.**copy**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+copy : Array<a> -> Array<a>
+```
+
+Produces a shallow copy of the input array. The new array contains the
+same elements as the original.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<a>`|The array to copy|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array containing the elements from the input|
+
+### Array.**forEach**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Argument order changed to data-last</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+forEach : ((a -> b), Array<a>) -> Void
+```
+
+Iterates an array, calling an iterator function on each element.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> b`|The iterator function to call with each element|
+|`array`|`Array<a>`|The array to iterate|
+
+### Array.**forEachi**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Argument order changed to data-last</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+forEachi : (((a, Number) -> b), Array<a>) -> Void
+```
+
+Iterates an array, calling an iterator function with each element.
+Also passes the index as the second argument to the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> b`|The iterator function to call with each element|
+|`array`|`Array<a>`|The array to iterate|
+
+### Array.**map**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Argument order changed to data-last</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+map : ((a -> b), Array<a>) -> Array<b>
+```
+
+Produces a new array initialized with the results of a mapper function
+called on each element of the input array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array with mapped values|
+
+### Array.**mapi**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+mapi : (((a, Number) -> b), Array<a>) -> Array<b>
+```
+
+Produces a new array initialized with the results of a mapper function
+called on each element of the input array and its index.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array with mapped values|
+
+### Array.**reduce**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reduce : (((a, b) -> a), a, Array<b>) -> a
+```
+
+Combines all elements of an array using a reducer function,
+starting from the "head", or left side, of the array.
+
+In `Array.reduce(fn, initial, array)`, `fn` is called with
+an accumulator and each element of the array, and returns
+a new accumulator. The final value is the last accumulator
+returned. The accumulator starts with value `initial`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`initial`|`a`|The initial value to use for the accumulator on the first iteration|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`a`|The final accumulator returned from `fn`|
+
+Examples:
+
+```grain
+Array.reduce((a, b) => a + b, 0, [> 1, 2, 3]) // 6
+```
+
+### Array.**reducei**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reducei : (((a, b, Number) -> a), a, Array<b>) -> a
+```
+
+Combines all elements of an array using a reducer function,
+starting from the "head", or left side, of the array.
+
+In `Array.reducei(fn, initial, array)`, `fn` is called with
+an accumulator, each element of the array, and the index
+of that element, and returns a new accumulator. The final
+value is the last accumulator returned. The accumulator
+starts with value `initial`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, b, Number) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`initial`|`a`|The initial value to use for the accumulator on the first iteration|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`a`|The final accumulator returned from `fn`|
+
+### Array.**flatMap**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+flatMap : ((a -> Array<b>), Array<a>) -> Array<b>
+```
+
+Produces a new array by calling a function on each element
+of the input array. Each iteration produces an intermediate
+array, which are all appended to produce a "flattened" array
+of all results.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Array<b>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array|
+
+### Array.**every**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+every : ((a -> Bool), Array<a>) -> Bool
+```
+
+Checks that the given condition is satisfied for all
+elements in the input array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to check|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if all elements satify the condition, otherwise `false`|
+
+### Array.**some**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+some : ((a -> Bool), Array<a>) -> Bool
+```
+
+Checks that the given condition is satisfied **at least
+once** by an item in the input array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if one or more elements satify the condition, otherwise `false`|
+
+### Array.**fill**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fill : (a, Array<a>) -> Void
+```
+
+Replaces all elements in an array with the new value provided.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`a`|The value replacing each element|
+|`array`|`Array<a>`|The array to update|
+
+### Array.**fillRange**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fillRange : (a, Number, Number, Array<a>) -> Void
+```
+
+Replaces all elements in the provided index range in the array
+with the new value provided. Fails if the index is out-of-bounds.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`a`|The value replacing each element between the indexes|
+|`start`|`Number`|The index to begin replacement|
+|`stop`|`Number`|The (exclusive) index to end replacement|
+|`array`|`Array<a>`|The array to update|
+
+### Array.**reverse**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reverse : Array<a> -> Array<a>
+```
+
+Creates a new array with all elements in reverse order.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<a>`|The array to reverse|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array|
+
+### Array.**toList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toList : Array<a> -> List<a>
+```
+
+Converts the input array to a list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<a>`|The array to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The list containing all elements from the array|
+
+### Array.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : List<a> -> Array<a>
+```
+
+Converts the input list to an array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The array containing all elements from the list|
+
+### Array.**contains**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+contains : (a, Array<a>) -> Bool
+```
+
+Checks if the value is an element of the input array.
+Uses the generic `==` structural equality operator.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`search`|`a`|The value to compare|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the value exists in the array, otherwise `false`|
+
+### Array.**find**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+find : ((a -> Bool), Array<a>) -> Option<a>
+```
+
+Finds the first element in an array that satifies the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to search|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|`Some(element)` containing the first value found and `None` otherwise|
+
+### Array.**findIndex**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+findIndex : ((a -> Bool), Array<a>) -> Option<Number>
+```
+
+Finds the first index in an array where the element satifies the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to search|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<Number>`|`Some(index)` containing the index of the first element found and `None` otherwise|
+
+### Array.**product**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+product : (Array<a>, Array<a0>) -> Array<(a, a0)>
+```
+
+Combines two arrays into a Cartesian product of tuples containing
+all ordered pairs `(a, b)`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array1`|`Array<a>`|The array to provide values for the first tuple element|
+|`array2`|`Array<a>`|The array to provide values for the second tuple element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<(a, a0)>`|The new array containing all pairs of `(a, b)`|
+
+### Array.**count**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+count : ((a -> Bool), Array<a>) -> Number
+```
+
+Counts the number of elements in an array that satisfy the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The total number of elements that satisfy the condition|
+
+### Array.**counti**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+counti : (((a, Number) -> Bool), Array<a>) -> Number
+```
+
+Counts the number of elements in an array that satisfy the
+given condition. Also passes the index to the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The total number of elements that satisfy the condition|
+
+### Array.**filter**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+filter : ((a -> Bool), Array<a>) -> Array<a>
+```
+
+Produces a new array by calling a function on each element of
+the input array and only including it in the result array if the element satisfies
+the condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array containing elements where `fn` returned `true`|
+
+### Array.**filteri**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+filteri : (((a, Number) -> Bool), Array<a>) -> Array<a>
+```
+
+Produces a new array by calling a function on each element of
+the input array and only including it in the result array if the element satisfies
+the condition. Also passes the index to the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`array`|`Array<a>`|The array to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array containing elements where `fn` returned `true`|
+
+### Array.**unique**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+unique : Array<a> -> Array<a>
+```
+
+Produces a new array with any duplicates removed.
+Uses the generic `==` structural equality operator.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<a>`|The array to filter|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The new array with only unique values|
+
+### Array.**zip**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+zip : (Array<a>, Array<a0>) -> Array<(a, a0)>
+```
+
+Produces a new array filled with tuples of elements from both given arrays.
+The first tuple will contain the first item of each array, the second tuple
+will contain the second item of each array, and so on.
+
+Calling this function with arrays of different sizes will throw an error.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array1`|`Array<a>`|The array to provide values for the first tuple element|
+|`array2`|`Array<a>`|The array to provide values for the second tuple element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<(a, a0)>`|The new array containing indexed pairs of `(a, b)`|
+
+### Array.**unzip**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+unzip : Array<(a, b)> -> (Array<a>, Array<b>)
+```
+
+Produces two arrays by splitting apart an array of tuples.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`array`|`Array<(a, b)>`|The array of tuples to split|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`(Array<a>, Array<b>)`|An array containing all elements from the first tuple element, and an array containing all elements from the second tuple element|
+
+### Array.**join**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+join : (String, Array<String>) -> String
+```
+
+Concatenates an array of strings into a single string, separated by a separator string.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`separator`|`String`|The separator to insert between items in the string|
+|`items`|`Array<String>`|The input strings|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|The concatenated string|
+
+### Array.**slice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+slice : (Number, Number, Array<a>) -> Array<a>
+```
+
+Slices an array given zero-based start and end indexes. The value
+at the end index will not be included in the result.
+
+If either index is a negative number, it will be treated as a reverse index from
+the end of the array. e.g. `slice(1, -1, [> 'a', 'b', 'c']) == [> 'b']`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`startIndex`|`Number`|The index of the array where the slice will begin (inclusive)|
+|`endIndex`|`Number`|The index of the array where the slice will end (exclusive)|
+|`array`|`Array<a>`|The array to be sliced|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Array<a>`|The subset of the array that was sliced|
+


### PR DESCRIPTION
This updates the Array module doc blocks with `@since` and `@history` attributes. I also noticed that I missed 1 `@returns` in my initial PR.

I also checked in the generated `array.md` file.