### PR TITLE
feat(stdlib)!: Convert sys functions to return Results instead of throwing errors

### DIFF
--- a/compiler/test/stdlib/sys.file.test.gr
+++ b/compiler/test/stdlib/sys.file.test.gr
@@ -1,7 +1,8 @@
 import Fs from "sys/file"
+import Result from "result"
 
 // fdRead
-let foo = Fs.pathOpen(
+let foo = Result.unwrap(Fs.pathOpen(
   Fs.pwdfd,
   [Fs.SymlinkFollow],
   "test/test-data/foo.txt",
@@ -9,9 +10,9 @@ let foo = Fs.pathOpen(
   [Fs.FdRead],
   [Fs.FdRead],
   []
-)
+))
 
-let (buf, nread) = Fs.fdRead(foo, 40)
+let (buf, nread) = Result.unwrap(Fs.fdRead(foo, 40))
 
 Fs.fdClose(foo)
 
@@ -19,7 +20,7 @@ assert buf == "foo, bar, & baz"
 assert nread == 15
 
 // fdWrite
-let foo = Fs.pathOpen(
+let foo = Result.unwrap(Fs.pathOpen(
   Fs.pwdfd,
   [Fs.SymlinkFollow],
   "test/test-data/bar.txt",
@@ -27,13 +28,13 @@ let foo = Fs.pathOpen(
   [Fs.FdRead, Fs.FdWrite, Fs.FdSeek, Fs.FdSetSize],
   [Fs.FdRead, Fs.FdWrite, Fs.FdSeek, Fs.FdSetSize],
   []
-)
+))
 
-assert Fs.fdWrite(foo, "this and that") == 13
+assert Fs.fdWrite(foo, "this and that") == Ok(13)
 
 Fs.fdSeek(foo, 0L, Fs.Set)
 
-let (buf, nread) = Fs.fdRead(foo, 40)
+let (buf, nread) = Result.unwrap(Fs.fdRead(foo, 40))
 
 Fs.fdSetSize(foo, 0L)
 

--- a/compiler/test/stdlib/sys.process.test.gr
+++ b/compiler/test/stdlib/sys.process.test.gr
@@ -1,3 +1,22 @@
+import Array from "array"
 import Process from "sys/process"
+
+// Just a smoke test
+match (Process.argv()) {
+  Ok(arr) => assert Array.length(arr) > 0,
+  Err(err) => throw err
+}
+
+// Just a smoke test
+match (Process.env()) {
+  Ok(arr) => assert Array.length(arr) > 0,
+  Err(err) => throw err
+}
+
+// Just a smoke test
+match (Process.sigRaise(Process.VTALRM)) {
+  Ok(a) => assert a == void,
+  Err(err) => throw err
+}
 
 Process.exit(5)

--- a/compiler/test/stdlib/sys.random.test.gr
+++ b/compiler/test/stdlib/sys.random.test.gr
@@ -1,0 +1,11 @@
+import Random from "sys/random"
+
+let r1 = Random.random()
+let r2 = Random.random()
+
+// Just a smoke test, there's a miniscule chance this could fail
+match ((r1, r2)) {
+  (Ok(x), Ok(y)) => assert x != y,
+  (Err(err), _) => throw err,
+  (_, Err(err)) => throw err
+}

--- a/compiler/test/stdlib/sys.time.test.gr
+++ b/compiler/test/stdlib/sys.time.test.gr
@@ -3,11 +3,12 @@ import {
 } from "int64"
 import Time from "sys/time"
 
-let t1 = Time.realTime()
-let t2 = Time.realTime()
+
+let t1 = Time.monotonicTime()
+let t2 = Time.monotonicTime()
 
 match ((t1, t2)) {
-  (Ok(x), Ok(y)) => assert x < y,
+  (Ok(x), Ok(y)) => x < y,
   (Err(err), _) => throw err,
   (_, Err(err)) => throw err
 }

--- a/compiler/test/stdlib/sys.time.test.gr
+++ b/compiler/test/stdlib/sys.time.test.gr
@@ -1,0 +1,13 @@
+import {
+  lt as (<)
+} from "int64"
+import Time from "sys/time"
+
+let t1 = Time.realTime()
+let t2 = Time.realTime()
+
+match ((t1, t2)) {
+  (Ok(x), Ok(y)) => assert x < y,
+  (Err(err), _) => throw err,
+  (_, Err(err)) => throw err
+}

--- a/compiler/test/stdlib/sys.time.test.gr
+++ b/compiler/test/stdlib/sys.time.test.gr
@@ -3,12 +3,41 @@ import {
 } from "int64"
 import Time from "sys/time"
 
+let mt1 = Time.monotonicTime()
+let mt2 = Time.monotonicTime()
 
-let t1 = Time.monotonicTime()
-let t2 = Time.monotonicTime()
-
-match ((t1, t2)) {
-  (Ok(x), Ok(y)) => x < y,
+// Just a smoke test, there's a chance this could fail
+match ((mt1, mt2)) {
+  (Ok(x), Ok(y)) => assert x < y,
   (Err(err), _) => throw err,
   (_, Err(err)) => throw err
+}
+
+let pct1 = Time.processCpuTime()
+let pct2 = Time.processCpuTime()
+
+// Just a smoke test, there's a chance this could fail
+match ((pct1, pct2)) {
+  (Ok(x), Ok(y)) => assert x < y,
+  (Err(err), _) => throw err,
+  (_, Err(err)) => throw err
+}
+
+let tct1 = Time.threadCpuTime()
+let tct2 = Time.threadCpuTime()
+
+// Just a smoke test, there's a chance this could fail
+match ((tct1, tct2)) {
+  (Ok(x), Ok(y)) => assert x < y,
+  (Err(err), _) => throw err,
+  (_, Err(err)) => throw err
+}
+
+let epoch = 0L
+let rt = Time.realTime()
+
+// Just a smoke test, there's a chance this could fail if system dates are bad
+match (rt) {
+  Ok(now) => assert epoch < now,
+  Err(err) => throw err,
 }

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -105,6 +105,7 @@ describe("stdlib", ({test}) => {
   assertStdlib("string.test");
   assertStdlib("sys.file.test");
   assertStdlib(~code=5, "sys.process.test");
+  assertStdlib("sys.random.test");
   assertStdlib("wasmf32.test");
   assertStdlib("wasmf64.test");
   assertStdlib("wasmi32.test");

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -106,6 +106,7 @@ describe("stdlib", ({test}) => {
   assertStdlib("sys.file.test");
   assertStdlib(~code=5, "sys.process.test");
   assertStdlib("sys.random.test");
+  assertStdlib("sys.time.test");
   assertStdlib("wasmf32.test");
   assertStdlib("wasmf64.test");
   assertStdlib("wasmi32.test");

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -381,14 +381,14 @@ export let pathOpen = (
   )
   if (err != Wasi._ESUCCESS) {
     Memory.free(newFd)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let fd = FileDescriptor(tagSimpleNumber(WasmI32.load(newFd, 0n)))
+
+    Memory.free(newFd)
+
+    Ok(fd)
   }
-
-  let fd = FileDescriptor(tagSimpleNumber(WasmI32.load(newFd, 0n)))
-
-  Memory.free(newFd)
-
-  fd
 }
 
 // Read from a file descriptor
@@ -414,16 +414,16 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    nread = WasmI32.load(nread, 0n)
+
+    WasmI32.store(strPtr, nread, 4n)
+
+    Memory.free(iovs)
+
+    Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
-
-  nread = WasmI32.load(nread, 0n)
-
-  WasmI32.store(strPtr, nread, 4n)
-
-  Memory.free(iovs)
-
-  (WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread))
 }
 
 // Read from a file descriptor without updating the file descriptor's offset
@@ -452,16 +452,16 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    nread = WasmI32.load(nread, 0n)
+
+    WasmI32.store(strPtr, nread, 4n)
+
+    Memory.free(iovs)
+
+    Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
-
-  nread = WasmI32.load(nread, 0n)
-
-  WasmI32.store(strPtr, nread, 4n)
-
-  Memory.free(iovs)
-
-  (WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread))
 }
 
 // Write to a file descriptor
@@ -484,14 +484,14 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
   let err = Wasi.fd_write(fd, iovs, 1n, nwritten)
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    nwritten = WasmI32.load(nwritten, 0n)
+
+    Memory.free(iovs)
+
+    Ok(tagSimpleNumber(nwritten))
   }
-
-  nwritten = WasmI32.load(nwritten, 0n)
-
-  Memory.free(iovs)
-
-  tagSimpleNumber(nwritten)
 }
 
 // Write to a file descriptor without updating the file descriptor's offset
@@ -517,14 +517,14 @@ export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
   let err = Wasi.fd_pwrite(fd, iovs, 1n, offset, nwritten)
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    nwritten = WasmI32.load(nwritten, 0n)
+
+    Memory.free(iovs)
+
+    Ok(tagSimpleNumber(nwritten))
   }
-
-  nwritten = WasmI32.load(nwritten, 0n)
-
-  Memory.free(iovs)
-
-  tagSimpleNumber(nwritten)
 }
 
 // Allocate space within a file
@@ -542,7 +542,9 @@ export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
 
   let err = Wasi.fd_allocate(fd, offset, size)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -555,7 +557,9 @@ export let fdClose = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_close(fd)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -568,7 +572,9 @@ export let fdDatasync = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_datasync(fd)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -581,7 +587,9 @@ export let fdSync = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_sync(fd)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -613,41 +621,41 @@ export let fdStats = (fd: FileDescriptor) => {
   let err = Wasi.fd_fdstat_get(fd, structPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(structPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let filetype = WasmI32.load8U(structPtr, 0n)
+
+    let filetype = filetypeFromNumber(filetype)
+
+    let flagsToWasmVal = (flag, i) => {
+      let fdflags = WasmI32.load16U(structPtr, 4n)
+      WasmI32.gtU((fdflags & (1n << (WasmI32.fromGrain(i) >> 1n))), 0n)
+    }
+    let fdflagsList = List.filteri(flagsToWasmVal, orderedFdflags)
+    Memory.free(WasmI32.fromGrain(flagsToWasmVal))
+
+    let (&) = WasmI64.and
+    let (>) = WasmI64.gtU
+    let (<<) = WasmI64.shl
+
+    let flagsToWasmVal = (flag, i) => {
+      let rights = WasmI64.load(structPtr, 8n)
+      (rights & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
+    }
+    let rightsList = List.filteri(flagsToWasmVal, orderedRights)
+    Memory.free(WasmI32.fromGrain(flagsToWasmVal))
+
+    let flagsToWasmVal = (flag, i) => {
+      let rightsInheriting = WasmI64.load(structPtr, 16n)
+      (rightsInheriting & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
+    }
+    let rightsInheritingList = List.filteri(flagsToWasmVal, orderedRights)
+    Memory.free(WasmI32.fromGrain(flagsToWasmVal))
+
+    Memory.free(structPtr)
+
+    Ok({ filetype, flags: fdflagsList, rights: rightsList, rightsInheriting: rightsInheritingList })
   }
-
-  let filetype = WasmI32.load8U(structPtr, 0n)
-
-  let filetype = filetypeFromNumber(filetype)
-
-  let flagsToWasmVal = (flag, i) => {
-    let fdflags = WasmI32.load16U(structPtr, 4n)
-    WasmI32.gtU((fdflags & (1n << (WasmI32.fromGrain(i) >> 1n))), 0n)
-  }
-  let fdflagsList = List.filteri(flagsToWasmVal, orderedFdflags)
-  Memory.free(WasmI32.fromGrain(flagsToWasmVal))
-
-  let (&) = WasmI64.and
-  let (>) = WasmI64.gtU
-  let (<<) = WasmI64.shl
-
-  let flagsToWasmVal = (flag, i) => {
-    let rights = WasmI64.load(structPtr, 8n)
-    (rights & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
-  }
-  let rightsList = List.filteri(flagsToWasmVal, orderedRights)
-  Memory.free(WasmI32.fromGrain(flagsToWasmVal))
-
-  let flagsToWasmVal = (flag, i) => {
-    let rightsInheriting = WasmI64.load(structPtr, 16n)
-    (rightsInheriting & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
-  }
-  let rightsInheritingList = List.filteri(flagsToWasmVal, orderedRights)
-  Memory.free(WasmI32.fromGrain(flagsToWasmVal))
-
-  Memory.free(structPtr)
-
-  { filetype, flags: fdflagsList, rights: rightsList, rightsInheriting: rightsInheritingList }
 }
 
 // Update the flags associated with a file descriptor
@@ -662,7 +670,9 @@ export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
 
   let err = Wasi.fd_fdstat_set_flags(fd, flags)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -680,7 +690,9 @@ export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheri
 
   let err = Wasi.fd_fdstat_set_rights(fd, rights, rightsInheriting)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -697,21 +709,21 @@ export let fdFilestats = (fd: FileDescriptor) => {
   let err = Wasi.fd_filestat_get(fd, filestats)
   if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
+    let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
+    let filetype = filetypeFromNumber(WasmI32.load8U(filestats, 16n))
+    let linkcount = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 24n))): Int64
+    let size = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 32n))): Int64
+    let accessed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 40n))): Int64
+    let modified = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 48n))): Int64
+    let changed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 56n))): Int64
+
+    Memory.free(filestats)
+
+    Ok({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
-
-  let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
-  let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
-  let filetype = filetypeFromNumber(WasmI32.load8U(filestats, 16n))
-  let linkcount = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 24n))): Int64
-  let size = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 32n))): Int64
-  let accessed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 40n))): Int64
-  let modified = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 48n))): Int64
-  let changed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 56n))): Int64
-
-  Memory.free(filestats)
-
-  { device, inode, filetype, linkcount, size, accessed, modified, changed }
 }
 
 // Set (truncate) the size of a file
@@ -726,7 +738,9 @@ export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
 
   let err = Wasi.fd_filestat_set_size(fd, size)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -742,7 +756,9 @@ export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
 
   let err = Wasi.fd_filestat_set_times(fd, time, 0N, Wasi._TIME_SET_ATIM)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -755,7 +771,9 @@ export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -771,7 +789,9 @@ export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, time, Wasi._TIME_SET_MTIM)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -784,7 +804,9 @@ export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -808,86 +830,93 @@ export let fdReaddir = (fd: FileDescriptor) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
     Memory.free(bufUsed)
-    throw Wasi.SystemError(tagSimpleNumber(err))
-  }
-
-  let used = WasmI32.load(bufUsed, 0n)
-
-  if (used <= 0n) {
-    Memory.free(buf)
-    Memory.free(bufUsed)
-    WasmI32.toGrain(allocateArray(0n)): Array<DirectoryEntry>
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    bufLen = WasmI32.load(buf, 16n) + structWidth * 2n
+    let used = WasmI32.load(bufUsed, 0n)
 
-    Memory.free(buf)
+    if (used <= 0n) {
+      Memory.free(buf)
+      Memory.free(bufUsed)
+      Ok(WasmI32.toGrain(allocateArray(0n)): Array<DirectoryEntry>)
+    } else {
+      bufLen = WasmI32.load(buf, 16n) + structWidth * 2n
 
-    // simple linked list
-    // ptr +0n -> current buffer
-    // ptr +4n -> bufs
-    let mut bufs = 0n
+      Memory.free(buf)
 
-    let mut numEntries = 0n
+      // simple linked list
+      // ptr +0n -> current buffer
+      // ptr +4n -> bufs
+      let mut bufs = 0n
 
-    while (true) {
-      numEntries += 1n
+      let mut numEntries = 0n
+      let mut hasErr = None
 
-      buf = Memory.malloc(bufLen)
-      let cons = Memory.malloc(8n)
-      WasmI32.store(cons, buf, 0n)
-      WasmI32.store(cons, bufs, 4n)
-      bufs = cons
+      while (true) {
+        numEntries += 1n
 
-      let err = Wasi.fd_readdir(fd, buf, bufLen, cookie, bufUsed)
-      if (err != Wasi._ESUCCESS) {
-        while (bufs != 0n) {
-          Memory.free(WasmI32.load(bufs, 0n))
-          let next = WasmI32.load(bufs, 4n)
-          Memory.free(bufs)
-          bufs = next
+        buf = Memory.malloc(bufLen)
+        let cons = Memory.malloc(8n)
+        WasmI32.store(cons, buf, 0n)
+        WasmI32.store(cons, bufs, 4n)
+        bufs = cons
+
+        let err = Wasi.fd_readdir(fd, buf, bufLen, cookie, bufUsed)
+        if (err != Wasi._ESUCCESS) {
+          while (bufs != 0n) {
+            Memory.free(WasmI32.load(bufs, 0n))
+            let next = WasmI32.load(bufs, 4n)
+            Memory.free(bufs)
+            bufs = next
+          }
+          Memory.free(bufUsed)
+          hasErr = Some(Err(Wasi.SystemError(tagSimpleNumber(err))))
+          break
         }
-        Memory.free(bufUsed)
-        throw Wasi.SystemError(tagSimpleNumber(err))
+
+        if (WasmI32.load(bufUsed, 0n) != bufLen) {
+          break
+        } else {
+          let curLen = WasmI32.load(buf, 16n)
+          cookie = WasmI64.load(buf, 0n)
+          let nextDirentPtr = buf + structWidth + curLen
+          bufLen = WasmI32.load(nextDirentPtr, 16n) + structWidth * 2n
+        }
       }
 
-      if (WasmI32.load(bufUsed, 0n) != bufLen) {
-        break
-      } else {
-        let curLen = WasmI32.load(buf, 16n)
-        cookie = WasmI64.load(buf, 0n)
-        let nextDirentPtr = buf + structWidth + curLen
-        bufLen = WasmI32.load(nextDirentPtr, 16n) + structWidth * 2n
+      match (hasErr) {
+        Some(err) => err,
+        None => {
+          Memory.free(bufUsed)
+
+          let arr = allocateArray(numEntries)
+
+          for (let mut i = numEntries - 1n; i >= 0n; i -= 1n) {
+            let ent = WasmI32.load(bufs, 0n)
+
+            let inode = WasmI32.toGrain(newInt64(WasmI64.load(ent, 8n))): Int64
+
+            let dirnameLen = WasmI32.load(ent, 16n)
+            let dirname = allocateString(dirnameLen)
+            Memory.copy(dirname + 8n, ent + structWidth, dirnameLen)
+            let path = WasmI32.toGrain(dirname): String
+
+            let filetype = filetypeFromNumber(WasmI32.load8U(ent, 20n))
+
+            let dirent = { inode, path, filetype }
+
+            WasmI32.store(arr + i * 4n, WasmI32.fromGrain(dirent), 8n)
+
+            let next = WasmI32.load(bufs, 4n)
+            Memory.free(bufs)
+            Memory.free(ent)
+
+            bufs = next
+          }
+
+          Ok(WasmI32.toGrain(arr): Array<DirectoryEntry>)
+        }
       }
     }
-
-    Memory.free(bufUsed)
-
-    let arr = allocateArray(numEntries)
-
-    for (let mut i = numEntries - 1n; i >= 0n; i -= 1n) {
-      let ent = WasmI32.load(bufs, 0n)
-
-      let inode = WasmI32.toGrain(newInt64(WasmI64.load(ent, 8n))): Int64
-
-      let dirnameLen = WasmI32.load(ent, 16n)
-      let dirname = allocateString(dirnameLen)
-      Memory.copy(dirname + 8n, ent + structWidth, dirnameLen)
-      let path = WasmI32.toGrain(dirname): String
-
-      let filetype = filetypeFromNumber(WasmI32.load8U(ent, 20n))
-
-      let dirent = { inode, path, filetype }
-
-      WasmI32.store(arr + i * 4n, WasmI32.fromGrain(dirent), 8n)
-
-      let next = WasmI32.load(bufs, 4n)
-      Memory.free(bufs)
-      Memory.free(ent)
-
-      bufs = next
-    }
-
-    WasmI32.toGrain(arr): Array<DirectoryEntry>
   }
 }
 
@@ -905,7 +934,9 @@ export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
 
   let err = Wasi.fd_renumber(fromFd, toFd)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -933,10 +964,10 @@ export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
   let err = Wasi.fd_seek(fd, offset, whence, newoffsetPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(newoffset)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(WasmI32.toGrain(newoffset): Int64)
   }
-
-  WasmI32.toGrain(newoffset): Int64
 }
 
 // Read a file descriptor's offset
@@ -953,10 +984,10 @@ export let fdTell = (fd: FileDescriptor) => {
   let err = Wasi.fd_tell(fd, offsetPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(offset)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(WasmI32.toGrain(offset): Int64)
   }
-
-  WasmI32.toGrain(offset): Int64
 }
 
 
@@ -974,7 +1005,9 @@ export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_create_directory(fd, stringPtr + 8n, size)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -999,22 +1032,22 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
   let err = Wasi.path_filestat_get(fd, combinedDirFlags, pathPtr, pathSize, filestats)
   if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
+    let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
+    let filetype = filetypeFromNumber(WasmI32.load8U(filestats, 16n))
+    let linkcount = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 24n))): Int64
+    let size = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 32n))): Int64
+    let accessed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 40n))): Int64
+    let modified = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 48n))): Int64
+    let changed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 56n))): Int64
+
+
+    Memory.free(filestats)
+
+    Ok({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
-
-  let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
-  let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
-  let filetype = filetypeFromNumber(WasmI32.load8U(filestats, 16n))
-  let linkcount = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 24n))): Int64
-  let size = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 32n))): Int64
-  let accessed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 40n))): Int64
-  let modified = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 48n))): Int64
-  let changed = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 56n))): Int64
-
-
-  Memory.free(filestats)
-
-  { device, inode, filetype, linkcount, size, accessed, modified, changed }
 }
 
 // Set the access (created) time of a file
@@ -1037,7 +1070,9 @@ export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, 
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, time, 0N, Wasi._TIME_SET_ATIM)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1058,7 +1093,9 @@ export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1082,7 +1119,9 @@ export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, time, Wasi._TIME_SET_MTIM)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1103,7 +1142,9 @@ export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFl
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1132,7 +1173,9 @@ export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sou
 
   let err = Wasi.path_link(sourceFd, combinedDirFlags, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1153,7 +1196,9 @@ export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: St
 
   let err = Wasi.path_symlink(sourcePtr + 8n, sourceSize, fd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1170,7 +1215,9 @@ export let pathUnlink = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_unlink_file(fd, pathPtr + 8n, pathSize)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1198,13 +1245,13 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(grainStrPtr)
     Memory.free(nread)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let read = tagSimpleNumber(WasmI32.load(nread, 0n))
+    Memory.free(nread)
+
+    Ok((WasmI32.toGrain(grainStrPtr): String, read))
   }
-
-  let read = tagSimpleNumber(WasmI32.load(nread, 0n))
-  Memory.free(nread)
-
-  (WasmI32.toGrain(grainStrPtr): String, read)
 }
 
 // Remove a directory
@@ -1220,7 +1267,9 @@ export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_remove_directory(fd, pathPtr + 8n, pathSize)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -1246,6 +1295,8 @@ export let pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd:
 
   let err = Wasi.path_rename(sourceFd, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -1,4 +1,11 @@
 /* grainc-flags --no-gc */
+/**
+ * @module Sys/File: Utilities for accessing the filesystem & working with files.
+ *
+ * Many of the functions in this module are not intended to be used directly, but rather for other libraries to be built on top of them.
+ *
+ * @example import File from "sys/file"
+ */
 
 import WasmI32, {
   add as (+),
@@ -23,21 +30,26 @@ import { tagSimpleNumber, allocateArray, allocateString, loadAdtVal, newInt64, a
 
 import List from "list"
 
+/**
+ * @section Types: Type declarations included in the Sys/File module.
+ */
+
+/**
+ * Represents a handle to an open file on the system.
+ */
 export enum FileDescriptor {
   FileDescriptor(Number)
 }
 
-export let stdin = FileDescriptor(0)
-export let stdout = FileDescriptor(1)
-export let stderr = FileDescriptor(2)
-export let pwdfd = FileDescriptor(3)
-
+/**
+ * Flags that determine how paths should be resolved when looking up a file or directory.
+ */
 export enum LookupFlag {
   // Follow symlinks
   SymlinkFollow
 }
 
-
+// TODO(#775): This has specific ordering requirements because of ambiguous type inference
 let rec combineLookupFlagsHelp = (acc, dirflags) => {
   match (dirflags) {
     [hd, ...tl] => {
@@ -53,6 +65,9 @@ let combineLookupFlags = (dirflags) => {
   combineLookupFlagsHelp(0n, dirflags)
 }
 
+/**
+ * Flags that determine how a file or directory should be opened.
+ */
 export enum OpenFlag {
   // Create file if it does not exist.
   Create,
@@ -64,6 +79,7 @@ export enum OpenFlag {
   Truncate,
 }
 
+// TODO(#775): This has specific ordering requirements because of ambiguous type inference
 let rec combineOpenFlagsHelp = (acc, dirflags) => {
   match (dirflags) {
     [hd, ...tl] => {
@@ -82,6 +98,10 @@ let combineOpenFlags = (dirflags) => {
   combineOpenFlagsHelp(0n, dirflags)
 }
 
+/**
+ * Flags that determine which rights a `FileDescriptor` should have
+ * and which rights new `FileDescriptor`s should inherit from it.
+ */
 export enum Rights {
   // The right to invoke `fdDatasync`.
   // If `PathOpen` is set, includes the right to invoke
@@ -187,6 +207,7 @@ let _RIGHT_PATH_UNLINK_FILE = 67108864N
 let _RIGHT_POLL_FD_READWRITE = 134217728N
 let _RIGHT_SOCK_SHUTDOWN = 268435456N
 
+// TODO(#775): This has specific ordering requirements because of ambiguous type inference
 let rec combineRightsHelp = (acc, dirflags) => {
   match (dirflags) {
     [] => acc,
@@ -231,6 +252,9 @@ let combineRights = (dirflags) => {
   combineRightsHelp(0N, dirflags)
 }
 
+/**
+ * Flags that determine the mode(s) that a `FileDescriptor` operates in.
+ */
 export enum FdFlag {
   // Append mode: Data written to the file is always appended to the file's end.
   Append,
@@ -246,6 +270,7 @@ export enum FdFlag {
   Sync,
 }
 
+// TODO(#775): This has specific ordering requirements because of ambiguous type inference
 let rec combineFdFlagsHelp = (acc, dirflags) => {
   match (dirflags) {
     [hd, ...tl] => {
@@ -265,6 +290,9 @@ let combineFdFlags = (dirflags) => {
   combineFdFlagsHelp(0n, dirflags)
 }
 
+/**
+ * The type of file a `FileDescriptor` refers to.
+ */
 export enum Filetype {
   // The type of the file descriptor or file is unknown or is different from any of the other types specified.
   Unknown,
@@ -284,39 +312,7 @@ export enum Filetype {
   SymbolicLink,
 }
 
-export enum Whence {
-  // Seek relative to start-of-file.
-  Set,
-  // Seek relative to current position.
-  Current,
-  // Seek relative to end-of-file.
-  End,
-}
-
-export record Stats {
-  filetype: Filetype,
-  flags: List<FdFlag>,
-  rights: List<Rights>,
-  rightsInheriting: List<Rights>
-}
-
-export record Filestats {
-  device: Int64,
-  inode: Int64,
-  filetype: Filetype,
-  linkcount: Int64,
-  size: Int64,
-  accessed: Int64,
-  modified: Int64,
-  changed: Int64
-}
-
-export record DirectoryEntry {
-  inode: Int64,
-  filetype: Filetype,
-  path: String
-}
-
+// TODO(#775): This has specific ordering requirements because of ambiguous type inference
 let filetypeFromNumber = (filetype) => {
   match (filetype) {
     0n => Unknown,
@@ -331,15 +327,84 @@ let filetypeFromNumber = (filetype) => {
   }
 }
 
-// Open a file or directory
-// @param dirFd: FileDescriptor The directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to the file or directory
-// @param openFlags: List<OpenFlag> Flags that decide how the path will be opened
-// @param rights: List<Rights> The rights that dictate what may be done with the returned file descriptor
-// @param rightsInheriting: List<Rights> The rights that dictate what may be done with file descriptors derived from this file descriptor
-// @param flags: List<FdFlag> Flags which affect read/write operations on this file descriptor
-// @returns FileDescriptor The opened file or directory
+/**
+ * Flags that determine where seeking should begin in a file.
+ */
+export enum Whence {
+  // Seek relative to start-of-file.
+  Set,
+  // Seek relative to current position.
+  Current,
+  // Seek relative to end-of-file.
+  End,
+}
+
+/**
+ * Information about a `FileDescriptor`.
+ */
+export record Stats {
+  filetype: Filetype,
+  flags: List<FdFlag>,
+  rights: List<Rights>,
+  rightsInheriting: List<Rights>
+}
+
+/**
+ * Information about the file that a `FileDescriptor` refers to.
+ */
+export record Filestats {
+  device: Int64,
+  inode: Int64,
+  filetype: Filetype,
+  linkcount: Int64,
+  size: Int64,
+  accessed: Int64,
+  modified: Int64,
+  changed: Int64
+}
+
+/**
+ * An entry in a directory.
+ */
+export record DirectoryEntry {
+  inode: Int64,
+  filetype: Filetype,
+  path: String
+}
+
+/**
+ * @section Values: Functions and constants included in the Sys/File module.
+ */
+
+/**
+ * The `FileDescriptor` for `stdin`.
+ */
+export let stdin = FileDescriptor(0)
+/**
+ * The `FileDescriptor` for `stdout`.
+ */
+export let stdout = FileDescriptor(1)
+/**
+ * The `FileDescriptor` for `stderr`.
+ */
+export let stderr = FileDescriptor(2)
+/**
+ * The `FileDescriptor` for the current working directory of the process.
+ */
+export let pwdfd = FileDescriptor(3)
+
+/**
+ * Open a file or directory.
+ *
+ * @param dirFd: The directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to the file or directory
+ * @param openFlags: Flags that decide how the path will be opened
+ * @param rights: The rights that dictate what may be done with the returned file descriptor
+ * @param rightsInheriting: The rights that dictate what may be done with file descriptors derived from this file descriptor
+ * @param flags: Flags which affect read/write operations on this file descriptor
+ * @returns `Ok(fd)` of the opened file or directory if successful or `Err(exception)` otherwise
+ */
 export let pathOpen = (
   dirFd: FileDescriptor,
   dirFlags: List<LookupFlag>,
@@ -391,10 +456,13 @@ export let pathOpen = (
   }
 }
 
-// Read from a file descriptor
-// @param fd: FileDescriptor The file descriptor to read from
-// @param size: Number The maximum number of bytes to read from the file descriptor
-// @returns (String, Number) The bytes read and the number of bytes read
+/**
+ * Read from a file descriptor.
+ *
+ * @param fd: The file descriptor to read from
+ * @param size: The maximum number of bytes to read from the file descriptor
+ * @returns `Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
+ */
 export let fdRead = (fd: FileDescriptor, size: Number) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -426,11 +494,14 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
   }
 }
 
-// Read from a file descriptor without updating the file descriptor's offset
-// @param fd: FileDescriptor The file descriptor to read from
-// @param offset: Int64 The position within the file to begin reading
-// @param size: Number The maximum number of bytes to read from the file descriptor
-// @returns (String, Number) The bytes read and the number of bytes read
+/**
+ * Read from a file descriptor without updating the file descriptor's offset.
+ *
+ * @param fd: The file descriptor to read from
+ * @param offset: The position within the file to begin reading
+ * @param size: The maximum number of bytes to read from the file descriptor
+ * @returns `Ok((contents, numBytes)) of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
+ */
 export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -464,10 +535,13 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   }
 }
 
-// Write to a file descriptor
-// @param fd: FileDescriptor The file descriptor to which data will be written
-// @param data: String The data to be written
-// @returns Number The number of bytes written
+/**
+ * Write to a file descriptor.
+ *
+ * @param fd: The file descriptor to which data will be written
+ * @param data: The data to be written
+ * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(Exception)` otherwise
+ */
 export let fdWrite = (fd: FileDescriptor, data: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -494,11 +568,14 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
   }
 }
 
-// Write to a file descriptor without updating the file descriptor's offset
-// @param fd: FileDescriptor The file descriptor to which data will be written
-// @param data: String The data to be written
-// @param offset: Int64 The position within the file to begin writing
-// @returns Number The number of bytes written
+/**
+ * Write to a file descriptor without updating the file descriptor's offset.
+ *
+ * @param fd: The file descriptor to which data will be written
+ * @param data: The data to be written
+ * @param offset: The position within the file to begin writing
+ * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(exception)` otherwise
+ */
 export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -527,10 +604,14 @@ export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
   }
 }
 
-// Allocate space within a file
-// @param fd: FileDescriptor The file descriptor in which space will be allocated
-// @param offset: Int64 The position within the file to begin writing
-// @param size: Int64 The number of bytes to allocate
+/**
+ * Allocate space within a file.
+ *
+ * @param fd: The file descriptor in which space will be allocated
+ * @param offset: The position within the file to begin writing
+ * @param size: The number of bytes to allocate
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -548,8 +629,12 @@ export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
   }
 }
 
-// Close a file descriptor
-// @param fd: FileDescriptor The file descriptor to close
+/**
+ * Close a file descriptor.
+ *
+ * @param fd: The file descriptor to close
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdClose = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -563,8 +648,12 @@ export let fdClose = (fd: FileDescriptor) => {
   }
 }
 
-// Synchronize the data of a file to disk
-// @param fd: FileDescriptor The file descriptor to synchronize
+/**
+ * Synchronize the data of a file to disk.
+ *
+ * @param fd: The file descriptor to synchronize
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdDatasync = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -578,8 +667,12 @@ export let fdDatasync = (fd: FileDescriptor) => {
   }
 }
 
-// Synchronize the data and metadata of a file to disk
-// @param fd: FileDescriptor The file descriptor to synchronize
+/**
+ * Synchronize the data and metadata of a file to disk.
+ *
+ * @param fd: The file descriptor to synchronize
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSync = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -608,9 +701,12 @@ let wasmSafeCons = (a, b) => {
 let orderedFdflags = wasmSafeCons(Append, wasmSafeCons(Dsync, wasmSafeCons(Nonblock, wasmSafeCons(Rsync, wasmSafeCons(Sync, [])))))
 let orderedRights = wasmSafeCons(FdDatasync, wasmSafeCons(FdRead, wasmSafeCons(FdSeek, wasmSafeCons(FdSetFlags, wasmSafeCons(FdSync, wasmSafeCons(FdTell, wasmSafeCons(FdWrite, wasmSafeCons(FdAdvise, wasmSafeCons(FdAllocate, wasmSafeCons(PathCreateDirectory, wasmSafeCons(PathCreateFile, wasmSafeCons(PathLinkSource, wasmSafeCons(PathLinkTarget, wasmSafeCons(PathOpen, wasmSafeCons(FdReaddir, wasmSafeCons(PathReadlink, wasmSafeCons(PathRenameSource, wasmSafeCons(PathRenameTarget, wasmSafeCons(PathFilestats, wasmSafeCons(PathSetSize, wasmSafeCons(PathSetTimes, wasmSafeCons(FdFilestats, wasmSafeCons(FdSetSize, wasmSafeCons(FdSetTimes, wasmSafeCons(PathSymlink, wasmSafeCons(PathRemoveDirectory, wasmSafeCons(PathUnlinkFile, wasmSafeCons(PollFdReadwrite, wasmSafeCons(SockShutdown, [])))))))))))))))))))))))))))))
 
-// Retrieve information about a file descriptor
-// @param fd: FileDescriptor The file descriptor of which to retrieve information
-// @returns Stats A record containing the filetype, flags, rights, and inheriting rights associated with the file descriptor
+/**
+ * Retrieve information about a file descriptor.
+ *
+ * @param fd: The file descriptor of which to retrieve information
+ * @returns `Ok(stats)` of the `Stats` associated with the file descriptor if successful or `Err(exception)` otherwise
+ */
 export let fdStats = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -658,9 +754,13 @@ export let fdStats = (fd: FileDescriptor) => {
   }
 }
 
-// Update the flags associated with a file descriptor
-// @param fd: FileDescriptor The file descriptor to update flags
-// @param flags: List<FdFlag> The flags to apply to the file descriptor
+/**
+ * Update the flags associated with a file descriptor.
+ *
+ * @param fd: The file descriptor to update flags
+ * @param flags: The flags to apply to the file descriptor
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -676,10 +776,14 @@ export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
   }
 }
 
-// Update the rights associated with a file descriptor
-// @param fd: FileDescriptor The file descriptor to update rights
-// @param rights: List<Rights> Rights to apply to the file descriptor
-// @param rightsInheriting: List<Rights> Inheriting rights to apply to the file descriptor
+/**
+ * Update the rights associated with a file descriptor.
+ *
+ * @param fd: The file descriptor to update rights
+ * @param rights: Rights to apply to the file descriptor
+ * @param rightsInheriting: Inheriting rights to apply to the file descriptor
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -696,9 +800,12 @@ export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheri
   }
 }
 
-// Retrieve information about a file
-// @param fd: FileDescriptor The file descriptor of the file to retrieve information
-// @returns Filestats A record containing the information about the file
+/**
+ * Retrieve information about a file.
+ *
+ * @param fd: The file descriptor of the file to retrieve information
+ * @returns `Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise
+ */
 export let fdFilestats = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -726,9 +833,13 @@ export let fdFilestats = (fd: FileDescriptor) => {
   }
 }
 
-// Set (truncate) the size of a file
-// @param fd: FileDescriptor The file descriptor of the file to truncate
-// @param size: Int64 The number of bytes to retain in the file
+/**
+ * Set (truncate) the size of a file.
+ *
+ * @param fd: The file descriptor of the file to truncate
+ * @param size: The number of bytes to retain in the file
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -744,9 +855,13 @@ export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
   }
 }
 
-// Set the access (created) time of a file
-// @param fd: FileDescriptor The file descriptor of the file to update
-// @param timestamp: Int64 The time to set
+/**
+ * Set the access (created) time of a file.
+ *
+ * @param fd: The file descriptor of the file to update
+ * @param timestamp: The time to set
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -762,8 +877,12 @@ export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
   }
 }
 
-// Set the access (created) time of a file to the current time
-// @param fd: FileDescriptor The file descriptor of the file to update
+/**
+ * Set the access (created) time of a file to the current time.
+ *
+ * @param fd: The file descriptor of the file to update
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -777,9 +896,13 @@ export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
   }
 }
 
-// Set the modified time of a file
-// @param fd: FileDescriptor The file descriptor of the file to update
-// @param timestamp: Int64 The time to set
+/**
+ * Set the modified time of a file.
+ *
+ * @param fd: The file descriptor of the file to update
+ * @param timestamp: The time to set
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -795,8 +918,12 @@ export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
   }
 }
 
-// Set the modified time of a file to the current time
-// @param fd: FileDescriptor The file descriptor of the file to update
+/**
+ * Set the modified time of a file to the current time.
+ *
+ * @param fd: The file descriptor of the file to update
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -810,9 +937,12 @@ export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
   }
 }
 
-// Read the entires of a directory
-// @param fd: FileDescriptor The directory to read
-// @returns Array<DirectoryEntry> An array of records containing information about each entry in the directory
+/**
+ * Read the entires of a directory.
+ *
+ * @param fd: The directory to read
+ * @returns `Ok(dirEntries)` of an array of `DirectoryEntry` for each entry in the directory if successful or `Err(exception)` otherwise
+ */
 export let fdReaddir = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -920,9 +1050,13 @@ export let fdReaddir = (fd: FileDescriptor) => {
   }
 }
 
-// Atomically replace a file descriptor by renumbering another file descriptor
-// @param fromFd: FileDescriptor The file descriptor to renumber
-// @param toFd: FileDescriptor The file descriptor to overwrite
+/**
+ * Atomically replace a file descriptor by renumbering another file descriptor.
+ *
+ * @param fromFd: The file descriptor to renumber
+ * @param toFd: The file descriptor to overwrite
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
   let fromFd = match (fromFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -940,11 +1074,14 @@ export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
   }
 }
 
-// Update a file descriptor's offset
-// @param fd: FileDescriptor The file descriptor to operate on
-// @param offset: Int64 The number of bytes to move the offset
-// @param whence: Whence The location from which the offset is relative
-// @returns Int64 The new offset of the file descriptor, relative to the start of the file
+/**
+ * Update a file descriptor's offset.
+ *
+ * @param fd: The file descriptor to operate on
+ * @param offset: The number of bytes to move the offset
+ * @param whence: The location from which the offset is relative
+ * @returns `Ok(offset)` of the new offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise
+ */
 export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -970,9 +1107,12 @@ export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
   }
 }
 
-// Read a file descriptor's offset
-// @param fd: FileDescriptor The file descriptor to read the offset
-// @returns Int64 The offset of the file descriptor, relative to the start of the file
+/**
+ * Read a file descriptor's offset.
+ *
+ * @param fd: The file descriptor to read the offset
+ * @returns `Ok(offset)` of the offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise
+ */
 export let fdTell = (fd: FileDescriptor) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -990,10 +1130,13 @@ export let fdTell = (fd: FileDescriptor) => {
   }
 }
 
-
-// Create a directory
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param path: String The path to the new directory
+/**
+ * Create a directory.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param path: The path to the new directory
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1011,11 +1154,14 @@ export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
   }
 }
 
-// Retrieve information about a file
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to retrieve information about
-// @returns Filestats A record containing information about the file
+/**
+ * Retrieve information about a file.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to retrieve information about
+ * @returns `Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise
+ */
 export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1050,11 +1196,15 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
   }
 }
 
-// Set the access (created) time of a file
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to set the time
-// @param timestamp: Int64 The time to set
+/**
+ * Set the access (created) time of a file.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to set the time
+ * @param timestamp: The time to set
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1076,10 +1226,14 @@ export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, 
   }
 }
 
-// Set the access (created) time of a file to the current time
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to set the time
+/**
+ * Set the access (created) time of a file to the current time.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to set the time
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1099,11 +1253,15 @@ export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag
   }
 }
 
-// Set the modified time of a file
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to set the time
-// @param timestamp: Int64 The time to set
+/**
+ * Set the modified time of a file.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to set the time
+ * @param timestamp: The time to set
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1125,10 +1283,14 @@ export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>
   }
 }
 
-// Set the modified time of a file to the current time
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param path: String The path to set the time
+/**
+ * Set the modified time of a file to the current time.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param path: The path to set the time
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1148,12 +1310,16 @@ export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFl
   }
 }
 
-// Create a hard link
-// @param sourceFd: FileDescriptor The file descriptor of the directory in which the source path resolution starts
-// @param dirFlags: List<LookupFlag> Flags which affect path resolution
-// @param sourcePath: String The path to the source of the link
-// @param targetFd: FileDescriptor The file descriptor of the directory in which the target path resolution starts
-// @param targetPath: String The path to the target of the link
+/**
+ * Create a hard link.
+ *
+ * @param sourceFd: The file descriptor of the directory in which the source path resolution starts
+ * @param dirFlags: Flags which affect path resolution
+ * @param sourcePath: The path to the source of the link
+ * @param targetFd: The file descriptor of the directory in which the target path resolution starts
+ * @param targetPath: The path to the target of the link
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
   let sourceFd = match (sourceFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1179,10 +1345,14 @@ export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sou
   }
 }
 
-// Create a symlink
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param sourcePath: String The path to the source of the link
-// @param targetPath: String The path to the target of the link
+/**
+ * Create a symlink.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param sourcePath: The path to the source of the link
+ * @param targetPath: The path to the target of the link
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1202,9 +1372,13 @@ export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: St
   }
 }
 
-// Unlink a file
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param path: String The path of the file to unlink
+/**
+ * Unlink a file.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param path: The path of the file to unlink
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathUnlink = (fd: FileDescriptor, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1221,11 +1395,14 @@ export let pathUnlink = (fd: FileDescriptor, path: String) => {
   }
 }
 
-// Read the contents of a symbolic link
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param path: String The path to the symlink
-// @param size: The number of bytes to read
-// @returns (String, Number) The bytes read and the number of bytes read
+/**
+ * Read the contents of a symbolic link.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param path: The path to the symlink
+ * @param size: The number of bytes to read
+ * @returns `Ok((contents, numBytes))` of the bytes read and the number of bytes read if successful or `Err(exception)` otherwise
+ */
 export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1254,9 +1431,13 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
   }
 }
 
-// Remove a directory
-// @param fd: FileDescriptor The file descriptor of the directory in which path resolution starts
-// @param path: String The path to the directory to remove
+/**
+ * Remove a directory.
+ *
+ * @param fd: The file descriptor of the directory in which path resolution starts
+ * @param path: The path to the directory to remove
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
@@ -1273,11 +1454,15 @@ export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
   }
 }
 
-// Rename a file or directory
-// @param sourceFd: FileDescriptor The file descriptor of the directory in which the source path resolution starts
-// @param sourcePath: String The path of the file to rename
-// @param targetFd: FileDescriptor The file descriptor of the directory in which the target path resolution starts
-// @param targetPath: String The new path of the file
+/**
+ * Rename a file or directory.
+ *
+ * @param sourceFd: The file descriptor of the directory in which the source path resolution starts
+ * @param sourcePath: The path of the file to rename
+ * @param targetFd: The file descriptor of the directory in which the target path resolution starts
+ * @param targetPath: The new path of the file
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
   let sourceFd = match (sourceFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -393,6 +393,18 @@ export let stderr = FileDescriptor(2)
  */
 export let pwdfd = FileDescriptor(3)
 
+let wasmSafeOk = (val) => {
+  Memory.incRef(WasmI32.fromGrain(Ok))
+  Memory.incRef(WasmI32.fromGrain(val))
+  Ok(val)
+}
+
+let wasmSafeErr = (err) => {
+  Memory.incRef(WasmI32.fromGrain(Err))
+  Memory.incRef(WasmI32.fromGrain(err))
+  Err(err)
+}
+
 /**
  * Open a file or directory.
  *
@@ -446,13 +458,13 @@ export let pathOpen = (
   )
   if (err != Wasi._ESUCCESS) {
     Memory.free(newFd)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let fd = FileDescriptor(tagSimpleNumber(WasmI32.load(newFd, 0n)))
 
     Memory.free(newFd)
 
-    Ok(fd)
+    wasmSafeOk(fd)
   }
 }
 
@@ -482,7 +494,7 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     nread = WasmI32.load(nread, 0n)
 
@@ -490,7 +502,7 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
 
     Memory.free(iovs)
 
-    Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
+    wasmSafeOk((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
 }
 
@@ -523,7 +535,7 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     nread = WasmI32.load(nread, 0n)
 
@@ -531,7 +543,7 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
 
     Memory.free(iovs)
 
-    Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
+    wasmSafeOk((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
 }
 
@@ -558,13 +570,13 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
   let err = Wasi.fd_write(fd, iovs, 1n, nwritten)
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     nwritten = WasmI32.load(nwritten, 0n)
 
     Memory.free(iovs)
 
-    Ok(tagSimpleNumber(nwritten))
+    wasmSafeOk(tagSimpleNumber(nwritten))
   }
 }
 
@@ -594,13 +606,13 @@ export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
   let err = Wasi.fd_pwrite(fd, iovs, 1n, offset, nwritten)
   if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     nwritten = WasmI32.load(nwritten, 0n)
 
     Memory.free(iovs)
 
-    Ok(tagSimpleNumber(nwritten))
+    wasmSafeOk(tagSimpleNumber(nwritten))
   }
 }
 
@@ -623,9 +635,9 @@ export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
 
   let err = Wasi.fd_allocate(fd, offset, size)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -642,9 +654,9 @@ export let fdClose = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_close(fd)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -661,9 +673,9 @@ export let fdDatasync = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_datasync(fd)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -680,9 +692,9 @@ export let fdSync = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_sync(fd)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -717,7 +729,7 @@ export let fdStats = (fd: FileDescriptor) => {
   let err = Wasi.fd_fdstat_get(fd, structPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(structPtr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let filetype = WasmI32.load8U(structPtr, 0n)
 
@@ -750,7 +762,7 @@ export let fdStats = (fd: FileDescriptor) => {
 
     Memory.free(structPtr)
 
-    Ok({ filetype, flags: fdflagsList, rights: rightsList, rightsInheriting: rightsInheritingList })
+    wasmSafeOk({ filetype, flags: fdflagsList, rights: rightsList, rightsInheriting: rightsInheritingList })
   }
 }
 
@@ -770,9 +782,9 @@ export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
 
   let err = Wasi.fd_fdstat_set_flags(fd, flags)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -794,9 +806,9 @@ export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheri
 
   let err = Wasi.fd_fdstat_set_rights(fd, rights, rightsInheriting)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -816,7 +828,7 @@ export let fdFilestats = (fd: FileDescriptor) => {
   let err = Wasi.fd_filestat_get(fd, filestats)
   if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
     let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
@@ -829,7 +841,7 @@ export let fdFilestats = (fd: FileDescriptor) => {
 
     Memory.free(filestats)
 
-    Ok({ device, inode, filetype, linkcount, size, accessed, modified, changed })
+    wasmSafeOk({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
 }
 
@@ -849,9 +861,9 @@ export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
 
   let err = Wasi.fd_filestat_set_size(fd, size)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -871,9 +883,9 @@ export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
 
   let err = Wasi.fd_filestat_set_times(fd, time, 0N, Wasi._TIME_SET_ATIM)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -890,9 +902,9 @@ export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -912,9 +924,9 @@ export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, time, Wasi._TIME_SET_MTIM)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -931,9 +943,9 @@ export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -960,14 +972,14 @@ export let fdReaddir = (fd: FileDescriptor) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
     Memory.free(bufUsed)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let used = WasmI32.load(bufUsed, 0n)
 
     if (used <= 0n) {
       Memory.free(buf)
       Memory.free(bufUsed)
-      Ok(WasmI32.toGrain(allocateArray(0n)): Array<DirectoryEntry>)
+      wasmSafeOk(WasmI32.toGrain(allocateArray(0n)): Array<DirectoryEntry>)
     } else {
       bufLen = WasmI32.load(buf, 16n) + structWidth * 2n
 
@@ -1043,7 +1055,7 @@ export let fdReaddir = (fd: FileDescriptor) => {
             bufs = next
           }
 
-          Ok(WasmI32.toGrain(arr): Array<DirectoryEntry>)
+          wasmSafeOk(WasmI32.toGrain(arr): Array<DirectoryEntry>)
         }
       }
     }
@@ -1068,9 +1080,9 @@ export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
 
   let err = Wasi.fd_renumber(fromFd, toFd)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1101,9 +1113,9 @@ export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
   let err = Wasi.fd_seek(fd, offset, whence, newoffsetPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(newoffset)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(WasmI32.toGrain(newoffset): Int64)
+    wasmSafeOk(WasmI32.toGrain(newoffset): Int64)
   }
 }
 
@@ -1124,9 +1136,9 @@ export let fdTell = (fd: FileDescriptor) => {
   let err = Wasi.fd_tell(fd, offsetPtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(offset)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(WasmI32.toGrain(offset): Int64)
+    wasmSafeOk(WasmI32.toGrain(offset): Int64)
   }
 }
 
@@ -1148,9 +1160,9 @@ export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_create_directory(fd, stringPtr + 8n, size)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1178,7 +1190,7 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
   let err = Wasi.path_filestat_get(fd, combinedDirFlags, pathPtr, pathSize, filestats)
   if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let device = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 0n))): Int64
     let inode = WasmI32.toGrain(newInt64(WasmI64.load(filestats, 8n))): Int64
@@ -1192,7 +1204,7 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
 
     Memory.free(filestats)
 
-    Ok({ device, inode, filetype, linkcount, size, accessed, modified, changed })
+    wasmSafeOk({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
 }
 
@@ -1220,9 +1232,9 @@ export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, 
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, time, 0N, Wasi._TIME_SET_ATIM)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1247,9 +1259,9 @@ export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1277,9 +1289,9 @@ export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, time, Wasi._TIME_SET_MTIM)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1304,9 +1316,9 @@ export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFl
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1339,9 +1351,9 @@ export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sou
 
   let err = Wasi.path_link(sourceFd, combinedDirFlags, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1366,9 +1378,9 @@ export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: St
 
   let err = Wasi.path_symlink(sourcePtr + 8n, sourceSize, fd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1389,9 +1401,9 @@ export let pathUnlink = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_unlink_file(fd, pathPtr + 8n, pathSize)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1422,12 +1434,12 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
   if (err != Wasi._ESUCCESS) {
     Memory.free(grainStrPtr)
     Memory.free(nread)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let read = tagSimpleNumber(WasmI32.load(nread, 0n))
     Memory.free(nread)
 
-    Ok((WasmI32.toGrain(grainStrPtr): String, read))
+    wasmSafeOk((WasmI32.toGrain(grainStrPtr): String, read))
   }
 }
 
@@ -1448,9 +1460,9 @@ export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
 
   let err = Wasi.path_remove_directory(fd, pathPtr + 8n, pathSize)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -1480,8 +1492,8 @@ export let pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd:
 
   let err = Wasi.path_rename(sourceFd, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -417,7 +417,7 @@ let wasmSafeErr = (err) => {
  * @param flags: Flags which affect read/write operations on this file descriptor
  * @returns `Ok(fd)` of the opened file or directory if successful or `Err(exception)` otherwise
  */
-export let pathOpen = (
+export let rec pathOpen = (
   dirFd: FileDescriptor,
   dirFlags: List<LookupFlag>,
   path: String,
@@ -426,6 +426,9 @@ export let pathOpen = (
   rightsInheriting: List<Rights>,
   flags: List<FdFlag>
 ) => {
+  let dirFdArg = dirFd
+  let pathArg = path
+  let rightsInheritingArg = rightsInheriting
   let dirFd = match (dirFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -456,7 +459,7 @@ export let pathOpen = (
     combinedFsFlags,
     newFd
   )
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(newFd)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -466,6 +469,15 @@ export let pathOpen = (
 
     wasmSafeOk(fd)
   }
+  Memory.decRef(WasmI32.fromGrain(dirFdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(pathArg))
+  Memory.decRef(WasmI32.fromGrain(openFlags))
+  Memory.decRef(WasmI32.fromGrain(rights))
+  Memory.decRef(WasmI32.fromGrain(rightsInheritingArg))
+  Memory.decRef(WasmI32.fromGrain(flags))
+  Memory.decRef(WasmI32.fromGrain(pathOpen))
+  ret
 }
 
 /**
@@ -475,7 +487,8 @@ export let pathOpen = (
  * @param size: The maximum number of bytes to read from the file descriptor
  * @returns `Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
  */
-export let fdRead = (fd: FileDescriptor, size: Number) => {
+export let rec fdRead = (fd: FileDescriptor, size: Number) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -491,7 +504,7 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
   let mut nread = iovs + (3n * 4n)
 
   let err = Wasi.fd_read(fd, iovs, 1n, nread)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
@@ -504,6 +517,10 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
 
     wasmSafeOk((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
+  Memory.decRef(WasmI32.fromGrain(fd))
+  Memory.decRef(WasmI32.fromGrain(size))
+  Memory.decRef(WasmI32.fromGrain(fdRead))
+  ret
 }
 
 /**
@@ -514,7 +531,9 @@ export let fdRead = (fd: FileDescriptor, size: Number) => {
  * @param size: The maximum number of bytes to read from the file descriptor
  * @returns `Ok((contents, numBytes)) of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
  */
-export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
+export let rec fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
+  let fdArg = fd
+  let offsetArg = offset
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -532,7 +551,7 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   let mut nread = iovs + (3n * 4n)
 
   let err = Wasi.fd_pread(fd, iovs, 1n, offset, nread)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     Memory.free(strPtr)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
@@ -545,6 +564,11 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
 
     wasmSafeOk((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(offsetArg))
+  Memory.decRef(WasmI32.fromGrain(size))
+  Memory.decRef(WasmI32.fromGrain(fdPread))
+  ret
 }
 
 /**
@@ -554,7 +578,8 @@ export let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
  * @param data: The data to be written
  * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(Exception)` otherwise
  */
-export let fdWrite = (fd: FileDescriptor, data: String) => {
+export let rec fdWrite = (fd: FileDescriptor, data: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -568,7 +593,7 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
   let mut nwritten = iovs + (3n * 4n)
 
   let err = Wasi.fd_write(fd, iovs, 1n, nwritten)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(iovs)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -578,6 +603,10 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
 
     wasmSafeOk(tagSimpleNumber(nwritten))
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(data))
+  Memory.decRef(WasmI32.fromGrain(fdWrite))
+  ret
 }
 
 /**
@@ -588,7 +617,9 @@ export let fdWrite = (fd: FileDescriptor, data: String) => {
  * @param offset: The position within the file to begin writing
  * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(exception)` otherwise
  */
-export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
+export let rec fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
+  let fdArg = fd
+  let offsetArg = offset
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -614,6 +645,10 @@ export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
 
     wasmSafeOk(tagSimpleNumber(nwritten))
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(data))
+  Memory.decRef(WasmI32.fromGrain(offsetArg))
+  Memory.decRef(WasmI32.fromGrain(fdPwrite))
 }
 
 /**
@@ -624,7 +659,10 @@ export let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
  * @param size: The number of bytes to allocate
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
+export let rec fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
+  let fdArg = fd
+  let offsetArg = offset
+  let sizeArg = size
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -634,11 +672,16 @@ export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
   let size = WasmI64.load(WasmI32.fromGrain(size), 8n)
 
   let err = Wasi.fd_allocate(fd, offset, size)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(offsetArg))
+  Memory.decRef(WasmI32.fromGrain(sizeArg))
+  Memory.decRef(WasmI32.fromGrain(fdAllocate))
+  ret
 }
 
 /**
@@ -647,17 +690,21 @@ export let fdAllocate = (fd: FileDescriptor, offset: Int64, size: Int64) => {
  * @param fd: The file descriptor to close
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdClose = (fd: FileDescriptor) => {
+export let rec fdClose = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
 
   let err = Wasi.fd_close(fd)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdClose))
+  ret
 }
 
 /**
@@ -666,17 +713,21 @@ export let fdClose = (fd: FileDescriptor) => {
  * @param fd: The file descriptor to synchronize
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdDatasync = (fd: FileDescriptor) => {
+export let rec fdDatasync = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
 
   let err = Wasi.fd_datasync(fd)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdDatasync))
+  ret
 }
 
 /**
@@ -685,17 +736,21 @@ export let fdDatasync = (fd: FileDescriptor) => {
  * @param fd: The file descriptor to synchronize
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSync = (fd: FileDescriptor) => {
+export let rec fdSync = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
 
   let err = Wasi.fd_sync(fd)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdSync))
+  ret
 }
 
 
@@ -719,7 +774,8 @@ let orderedRights = wasmSafeCons(FdDatasync, wasmSafeCons(FdRead, wasmSafeCons(F
  * @param fd: The file descriptor of which to retrieve information
  * @returns `Ok(stats)` of the `Stats` associated with the file descriptor if successful or `Err(exception)` otherwise
  */
-export let fdStats = (fd: FileDescriptor) => {
+export let rec fdStats = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -727,7 +783,7 @@ export let fdStats = (fd: FileDescriptor) => {
   let structPtr = Memory.malloc(24n)
 
   let err = Wasi.fd_fdstat_get(fd, structPtr)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(structPtr)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -739,6 +795,9 @@ export let fdStats = (fd: FileDescriptor) => {
       let fdflags = WasmI32.load16U(structPtr, 4n)
       WasmI32.gtU((fdflags & (1n << (WasmI32.fromGrain(i) >> 1n))), 0n)
     }
+    Memory.incRef(WasmI32.fromGrain(List.filteri))
+    Memory.incRef(WasmI32.fromGrain(flagsToWasmVal))
+    Memory.incRef(WasmI32.fromGrain(orderedFdflags))
     let fdflagsList = List.filteri(flagsToWasmVal, orderedFdflags)
     Memory.free(WasmI32.fromGrain(flagsToWasmVal))
 
@@ -750,6 +809,9 @@ export let fdStats = (fd: FileDescriptor) => {
       let rights = WasmI64.load(structPtr, 8n)
       (rights & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
     }
+    Memory.incRef(WasmI32.fromGrain(List.filteri))
+    Memory.incRef(WasmI32.fromGrain(flagsToWasmVal))
+    Memory.incRef(WasmI32.fromGrain(orderedRights))
     let rightsList = List.filteri(flagsToWasmVal, orderedRights)
     Memory.free(WasmI32.fromGrain(flagsToWasmVal))
 
@@ -757,6 +819,9 @@ export let fdStats = (fd: FileDescriptor) => {
       let rightsInheriting = WasmI64.load(structPtr, 16n)
       (rightsInheriting & (1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n))) > 0N
     }
+    Memory.incRef(WasmI32.fromGrain(List.filteri))
+    Memory.incRef(WasmI32.fromGrain(flagsToWasmVal))
+    Memory.incRef(WasmI32.fromGrain(orderedRights))
     let rightsInheritingList = List.filteri(flagsToWasmVal, orderedRights)
     Memory.free(WasmI32.fromGrain(flagsToWasmVal))
 
@@ -764,6 +829,9 @@ export let fdStats = (fd: FileDescriptor) => {
 
     wasmSafeOk({ filetype, flags: fdflagsList, rights: rightsList, rightsInheriting: rightsInheritingList })
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdStats))
+  ret
 }
 
 /**
@@ -773,7 +841,9 @@ export let fdStats = (fd: FileDescriptor) => {
  * @param flags: The flags to apply to the file descriptor
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
+export let rec fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
+  let fdArg = fd
+  let flagsArg = flags
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -781,11 +851,15 @@ export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
   let flags = combineFdFlags(flags)
 
   let err = Wasi.fd_fdstat_set_flags(fd, flags)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(flagsArg))
+  Memory.decRef(WasmI32.fromGrain(fdSetFlags))
+  ret
 }
 
 /**
@@ -796,7 +870,10 @@ export let fdSetFlags = (fd: FileDescriptor, flags: List<FdFlag>) => {
  * @param rightsInheriting: Inheriting rights to apply to the file descriptor
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) => {
+export let rec fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) => {
+  let fdArg = fd
+  let rightsArg = rights
+  let rightsInheritingArg = rightsInheriting
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -805,11 +882,16 @@ export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheri
   let rightsInheriting = combineRights(rightsInheriting)
 
   let err = Wasi.fd_fdstat_set_rights(fd, rights, rightsInheriting)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(rightsArg))
+  Memory.decRef(WasmI32.fromGrain(rightsInheritingArg))
+  Memory.decRef(WasmI32.fromGrain(fdSetRights))
+  ret
 }
 
 /**
@@ -818,7 +900,8 @@ export let fdSetRights = (fd: FileDescriptor, rights: List<Rights>, rightsInheri
  * @param fd: The file descriptor of the file to retrieve information
  * @returns `Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise
  */
-export let fdFilestats = (fd: FileDescriptor) => {
+export let rec fdFilestats = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -826,7 +909,7 @@ export let fdFilestats = (fd: FileDescriptor) => {
   let filestats = Memory.malloc(64n)
 
   let err = Wasi.fd_filestat_get(fd, filestats)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -843,6 +926,9 @@ export let fdFilestats = (fd: FileDescriptor) => {
 
     wasmSafeOk({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdFilestats))
+  ret
 }
 
 /**
@@ -852,7 +938,9 @@ export let fdFilestats = (fd: FileDescriptor) => {
  * @param size: The number of bytes to retain in the file
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
+export let rec fdSetSize = (fd: FileDescriptor, size: Int64) => {
+  let fdArg = fd
+  let sizeArg = size
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -860,11 +948,15 @@ export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
   let size = WasmI64.load(WasmI32.fromGrain(size), 8n)
 
   let err = Wasi.fd_filestat_set_size(fd, size)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(sizeArg))
+  Memory.decRef(WasmI32.fromGrain(fdSetSize))
+  ret
 }
 
 /**
@@ -874,7 +966,8 @@ export let fdSetSize = (fd: FileDescriptor, size: Int64) => {
  * @param timestamp: The time to set
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
+export let rec fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -882,11 +975,15 @@ export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
   let time = WasmI64.load(WasmI32.fromGrain(timestamp), 8n)
 
   let err = Wasi.fd_filestat_set_times(fd, time, 0N, Wasi._TIME_SET_ATIM)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(timestamp))
+  Memory.decRef(WasmI32.fromGrain(fdSetAccessTime))
+  ret
 }
 
 /**
@@ -895,17 +992,21 @@ export let fdSetAccessTime = (fd: FileDescriptor, timestamp: Int64) => {
  * @param fd: The file descriptor of the file to update
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
+export let rec fdSetAccessTimeNow = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdSetAccessTimeNow))
+  ret
 }
 
 /**
@@ -915,7 +1016,8 @@ export let fdSetAccessTimeNow = (fd: FileDescriptor) => {
  * @param timestamp: The time to set
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
+export let rec fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -923,11 +1025,15 @@ export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
   let time = WasmI64.load(WasmI32.fromGrain(timestamp), 8n)
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, time, Wasi._TIME_SET_MTIM)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(timestamp))
+  Memory.decRef(WasmI32.fromGrain(fdSetModifiedTime))
+  ret
 }
 
 /**
@@ -936,17 +1042,21 @@ export let fdSetModifiedTime = (fd: FileDescriptor, timestamp: Int64) => {
  * @param fd: The file descriptor of the file to update
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
+export let rec fdSetModifiedTimeNow = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
 
   let err = Wasi.fd_filestat_set_times(fd, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdSetModifiedTime))
+  ret
 }
 
 /**
@@ -955,7 +1065,8 @@ export let fdSetModifiedTimeNow = (fd: FileDescriptor) => {
  * @param fd: The directory to read
  * @returns `Ok(dirEntries)` of an array of `DirectoryEntry` for each entry in the directory if successful or `Err(exception)` otherwise
  */
-export let fdReaddir = (fd: FileDescriptor) => {
+export let rec fdReaddir = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -969,7 +1080,7 @@ export let fdReaddir = (fd: FileDescriptor) => {
   let mut bufLen = structWidth
 
   let err = Wasi.fd_readdir(fd, buf, bufLen, cookie, bufUsed)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
     Memory.free(bufUsed)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
@@ -1060,6 +1171,9 @@ export let fdReaddir = (fd: FileDescriptor) => {
       }
     }
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdReaddir))
+  ret
 }
 
 /**
@@ -1069,7 +1183,9 @@ export let fdReaddir = (fd: FileDescriptor) => {
  * @param toFd: The file descriptor to overwrite
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
+export let rec fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
+  let fromFdArg = fromFd
+  let toFdArg = toFd
   let fromFd = match (fromFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1079,11 +1195,15 @@ export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
   }
 
   let err = Wasi.fd_renumber(fromFd, toFd)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fromFdArg))
+  Memory.decRef(WasmI32.fromGrain(toFdArg))
+  Memory.decRef(WasmI32.fromGrain(fdRenumber))
+  ret
 }
 
 /**
@@ -1094,7 +1214,10 @@ export let fdRenumber = (fromFd: FileDescriptor, toFd: FileDescriptor) => {
  * @param whence: The location from which the offset is relative
  * @returns `Ok(offset)` of the new offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise
  */
-export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
+export let rec fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
+  let fdArg = fd
+  let offsetArg = offset
+  let whenceArg = whence
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1111,12 +1234,17 @@ export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
   let newoffsetPtr = newoffset + 8n
 
   let err = Wasi.fd_seek(fd, offset, whence, newoffsetPtr)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(newoffset)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(WasmI32.toGrain(newoffset): Int64)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(offsetArg))
+  Memory.decRef(WasmI32.fromGrain(whenceArg))
+  Memory.decRef(WasmI32.fromGrain(fdSeek))
+  ret
 }
 
 /**
@@ -1125,7 +1253,8 @@ export let fdSeek = (fd: FileDescriptor, offset: Int64, whence: Whence) => {
  * @param fd: The file descriptor to read the offset
  * @returns `Ok(offset)` of the offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise
  */
-export let fdTell = (fd: FileDescriptor) => {
+export let rec fdTell = (fd: FileDescriptor) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1134,12 +1263,15 @@ export let fdTell = (fd: FileDescriptor) => {
   let offsetPtr = offset + 8n
 
   let err = Wasi.fd_tell(fd, offsetPtr)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(offset)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(WasmI32.toGrain(offset): Int64)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(fdTell))
+  ret
 }
 
 /**
@@ -1149,7 +1281,8 @@ export let fdTell = (fd: FileDescriptor) => {
  * @param path: The path to the new directory
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
+export let rec pathCreateDirectory = (fd: FileDescriptor, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1159,11 +1292,15 @@ export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
   let size = WasmI32.load(stringPtr, 4n)
 
   let err = Wasi.path_create_directory(fd, stringPtr + 8n, size)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathCreateDirectory))
+  ret
 }
 
 /**
@@ -1174,7 +1311,8 @@ export let pathCreateDirectory = (fd: FileDescriptor, path: String) => {
  * @param path: The path to retrieve information about
  * @returns `Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise
  */
-export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
+export let rec pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1188,7 +1326,7 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
   let filestats = Memory.malloc(64n)
 
   let err = Wasi.path_filestat_get(fd, combinedDirFlags, pathPtr, pathSize, filestats)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(filestats)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -1206,6 +1344,11 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
 
     wasmSafeOk({ device, inode, filetype, linkcount, size, accessed, modified, changed })
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathFilestats))
+  ret
 }
 
 /**
@@ -1217,7 +1360,8 @@ export let pathFilestats = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path
  * @param timestamp: The time to set
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
+export let rec pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1231,11 +1375,17 @@ export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, 
   let time = WasmI64.load(WasmI32.fromGrain(timestamp), 8n)
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, time, 0N, Wasi._TIME_SET_ATIM)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(timestamp))
+  Memory.decRef(WasmI32.fromGrain(pathSetAccessTime))
+  ret
 }
 
 /**
@@ -1247,6 +1397,7 @@ export let pathSetAccessTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, 
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
 export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1258,11 +1409,16 @@ export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag
   pathPtr += 8n
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_ATIM_NOW)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathSetAccessTime))
+  ret
 }
 
 /**
@@ -1274,7 +1430,8 @@ export let pathSetAccessTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag
  * @param timestamp: The time to set
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
+export let rec pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String, timestamp: Int64) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1288,11 +1445,17 @@ export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>
   let time = WasmI64.load(WasmI32.fromGrain(timestamp), 8n)
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, time, Wasi._TIME_SET_MTIM)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(timestamp))
+  Memory.decRef(WasmI32.fromGrain(pathSetModifiedTime))
+  ret
 }
 
 /**
@@ -1303,7 +1466,8 @@ export let pathSetModifiedTime = (fd: FileDescriptor, dirFlags: List<LookupFlag>
  * @param path: The path to set the time
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
+export let rec pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1315,11 +1479,16 @@ export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFl
   pathPtr += 8n
 
   let err = Wasi.path_filestat_set_times(fd, combinedDirFlags, pathPtr, pathSize, 0N, 0N, Wasi._TIME_SET_MTIM_NOW)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathSetModifiedTimeNow))
+  ret
 }
 
 /**
@@ -1332,7 +1501,9 @@ export let pathSetModifiedTimeNow = (fd: FileDescriptor, dirFlags: List<LookupFl
  * @param targetPath: The path to the target of the link
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
+export let rec pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
+  let sourceFdArg = sourceFd
+  let targetFdArg = targetFd
   let sourceFd = match (sourceFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1350,11 +1521,18 @@ export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sou
   let targetSize = WasmI32.load(targetPtr, 4n)
 
   let err = Wasi.path_link(sourceFd, combinedDirFlags, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(sourceFdArg))
+  Memory.decRef(WasmI32.fromGrain(dirFlags))
+  Memory.decRef(WasmI32.fromGrain(sourcePath))
+  Memory.decRef(WasmI32.fromGrain(targetFdArg))
+  Memory.decRef(WasmI32.fromGrain(targetPath))
+  Memory.decRef(WasmI32.fromGrain(pathLink))
+  ret
 }
 
 /**
@@ -1365,7 +1543,8 @@ export let pathLink = (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sou
  * @param targetPath: The path to the target of the link
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: String) => {
+export let rec pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1377,11 +1556,16 @@ export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: St
   let targetSize = WasmI32.load(targetPtr, 4n)
 
   let err = Wasi.path_symlink(sourcePtr + 8n, sourceSize, fd, targetPtr + 8n, targetSize)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(sourcePath))
+  Memory.decRef(WasmI32.fromGrain(targetPath))
+  Memory.decRef(WasmI32.fromGrain(pathSymlink))
+  ret
 }
 
 /**
@@ -1391,7 +1575,8 @@ export let pathSymlink = (fd: FileDescriptor, sourcePath: String, targetPath: St
  * @param path: The path of the file to unlink
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathUnlink = (fd: FileDescriptor, path: String) => {
+export let rec pathUnlink = (fd: FileDescriptor, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1400,11 +1585,15 @@ export let pathUnlink = (fd: FileDescriptor, path: String) => {
   let pathSize = WasmI32.load(pathPtr, 4n)
 
   let err = Wasi.path_unlink_file(fd, pathPtr + 8n, pathSize)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathUnlink))
+  ret
 }
 
 /**
@@ -1415,7 +1604,9 @@ export let pathUnlink = (fd: FileDescriptor, path: String) => {
  * @param size: The number of bytes to read
  * @returns `Ok((contents, numBytes))` of the bytes read and the number of bytes read if successful or `Err(exception)` otherwise
  */
-export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
+export let rec pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
+  let fdArg = fd
+  let sizeArg = size
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1431,7 +1622,7 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
   let nread = Memory.malloc(4n)
 
   let err = Wasi.path_readlink(fd, pathPtr, pathSize + 8n, strPtr, size, nread)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(grainStrPtr)
     Memory.free(nread)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
@@ -1441,6 +1632,11 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
 
     wasmSafeOk((WasmI32.toGrain(grainStrPtr): String, read))
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(sizeArg))
+  Memory.decRef(WasmI32.fromGrain(pathReadlink))
+  ret
 }
 
 /**
@@ -1450,7 +1646,8 @@ export let pathReadlink = (fd: FileDescriptor, path: String, size: Number) => {
  * @param path: The path to the directory to remove
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
+export let rec pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
+  let fdArg = fd
   let fd = match (fd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1459,11 +1656,15 @@ export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
   let pathSize = WasmI32.load(pathPtr, 4n)
 
   let err = Wasi.path_remove_directory(fd, pathPtr + 8n, pathSize)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(fdArg))
+  Memory.decRef(WasmI32.fromGrain(path))
+  Memory.decRef(WasmI32.fromGrain(pathRemoveDirectory))
+  ret
 }
 
 /**
@@ -1475,7 +1676,9 @@ export let pathRemoveDirectory = (fd: FileDescriptor, path: String) => {
  * @param targetPath: The new path of the file
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
+export let rec pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd: FileDescriptor, targetPath: String) => {
+  let sourceFdArg = sourceFd
+  let targetFdArg = targetFd
   let sourceFd = match (sourceFd) {
     FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n
   }
@@ -1491,9 +1694,15 @@ export let pathRename = (sourceFd: FileDescriptor, sourcePath: String, targetFd:
   let targetSize = WasmI32.load(targetPtr, 4n)
 
   let err = Wasi.path_rename(sourceFd, sourcePtr + 8n, sourceSize, targetFd, targetPtr + 8n, targetSize)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(sourceFdArg))
+  Memory.decRef(WasmI32.fromGrain(sourcePath))
+  Memory.decRef(WasmI32.fromGrain(targetFdArg))
+  Memory.decRef(WasmI32.fromGrain(targetPath))
+  Memory.decRef(WasmI32.fromGrain(pathRename))
+  ret
 }

--- a/stdlib/sys/file.md
+++ b/stdlib/sys/file.md
@@ -1,0 +1,953 @@
+---
+title: Sys/File
+---
+
+Utilities for accessing the filesystem & working with files.
+
+Many of the functions in this module are not intended to be used directly, but rather for other libraries to be built on top of them.
+
+```grain
+import File from "sys/file"
+```
+
+## Types
+
+Type declarations included in the Sys/File module.
+
+### File.**FileDescriptor**
+
+```grain
+enum FileDescriptor {
+  FileDescriptor(Number),
+}
+```
+
+Represents a handle to an open file on the system.
+
+### File.**LookupFlag**
+
+```grain
+enum LookupFlag {
+  SymlinkFollow,
+}
+```
+
+Flags that determine how paths should be resolved when looking up a file or directory.
+
+### File.**OpenFlag**
+
+```grain
+enum OpenFlag {
+  Create,
+  Directory,
+  Exclusive,
+  Truncate,
+}
+```
+
+Flags that determine how a file or directory should be opened.
+
+### File.**Rights**
+
+```grain
+enum Rights {
+  FdDatasync,
+  FdRead,
+  FdSeek,
+  FdSetFlags,
+  FdSync,
+  FdTell,
+  FdWrite,
+  FdAdvise,
+  FdAllocate,
+  PathCreateDirectory,
+  PathCreateFile,
+  PathLinkSource,
+  PathLinkTarget,
+  PathOpen,
+  FdReaddir,
+  PathReadlink,
+  PathRenameSource,
+  PathRenameTarget,
+  PathFilestats,
+  PathSetSize,
+  PathSetTimes,
+  FdFilestats,
+  FdSetSize,
+  FdSetTimes,
+  PathSymlink,
+  PathRemoveDirectory,
+  PathUnlinkFile,
+  PollFdReadwrite,
+  SockShutdown,
+}
+```
+
+Flags that determine which rights a `FileDescriptor` should have
+and which rights new `FileDescriptor`s should inherit from it.
+
+### File.**FdFlag**
+
+```grain
+enum FdFlag {
+  Append,
+  Dsync,
+  Nonblock,
+  Rsync,
+  Sync,
+}
+```
+
+Flags that determine the mode(s) that a `FileDescriptor` operates in.
+
+### File.**Filetype**
+
+```grain
+enum Filetype {
+  Unknown,
+  BlockDevice,
+  CharacterDevice,
+  Directory,
+  RegularFile,
+  SocketDatagram,
+  SocketStream,
+  SymbolicLink,
+}
+```
+
+The type of file a `FileDescriptor` refers to.
+
+### File.**Whence**
+
+```grain
+enum Whence {
+  Set,
+  Current,
+  End,
+}
+```
+
+Flags that determine where seeking should begin in a file.
+
+### File.**Stats**
+
+```grain
+record Stats {
+  filetype: Filetype,
+  flags: List<FdFlag>,
+  rights: List<Rights>,
+  rightsInheriting: List<Rights>,
+}
+```
+
+Information about a `FileDescriptor`.
+
+### File.**Filestats**
+
+```grain
+record Filestats {
+  device: Int64,
+  inode: Int64,
+  filetype: Filetype,
+  linkcount: Int64,
+  size: Int64,
+  accessed: Int64,
+  modified: Int64,
+  changed: Int64,
+}
+```
+
+Information about the file that a `FileDescriptor` refers to.
+
+### File.**DirectoryEntry**
+
+```grain
+record DirectoryEntry {
+  inode: Int64,
+  filetype: Filetype,
+  path: String,
+}
+```
+
+An entry in a directory.
+
+## Values
+
+Functions and constants included in the Sys/File module.
+
+### File.**stdin**
+
+```grain
+stdin : FileDescriptor
+```
+
+The `FileDescriptor` for `stdin`.
+
+### File.**stdout**
+
+```grain
+stdout : FileDescriptor
+```
+
+The `FileDescriptor` for `stdout`.
+
+### File.**stderr**
+
+```grain
+stderr : FileDescriptor
+```
+
+The `FileDescriptor` for `stderr`.
+
+### File.**pwdfd**
+
+```grain
+pwdfd : FileDescriptor
+```
+
+The `FileDescriptor` for the current working directory of the process.
+
+### File.**pathOpen**
+
+```grain
+pathOpen :
+  (FileDescriptor, List<LookupFlag>, String, List<OpenFlag>, List<Rights>,
+   List<Rights>, List<FdFlag>) -> Result<FileDescriptor, Exception>
+```
+
+Open a file or directory.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`dirFd`|`FileDescriptor`|The directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to the file or directory|
+|`openFlags`|`List<OpenFlag>`|Flags that decide how the path will be opened|
+|`rights`|`List<Rights>`|The rights that dictate what may be done with the returned file descriptor|
+|`rightsInheriting`|`List<Rights>`|The rights that dictate what may be done with file descriptors derived from this file descriptor|
+|`flags`|`List<FdFlag>`|Flags which affect read/write operations on this file descriptor|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<FileDescriptor, Exception>`|`Ok(fd)` of the opened file or directory if successful or `Err(exception)` otherwise|
+
+### File.**fdRead**
+
+```grain
+fdRead : (FileDescriptor, Number) -> Result<(String, Number), Exception>
+```
+
+Read from a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to read from|
+|`size`|`Number`|The maximum number of bytes to read from the file descriptor|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<(String, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+
+### File.**fdPread**
+
+```grain
+fdPread :
+  (FileDescriptor, Int64, Number) -> Result<(String, Number), Exception>
+```
+
+Read from a file descriptor without updating the file descriptor's offset.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to read from|
+|`offset`|`Int64`|The position within the file to begin reading|
+|`size`|`Number`|The maximum number of bytes to read from the file descriptor|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<(String, Number), Exception>`|`Ok((contents, numBytes)) of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+
+### File.**fdWrite**
+
+```grain
+fdWrite : (FileDescriptor, String) -> Result<Number, Exception>
+```
+
+Write to a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to which data will be written|
+|`data`|`String`|The data to be written|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Number, Exception>`|`Ok(numBytes)` of the number of bytes written if successful or `Err(Exception)` otherwise|
+
+### File.**fdPwrite**
+
+```grain
+fdPwrite : (FileDescriptor, String, Int64) -> Result<Number, Exception>
+```
+
+Write to a file descriptor without updating the file descriptor's offset.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to which data will be written|
+|`data`|`String`|The data to be written|
+|`offset`|`Int64`|The position within the file to begin writing|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Number, Exception>`|`Ok(numBytes)` of the number of bytes written if successful or `Err(exception)` otherwise|
+
+### File.**fdAllocate**
+
+```grain
+fdAllocate : (FileDescriptor, Int64, Int64) -> Result<Void, Exception>
+```
+
+Allocate space within a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor in which space will be allocated|
+|`offset`|`Int64`|The position within the file to begin writing|
+|`size`|`Int64`|The number of bytes to allocate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdClose**
+
+```grain
+fdClose : FileDescriptor -> Result<Void, Exception>
+```
+
+Close a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to close|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdDatasync**
+
+```grain
+fdDatasync : FileDescriptor -> Result<Void, Exception>
+```
+
+Synchronize the data of a file to disk.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to synchronize|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSync**
+
+```grain
+fdSync : FileDescriptor -> Result<Void, Exception>
+```
+
+Synchronize the data and metadata of a file to disk.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to synchronize|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdStats**
+
+```grain
+fdStats : FileDescriptor -> Result<Stats, Exception>
+```
+
+Retrieve information about a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of which to retrieve information|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Stats, Exception>`|`Ok(stats)` of the `Stats` associated with the file descriptor if successful or `Err(exception)` otherwise|
+
+### File.**fdSetFlags**
+
+```grain
+fdSetFlags : (FileDescriptor, List<FdFlag>) -> Result<Void, Exception>
+```
+
+Update the flags associated with a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to update flags|
+|`flags`|`List<FdFlag>`|The flags to apply to the file descriptor|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSetRights**
+
+```grain
+fdSetRights :
+  (FileDescriptor, List<Rights>, List<Rights>) -> Result<Void, Exception>
+```
+
+Update the rights associated with a file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to update rights|
+|`rights`|`List<Rights>`|Rights to apply to the file descriptor|
+|`rightsInheriting`|`List<Rights>`|Inheriting rights to apply to the file descriptor|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdFilestats**
+
+```grain
+fdFilestats : FileDescriptor -> Result<Filestats, Exception>
+```
+
+Retrieve information about a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to retrieve information|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Filestats, Exception>`|`Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise|
+
+### File.**fdSetSize**
+
+```grain
+fdSetSize : (FileDescriptor, Int64) -> Result<Void, Exception>
+```
+
+Set (truncate) the size of a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to truncate|
+|`size`|`Int64`|The number of bytes to retain in the file|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSetAccessTime**
+
+```grain
+fdSetAccessTime : (FileDescriptor, Int64) -> Result<Void, Exception>
+```
+
+Set the access (created) time of a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to update|
+|`timestamp`|`Int64`|The time to set|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSetAccessTimeNow**
+
+```grain
+fdSetAccessTimeNow : FileDescriptor -> Result<Void, Exception>
+```
+
+Set the access (created) time of a file to the current time.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to update|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSetModifiedTime**
+
+```grain
+fdSetModifiedTime : (FileDescriptor, Int64) -> Result<Void, Exception>
+```
+
+Set the modified time of a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to update|
+|`timestamp`|`Int64`|The time to set|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSetModifiedTimeNow**
+
+```grain
+fdSetModifiedTimeNow : FileDescriptor -> Result<Void, Exception>
+```
+
+Set the modified time of a file to the current time.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the file to update|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdReaddir**
+
+```grain
+fdReaddir : FileDescriptor -> Result<Array<DirectoryEntry>, Exception>
+```
+
+Read the entires of a directory.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The directory to read|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Array<DirectoryEntry>, Exception>`|`Ok(dirEntries)` of an array of `DirectoryEntry` for each entry in the directory if successful or `Err(exception)` otherwise|
+
+### File.**fdRenumber**
+
+```grain
+fdRenumber : (FileDescriptor, FileDescriptor) -> Result<Void, Exception>
+```
+
+Atomically replace a file descriptor by renumbering another file descriptor.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fromFd`|`FileDescriptor`|The file descriptor to renumber|
+|`toFd`|`FileDescriptor`|The file descriptor to overwrite|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**fdSeek**
+
+```grain
+fdSeek : (FileDescriptor, Int64, Whence) -> Result<Int64, Exception>
+```
+
+Update a file descriptor's offset.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to operate on|
+|`offset`|`Int64`|The number of bytes to move the offset|
+|`whence`|`Whence`|The location from which the offset is relative|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(offset)` of the new offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise|
+
+### File.**fdTell**
+
+```grain
+fdTell : FileDescriptor -> Result<Int64, Exception>
+```
+
+Read a file descriptor's offset.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor to read the offset|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(offset)` of the offset of the file descriptor, relative to the start of the file, if successful or `Err(exception)` otherwise|
+
+### File.**pathCreateDirectory**
+
+```grain
+pathCreateDirectory : (FileDescriptor, String) -> Result<Void, Exception>
+```
+
+Create a directory.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`path`|`String`|The path to the new directory|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathFilestats**
+
+```grain
+pathFilestats :
+  (FileDescriptor, List<LookupFlag>, String) -> Result<Filestats, Exception>
+```
+
+Retrieve information about a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to retrieve information about|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Filestats, Exception>`|`Ok(info)` of the `Filestats` associated with the file descriptor if successful or `Err(exception)` otherwise|
+
+### File.**pathSetAccessTime**
+
+```grain
+pathSetAccessTime :
+  (FileDescriptor, List<LookupFlag>, String, Int64) ->
+   Result<Void, Exception>
+```
+
+Set the access (created) time of a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to set the time|
+|`timestamp`|`Int64`|The time to set|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathSetAccessTimeNow**
+
+```grain
+pathSetAccessTimeNow :
+  (FileDescriptor, List<LookupFlag>, String) -> Result<Void, Exception>
+```
+
+Set the access (created) time of a file to the current time.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to set the time|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathSetModifiedTime**
+
+```grain
+pathSetModifiedTime :
+  (FileDescriptor, List<LookupFlag>, String, Int64) ->
+   Result<Void, Exception>
+```
+
+Set the modified time of a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to set the time|
+|`timestamp`|`Int64`|The time to set|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathSetModifiedTimeNow**
+
+```grain
+pathSetModifiedTimeNow :
+  (FileDescriptor, List<LookupFlag>, String) -> Result<Void, Exception>
+```
+
+Set the modified time of a file to the current time.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`path`|`String`|The path to set the time|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathLink**
+
+```grain
+pathLink :
+  (FileDescriptor, List<LookupFlag>, String, FileDescriptor, String) ->
+   Result<Void, Exception>
+```
+
+Create a hard link.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`sourceFd`|`FileDescriptor`|The file descriptor of the directory in which the source path resolution starts|
+|`dirFlags`|`List<LookupFlag>`|Flags which affect path resolution|
+|`sourcePath`|`String`|The path to the source of the link|
+|`targetFd`|`FileDescriptor`|The file descriptor of the directory in which the target path resolution starts|
+|`targetPath`|`String`|The path to the target of the link|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathSymlink**
+
+```grain
+pathSymlink : (FileDescriptor, String, String) -> Result<Void, Exception>
+```
+
+Create a symlink.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`sourcePath`|`String`|The path to the source of the link|
+|`targetPath`|`String`|The path to the target of the link|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathUnlink**
+
+```grain
+pathUnlink : (FileDescriptor, String) -> Result<Void, Exception>
+```
+
+Unlink a file.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`path`|`String`|The path of the file to unlink|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathReadlink**
+
+```grain
+pathReadlink :
+  (FileDescriptor, String, Number) -> Result<(String, Number), Exception>
+```
+
+Read the contents of a symbolic link.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`path`|`String`|The path to the symlink|
+|`size`|`Number`|The number of bytes to read|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<(String, Number), Exception>`|`Ok((contents, nBytes))` of the bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+
+### File.**pathRemoveDirectory**
+
+```grain
+pathRemoveDirectory : (FileDescriptor, String) -> Result<Void, Exception>
+```
+
+Remove a directory.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fd`|`FileDescriptor`|The file descriptor of the directory in which path resolution starts|
+|`path`|`String`|The path to the directory to remove|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### File.**pathRename**
+
+```grain
+pathRename :
+  (FileDescriptor, String, FileDescriptor, String) -> Result<Void, Exception>
+```
+
+Rename a file or directory.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`sourceFd`|`FileDescriptor`|The file descriptor of the directory in which the source path resolution starts|
+|`sourcePath`|`String`|The path of the file to rename|
+|`targetFd`|`FileDescriptor`|The file descriptor of the directory in which the target path resolution starts|
+|`targetPath`|`String`|The new path of the file|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -1,4 +1,11 @@
 /* grainc-flags --no-gc */
+/**
+ * @module Sys/Process: Utilities for accessing functionality and information about the Grain program's process.
+ *
+ * This includes things like accessing environment variables and sending signals.
+ *
+ * @example import Process from "sys/process"
+ */
 
 import WasmI32, {
   add as (+),
@@ -14,6 +21,13 @@ import Memory from "runtime/unsafe/memory"
 import Wasi from "runtime/wasi"
 import { tagSimpleNumber, allocateArray, allocateString } from "runtime/dataStructures"
 
+/**
+ * @section Types: Type declarations included in the Sys/Process module.
+ */
+
+/**
+ * Signals that can be sent to the host system.
+ */
 export enum Signal {
   // Hangup.
   HUP,
@@ -73,8 +87,15 @@ export enum Signal {
   SYS,
 }
 
-// Access command line arguments
-// @returns Array<String> The positional string arguments to the process
+/**
+ * @section Values: Functions and constants included in the Sys/Process module.
+ */
+
+/**
+ * Access command line arguments.
+ *
+ * @returns `Ok(args)` of an array containing positional string arguments to the process if successful or `Err(exception)` otherwise
+ */
 export let argv = () => {
   let argcPtr = Memory.malloc(8n)
   let argvBufSizePtr = argcPtr + 4n
@@ -122,8 +143,11 @@ export let argv = () => {
   }
 }
 
-// Access environment variables
-// @returns Array<String> The environment variables supplied to the process
+/**
+ * Access environment variables.
+ *
+ * @returns `Ok(vars)` of an array containing environment variables supplied to the process if successful or `Err(exception)` otherwise
+ */
 export let env = () => {
   let envcPtr = Memory.malloc(8n)
   let envvBufSizePtr = envcPtr + 4n
@@ -171,8 +195,12 @@ export let env = () => {
   }
 }
 
-// Terminate the process normally
-// @param code: Number The value to exit with. An exit code of 0 is considered normal, with other values having meaning depending on the platform
+/**
+ * Terminate the process normally.
+ *
+ * @param code: The value to exit with. An exit code of 0 is considered normal, with other values having meaning depending on the platform
+ * @returns `Err(exception)` if unsuccessful. Will not actually return a value if successful, as the process has ended
+ */
 export let exit = (code: Number) => {
   let mut code = WasmI32.fromGrain(code)
 
@@ -186,8 +214,12 @@ export let exit = (code: Number) => {
   }
 }
 
-// Send a signal to the process of the calling thread
-// @param signal: Signal The signal to send
+/**
+ * Send a signal to the process of the calling thread.
+ *
+ * @param signal: The signal to send
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let sigRaise = (signalPtr: Signal) => {
   let signal = WasmI32.fromGrain(signalPtr)
   let signal = WasmI32.load(signal, 12n) >> 1n
@@ -199,7 +231,11 @@ export let sigRaise = (signalPtr: Signal) => {
   }
 }
 
-// Yield execution to the calling thread
+/**
+ * Yield execution to the calling thread.
+ *
+ * @returns `Ok(void)` if successful or `Err(exception)` otherwise
+ */
 export let schedYield = () => {
   let err = Wasi.sched_yield()
   if (err != Wasi._ESUCCESS) {

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -82,44 +82,44 @@ export let argv = () => {
   let mut err = Wasi.args_sizes_get(argcPtr, argvBufSizePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(argcPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
-  }
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let argc = WasmI32.load(argcPtr, 0n)
+    let argvBufSize = WasmI32.load(argvBufSizePtr, 0n)
 
-  let argc = WasmI32.load(argcPtr, 0n)
-  let argvBufSize = WasmI32.load(argvBufSizePtr, 0n)
+    let argvPtr = Memory.malloc(argc * 4n)
+    let argvBufPtr = Memory.malloc(argvBufSize)
 
-  let argvPtr = Memory.malloc(argc * 4n)
-  let argvBufPtr = Memory.malloc(argvBufSize)
+    err = Wasi.args_get(argvPtr, argvBufPtr)
+    if (err != Wasi._ESUCCESS) {
+      Memory.free(argcPtr)
+      Memory.free(argvPtr)
+      Memory.free(argvBufPtr)
+      Err(Wasi.SystemError(tagSimpleNumber(err)))
+    } else {
+      let arr = allocateArray(argc)
 
-  err = Wasi.args_get(argvPtr, argvBufPtr)
-  if (err != Wasi._ESUCCESS) {
-    Memory.free(argcPtr)
-    Memory.free(argvPtr)
-    Memory.free(argvBufPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
-  }
+      let argsLength = argc * 4n
+      for (let mut i = 0n; i < argsLength; i += 4n) {
+        let strPtr = WasmI32.load(argvPtr + i, 0n)
+        let mut strLength = 0n
+        while (WasmI32.load8U(strPtr + strLength, 0n) != 0n) {
+          strLength += 1n
+        }
 
-  let arr = allocateArray(argc)
+        let grainStrPtr = allocateString(strLength)
+        Memory.copy(grainStrPtr + 8n, strPtr, strLength)
 
-  let argsLength = argc * 4n
-  for (let mut i = 0n; i < argsLength; i += 4n) {
-    let strPtr = WasmI32.load(argvPtr + i, 0n)
-    let mut strLength = 0n
-    while (WasmI32.load8U(strPtr + strLength, 0n) != 0n) {
-      strLength += 1n
+        WasmI32.store(arr + i, grainStrPtr, 8n)
+      }
+
+      Memory.free(argcPtr)
+      Memory.free(argvPtr)
+      Memory.free(argvBufPtr)
+
+      Ok(WasmI32.toGrain(arr): Array<String>)
     }
-
-    let grainStrPtr = allocateString(strLength)
-    Memory.copy(grainStrPtr + 8n, strPtr, strLength)
-
-    WasmI32.store(arr + i, grainStrPtr, 8n)
   }
-
-  Memory.free(argcPtr)
-  Memory.free(argvPtr)
-  Memory.free(argvBufPtr)
-
-  WasmI32.toGrain(arr): Array<String>
 }
 
 // Access environment variables
@@ -131,44 +131,44 @@ export let env = () => {
   let mut err = Wasi.environ_sizes_get(envcPtr, envvBufSizePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(envcPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
-  }
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let envc = WasmI32.load(envcPtr, 0n)
+    let envvBufSize = WasmI32.load(envvBufSizePtr, 0n)
 
-  let envc = WasmI32.load(envcPtr, 0n)
-  let envvBufSize = WasmI32.load(envvBufSizePtr, 0n)
+    let envvPtr = Memory.malloc(envc * 4n)
+    let envvBufPtr = Memory.malloc(envvBufSize)
 
-  let envvPtr = Memory.malloc(envc * 4n)
-  let envvBufPtr = Memory.malloc(envvBufSize)
+    err = Wasi.environ_get(envvPtr, envvBufPtr)
+    if (err != Wasi._ESUCCESS) {
+      Memory.free(envcPtr)
+      Memory.free(envvPtr)
+      Memory.free(envvBufPtr)
+      Err(Wasi.SystemError(tagSimpleNumber(err)))
+    } else {
+      let arr = allocateArray(envc)
 
-  err = Wasi.environ_get(envvPtr, envvBufPtr)
-  if (err != Wasi._ESUCCESS) {
-    Memory.free(envcPtr)
-    Memory.free(envvPtr)
-    Memory.free(envvBufPtr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
-  }
+      let envsLength = envc * 4n
+      for (let mut i = 0n; i < envsLength; i += 4n) {
+        let strPtr = WasmI32.load(envvPtr + i, 0n)
+        let mut strLength = 0n
+        while (WasmI32.load8U(strPtr + strLength, 0n) != 0n) {
+          strLength += 1n
+        }
 
-  let arr = allocateArray(envc)
+        let grainStrPtr = allocateString(strLength)
+        Memory.copy(grainStrPtr + 8n, strPtr, strLength)
 
-  let envsLength = envc * 4n
-  for (let mut i = 0n; i < envsLength; i += 4n) {
-    let strPtr = WasmI32.load(envvPtr + i, 0n)
-    let mut strLength = 0n
-    while (WasmI32.load8U(strPtr + strLength, 0n) != 0n) {
-      strLength += 1n
+        WasmI32.store(arr + i, grainStrPtr, 8n)
+      }
+
+      Memory.free(envcPtr)
+      Memory.free(envvPtr)
+      Memory.free(envvBufPtr)
+
+      Ok(WasmI32.toGrain(arr): Array<String>)
     }
-
-    let grainStrPtr = allocateString(strLength)
-    Memory.copy(grainStrPtr + 8n, strPtr, strLength)
-
-    WasmI32.store(arr + i, grainStrPtr, 8n)
   }
-
-  Memory.free(envcPtr)
-  Memory.free(envvPtr)
-  Memory.free(envvBufPtr)
-
-  WasmI32.toGrain(arr): Array<String>
 }
 
 // Terminate the process normally
@@ -177,11 +177,13 @@ export let exit = (code: Number) => {
   let mut code = WasmI32.fromGrain(code)
 
   if ((code & 1n) == 0n) {
-    throw InvalidArgument("Invalid exit code")
+    Err(InvalidArgument("Invalid exit code"))
+  } else {
+    code = code >> 1n
+    Wasi.proc_exit(code)
+    // Never actually hit because it exited
+    Ok(void)
   }
-
-  code = code >> 1n
-  Wasi.proc_exit(code)
 }
 
 // Send a signal to the process of the calling thread
@@ -191,7 +193,9 @@ export let sigRaise = (signalPtr: Signal) => {
   let signal = WasmI32.load(signal, 12n) >> 1n
   let err = Wasi.proc_raise(signal)
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }
 
@@ -199,6 +203,8 @@ export let sigRaise = (signalPtr: Signal) => {
 export let schedYield = () => {
   let err = Wasi.sched_yield()
   if (err != Wasi._ESUCCESS) {
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(void)
   }
 }

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -108,12 +108,12 @@ let wasmSafeErr = (err) => {
  *
  * @returns `Ok(args)` of an array containing positional string arguments to the process if successful or `Err(exception)` otherwise
  */
-export let argv = () => {
+export let rec argv = () => {
   let argcPtr = Memory.malloc(8n)
   let argvBufSizePtr = argcPtr + 4n
 
   let mut err = Wasi.args_sizes_get(argcPtr, argvBufSizePtr)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(argcPtr)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -153,6 +153,8 @@ export let argv = () => {
       wasmSafeOk(WasmI32.toGrain(arr): Array<String>)
     }
   }
+  Memory.decRef(WasmI32.fromGrain(argv))
+  ret
 }
 
 /**
@@ -160,12 +162,12 @@ export let argv = () => {
  *
  * @returns `Ok(vars)` of an array containing environment variables supplied to the process if successful or `Err(exception)` otherwise
  */
-export let env = () => {
+export let rec env = () => {
   let envcPtr = Memory.malloc(8n)
   let envvBufSizePtr = envcPtr + 4n
 
   let mut err = Wasi.environ_sizes_get(envcPtr, envvBufSizePtr)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(envcPtr)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -205,6 +207,8 @@ export let env = () => {
       wasmSafeOk(WasmI32.toGrain(arr): Array<String>)
     }
   }
+  Memory.decRef(WasmI32.fromGrain(env))
+  ret
 }
 
 /**
@@ -213,10 +217,10 @@ export let env = () => {
  * @param code: The value to exit with. An exit code of 0 is considered normal, with other values having meaning depending on the platform
  * @returns `Err(exception)` if unsuccessful. Will not actually return a value if successful, as the process has ended
  */
-export let exit = (code: Number) => {
+export let rec exit = (code: Number) => {
   let mut code = WasmI32.fromGrain(code)
 
-  if ((code & 1n) == 0n) {
+  let ret = if ((code & 1n) == 0n) {
     wasmSafeErr(InvalidArgument("Invalid exit code"))
   } else {
     code = code >> 1n
@@ -224,6 +228,8 @@ export let exit = (code: Number) => {
     // Never actually hit because it exited
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(exit))
+  ret
 }
 
 /**
@@ -232,15 +238,17 @@ export let exit = (code: Number) => {
  * @param signal: The signal to send
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let sigRaise = (signalPtr: Signal) => {
+export let rec sigRaise = (signalPtr: Signal) => {
   let signal = WasmI32.fromGrain(signalPtr)
   let signal = WasmI32.load(signal, 12n) >> 1n
   let err = Wasi.proc_raise(signal)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(sigRaise))
+  ret
 }
 
 /**
@@ -248,11 +256,13 @@ export let sigRaise = (signalPtr: Signal) => {
  *
  * @returns `Ok(void)` if successful or `Err(exception)` otherwise
  */
-export let schedYield = () => {
+export let rec schedYield = () => {
   let err = Wasi.sched_yield()
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     wasmSafeOk(void)
   }
+  Memory.decRef(WasmI32.fromGrain(schedYield))
+  ret
 }

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -91,6 +91,18 @@ export enum Signal {
  * @section Values: Functions and constants included in the Sys/Process module.
  */
 
+let wasmSafeOk = (val) => {
+  Memory.incRef(WasmI32.fromGrain(Ok))
+  Memory.incRef(WasmI32.fromGrain(val))
+  Ok(val)
+}
+
+let wasmSafeErr = (err) => {
+  Memory.incRef(WasmI32.fromGrain(Err))
+  Memory.incRef(WasmI32.fromGrain(err))
+  Err(err)
+}
+
 /**
  * Access command line arguments.
  *
@@ -103,7 +115,7 @@ export let argv = () => {
   let mut err = Wasi.args_sizes_get(argcPtr, argvBufSizePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(argcPtr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let argc = WasmI32.load(argcPtr, 0n)
     let argvBufSize = WasmI32.load(argvBufSizePtr, 0n)
@@ -116,7 +128,7 @@ export let argv = () => {
       Memory.free(argcPtr)
       Memory.free(argvPtr)
       Memory.free(argvBufPtr)
-      Err(Wasi.SystemError(tagSimpleNumber(err)))
+      wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
     } else {
       let arr = allocateArray(argc)
 
@@ -138,7 +150,7 @@ export let argv = () => {
       Memory.free(argvPtr)
       Memory.free(argvBufPtr)
 
-      Ok(WasmI32.toGrain(arr): Array<String>)
+      wasmSafeOk(WasmI32.toGrain(arr): Array<String>)
     }
   }
 }
@@ -155,7 +167,7 @@ export let env = () => {
   let mut err = Wasi.environ_sizes_get(envcPtr, envvBufSizePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(envcPtr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let envc = WasmI32.load(envcPtr, 0n)
     let envvBufSize = WasmI32.load(envvBufSizePtr, 0n)
@@ -168,7 +180,7 @@ export let env = () => {
       Memory.free(envcPtr)
       Memory.free(envvPtr)
       Memory.free(envvBufPtr)
-      Err(Wasi.SystemError(tagSimpleNumber(err)))
+      wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
     } else {
       let arr = allocateArray(envc)
 
@@ -190,7 +202,7 @@ export let env = () => {
       Memory.free(envvPtr)
       Memory.free(envvBufPtr)
 
-      Ok(WasmI32.toGrain(arr): Array<String>)
+      wasmSafeOk(WasmI32.toGrain(arr): Array<String>)
     }
   }
 }
@@ -205,12 +217,12 @@ export let exit = (code: Number) => {
   let mut code = WasmI32.fromGrain(code)
 
   if ((code & 1n) == 0n) {
-    Err(InvalidArgument("Invalid exit code"))
+    wasmSafeErr(InvalidArgument("Invalid exit code"))
   } else {
     code = code >> 1n
     Wasi.proc_exit(code)
     // Never actually hit because it exited
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -225,9 +237,9 @@ export let sigRaise = (signalPtr: Signal) => {
   let signal = WasmI32.load(signal, 12n) >> 1n
   let err = Wasi.proc_raise(signal)
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }
 
@@ -239,8 +251,8 @@ export let sigRaise = (signalPtr: Signal) => {
 export let schedYield = () => {
   let err = Wasi.sched_yield()
   if (err != Wasi._ESUCCESS) {
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(void)
+    wasmSafeOk(void)
   }
 }

--- a/stdlib/sys/process.md
+++ b/stdlib/sys/process.md
@@ -1,0 +1,141 @@
+---
+title: Sys/Process
+---
+
+Utilities for accessing functionality and information about the Grain program's process.
+
+This includes things like accessing environment variables and sending signals.
+
+```grain
+import Process from "sys/process"
+```
+
+## Types
+
+Type declarations included in the Sys/Process module.
+
+### Process.**Signal**
+
+```grain
+enum Signal {
+  HUP,
+  INT,
+  QUIT,
+  ILL,
+  TRAP,
+  ABRT,
+  BUS,
+  FPE,
+  KILL,
+  USR1,
+  SEGV,
+  USR2,
+  PIPE,
+  ALRM,
+  TERM,
+  CHLD,
+  CONT,
+  STOP,
+  TSTP,
+  TTIN,
+  TTOU,
+  URG,
+  XCPU,
+  XFSZ,
+  VTALRM,
+  PROF,
+  WINCH,
+  POLL,
+  PWR,
+  SYS,
+}
+```
+
+Signals that can be sent to the host system.
+
+## Values
+
+Functions and constants included in the Sys/Process module.
+
+### Process.**argv**
+
+```grain
+argv : () -> Result<Array<String>, Exception>
+```
+
+Access command line arguments.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Array<String>, Exception>`|`Ok(args)` of an array containing positional string arguments to the process if successful or `Err(exception)` otherwise|
+
+### Process.**env**
+
+```grain
+env : () -> Result<Array<String>, Exception>
+```
+
+Access environment variables.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Array<String>, Exception>`|`Ok(vars)` of an array containing environment variables supplied to the process if successful or `Err(exception)` otherwise|
+
+### Process.**exit**
+
+```grain
+exit : Number -> Result<Void, Exception>
+```
+
+Terminate the process normally.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`code`|`Number`|The value to exit with. An exit code of 0 is considered normal, with other values having meaning depending on the platform|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Err(exception)` if unsuccessful. Will not actually return a value if successful, as the process has ended|
+
+### Process.**sigRaise**
+
+```grain
+sigRaise : Signal -> Result<Void, Exception>
+```
+
+Send a signal to the process of the calling thread.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`signal`|`Signal`|The signal to send|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+
+### Process.**schedYield**
+
+```grain
+schedYield : () -> Result<Void, Exception>
+```
+
+Yield execution to the calling thread.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Void, Exception>`|`Ok(void)` if successful or `Err(exception)` otherwise|
+

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -1,4 +1,9 @@
 /* grainc-flags --no-gc */
+/**
+ * @module Sys/Random: System access to random values.
+ *
+ * @example import Random from "sys/random"
+ */
 
 import WasmI32, {
   eq as (==),
@@ -8,8 +13,15 @@ import Memory from "runtime/unsafe/memory"
 import Wasi from "runtime/wasi"
 import { tagSimpleNumber } from "runtime/dataStructures"
 
-// Produce a random number. This function can be slow, so it's best to seed a generator if lots of random data is needed
-// @returns Number
+/**
+ * @section Values: Functions and constants included in the Sys/Random module.
+ */
+
+/**
+ * Produce a random number. This function can be slow, so it's best to seed a generator if lots of random data is needed.
+ *
+ * @returns `Ok(num)` of a random number if successful or `Err(exception)` otherwise
+ */
 export let random = () => {
   let buf = Memory.malloc(4n)
 

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -16,10 +16,10 @@ export let random = () => {
   let err = Wasi.random_get(buf, 4n)
   if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    let rand = WasmI32.load(buf, 0n)
+    Memory.free(buf)
+    Ok(tagSimpleNumber(rand))
   }
-
-  let rand = WasmI32.load(buf, 0n)
-  Memory.free(buf)
-  tagSimpleNumber(rand)
 }

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -17,6 +17,18 @@ import { tagSimpleNumber } from "runtime/dataStructures"
  * @section Values: Functions and constants included in the Sys/Random module.
  */
 
+let wasmSafeOk = (val) => {
+  Memory.incRef(WasmI32.fromGrain(Ok))
+  Memory.incRef(WasmI32.fromGrain(val))
+  Ok(val)
+}
+
+let wasmSafeErr = (err) => {
+  Memory.incRef(WasmI32.fromGrain(Err))
+  Memory.incRef(WasmI32.fromGrain(err))
+  Err(err)
+}
+
 /**
  * Produce a random number. This function can be slow, so it's best to seed a generator if lots of random data is needed.
  *
@@ -28,10 +40,10 @@ export let random = () => {
   let err = Wasi.random_get(buf, 4n)
   if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
     let rand = WasmI32.load(buf, 0n)
     Memory.free(buf)
-    Ok(tagSimpleNumber(rand))
+    wasmSafeOk(tagSimpleNumber(rand))
   }
 }

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -34,11 +34,11 @@ let wasmSafeErr = (err) => {
  *
  * @returns `Ok(num)` of a random number if successful or `Err(exception)` otherwise
  */
-export let random = () => {
+export let rec random = () => {
   let buf = Memory.malloc(4n)
 
   let err = Wasi.random_get(buf, 4n)
-  if (err != Wasi._ESUCCESS) {
+  let ret = if (err != Wasi._ESUCCESS) {
     Memory.free(buf)
     wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
@@ -46,4 +46,6 @@ export let random = () => {
     Memory.free(buf)
     wasmSafeOk(tagSimpleNumber(rand))
   }
+  Memory.decRef(WasmI32.fromGrain(random))
+  ret
 }

--- a/stdlib/sys/random.md
+++ b/stdlib/sys/random.md
@@ -1,0 +1,28 @@
+---
+title: Sys/Random
+---
+
+System access to random values.
+
+```grain
+import Random from "sys/random"
+```
+
+## Values
+
+Functions and constants included in the Sys/Random module.
+
+### Random.**random**
+
+```grain
+random : () -> Result<Number, Exception>
+```
+
+Produce a random number. This function can be slow, so it's best to seed a generator if lots of random data is needed.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Number, Exception>`|`Ok(num)` of a random number if successful or `Err(exception)` otherwise|
+

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -1,4 +1,9 @@
 /* grainc-flags --no-gc */
+/**
+ * @module Sys/Time: Access to system clocks.
+ *
+ * @example import Time from "sys/time"
+ */
 
 import WasmI32, {
   add as (+),
@@ -9,6 +14,10 @@ import Memory from "runtime/unsafe/memory"
 import Wasi from "runtime/wasi"
 import Errors from "runtime/unsafe/errors"
 import { allocateInt64, tagSimpleNumber } from "runtime/dataStructures"
+
+/**
+ * @section Values: Functions and constants included in the Sys/Time module.
+ */
 
 let getClockTime = (clockid, precision) => {
   let int64Ptr = allocateInt64()
@@ -22,30 +31,42 @@ let getClockTime = (clockid, precision) => {
   }
 }
 
-// Get the current time, in nanoseconds.
-// Time value 0 corresponds with 1970-01-01T00:00:00Z.
-// @returns Int64 The current time
+/**
+ * Get the current time, in nanoseconds.
+ * Time value 0 corresponds with 1970-01-01T00:00:00Z.
+ *
+ * @returns `Ok(time)` of the current time if successful or `Err(exception)` otherwise
+ */
 export let realTime = () => {
   getClockTime(Wasi._CLOCK_REALTIME, 1000N)
 }
 
-// Get the time of the system's high-resolution clock, in nanoseconds.
-// This system clock cannot be adjusted and cannot have negative time jumps.
-// The epoch of this clock is undefined, and thus time value 0 is meaningless.
-// Useful for calculation of precise time intervals.
-// @returns Int64 The current time
+/**
+ * Get the time of the system's high-resolution clock, in nanoseconds.
+ * This system clock cannot be adjusted and cannot have negative time jumps.
+ * The epoch of this clock is undefined, and thus time value 0 is meaningless.
+ * Useful for calculation of precise time intervals.
+ *
+ * @returns `Ok(time)` of the current time if successful or `Err(exception)` otherwise
+ */
 export let monotonicTime = () => {
   getClockTime(Wasi._CLOCK_MONOTONIC, 1N)
 }
 
-// Get the number of nanoseconds elapsed since the process began
-// @returns Int64
+/**
+ * Get the number of nanoseconds elapsed since the process began.
+ *
+ * @returns `Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise
+ */
 export let processCpuTime = () => {
   getClockTime(Wasi._CLOCK_PROCESS_CPUTIME, 1N)
 }
 
-// Get the number of nanoseconds elapsed since the thread began
-// @returns Int64
+/**
+ * Get the number of nanoseconds elapsed since the thread began.
+ *
+ * @returns `Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise
+ */
 export let threadCpuTime = () => {
   getClockTime(Wasi._CLOCK_THREAD_CPUTIME, 1N)
 }

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -16,10 +16,10 @@ let getClockTime = (clockid, precision) => {
   let err = Wasi.clock_time_get(clockid, precision, timePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(int64Ptr)
-    throw Wasi.SystemError(tagSimpleNumber(err))
+    Err(Wasi.SystemError(tagSimpleNumber(err)))
+  } else {
+    Ok(WasmI32.toGrain(int64Ptr): Int64)
   }
-
-  WasmI32.toGrain(int64Ptr): Int64
 }
 
 // Get the current time, in nanoseconds.

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -49,8 +49,10 @@ let getClockTime = (clockid, precision) => {
  *
  * @returns `Ok(time)` of the current time if successful or `Err(exception)` otherwise
  */
-export let realTime = () => {
-  getClockTime(Wasi._CLOCK_REALTIME, 1000N)
+export let rec realTime = () => {
+  let ret = getClockTime(Wasi._CLOCK_REALTIME, 1000N)
+  Memory.decRef(WasmI32.fromGrain(realTime))
+  ret
 }
 
 /**
@@ -61,8 +63,10 @@ export let realTime = () => {
  *
  * @returns `Ok(time)` of the current time if successful or `Err(exception)` otherwise
  */
-export let monotonicTime = () => {
-  getClockTime(Wasi._CLOCK_MONOTONIC, 1N)
+export let rec monotonicTime = () => {
+  let ret = getClockTime(Wasi._CLOCK_MONOTONIC, 1N)
+  Memory.decRef(WasmI32.fromGrain(monotonicTime))
+  ret
 }
 
 /**
@@ -70,8 +74,10 @@ export let monotonicTime = () => {
  *
  * @returns `Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise
  */
-export let processCpuTime = () => {
-  getClockTime(Wasi._CLOCK_PROCESS_CPUTIME, 1N)
+export let rec processCpuTime = () => {
+  let ret = getClockTime(Wasi._CLOCK_PROCESS_CPUTIME, 1N)
+  Memory.decRef(WasmI32.fromGrain(processCpuTime))
+  ret
 }
 
 /**
@@ -79,6 +85,8 @@ export let processCpuTime = () => {
  *
  * @returns `Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise
  */
-export let threadCpuTime = () => {
-  getClockTime(Wasi._CLOCK_THREAD_CPUTIME, 1N)
+export let rec threadCpuTime = () => {
+  let ret = getClockTime(Wasi._CLOCK_THREAD_CPUTIME, 1N)
+  Memory.decRef(WasmI32.fromGrain(threadCpuTime))
+  ret
 }

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -19,15 +19,27 @@ import { allocateInt64, tagSimpleNumber } from "runtime/dataStructures"
  * @section Values: Functions and constants included in the Sys/Time module.
  */
 
+let wasmSafeOk = (val) => {
+  Memory.incRef(WasmI32.fromGrain(Ok))
+  Memory.incRef(WasmI32.fromGrain(val))
+  Ok(val)
+}
+
+let wasmSafeErr = (err) => {
+  Memory.incRef(WasmI32.fromGrain(Err))
+  Memory.incRef(WasmI32.fromGrain(err))
+  Err(err)
+}
+
 let getClockTime = (clockid, precision) => {
   let int64Ptr = allocateInt64()
   let timePtr = int64Ptr + 8n
   let err = Wasi.clock_time_get(clockid, precision, timePtr)
   if (err != Wasi._ESUCCESS) {
     Memory.free(int64Ptr)
-    Err(Wasi.SystemError(tagSimpleNumber(err)))
+    wasmSafeErr(Wasi.SystemError(tagSimpleNumber(err)))
   } else {
-    Ok(WasmI32.toGrain(int64Ptr): Int64)
+    wasmSafeOk(WasmI32.toGrain(int64Ptr): Int64)
   }
 }
 

--- a/stdlib/sys/time.md
+++ b/stdlib/sys/time.md
@@ -1,0 +1,74 @@
+---
+title: Sys/Time
+---
+
+Access to system clocks.
+
+```grain
+import Time from "sys/time"
+```
+
+## Values
+
+Functions and constants included in the Sys/Time module.
+
+### Time.**realTime**
+
+```grain
+realTime : () -> Result<Int64, Exception>
+```
+
+Get the current time, in nanoseconds.
+Time value 0 corresponds with 1970-01-01T00:00:00Z.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(time)` of the current time if successful or `Err(exception)` otherwise|
+
+### Time.**monotonicTime**
+
+```grain
+monotonicTime : () -> Result<Int64, Exception>
+```
+
+Get the time of the system's high-resolution clock, in nanoseconds.
+This system clock cannot be adjusted and cannot have negative time jumps.
+The epoch of this clock is undefined, and thus time value 0 is meaningless.
+Useful for calculation of precise time intervals.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(time)` of the current time if successful or `Err(exception)` otherwise|
+
+### Time.**processCpuTime**
+
+```grain
+processCpuTime : () -> Result<Int64, Exception>
+```
+
+Get the number of nanoseconds elapsed since the process began.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise|
+
+### Time.**threadCpuTime**
+
+```grain
+threadCpuTime : () -> Result<Int64, Exception>
+```
+
+Get the number of nanoseconds elapsed since the thread began.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Int64, Exception>`|`Ok(elapsed)` of the elapsed nanoseconds if successful or `Err(exception)` otherwise|
+


### PR DESCRIPTION
Fixes #688

I changed all the methods in `stdlib/sys` that throw errors into Result-returning functions. This solves the issue where you want to see if a file exists and handle that case.

I also changed `sys/process.gr`, `sys/time.gr` and `sys/random.gr` but I'm unsure how bad it'll feel to use those methods. What are y'alls opinions?

I wanted to get feedback here before I update the docs, but those will go in this same PR.