### PR TITLE
feat(stdlib): Add Result.expect & Result.unwrap functions

### DIFF
--- a/compiler/test/stdlib/result.test.gr
+++ b/compiler/test/stdlib/result.test.gr
@@ -93,3 +93,17 @@ testMut(() => {
     Result.peekErr((v) => a = v, Err(2))
     assert a == 2
 })
+
+// Result.expect
+
+assert Result.expect("Fails with this message if Err", Ok(1)) == 1
+assert Result.expect("Fails with this message if Err", Ok("🌾")) == "🌾"
+// TODO: Test this when we can
+// assert Result.expect("Failed with this message", Err("Boom"))
+
+// Result.unwrap
+
+assert Result.unwrap(Ok(1)) == 1
+assert Result.unwrap(Ok("🌾")) == "🌾"
+// TODO: Test this when we can
+// assert Result.unwrap(Err("Boom"))

--- a/stdlib/result.gr
+++ b/stdlib/result.gr
@@ -85,3 +85,37 @@ export let peekOk = (fn, r) => {
 export let peekErr = (fn, r) => {
     peek(identity, fn, r)
 }
+
+/**
+ * Extracts the value inside an `Ok` result, otherwise throw an
+ * exception containing the message and contents of the `Err`.
+ *
+ * @param msg: The message to prepend if the result contains an `Err`
+ * @param result: The result to extract a value from
+ * @returns The value inside an `Ok` result
+ *
+ * @example Result.expect("Unexpected error", Ok(1234))
+ *
+ * @since v0.4.0
+ */
+export let expect = (msg, result) => {
+    match (result) {
+        Ok(x) => x,
+        Err(err) => fail msg ++ ": " ++ toString(err)
+    }
+}
+
+/**
+ * Extracts the value inside an `Ok` result, otherwise throw an
+ * exception containing a default message and contents of the `Err`.
+ *
+ * @param result: The result to extract a value from
+ * @returns The value inside an `Ok` result
+ *
+ * @example Result.unwrap(Err("This will throw"))
+ *
+ * @since v0.4.0
+ */
+export let unwrap = (result) => {
+    expect("Could not unwrap Err value", result)
+}


### PR DESCRIPTION
This adds `Result.expect` and `Result.unwrap` functions to the stdlib. I realized that my test changes in #792 wouldn't actually work, so I'll need these methods to write those tests in a (relatively) nice fashion.