### PR TITLE
feat(graindoc): Add support for extra information in module docblock

### DIFF
--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -71,6 +71,7 @@ let generate_docs =
     | Module({attr_name, attr_desc}) =>
       Buffer.add_string(buf, Markdown.frontmatter([("title", attr_name)]));
       Buffer.add_string(buf, Markdown.paragraph(attr_desc));
+      Buffer.add_string(buf, Markdown.paragraph(desc));
     | _ => failwith("Unreachable: Non-`module` attribute can't exist here.")
     };
 

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -71,7 +71,9 @@ let generate_docs =
     | Module({attr_name, attr_desc}) =>
       Buffer.add_string(buf, Markdown.frontmatter([("title", attr_name)]));
       Buffer.add_string(buf, Markdown.paragraph(attr_desc));
-      Buffer.add_string(buf, Markdown.paragraph(desc));
+      if (desc != "") {
+        Buffer.add_string(buf, Markdown.paragraph(desc));
+      };
     | _ => failwith("Unreachable: Non-`module` attribute can't exist here.")
     };
 


### PR DESCRIPTION
When I started writing the docs for our `stdlib/sys/file.gr` module, I noticed that I needed this extra content under the module definition:

> Many of the functions in this module are not intended to be used directly, but rather for other libraries to be built on top of them.

This is too long to inline into the `@module` attribute line, so instead I am now inserting any non-attribute content between the attr_desc and the example.