### PR TITLE
fix(graindoc): Ensure argument-less variants print with trailing comma

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -796,7 +796,7 @@ and print_out_constr = (ppf, (name, tyl, ret_type_opt)) => {
   switch (ret_type_opt) {
   | None =>
     switch (tyl) {
-    | [] => pp_print_string(ppf, name)
+    | [] => fprintf(ppf, "@[<2>%s,@]", name)
     | _ =>
       fprintf(
         ppf,


### PR DESCRIPTION
While working on the `stdlib/sys/file.gr` documentation, I found that variants without arguments don't actually print with a trailing comma. This fixes it.