### PR TITLE
chore(compiler): Introduce timeout for compiler tests

### DIFF
--- a/compiler/test/dune
+++ b/compiler/test/dune
@@ -4,7 +4,7 @@
  (name Grain_tests)
  (public_name grain-tests.framework)
  (libraries grain rely.lib)
- (modules TestFramework runner))
+ (modules TestFramework test_utils runner))
 
 (executable
  (name test)

--- a/compiler/test/test_utils.re
+++ b/compiler/test/test_utils.re
@@ -1,0 +1,22 @@
+exception Timeout;
+
+// https://stackoverflow.com/a/10789674
+let minisleep = (sec: float) => ignore(Unix.select([], [], [], sec));
+
+let waitpid_timeout = (timeout: float, ~wait=0.1, pid: int) => {
+  let start_time = Unix.time();
+  minisleep(0.1);
+  let (retpid_raw, status_raw) = Unix.waitpid([Unix.WNOHANG], pid);
+  let retpid = ref(retpid_raw);
+  let status = ref(status_raw);
+  while (retpid^ == 0) {
+    if (Unix.time() -. start_time > timeout) {
+      raise(Timeout);
+    };
+    minisleep(wait);
+    let (retpid_raw, status_raw) = Unix.waitpid([Unix.WNOHANG], pid);
+    retpid := retpid_raw;
+    status := status_raw;
+  };
+  (retpid^, status^);
+};


### PR DESCRIPTION
This PR introduces a timeout for tests in the test suite. This is useful when developing changes to the runtime, as memory corruption can often result in hangs. When this happens, the runner tells you the test suite but not the individual test which is hanging. With this change, hanging tests will fail, and they will then be displayed on the console.

I went ahead and set the timeout to 15 seconds, but this was an arbitrary choice.