### PR TITLE
fix(compiler): Do not add transitive dependencies as imports during CRC consistency check

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -747,7 +747,6 @@ let check_consistency = ps =>
         switch (crco) {
         | None => ()
         | Some(crc) =>
-          add_import(name);
           let resolved_file_name =
             Module_resolution.resolve_unit(
               ~base_dir=Filename.dirname(ps.ps_filename),

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -160,5 +160,5 @@ arrays › array_access
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
@@ -69,5 +69,5 @@ arrays › array1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -162,5 +162,5 @@ arrays › array_access4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -162,5 +162,5 @@ arrays › array_access2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -162,5 +162,5 @@ arrays › array_access3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -162,5 +162,5 @@ arrays › array_access5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
@@ -69,5 +69,5 @@ arrays › array3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
@@ -69,5 +69,5 @@ arrays › array1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1015
+ ;; custom section \"cmi\", size 253
 )

--- a/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop2.4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
@@ -28,5 +28,5 @@ basic functionality › neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp5
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › land4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lxor1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lor1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › precedence1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp16
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp3
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › orshadow
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › precedence2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -79,5 +79,5 @@ basic functionality › precedence3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lsl1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -82,5 +82,5 @@ basic functionality › unsafe_wasm_globals
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1198
+ ;; custom section \"cmi\", size 377
 )

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -154,5 +154,5 @@ basic functionality › comp22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › land1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -48,5 +48,5 @@ basic functionality › orshort2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › forty
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -79,5 +79,5 @@ basic functionality › precedence4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › assert2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › and2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lsl2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › comp17
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › fals
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › oct_neg
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › complex2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -28,5 +28,5 @@ basic functionality › int64_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -155,5 +155,5 @@ basic functionality › comp20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lor3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › decr_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › orshort1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop5
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › precedence5
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › if4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.4d6f9417.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4d6f9417.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › not1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -265,5 +265,5 @@ basic functionality › func_shadow
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1004
+ ;; custom section \"cmi\", size 242
 )

--- a/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › hex_neg
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -71,5 +71,5 @@ basic functionality › if_one_sided6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › and3
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › or4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › binop6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -87,5 +87,5 @@ basic functionality › block_no_expression
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1013
+ ;; custom section \"cmi\", size 251
 )

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -68,5 +68,5 @@ basic functionality › if_one_sided5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lor2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop3
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop2.2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › land2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › or1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › assert1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -483,5 +483,5 @@ basic functionality › pattern_match_unsafe_wasm
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1016
+ ;; custom section \"cmi\", size 254
 )

--- a/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › tru
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › asr1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › or3
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › and4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -29,5 +29,5 @@ basic functionality › division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1003
+ ;; custom section \"cmi\", size 241
 )

--- a/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › if_one_sided2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › bin_neg
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp13
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › andshadow
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1003
+ ;; custom section \"cmi\", size 241
 )

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -154,5 +154,5 @@ basic functionality › comp21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop2.3
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.970a2a2b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.970a2a2b.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › not2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lxor3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › incr_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
@@ -50,5 +50,5 @@ basic functionality › void
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -68,5 +68,5 @@ basic functionality › if_one_sided3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › and1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › hex
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp9
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › andshort2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1003
+ ;; custom section \"cmi\", size 241
 )

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lxor2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp8
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp7
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › if_one_sided
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lxor4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -48,5 +48,5 @@ basic functionality › complex1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › oct
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › or2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lsr2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -108,5 +108,5 @@ basic functionality › toplevel_statements
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1012
+ ;; custom section \"cmi\", size 250
 )

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lsr1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp14
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › incr_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › bin
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 997
+ ;; custom section \"cmi\", size 235
 )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › incr_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › lor4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › int64_pun_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › decr_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -48,5 +48,5 @@ basic functionality › andshort1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1003
+ ;; custom section \"cmi\", size 241
 )

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › land3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › comp18
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp15
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp10
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -71,5 +71,5 @@ basic functionality › if_one_sided4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › comp6
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › asr2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -28,5 +28,5 @@ basic functionality › int32_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
@@ -15,5 +15,5 @@ basic functionality › binop2.1
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › modulo2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -43,5 +43,5 @@ basic functionality › decr_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -155,5 +155,5 @@ basic functionality › comp19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -51,5 +51,5 @@ basic functionality › int64_pun_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -440,5 +440,5 @@ basic functionality › func_shadow_and_indirect_call
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1015
+ ;; custom section \"cmi\", size 253
 )

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -134,5 +134,5 @@ boxes › box_subtraction1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -163,5 +163,5 @@ boxes › box_multiplication2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1013
+ ;; custom section \"cmi\", size 251
 )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -163,5 +163,5 @@ boxes › box_division2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -163,5 +163,5 @@ boxes › box_addition2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -134,5 +134,5 @@ boxes › box_division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -163,5 +163,5 @@ boxes › box_subtraction2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -134,5 +134,5 @@ boxes › box_addition1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -134,5 +134,5 @@ boxes › box_multiplication1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1013
+ ;; custom section \"cmi\", size 251
 )

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -75,5 +75,5 @@ boxes › test_set_extra1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
+++ b/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
@@ -46,5 +46,5 @@ chars › char4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.259e330c.0.snapshot
+++ b/compiler/test/__snapshots__/chars.259e330c.0.snapshot
@@ -46,5 +46,5 @@ chars › char2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.51010573.0.snapshot
+++ b/compiler/test/__snapshots__/chars.51010573.0.snapshot
@@ -46,5 +46,5 @@ chars › char7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
+++ b/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
@@ -46,5 +46,5 @@ chars › char6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
+++ b/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
@@ -46,5 +46,5 @@ chars › char5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
+++ b/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
@@ -46,5 +46,5 @@ chars › char3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/comments.573e549e.0.snapshot
+++ b/compiler/test/__snapshots__/comments.573e549e.0.snapshot
@@ -15,5 +15,5 @@ comments › comment_alone
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
+++ b/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
@@ -15,5 +15,5 @@ comments › comment_block
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
+++ b/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
@@ -15,5 +15,5 @@ comments › comment_shebang
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
+++ b/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
@@ -15,5 +15,5 @@ comments › comment_doc
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -265,5 +265,5 @@ enums › adt_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1266
+ ;; custom section \"cmi\", size 504
 )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -635,5 +635,5 @@ enums › enum_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1634
+ ;; custom section \"cmi\", size 872
 )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -269,5 +269,5 @@ exceptions › exception_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1855
+ ;; custom section \"cmi\", size 1093
 )

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -148,5 +148,5 @@ exceptions › exception_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1328
+ ;; custom section \"cmi\", size 566
 )

--- a/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
+++ b/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
@@ -29,5 +29,5 @@ exports › export7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1051
+ ;; custom section \"cmi\", size 289
 )

--- a/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
@@ -29,5 +29,5 @@ exports › export4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1054
+ ;; custom section \"cmi\", size 292
 )

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -44,5 +44,5 @@ exports › export9
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1051
+ ;; custom section \"cmi\", size 289
 )

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -79,5 +79,5 @@ exports › export8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1051
+ ;; custom section \"cmi\", size 289
 )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -87,5 +87,5 @@ functions › dup_func
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -141,5 +141,5 @@ functions › shorthand_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -105,5 +105,5 @@ functions › shorthand_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -459,5 +459,5 @@ functions › lam_destructure_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -137,5 +137,5 @@ functions › lambda_pat_any
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1008
+ ;; custom section \"cmi\", size 246
 )

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -222,5 +222,5 @@ functions › curried_func
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -105,5 +105,5 @@ functions › app_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -105,5 +105,5 @@ functions › shorthand_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -298,5 +298,5 @@ functions › lam_destructure_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -425,5 +425,5 @@ functions › lam_destructure_7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -141,5 +141,5 @@ functions › shorthand_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -298,5 +298,5 @@ functions › lam_destructure_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -425,5 +425,5 @@ functions › lam_destructure_8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -137,5 +137,5 @@ functions › lam_destructure_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -137,5 +137,5 @@ functions › lam_destructure_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
@@ -15,5 +15,5 @@ functions › multi_bind2
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -362,5 +362,5 @@ functions › func_record_associativity2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1525
+ ;; custom section \"cmi\", size 763
 )

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -148,5 +148,5 @@ functions › fn_trailing_comma
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -459,5 +459,5 @@ functions › lam_destructure_6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -271,5 +271,5 @@ functions › func_record_associativity1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1272
+ ;; custom section \"cmi\", size 510
 )

--- a/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
@@ -52,5 +52,5 @@ imports › import_all_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1062
+ ;; custom section \"cmi\", size 300
 )

--- a/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
@@ -29,5 +29,5 @@ imports › import_some
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1055
+ ;; custom section \"cmi\", size 293
 )

--- a/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
@@ -29,5 +29,5 @@ imports › import_all_except_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1070
+ ;; custom section \"cmi\", size 308
 )

--- a/compiler/test/__snapshots__/imports.259f419e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.259f419e.0.snapshot
@@ -29,5 +29,5 @@ imports › import_relative_path1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1072
+ ;; custom section \"cmi\", size 310
 )

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -73,5 +73,5 @@ imports › import_alias_multiple_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1073
+ ;; custom section \"cmi\", size 311
 )

--- a/compiler/test/__snapshots__/imports.45beae05.0.snapshot
+++ b/compiler/test/__snapshots__/imports.45beae05.0.snapshot
@@ -29,5 +29,5 @@ imports › annotation_across_import
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1064
+ ;; custom section \"cmi\", size 302
 )

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -44,5 +44,5 @@ imports › import_alias_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1065
+ ;; custom section \"cmi\", size 303
 )

--- a/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
@@ -29,5 +29,5 @@ imports › import_alias
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1056
+ ;; custom section \"cmi\", size 294
 )

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -44,5 +44,5 @@ imports › import_some_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1064
+ ;; custom section \"cmi\", size 302
 )

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -70,5 +70,5 @@ imports › import_relative_path4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1083
+ ;; custom section \"cmi\", size 284
 )

--- a/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
@@ -29,5 +29,5 @@ imports › import_all_except_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1069
+ ;; custom section \"cmi\", size 307
 )

--- a/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
@@ -52,5 +52,5 @@ imports › import_some_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1063
+ ;; custom section \"cmi\", size 301
 )

--- a/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
@@ -29,5 +29,5 @@ imports › import_module
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1057
+ ;; custom section \"cmi\", size 295
 )

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -44,5 +44,5 @@ imports › import_module2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1058
+ ;; custom section \"cmi\", size 296
 )

--- a/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
@@ -52,5 +52,5 @@ imports › import_same_module_unify2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1065
+ ;; custom section \"cmi\", size 303
 )

--- a/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
@@ -30,5 +30,5 @@ imports › import_with_export_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1071
+ ;; custom section \"cmi\", size 309
 )

--- a/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
@@ -52,5 +52,5 @@ imports › import_same_module_unify
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1064
+ ;; custom section \"cmi\", size 302
 )

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -44,5 +44,5 @@ imports › import_all_except_multiple_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1078
+ ;; custom section \"cmi\", size 316
 )

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -44,5 +44,5 @@ imports › import_alias_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1064
+ ;; custom section \"cmi\", size 302
 )

--- a/compiler/test/__snapshots__/imports.e295854d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e295854d.0.snapshot
@@ -29,5 +29,5 @@ imports › import_relative_path2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1080
+ ;; custom section \"cmi\", size 318
 )

--- a/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
@@ -29,5 +29,5 @@ imports › import_relative_path3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1062
+ ;; custom section \"cmi\", size 300
 )

--- a/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
@@ -53,5 +53,5 @@ imports › import_muliple_modules
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1112
+ ;; custom section \"cmi\", size 350
 )

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -73,5 +73,5 @@ imports › import_some_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1057
+ ;; custom section \"cmi\", size 295
 )

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -102,5 +102,5 @@ let mut › let-mut_division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_multiplication2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1017
+ ;; custom section \"cmi\", size 255
 )

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -93,5 +93,5 @@ let mut › let-mut3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_division3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -163,5 +163,5 @@ let mut › let-mut2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -102,5 +102,5 @@ let mut › let-mut_multiplication1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1017
+ ;; custom section \"cmi\", size 255
 )

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_multiplication3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1017
+ ;; custom section \"cmi\", size 255
 )

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -94,5 +94,5 @@ let mut › let-mut4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -102,5 +102,5 @@ let mut › let-mut_subtraction1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1014
+ ;; custom section \"cmi\", size 252
 )

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_subtraction2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1014
+ ;; custom section \"cmi\", size 252
 )

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_addition2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -102,5 +102,5 @@ let mut › let-mut_addition1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_subtraction3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1014
+ ;; custom section \"cmi\", size 252
 )

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_addition3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -122,5 +122,5 @@ let mut › let-mut_division2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -57,5 +57,5 @@ let mut › let-mut1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1002
+ ;; custom section \"cmi\", size 240
 )

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -129,5 +129,5 @@ lists › list_spread
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -104,5 +104,5 @@ lists › list1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1014
+ ;; custom section \"cmi\", size 252
 )

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -104,5 +104,5 @@ lists › list1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1008
+ ;; custom section \"cmi\", size 246
 )

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -326,5 +326,5 @@ loops › loop2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -237,5 +237,5 @@ loops › loop5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -154,5 +154,5 @@ loops › loop3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -238,5 +238,5 @@ loops › loop4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 999
+ ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -113,5 +113,5 @@ optimizations › trs1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 998
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -233,5 +233,5 @@ optimizations › test_dead_branch_elimination_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1024
+ ;; custom section \"cmi\", size 262
 )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -254,5 +254,5 @@ pattern matching › record_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1260
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -347,5 +347,5 @@ pattern matching › adt_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1260
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -937,5 +937,5 @@ pattern matching › tuple_match_deep4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -736,5 +736,5 @@ pattern matching › adt_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -233,5 +233,5 @@ pattern matching › record_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1260
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -330,5 +330,5 @@ pattern matching › constant_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -197,5 +197,5 @@ pattern matching › guarded_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -333,5 +333,5 @@ pattern matching › tuple_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -233,5 +233,5 @@ pattern matching › record_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1260
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -696,5 +696,5 @@ pattern matching › constant_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -302,5 +302,5 @@ pattern matching › record_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1260
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -192,5 +192,5 @@ pattern matching › constant_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -987,5 +987,5 @@ pattern matching › tuple_match_deep6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -244,5 +244,5 @@ pattern matching › tuple_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -911,5 +911,5 @@ pattern matching › tuple_match_deep3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -660,5 +660,5 @@ pattern matching › adt_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -702,5 +702,5 @@ pattern matching › tuple_match_deep2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -252,5 +252,5 @@ pattern matching › record_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1518
+ ;; custom section \"cmi\", size 756
 )

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -255,5 +255,5 @@ pattern matching › guarded_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -197,5 +197,5 @@ pattern matching › guarded_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -686,5 +686,5 @@ pattern matching › adt_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -255,5 +255,5 @@ pattern matching › guarded_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1009
+ ;; custom section \"cmi\", size 247
 )

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -711,5 +711,5 @@ pattern matching › adt_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -761,5 +761,5 @@ pattern matching › adt_match_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -962,5 +962,5 @@ pattern matching › tuple_match_deep5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -671,5 +671,5 @@ pattern matching › constant_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -1012,5 +1012,5 @@ pattern matching › tuple_match_deep7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1011
+ ;; custom section \"cmi\", size 249
 )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -239,5 +239,5 @@ records › record_get_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1265
+ ;; custom section \"cmi\", size 503
 )

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -131,5 +131,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1577
+ ;; custom section \"cmi\", size 815
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -131,5 +131,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1561
+ ;; custom section \"cmi\", size 799
 )

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -233,5 +233,5 @@ records › record_destruct_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1263
+ ;; custom section \"cmi\", size 501
 )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -302,5 +302,5 @@ records › record_destruct_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1263
+ ;; custom section \"cmi\", size 501
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -131,5 +131,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1572
+ ;; custom section \"cmi\", size 810
 )

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -332,5 +332,5 @@ records › record_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1530
+ ;; custom section \"cmi\", size 768
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1880
+ ;; custom section \"cmi\", size 1118
 )

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -233,5 +233,5 @@ records › record_destruct_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1263
+ ;; custom section \"cmi\", size 501
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -131,5 +131,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1570
+ ;; custom section \"cmi\", size 808
 )

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -252,5 +252,5 @@ records › record_destruct_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1521
+ ;; custom section \"cmi\", size 759
 )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -254,5 +254,5 @@ records › record_destruct_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1263
+ ;; custom section \"cmi\", size 501
 )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -267,5 +267,5 @@ records › record_get_multilevel
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1524
+ ;; custom section \"cmi\", size 762
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -208,5 +208,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2203
+ ;; custom section \"cmi\", size 1441
 )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -161,5 +161,5 @@ records › record_get_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1258
+ ;; custom section \"cmi\", size 496
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1871
+ ;; custom section \"cmi\", size 1109
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1873
+ ;; custom section \"cmi\", size 1111
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -208,5 +208,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2197
+ ;; custom section \"cmi\", size 1435
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -131,5 +131,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1571
+ ;; custom section \"cmi\", size 809
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1874
+ ;; custom section \"cmi\", size 1112
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1883
+ ;; custom section \"cmi\", size 1121
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -208,5 +208,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2198
+ ;; custom section \"cmi\", size 1436
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1882
+ ;; custom section \"cmi\", size 1120
 )

--- a/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
@@ -15,5 +15,5 @@ stdlib › stdlib_equal_4
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -362,5 +362,5 @@ stdlib › stdlib_equal_20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1261
+ ;; custom section \"cmi\", size 499
 )

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -139,5 +139,5 @@ stdlib › stdlib_equal_18
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -161,5 +161,5 @@ stdlib › stdlib_equal_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -104,5 +104,5 @@ stdlib › stdlib_cons
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1005
+ ;; custom section \"cmi\", size 243
 )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -362,5 +362,5 @@ stdlib › stdlib_equal_19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1261
+ ;; custom section \"cmi\", size 499
 )

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -139,5 +139,5 @@ stdlib › stdlib_equal_16
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -189,5 +189,5 @@ stdlib › stdlib_equal_12
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -362,5 +362,5 @@ stdlib › stdlib_equal_21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1261
+ ;; custom section \"cmi\", size 499
 )

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -135,5 +135,5 @@ stdlib › stdlib_equal_15
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -135,5 +135,5 @@ stdlib › stdlib_equal_14
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -205,5 +205,5 @@ stdlib › stdlib_equal_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -154,5 +154,5 @@ stdlib › stdlib_equal_11
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -140,5 +140,5 @@ stdlib › stdlib_equal_9
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -161,5 +161,5 @@ stdlib › stdlib_equal_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1008
+ ;; custom section \"cmi\", size 246
 )

--- a/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
@@ -15,5 +15,5 @@ stdlib › stdlib_equal_6
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -362,5 +362,5 @@ stdlib › stdlib_equal_22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1261
+ ;; custom section \"cmi\", size 499
 )

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -147,5 +147,5 @@ stdlib › stdlib_equal_10
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -131,5 +131,5 @@ stdlib › stdlib_equal_13
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
@@ -15,5 +15,5 @@ stdlib › stdlib_equal_7
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
@@ -15,5 +15,5 @@ stdlib › stdlib_equal_5
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -131,5 +131,5 @@ stdlib › stdlib_equal_8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1052
+ ;; custom section \"cmi\", size 290
 )

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -139,5 +139,5 @@ stdlib › stdlib_equal_17
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1053
+ ;; custom section \"cmi\", size 291
 )

--- a/compiler/test/__snapshots__/strings.434adad0.0.snapshot
+++ b/compiler/test/__snapshots__/strings.434adad0.0.snapshot
@@ -50,5 +50,5 @@ strings › string2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/strings.a67428df.0.snapshot
+++ b/compiler/test/__snapshots__/strings.a67428df.0.snapshot
@@ -50,5 +50,5 @@ strings › string1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
+++ b/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
@@ -66,5 +66,5 @@ strings › string3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1001
+ ;; custom section \"cmi\", size 239
 )

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -139,5 +139,5 @@ strings › concat
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1000
+ ;; custom section \"cmi\", size 238
 )

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -219,5 +219,5 @@ tuples › nested_tup_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -196,5 +196,5 @@ tuples › nested_tup_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/tuples.4e8e882f.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.4e8e882f.0.snapshot
@@ -15,5 +15,5 @@ tuples › no_singleton_tup
  (func $_start (; has Stack IR ;)
   (nop)
  )
- ;; custom section \"cmi\", size 1010
+ ;; custom section \"cmi\", size 248
 )

--- a/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
@@ -69,5 +69,5 @@ tuples › tup1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1007
+ ;; custom section \"cmi\", size 245
 )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -106,5 +106,5 @@ tuples › big_tup_access
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1008
+ ;; custom section \"cmi\", size 246
 )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -219,5 +219,5 @@ tuples › nested_tup_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1006
+ ;; custom section \"cmi\", size 244
 )

--- a/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
@@ -69,5 +69,5 @@ tuples › tup1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1013
+ ;; custom section \"cmi\", size 251
 )


### PR DESCRIPTION
I ran into this when doing some development today, and I'm not precisely sure why it isn't captured by the existing relative import tests. Basically, the CRC check introduces transitive dependencies as direct dependencies, which causes them to bubble up in the CMIs of modules in the dependency tree. This is a problem for two reasons:

1. It makes the CMIs much bigger than needed (since they don't contain just the direct dependencies)
2. Relative imports can result in CMIs containing bogus dependencies (since they are the relative path relative to _some other module_, as opposed to the module whose CMI it is placed in).

I found the source of the problem and removed it. This doesn't appear to have been a deliberate decision by us; it appears to have been a holdover from the OCaml typechecker (which doesn't need to worry about the issue, since they don't do dependency compilation). 

NB: The snapshots are changed since the CMIs are now smaller.