### PR TITLE
fix(js-runner): Monkeypatch fs_write in browser environment

### DIFF
--- a/js-runner/src/core/grain-module.js
+++ b/js-runner/src/core/grain-module.js
@@ -6,6 +6,21 @@ let bindings;
 
 if (__RUNNER_BROWSER) {
   const wasmFs = new WasmFs();
+  const decoder = new TextDecoder("utf-8");
+  // Monkeypatching the writeSync for stdout/stderr printing
+  const originalWriteSync = wasmFs.fs.writeSync;
+  wasmFs.fs.writeSync = (fd, buf, offset, length, position) => {
+    if (fd === 1) {
+      console.log(decoder.decode(buf));
+      return;
+    }
+    if (fd === 2) {
+      console.error(decoder.decode(buf));
+      return
+    }
+
+    originalWriteSync(fd, buf, offset, length, position);
+  };
   bindings = {
     ...wasiBindings.default,
     fs: wasmFs.fs,

--- a/js-runner/src/core/grain-module.js
+++ b/js-runner/src/core/grain-module.js
@@ -16,7 +16,7 @@ if (__RUNNER_BROWSER) {
     }
     if (fd === 2) {
       console.error(decoder.decode(buf));
-      return
+      return;
     }
 
     originalWriteSync(fd, buf, offset, length, position);


### PR DESCRIPTION
While trying to update the Grain web example, I found out that using fd_write on `/dev/stdout` doesn't actually log in the browser.

This monkeypatches the memfs library used by wasmerjs to `console.log` or `console.error` when fd 0 or 1 is written to.

The downside to this patching is that the newline at the end of our `print` is stored in a different iov (?) so it logs separately (here's a screenshot):
<img width="817" alt="Screen Shot 2021-08-29 at 5 49 33 PM" src="https://user-images.githubusercontent.com/992373/131272432-c15f8ff3-a22e-4b3e-95c3-763e7c218e17.png">
