### PR TITLE
fix(js-runner): Add default object for destructuring

### DIFF
--- a/js-runner/src/core/memory.js
+++ b/js-runner/src/core/memory.js
@@ -1,5 +1,5 @@
 export class ManagedMemory {
-  constructor({ initialMemoryPages, maximumMemoryPages }) {
+  constructor({ initialMemoryPages, maximumMemoryPages } = {}) {
     this._memory = new WebAssembly.Memory({
       initial: initialMemoryPages || 64,
       maximum: maximumMemoryPages,


### PR DESCRIPTION
While trying to update the Grain web example, I found out that our js-runner crashes if you don't provide an options object to `buildGrainRunner` due to trying to destructure from undefined in `ManagedMemory`.

This just adds a default object to the constructor of `ManagedMemory` so it doesn't crash like that.