### PR TITLE
chore: Upgrade esy

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -9,7 +9,7 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "esy": "0.6.10"
+    "esy": "0.6.11"
   },
   "scripts": {
     "link": "yarn link",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,10 +1408,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-esy@0.6.10:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/esy/-/esy-0.6.10.tgz#918de2ad7e40793978c63b8216563408527cc25e"
-  integrity sha512-O+mWNPB9NJqDr3CA1PUbWUO1ZSy53ksZWivGrvbquATR5INlp3CYguwkq4BzZACg1s1bVYyhr7byjB/l1nuGRA==
+esy@0.6.11:
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/esy/-/esy-0.6.11.tgz#120a4095db0cbeb430967f8bb307a3dbe3165512"
+  integrity sha512-LyrQWS/c7FYwjmgSlmYcj7w7as40iVuF6aCSHKMAZq1xgmdpjorQ7OEqg35ZUf8+xpUgKnDx4HrA3scdnfRTnA==
 
 events@^3.0.0:
   version "3.3.0"


### PR DESCRIPTION
Updating esy to 0.6.11 which has the "extra-sources" and `{post}` support for opam files. We'll need both of these in the future. 