### PR TITLE
fix(compiler): Fix incorrect char well-formedness error

### DIFF
--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -102,7 +102,7 @@ let malformed_characters = (errs, super) => {
   let iter_expr = (self, {pexp_desc: desc, pexp_loc: loc} as e) => {
     switch (desc) {
     | PExpConstant(PConstChar(c)) =>
-      if (Utf8.countInString(c) != 1) {
+      if (List.length(Utf8.decodeUtf8String(c)) != 1) {
         errs := [IllegalCharacterLiteral(c, loc), ...errs^];
       }
     | _ => ()

--- a/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
+++ b/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
@@ -1,0 +1,50 @@
+chars › char8
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
+ (global $global_1 i32 (i32.const 0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 8)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 2)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 11050210)
+     )
+     (local.get $0)
+    )
+    (local.get $0)
+   )
+  )
+ )
+ (func $_start (; has Stack IR ;)
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 237
+)

--- a/compiler/test/suites/chars.re
+++ b/compiler/test/suites/chars.re
@@ -13,6 +13,7 @@ describe("chars", ({test}) => {
   assertSnapshot("char5", "'\\u{41}'");
   assertSnapshot("char6", "'💯'");
   assertSnapshot("char7", "'\\u{1F33E}'");
+  assertSnapshot("char8", "'\\u2728'");
   assertRun("char_eq1", "print('🌾' == '🌾')", "true\n");
   assertRun("char_eq2", "print('🌾' == '💯')", "false\n");
   assertRun(


### PR DESCRIPTION
@jozanza noticed that 3-byte utf-8 characters trigger a well-formedness error for char literals. I think there's a bug in the utf8 library we're using (or that I just didn't understand what a few functions did), so here's an easy workaround. Issue to see what's up with the function we were using: https://github.com/reasonml/reason-native/issues/266