### PR TITLE
feat(linker): Add --use-start-section flag to use start section in output

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -121,6 +121,10 @@ program
     "--wasi-polyfill <filename>",
     "path to custom WASI implementation"
   )
+  .graincOption(
+    "--use-start-section",
+    "replaces the _start export with a start section during linking"
+  )
   .graincOption("--no-link", "disable static linking")
   .graincOption(
     "--no-pervasives",

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -600,16 +600,21 @@ let link_all = (linked_mod, dependencies, signature) => {
     );
 
   let start_name = gensym(grain_start);
-  ignore @@
-  Function.add_function(
-    linked_mod,
-    start_name,
-    Type.none,
-    Type.none,
-    [||],
-    Expression.Block.make(linked_mod, gensym("start"), starts),
-  );
-  ignore @@ Export.add_function_export(linked_mod, start_name, grain_start);
+  let start =
+    Function.add_function(
+      linked_mod,
+      start_name,
+      Type.none,
+      Type.none,
+      [||],
+      Expression.Block.make(linked_mod, gensym("start"), starts),
+    );
+
+  if (Grain_utils.Config.use_start_section^) {
+    Function.set_start(linked_mod, start);
+  } else {
+    ignore @@ Export.add_function_export(linked_mod, start_name, grain_start);
+  };
 };
 
 let link_modules = ({asm: wasm_mod, signature}) => {

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -530,6 +530,13 @@ let wasi_polyfill =
     None,
   );
 
+let use_start_section =
+  toggle_flag(
+    ~names=["use-start-section"],
+    ~doc="Replace the _start export with a start section during linking.",
+    false,
+  );
+
 let elide_type_info =
   toggle_flag(
     ~names=["elide-type-info"],

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -36,6 +36,10 @@ let bulk_memory: ref(bool);
 
 let wasi_polyfill: ref(option(string));
 
+/** Whether to replace the _start export with a start section during linking */
+
+let use_start_section: ref(bool);
+
 /** Whether optimizations should be run */
 
 let optimization_level: ref(optimization_level);


### PR DESCRIPTION
This adds a config (and corresponding flag) to the linker that allows people to disable the WASI convention of exporting a `_start` function and instead set a start section in the linked output. This is needed for NEAR because they don't call the `_start` function and rely on the start section during instantiation.

I want to make 1 more improvement to the added tests after @ospencer takes a stab at parsing the exports in our Wasm_utils.