### PR TITLE
fix(stdlib): Remove fd_sync calls that are not used

### DIFF
--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -451,10 +451,22 @@ let link_all = (linked_mod, dependencies, signature) => {
           let internal_name = Function.get_name(func);
           let wasi_polyfill = wasi_polyfill_module();
           let new_name =
-            Hashtbl.find(
+            Hashtbl.find_opt(
               Hashtbl.find(exported_names, wasi_polyfill),
               imported_name,
             );
+          let new_name =
+            switch (new_name) {
+            | Some(new_name) => new_name
+            | None =>
+              failwith(
+                Printf.sprintf(
+                  "Unable to locate `%s` in your polyfill. Required by `%s`",
+                  imported_name,
+                  dep,
+                ),
+              )
+            };
           Hashtbl.add(local_names, internal_name, new_name);
         } else {
           let imported_name = Import.function_import_get_base(func);

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -30,7 +30,6 @@ import WasmI32, {
 
 // Using foreigns directly here to avoid cyclic dependency
 import foreign wasm fd_write : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
-import foreign wasm fd_sync : (WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
 
 primitive (&&) : (Bool, Bool) -> Bool = "@and"
 primitive (||) : (Bool, Bool) -> Bool = "@or"
@@ -49,7 +48,8 @@ let mut _DEBUG = false
 let _HEADER_SIZE = 8n
 
 /*
-Debugging functions:
+//Debugging functions:
+import foreign wasm fd_sync : (WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
 
 // incRef debug messages: "decRef: 0xNNNNNN (prev count: nn)\n"
 let _INCREF_DEBUG_STR_1 = "incRef: 0x"

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -26,7 +26,6 @@ import NumberUtils from "runtime/numberUtils"
 import { allocateString, allocateArray } from "runtime/dataStructures"
 
 import foreign wasm fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
-import foreign wasm fd_sync : (WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
 
 primitive (!) : Bool -> Bool = "@not"
 primitive (&&) : (Bool, Bool) -> Bool = "@and"


### PR DESCRIPTION
Between #800 being submitted and merged, we also landed some changes to the stdlib that changed the calling convention in non-GC contexts. This required adding some `fd_sync` imports for debugging and they didn't get removed, which caused the linker to fail on our wasi polyfill tests.

Here, I've added a better error message for this case and then removed the 2 references to fd_sync in our stdlib, so the tests should pass again.