### PR TITLE
fix(cli): Fix the missing alias on foreign export and better line breaks

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -911,10 +911,16 @@ and print_type =
         } else {
           Doc.concat([
             Doc.lparen,
-            Doc.join(
-              Doc.concat([Doc.comma, Doc.space]),
-              List.map(t => print_type(t, original_source), types),
+            Doc.indent(
+              Doc.concat([
+                Doc.line,
+                Doc.join(
+                  Doc.concat([Doc.comma, Doc.line]),
+                  List.map(t => print_type(t, original_source), types),
+                ),
+              ]),
             ),
+            Doc.line,
             Doc.rparen,
           ]);
         },
@@ -2606,9 +2612,20 @@ let print_foreign_value_description =
 
   Doc.concat([
     fixedIdent,
-    Doc.text(" : "),
-    print_type(vd.pval_type, original_source),
+    Doc.text(":"),
     Doc.space,
+    print_type(vd.pval_type, original_source),
+    switch (vd.pval_name_alias) {
+    | None => Doc.space
+    | Some(alias) =>
+      Doc.concat([
+        Doc.space,
+        Doc.text("as"),
+        Doc.space,
+        Doc.text(alias.txt),
+        Doc.space,
+      ])
+    },
     Doc.text("from"),
     Doc.space,
     Doc.text("\""),

--- a/compiler/test/formatter_inputs/imports.gr
+++ b/compiler/test/formatter_inputs/imports.gr
@@ -8,3 +8,5 @@ import WasmI32, {
   xor as (^),
   shl as (<<)
 } from "runtime/unsafe/wasmi32"
+
+export foreign wasm storage_read: (WasmI64, WasmI64, WasmI64) -> WasmI64 as storageRead from "env"

--- a/compiler/test/formatter_outputs/imports.gr
+++ b/compiler/test/formatter_outputs/imports.gr
@@ -8,3 +8,9 @@ import WasmI32, {
   xor as (^),
   shl as (<<)
 } from "runtime/unsafe/wasmi32"
+
+export foreign wasm storage_read: (
+  WasmI64,
+  WasmI64,
+  WasmI64
+) -> WasmI64 as storageRead from "env"


### PR DESCRIPTION
Fixes #855 

Restore aliases to foreign exports.

Also break on the type for  lines over the length limit, and remove an extra space before the type colon:

export foreign wasm storage_read : (
  WasmI64,
  WasmI64,
  WasmI64
) -> WasmI64 as storageRead from "env"