### PR TITLE
fix(grainfmt): Handle trailing block comments better

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -2889,10 +2889,7 @@ let reformat_ast =
 
   let trailing_comment_docs =
     if (List.length(trailing_comments) > 0) {
-      Doc.concat([
-        print_multi_comments(trailing_comments, previous_line^),
-        Doc.hardLine,
-      ]);
+      Doc.concat([print_multi_comments(trailing_comments, previous_line^)]);
     } else {
       Doc.nil;
     };

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -264,3 +264,26 @@ let remove_comments_in_ignore_block = (loc: Location.t) => {
 
   all_locations := cleaned_list;
 };
+
+let get_comments_inside_location = (loc: Grain_parsing.Location.t) => {
+  let nodes =
+    List.filter(
+      n => {
+        switch (n) {
+        | Code(_) => false
+        | Comment((commentloc, _)) => is_first_inside_second(commentloc, loc)
+        }
+      },
+      all_locations^,
+    );
+
+  List.fold_left(
+    (acc, n) =>
+      switch (n) {
+      | Code(_) => acc
+      | Comment((_commentloc, c)) => acc @ [c]
+      },
+    [],
+    nodes,
+  );
+};

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -266,24 +266,18 @@ let remove_comments_in_ignore_block = (loc: Location.t) => {
 };
 
 let get_comments_inside_location = (loc: Grain_parsing.Location.t) => {
-  let nodes =
-    List.filter(
-      n => {
-        switch (n) {
-        | Code(_) => false
-        | Comment((commentloc, _)) => is_first_inside_second(commentloc, loc)
-        }
-      },
-      all_locations^,
-    );
-
   List.fold_left(
     (acc, n) =>
       switch (n) {
       | Code(_) => acc
-      | Comment((_commentloc, c)) => acc @ [c]
+      | Comment((commentloc, c)) =>
+        if (is_first_inside_second(commentloc, loc)) {
+          acc @ [c];
+        } else {
+          acc;
+        }
       },
     [],
-    nodes,
+    all_locations^,
   );
 };

--- a/compiler/grainformat/walktree.rei
+++ b/compiler/grainformat/walktree.rei
@@ -72,3 +72,8 @@ let walktree:
 
  */
 let remove_comments_in_ignore_block: Grain_utils__Warnings.loc => unit;
+
+/* return the comments inside a location */
+
+let get_comments_inside_location:
+  Grain_parsing.Location.t => list(Grain_parsing.Parsetree.comment);

--- a/compiler/test/formatter_inputs/comments.gr
+++ b/compiler/test/formatter_inputs/comments.gr
@@ -1,4 +1,5 @@
 /* Let's start with a block 
+ the line above ends with a space that we preserve
  followed by a blank line
 */
 
@@ -88,6 +89,13 @@ if (true) {
 
   let _KEY_LEN23 = 64
 }
+
+let noval = 5
+
+// Tell the host where the key and value are located and their lengths.
+// No empty line beneath this please
+let _KEY_LEN = 32
+let _KEY_LEN2 = 64
 
 /* ending block 2 */
 // trailing comment 2

--- a/compiler/test/formatter_inputs/comments.gr
+++ b/compiler/test/formatter_inputs/comments.gr
@@ -77,7 +77,17 @@ if (a /*why*/) {
 
 let myfun /*special*/ = (/*lead*/ x /*follow*/,y ) => x + 5 
 
+if (true) {
 
+  let noval = 5
+
+  // Tell the host where the key and value are located and their lengths.
+  // No empty line beneath this please
+  let _KEY_LEN = 32
+  let _KEY_LEN2 = 64
+
+  let _KEY_LEN23 = 64
+}
 
 /* ending block 2 */
 // trailing comment 2

--- a/compiler/test/formatter_outputs/comments.gr
+++ b/compiler/test/formatter_outputs/comments.gr
@@ -1,4 +1,5 @@
 /* Let's start with a block 
+ the line above ends with a space that we preserve
  followed by a blank line
 */
 
@@ -85,6 +86,13 @@ if (true) {
 
   let _KEY_LEN23 = 64
 }
+
+let noval = 5
+
+// Tell the host where the key and value are located and their lengths.
+// No empty line beneath this please
+let _KEY_LEN = 32
+let _KEY_LEN2 = 64
 
 /* ending block 2 */
 // trailing comment 2

--- a/compiler/test/formatter_outputs/comments.gr
+++ b/compiler/test/formatter_outputs/comments.gr
@@ -26,7 +26,7 @@ export let slice = (startIndex, endIndex, array) => {
 
 // leading
 
-if (/*before*/ true) /*whyt*/ {
+if (/*before*/ true /*whyt*/) {
   // 1
   //a
 
@@ -35,7 +35,6 @@ if (/*before*/ true) /*whyt*/ {
   true
   // c
   // d
-
   6
   // trail
 } else {
@@ -58,7 +57,7 @@ let a = false
 
 let zee = "zer"
 
-if (a) /*why*/ {
+if (a /*why*/) {
   /* block
    in here */
   // inner comment
@@ -73,7 +72,19 @@ if (a) /*why*/ {
   // end block
 }
 
-let myfun = /*special*/ (/*lead*/ x /*follow*/, y) => x + 5
+let myfun /*special*/ = (/*lead*/ x /*follow*/, y) => x + 5
+
+if (true) {
+
+  let noval = 5
+
+  // Tell the host where the key and value are located and their lengths.
+  // No empty line beneath this please
+  let _KEY_LEN = 32
+  let _KEY_LEN2 = 64
+
+  let _KEY_LEN23 = 64
+}
 
 /* ending block 2 */
 // trailing comment 2


### PR DESCRIPTION
Improvements to comment handling - handle trailing comments on the same line as the expression only, and then look for any remaining comments at the end of blocks.

Fixes #856 
