### PR TITLE
fix(compiler): Don't report comment locations when disabled

### DIFF
--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -519,6 +519,7 @@ type toplevel_stmt = {
 type comment_desc = {
   cmt_content: string,
   cmt_source: string,
+  [@sexp_drop_if sexp_locs_disabled]
   cmt_loc: Location.t,
 };
 

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -47,6 +47,7 @@ and type_extension = {
   ptyext_path: loc(Identifier.t),
   ptyext_params: list(parsed_type),
   ptyext_constructors: list(extension_constructor),
+  [@sexp_drop_if sexp_locs_disabled]
   ptyext_loc: Location.t,
 }
 
@@ -54,12 +55,14 @@ and type_extension = {
 and extension_constructor = {
   pext_name: loc(string),
   pext_kind: extension_constructor_kind,
+  [@sexp_drop_if sexp_locs_disabled]
   pext_loc: Location.t,
 }
 
 [@deriving (sexp, yojson)]
 and type_exception = {
   ptyexn_constructor: extension_constructor,
+  [@sexp_drop_if sexp_locs_disabled]
   ptyexn_loc: Location.t,
 }
 


### PR DESCRIPTION
Noticed when comparing ASTs for the formatter that comments still had their locations shown when location reporting was disabled.