### PR TITLE
feat(compiler): Support "or" pattern matching

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -735,12 +735,19 @@ and print_pattern =
         );
       };
 
-    | PPatOr(pattern1, pattern2) =>
-      /* currently unsupported so just replace with the original source */
-      let originalCode = get_original_code(pat.ppat_loc, original_source);
-      Walktree.remove_comments_in_ignore_block(pat.ppat_loc);
-
-      (Doc.text(originalCode), false);
+    | PPatOr(pattern1, pattern2) => (
+        Doc.group(
+          Doc.concat([
+            print_pattern(~pat=pattern1, ~parent_loc, ~original_source),
+            Doc.softLine,
+            Doc.ifBreaks(Doc.nil, Doc.space),
+            Doc.text("|"),
+            Doc.space,
+            print_pattern(~pat=pattern2, ~parent_loc, ~original_source),
+          ]),
+        ),
+        false,
+      )
     | PPatAlias(pattern, loc) =>
       /* currently unsupported so just replace with the original source */
       let originalCode = get_original_code(pat.ppat_loc, original_source);

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -317,7 +317,17 @@ module MatchTreeCompiler = {
       };
     };
     let res = extract_bindings(patt, expr);
-    /*Printf.eprintf "Bindings:\n%s\n" (Sexplib.Sexp.to_string_hum (sexp_of_list (sexp_of_pair sexp_of_string (fun x -> (sexp_of_string (Pretty.string_of_cexpr x)))) res));*/
+    /*
+       Printf.eprintf(
+         "Bindings:\n%s\n",
+         Sexplib.Sexp.to_string_hum(
+           sexp_of_list(
+             sexp_of_pair(Ident.sexp_of_t, sexp_of_comp_expression),
+             res,
+           ),
+         ),
+       );
+     */
     res;
   };
 

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -305,7 +305,15 @@ module MatchTreeCompiler = {
         | [] => []
         | _ => [(data_name, expr), ...binds]
         };
-      | TPatOr(_) => failwith("NYI: extract_bindings > TPatOr")
+      | TPatOr(left, right) =>
+        let left_binds = extract_bindings(left, expr);
+        let right_binds = extract_bindings(right, expr);
+        switch (left_binds, right_binds) {
+        | ([], []) => []
+        | (left_binds, []) => left_binds
+        | ([], right_binds) => right_binds
+        | (left_binds, right_binds) => List.concat([left_binds, right_binds])
+        };
       };
     };
     let res = extract_bindings(patt, expr);

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -154,6 +154,11 @@ module Pat = {
     );
   };
   let or_ = (~loc=?, a, b) => mk(~loc?, PPatOr(a, b));
+  let multiple_or = (~loc=?, a, b) => {
+    let hd = List.hd(b);
+    let tl = List.tl(b);
+    List.fold_left((a, b) => or_(~loc?, a, b), or_(~loc?, a, hd), tl);
+  };
   let alias = (~loc=?, a, b) => mk(~loc?, PPatAlias(a, b));
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -100,6 +100,7 @@ module Pat: {
   let constraint_: (~loc: loc=?, pattern, parsed_type) => pattern;
   let construct: (~loc: loc=?, id, list(pattern)) => pattern;
   let or_: (~loc: loc=?, pattern, pattern) => pattern;
+  let multiple_or: (~loc: loc=?, pattern, list(pattern)) => pattern;
   let alias: (~loc: loc=?, pattern, str) => pattern;
 };
 

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -157,7 +157,7 @@ binop_expr :
   | one_sided_if_expr { $1 } p10
   | assign_expr { $1 } p10
 
-pattern :
+single_pattern :
   | pattern colon typ { Pat.constraint_ ~loc:(symbol_rloc dyp) $1 $3 }
   | UNDERSCORE { Pat.any ~loc:(symbol_rloc dyp) () }
   | const { Pat.constant ~loc:(symbol_rloc dyp) $1 }
@@ -173,6 +173,10 @@ pattern :
   | type_id { Pat.construct ~loc:(symbol_rloc dyp) $1 [] }
   | lbrack patterns [comma ELLIPSIS any_or_var_pat {$3}]? rbrack { Pat.list ~loc:(symbol_rloc dyp) $2 $3 }
   | lbrack [ELLIPSIS any_or_var_pat {$2}]? rbrack { Pat.list ~loc:(symbol_rloc dyp) [] $2 }
+
+pattern :
+  | single_pattern
+  | single_pattern [eols? PIPE eols? single_pattern {$4}]+ { Pat.multiple_or ~loc:(symbol_rloc dyp) $1 $2  }
 
 any_or_var_pat :
   | UNDERSCORE { Pat.any ~loc:(symbol_rloc dyp) () }


### PR DESCRIPTION
This implements "or" pattern matches using `|` between patterns.

Closes #264

I'm not happy with the way they line-wrap, so I need some help from @marcusroberts to get that working right.

I'll also add some tests here shortly.