### PR TITLE
fix(grainfmt): Correctly add space between arguments in enum pattern

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -720,7 +720,7 @@ and print_pattern =
             if (List.length(patterns) > 0) {
               add_parens(
                 Doc.join(
-                  Doc.comma,
+                  Doc.concat([Doc.comma, Doc.space]),
                   List.map(
                     pat => print_pattern(~pat, ~parent_loc, ~original_source),
                     patterns,

--- a/compiler/test/formatter_inputs/matches.gr
+++ b/compiler/test/formatter_inputs/matches.gr
@@ -18,3 +18,13 @@ export let pop = (queue) => {
         { forwards: [head, ...ftail], backwards } => { forwards: ftail, backwards }
     }
 }
+
+enum Foo<a, b, c> { A(a, b), B(b, c) }
+
+match (A(1, 2)) {
+    A(a,b) => true,
+    B(
+        b,
+        c
+    ) => false
+}

--- a/compiler/test/formatter_outputs/matches.gr
+++ b/compiler/test/formatter_outputs/matches.gr
@@ -22,3 +22,10 @@ export let pop = queue => {
     { forwards: [head, ...ftail], backwards } => { forwards: ftail, backwards },
   }
 }
+
+enum Foo<a, b, c> { A(a, b), B(b, c) }
+
+match (A(1, 2)) {
+  A(a, b) => true,
+  B(b, c) => false,
+}


### PR DESCRIPTION
The formatter was removing the space between arguments, which I ran into this issue when writing some enum pattern matches. This fixes that so there is always a space after a comma.