### PR TITLE
fix(grainfmt): Use Doc.space and surround trailing type annotations with parens

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1806,7 +1806,7 @@ and print_expression =
           ),
           Doc.text(":"),
           Doc.space,
-          Doc.lparen, // needed to fix compiler bug (trailing type annotation needs paren)
+          Doc.lparen, // needed to fix compiler bug (trailing type annotation needs paren, #866)
           print_type(parsed_type, original_source),
           Doc.rparen,
         ]),

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1806,7 +1806,7 @@ and print_expression =
           ),
           Doc.text(":"),
           Doc.space,
-          Doc.lparen, // needed to fix compiler bug
+          Doc.lparen, // needed to fix compiler bug (trailing type annotation needs paren)
           print_type(parsed_type, original_source),
           Doc.rparen,
         ]),

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -600,7 +600,12 @@ and print_record_pattern =
           if (pun) {
             printed_ident;
           } else {
-            Doc.concat([printed_ident, Doc.text(": "), printed_pat]);
+            Doc.concat([
+              printed_ident,
+              Doc.text(":"),
+              Doc.space,
+              printed_pat,
+            ]);
           };
         },
         patternlocs,
@@ -877,7 +882,12 @@ and print_record =
 
               if (!pun) {
                 Doc.group(
-                  Doc.concat([printed_ident, Doc.text(": "), printed_expr]),
+                  Doc.concat([
+                    printed_ident,
+                    Doc.text(":"),
+                    Doc.space,
+                    printed_expr,
+                  ]),
                 );
               } else {
                 Doc.group(printed_ident);
@@ -1794,8 +1804,11 @@ and print_expression =
             ~parent_loc,
             expression,
           ),
-          Doc.text(": "),
+          Doc.text(":"),
+          Doc.space,
+          Doc.lparen, // needed to fix compiler bug
           print_type(parsed_type, original_source),
+          Doc.rparen,
         ]),
       )
     | PExpLambda(patterns, expression) =>
@@ -2026,7 +2039,8 @@ and print_expression =
           expression,
         ),
         Doc.space,
-        Doc.text(":= "),
+        Doc.text(":="),
+        Doc.space,
         print_expression(
           ~parentIsArrow=false,
           ~endChar=None,


### PR DESCRIPTION
The compiler currently needs parens around the trailing type annotation:

`let ret = WasmI32.toGrain(array): (Array<a>)`

so the formatter adds these now.  Also used Doc.space near colons as better form.