### PR TITLE
fix:(grainfmt): Handle comments in import statements

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -2492,6 +2492,8 @@ let import_print = (imp: Parsetree.import_declaration) => {
         switch (v) {
         | PImportModule(identloc) => print_ident(identloc.txt)
         | PImportAllExcept(identlocs) =>
+          let numVals = List.length(identlocs);
+
           Doc.concat([
             Doc.text("*"),
             if (List.length(identlocs) > 0) {
@@ -2499,22 +2501,62 @@ let import_print = (imp: Parsetree.import_declaration) => {
                 Doc.space,
                 Doc.text("except"),
                 Doc.space,
-                add_braces(
-                  Doc.join(
-                    Doc.comma,
-                    List.map(
-                      (identloc: Location.loc(Grain_parsing__Identifier.t)) =>
-                        print_ident(identloc.txt),
-                      identlocs,
+                Doc.lbrace,
+                Doc.indent(
+                  Doc.concat([
+                    Doc.line,
+                    Doc.join(
+                      Doc.line,
+                      List.mapi(
+                        (
+                          index,
+                          identloc: Location.loc(Grain_parsing__Identifier.t),
+                        ) => {
+                          let trailing_comma =
+                            if (index < numVals - 1) {
+                              Doc.comma;
+                            } else {
+                              Doc.nil;
+                            };
+                          let (_leading_comments, trailing_comments) =
+                            Walktree.partition_comments(identloc.loc, None);
+
+                          Walktree.remove_used_comments(
+                            [],
+                            trailing_comments,
+                          );
+
+                          let trailing_comment_docs =
+                            if (List.length(trailing_comments) > 0) {
+                              Doc.concat([
+                                print_multi_comments(
+                                  trailing_comments,
+                                  get_end_loc_line(identloc.loc),
+                                ),
+                              ]);
+                            } else {
+                              Doc.nil;
+                            };
+                          Doc.concat([
+                            print_ident(identloc.txt),
+                            trailing_comma,
+                            trailing_comment_docs,
+                          ]);
+                        },
+                        identlocs,
+                      ),
                     ),
-                  ),
+                  ]),
                 ),
+                Doc.line,
+                Doc.rbrace,
               ]);
             } else {
               Doc.nil;
             },
-          ])
+          ]);
         | PImportValues(identlocsopts) =>
+          let numVals = List.length(identlocsopts);
           Doc.concat([
             Doc.lbrace,
             Doc.indent(
@@ -2522,9 +2564,10 @@ let import_print = (imp: Parsetree.import_declaration) => {
                 Doc.line,
                 if (List.length(identlocsopts) > 0) {
                   Doc.join(
-                    Doc.concat([Doc.comma, Doc.line]),
-                    List.map(
+                    Doc.line,
+                    List.mapi(
                       (
+                        index,
                         identlocopt: (
                           Grain_parsing.Parsetree.loc(
                             Grain_parsing.Identifier.t,
@@ -2537,8 +2580,45 @@ let import_print = (imp: Parsetree.import_declaration) => {
                         ),
                       ) => {
                         let (loc, optloc) = identlocopt;
+                        let trailing_comma =
+                          if (index < numVals - 1) {
+                            Doc.comma;
+                          } else {
+                            Doc.nil;
+                          };
+
+                        let (_leading_comments, trailing_comments) =
+                          switch (optloc) {
+                          | None => Walktree.partition_comments(loc.loc, None)
+                          | Some(alias) =>
+                            Walktree.partition_comments(alias.loc, None)
+                          };
+                        Walktree.remove_used_comments([], trailing_comments);
+
+                        let trailing_comment_docs =
+                          if (List.length(trailing_comments) > 0) {
+                            Doc.concat([
+                              print_multi_comments(
+                                trailing_comments,
+                                get_end_loc_line(
+                                  switch (optloc) {
+                                  | None => loc.loc
+                                  | Some(alias) => alias.loc
+                                  },
+                                ),
+                              ),
+                            ]);
+                          } else {
+                            Doc.nil;
+                          };
+
                         switch (optloc) {
-                        | None => print_ident(loc.txt)
+                        | None =>
+                          Doc.concat([
+                            print_ident(loc.txt),
+                            trailing_comma,
+                            trailing_comment_docs,
+                          ])
                         | Some(alias) =>
                           Doc.concat([
                             print_ident(loc.txt),
@@ -2546,6 +2626,8 @@ let import_print = (imp: Parsetree.import_declaration) => {
                             Doc.text("as"),
                             Doc.space,
                             print_ident(alias.txt),
+                            trailing_comma,
+                            trailing_comment_docs,
                           ])
                         };
                       },
@@ -2559,7 +2641,7 @@ let import_print = (imp: Parsetree.import_declaration) => {
             ),
             Doc.line,
             Doc.rbrace,
-          ])
+          ]);
         }
       },
       imp.pimp_val,

--- a/compiler/test/formatter_inputs/imports.gr
+++ b/compiler/test/formatter_inputs/imports.gr
@@ -10,3 +10,17 @@ import WasmI32, {
 } from "runtime/unsafe/wasmi32"
 
 export foreign wasm storage_read: (WasmI64, WasmI64, WasmI64) -> WasmI64 as storageRead from "env"
+
+import WasmI32, {
+  eq, // comment1
+  // comment 3
+  and as (&), // comment 2
+  or as (|)
+  // no signed imports, as care should be taken to use signed or unsigned operators
+} from "runtime/unsafe/wasmi32"
+
+import * except {
+   eq, // comment
+   and
+   // just because
+ } from "runtime/unsafe/wasmi32"

--- a/compiler/test/formatter_outputs/imports.gr
+++ b/compiler/test/formatter_outputs/imports.gr
@@ -14,3 +14,17 @@ export foreign wasm storage_read: (
   WasmI64,
   WasmI64
 ) -> WasmI64 as storageRead from "env"
+
+import WasmI32, {
+  eq, // comment1
+  // comment 3
+  and as (&), // comment 2
+  or as (|)
+  // no signed imports, as care should be taken to use signed or unsigned operators
+} from "runtime/unsafe/wasmi32"
+
+import * except {
+  eq, // comment
+  and
+  // just because
+} from "runtime/unsafe/wasmi32"


### PR DESCRIPTION
Fixes #862 by properly re-printing comments found in import statements