### PR TITLE
feat(grainfmt): Add a mode to check the formatter's AST matches the original

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -180,6 +180,10 @@ program
 program
   .command("format [file]")
   .description("format a grain file")
+  .option(
+    "--check-formatter",
+    "compares formatted AST and so disables any AST changes"
+  )
   .action(function (file) {
     format(file, program);
   });

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -83,7 +83,7 @@ let format_code =
   // HELP NEEDED
   // I need to get this value from the command line and
 
-  let check_format = false;
+  let check_format = true;
 
   if (check_format) {
     Grain_utils.Config.formatter_maintain_ast := true;
@@ -122,10 +122,16 @@ let format_code =
   };
 };
 
-let grainformat = ((program, source: array(string))) =>
+let grainformat = ((program, source: array(string))) => {
+  // FIX here too
+  let check_format = true;
+  if (check_format) {
+    Grain_utils.Config.formatter_maintain_ast := true;
+  };
   try(format_code(program, source)) {
   | e => `Error((false, Printexc.to_string(e)))
   };
+};
 
 let input_file_conv = {
   open Arg;

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -123,7 +123,7 @@ let format_code =
 };
 
 let grainformat = ((program, source: array(string))) => {
-  // FIX here too
+  // FIX needed here too
   let check_format = true;
   if (check_format) {
     Grain_utils.Config.formatter_maintain_ast := true;

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -83,7 +83,7 @@ let format_code =
   // HELP NEEDED
   // I need to get this value from the command line and
 
-  let check_format = true;
+  let check_format = false;
 
   if (check_format) {
     Grain_utils.Config.formatter_maintain_ast := true;
@@ -114,7 +114,7 @@ let format_code =
     | _ => `Error((false, "Invalid compilation state from formatted code"))
     };
   } else {
-    Grain_utils.Config.formatter_maintain_ast := true;
+    Grain_utils.Config.formatter_maintain_ast := false;
     let reformatted_code = Reformat.reformat_ast(program, original_source);
 
     print_endline(reformatted_code);

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -83,7 +83,7 @@ let format_code =
   // HELP NEEDED
   // I need to get this value from the command line and
 
-  let check_format = true;
+  let check_format = false;
 
   if (check_format) {
     Grain_utils.Config.formatter_maintain_ast := true;
@@ -124,7 +124,7 @@ let format_code =
 
 let grainformat = ((program, source: array(string))) => {
   // FIX needed here too
-  let check_format = true;
+  let check_format = false;
   if (check_format) {
     Grain_utils.Config.formatter_maintain_ast := true;
   };

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -2927,3 +2927,37 @@ let reformat_ast =
   //   ),
   // );
 };
+
+let validate_reformat =
+    (
+      original: Parsetree.parsed_program,
+      reformatted: Parsetree.parsed_program,
+    ) => {
+  let orig_mode = Grain_utils.Config.sexp_locs_enabled^;
+  Grain_utils.Config.sexp_locs_enabled := false;
+
+  let original_s =
+    Sexplib.Sexp.to_string_hum(
+      Grain_parsing.Parsetree.sexp_of_parsed_program(original),
+    );
+
+  let formatted_s =
+    Sexplib.Sexp.to_string_hum(
+      Grain_parsing.Parsetree.sexp_of_parsed_program(reformatted),
+    );
+
+  // reset the mode just in case
+  Grain_utils.Config.sexp_locs_enabled := orig_mode;
+
+  // print_endline(original_s);
+
+  // print_endline("");
+
+  // print_endline(formatted_s);
+
+  if (original_s == formatted_s) {
+    true;
+  } else {
+    false;
+  };
+};

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -2917,7 +2917,6 @@ let reformat_ast =
   //Doc.debug(final_doc);
   //
 
-  Doc.toString(~width=80, final_doc) |> print_endline;
   //use this to see the AST in JSON
   // print_endline(
   //   Yojson.Basic.pretty_to_string(
@@ -2926,6 +2925,8 @@ let reformat_ast =
   //     ),
   //   ),
   // );
+
+  Doc.toString(~width=80, final_doc);
 };
 
 let validate_reformat =

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -2983,6 +2983,10 @@ let validate_reformat =
       Grain_parsing.Parsetree.sexp_of_parsed_program(reformatted),
     );
 
+  // print_endline(original_s);
+
+  // print_endline(formatted_s);
+
   // reset the mode just in case
   Grain_utils.Config.sexp_locs_enabled := orig_mode;
 

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -116,7 +116,7 @@ let get_end_loc_line = (loc: Grain_parsing.Location.t) => {
 };
 
 let comment_to_doc = (comment: Parsetree.comment) => {
-  Doc.text(String.trim(Comments.get_comment_source(comment)));
+  Doc.text(Comments.get_comment_source(comment));
 };
 
 let comment_hardline = (comment: Parsetree.comment) => {
@@ -2982,11 +2982,6 @@ let validate_reformat =
     Sexplib.Sexp.to_string_hum(
       Grain_parsing.Parsetree.sexp_of_parsed_program(reformatted),
     );
-
-  // print_endline(original_s);
-
-  // print_endline(formatted_s);
-
   // reset the mode just in case
   Grain_utils.Config.sexp_locs_enabled := orig_mode;
 

--- a/compiler/grainformat/res_minibuffer.re
+++ b/compiler/grainformat/res_minibuffer.re
@@ -89,6 +89,8 @@ let add_string = (b, s) => {
 };
 
 /* adds newline and trims all preceding whitespace */
+/* keeps the whitespace when we are running in formatter checker mode
+   where we want to preserver the AST  */
 let flush_newline = b => {
   if (! Grain_utils.Config.formatter_maintain_ast^) {
     let position = ref(b.position);

--- a/compiler/grainformat/res_minibuffer.re
+++ b/compiler/grainformat/res_minibuffer.re
@@ -90,10 +90,12 @@ let add_string = (b, s) => {
 
 /* adds newline and trims all preceding whitespace */
 let flush_newline = b => {
-  let position = ref(b.position);
-  while (Bytes.unsafe_get(b.buffer, position^ - 1) == ' ' && position^ >= 0) {
-    position := position^ - 1;
+  if (! Grain_utils.Config.formatter_maintain_ast^) {
+    let position = ref(b.position);
+    while (Bytes.unsafe_get(b.buffer, position^ - 1) == ' ' && position^ >= 0) {
+      position := position^ - 1;
+    };
+    b.position = position^;
   };
-  b.position = position^;
   add_char(b, '\n');
 };

--- a/compiler/src/diagnostics/comments.re
+++ b/compiler/src/diagnostics/comments.re
@@ -415,8 +415,13 @@ let print_comment = (comment: Parsetree.comment) => {
 
 let get_comment_source = (comment: Parsetree.comment) =>
   switch (comment) {
-  | Line(cmt)
   | Block(cmt)
-  | Doc(cmt)
-  | Shebang(cmt) => cmt.cmt_source
+  | Doc(cmt) => cmt.cmt_source
+  | Line(cmt)
+  | Shebang(cmt) =>
+    if (Grain_utils.Config.formatter_maintain_ast^) {
+      Str.global_replace(Str.regexp("[\n\r]+"), "", cmt.cmt_source);
+    } else {
+      String.trim(cmt.cmt_source);
+    }
   };

--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -117,7 +117,7 @@ let num_esc = (unicode_esc | unicode4_esc | hex_esc | oct_esc)
 let newline_char = ("\r\n"|'\n')
 let newline_chars = (newline_char | blank)* newline_char
 
-let line_comment = "//" (([^ '\r' '\n']*(newline_chars | eof)) | (newline_chars | eof))
+let line_comment = "//" (([^ '\r' '\n']*(newline_char | eof)) | (newline_char | eof))
 let shebang_comment = "#!" (([^ '\r' '\n']*(newline_chars | eof)) | (newline_chars | eof))
 
 rule token = parse

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -624,3 +624,10 @@ let get_implicit_opens = () => {
     ]);
   };
 };
+
+let formatter_maintain_ast =
+  toggle_flag(
+    ~names=["check-formatter"],
+    ~doc="Keep AST unchanged when reformatting",
+    false,
+  );

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -628,6 +628,6 @@ let get_implicit_opens = () => {
 let formatter_maintain_ast =
   toggle_flag(
     ~names=["check-formatter"],
-    ~doc="Keep AST unchanged when reformatting",
+    ~doc="Keep AST unchanged when reformatting for tests",
     false,
   );

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -193,3 +193,6 @@ type implicit_opens =
   | Gc_mod;
 
 let get_implicit_opens: unit => list(implicit_opens);
+
+/** don't make any changes to the AST when reformatting */
+let formatter_maintain_ast: ref(bool);

--- a/compiler/test/formatter_inputs/comments.gr
+++ b/compiler/test/formatter_inputs/comments.gr
@@ -44,7 +44,7 @@ if (/*before*/true /*whyt*/) {
   /* after*/
 }
 // trailing
- 
+
 
 // starting comment
 
@@ -99,5 +99,3 @@ let _KEY_LEN2 = 64
 
 /* ending block 2 */
 // trailing comment 2
-
-


### PR DESCRIPTION
This is an optional (default off for performance reasons) check that the AST produced by the formatter matches the original.
It also disables re-writing single expressions inside if statements into blocks as this intentionally modifies the AST.

Draft as I need some help with the command line arguments
