### PR TITLE
fix(compiler): Stop line comment lex absorbing the newlines after

### DIFF
--- a/compiler/src/parsing/lexer.mll
+++ b/compiler/src/parsing/lexer.mll
@@ -117,8 +117,8 @@ let num_esc = (unicode_esc | unicode4_esc | hex_esc | oct_esc)
 let newline_char = ("\r\n"|'\n')
 let newline_chars = (newline_char | blank)* newline_char
 
-let line_comment = "//" (([^ '\r' '\n']*(newline_chars | eof)) | (newline_chars | eof))
-let shebang_comment = "#!" (([^ '\r' '\n']*(newline_chars | eof)) | (newline_chars | eof))
+let line_comment = "//" (([^ '\r' '\n']*(newline_char | eof)) | (newline_char | eof))
+let shebang_comment = "#!" (([^ '\r' '\n']*(newline_char | eof)) | (newline_char | eof))
 
 rule token = parse
   | line_comment { parse_line_comment make_line_comment lexbuf; process_newlines lexbuf; EOL }


### PR DESCRIPTION
I believe a line comment should only ever be a single line.

The lexer was including any following newlines

// this is a comment\n
\n
\n

Change to add only the newline at the end of the comment to the comment source
