### PR TITLE
fix(cli): Manually bump CLI dependencies

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/grain-lang/grain#readme",
   "dependencies": {
-    "@grain/js-runner": "^0.3.0",
+    "@grain/js-runner": "^0.4.0",
     "@grain/stdlib": "^0.3.2",
     "commander": "^8.1.0"
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/grain-lang/grain#readme",
   "dependencies": {
     "@grain/js-runner": "^0.4.0",
-    "@grain/stdlib": "^0.3.2",
+    "@grain/stdlib": "^0.4.0",
     "commander": "^8.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to the rename of runtime to js-runner, this didn't get automatically bumped. This manually bumps it for this time, but it should be automatically bumped going forward.