### PR TITLE
fix(stdlib): Annotate generic types in Buffer

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -541,7 +541,7 @@ export let toStringSlice = (start, length, buffer) => {
  * @since v0.4.0
  */
 @disableGC
-export let rec addChar = (char, buffer) => {
+export let rec addChar = (char: Char, buffer: Buffer) => {
   let n = getCharAsWasmI32(char)
   let bytelen = getCharByteLength(n)
   match (bytelen) {
@@ -713,7 +713,7 @@ export let rec addStringSlice = (start, length, string, buffer) => {
  * @since v0.4.0
  */
 @disableGC
-export let rec addBytesSlice = (start, length, bytes, buffer) => {
+export let rec addBytesSlice = (start: Number, length: Number, bytes: Bytes, buffer: Buffer) => {
   Memory.incRef(WasmI32.fromGrain(autogrow))
   Memory.incRef(WasmI32.fromGrain(length))
   Memory.incRef(WasmI32.fromGrain(buffer))


### PR DESCRIPTION
I generated the Buffer docs and found out that these 2 functions have their parameters inferred as generic types, so we need to annotate them.