### PR TITLE
fix(grainfmt): Remove extra spacing from type signatures

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -923,14 +923,14 @@ and print_type =
             Doc.lparen,
             Doc.indent(
               Doc.concat([
-                Doc.line,
+                Doc.softLine,
                 Doc.join(
                   Doc.concat([Doc.comma, Doc.line]),
                   List.map(t => print_type(t, original_source), types),
                 ),
               ]),
             ),
-            Doc.line,
+            Doc.softLine,
             Doc.rparen,
           ]);
         },

--- a/compiler/test/formatter_inputs/function_params.gr
+++ b/compiler/test/formatter_inputs/function_params.gr
@@ -3,3 +3,11 @@ let single_arg = (x) => x
 let unit_arg = () => 3
 
 let two_args = (x,y) => 4
+
+export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+  (fd,
+    iovs,
+    iovs_len,
+    nwritten) => {
+  0n
+}

--- a/compiler/test/formatter_outputs/function_params.gr
+++ b/compiler/test/formatter_outputs/function_params.gr
@@ -3,3 +3,13 @@ let single_arg = x => x
 let unit_arg = () => 3
 
 let two_args = (x, y) => 4
+
+export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+  (
+    fd,
+    iovs,
+    iovs_len,
+    nwritten,
+  ) => {
+  0n
+}


### PR DESCRIPTION
Fixes #870 

Don't add spaces before/after types in function signature