### PR TITLE
fix(stdlib): Correct type signatures on some Array functions

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -245,7 +245,7 @@ export let forEach = (fn, array) => {
   let length = length(array)
   let mut count = 0
   while (count < length) {
-    fn(array[count])
+    fn(array[count]): Void
     count = incr(count)
   }
 }
@@ -264,7 +264,7 @@ export let forEachi = (fn, array) => {
   let length = length(array)
   let mut count = 0
   while (count < length) {
-    fn(array[count], count)
+    fn(array[count], count): (Void)
     count = incr(count)
   }
 }
@@ -607,7 +607,7 @@ export let findIndex = (fn, array) => {
  *
  * @since v0.2.0
  */
-export let product = (array1, array2) => {
+export let product = (array1: Array<a>, array2: Array<b>) => {
   let lenA = length(array1)
   let lenB = length(array2)
   let mut indexA = -1
@@ -750,7 +750,7 @@ export let unique = (array) => {
  *
  * @since v0.4.0
  */
-export let zip = (array1, array2) => {
+export let zip = (array1: Array<a>, array2: Array<b>) => {
   let len = length(array1)
   if (len != length(array2)) {
     fail "arguments to zip must be same length"

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -278,7 +278,7 @@ Returns:
 </details>
 
 ```grain
-forEach : ((a -> b), Array<a>) -> Void
+forEach : ((a -> Void), Array<a>) -> Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -287,7 +287,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The iterator function to call with each element|
+|`fn`|`a -> Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
 
 ### Array.**forEachi**
@@ -305,7 +305,7 @@ Parameters:
 </details>
 
 ```grain
-forEachi : (((a, Number) -> b), Array<a>) -> Void
+forEachi : (((a, Number) -> Void), Array<a>) -> Void
 ```
 
 Iterates an array, calling an iterator function with each element.
@@ -315,7 +315,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> b`|The iterator function to call with each element|
+|`fn`|`(a, Number) -> Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
 
 ### Array.**map**
@@ -740,7 +740,7 @@ No other changes yet.
 </details>
 
 ```grain
-product : (Array<a>, Array<a0>) -> Array<(a, a0)>
+product : (Array<a>, Array<b>) -> Array<(a, b)>
 ```
 
 Combines two arrays into a Cartesian product of tuples containing
@@ -751,13 +751,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`array1`|`Array<a>`|The array to provide values for the first tuple element|
-|`array2`|`Array<a>`|The array to provide values for the second tuple element|
+|`array2`|`Array<b>`|The array to provide values for the second tuple element|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Array<(a, a0)>`|The new array containing all pairs of `(a, b)`|
+|`Array<(a, b)>`|The new array containing all pairs of `(a, b)`|
 
 ### Array.**count**
 
@@ -902,7 +902,7 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (Array<a>, Array<a0>) -> Array<(a, a0)>
+zip : (Array<a>, Array<b>) -> Array<(a, b)>
 ```
 
 Produces a new array filled with tuples of elements from both given arrays.
@@ -916,13 +916,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`array1`|`Array<a>`|The array to provide values for the first tuple element|
-|`array2`|`Array<a>`|The array to provide values for the second tuple element|
+|`array2`|`Array<b>`|The array to provide values for the second tuple element|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Array<(a, a0)>`|The new array containing indexed pairs of `(a, b)`|
+|`Array<(a, b)>`|The new array containing indexed pairs of `(a, b)`|
 
 ### Array.**unzip**
 


### PR DESCRIPTION
While reviewing the website docs, I found some issues with the type signatures of Array functions.