### PR TITLE
chore(stdlib): Reorganize buffer library for better docs

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -504,7 +504,7 @@ export let addBufferSlice = (start, length, srcBuffer, dstBuffer) => {
 }
 
 /**
- * @section Raw bytes: Functions for working with the raw bytes in a buffer.
+ * @section Binary operations on integers: Functions for encoding and decoding integers stored in a buffer.
  */
 
 

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -96,295 +96,30 @@ let checkIsIndexInBounds = (i, len, buf) => {
   if (i >= buf.len || i + len > buf.len) throw Exception.IndexOutOfBounds
 }
 
-/**
- * @section Values: Functions for working with the Buffer data type.
- */
-
-/**
- * Gets a signed 8-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 32-bit integer representing a signed 8-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt8S = (index, buffer) => {
-  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
-  Bytes.getInt8S(index, buffer.data)
-}
-
-/**
- * Gets an unsigned 8-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 32-bit integer representing an unsigned 8-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt8U = (index, buffer) => {
-  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
-  Bytes.getInt8U(index, buffer.data)
-}
-
-/**
- * Sets a signed 8-bit integer starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setInt8 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
-  Bytes.setInt8(index, value, buffer.data)
-}
-
-/**
- * Appends a signed 8-bit integer to a buffer.
- *
- * @param value: The value to append
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let addInt8 = (value, buffer) => {
+let addInt8help = (value, buffer) => {
   autogrow(_8BIT_LEN, buffer)
   let index = buffer.len
   buffer.len = buffer.len + _8BIT_LEN
-  setInt8(index, value, buffer)
+  Bytes.setInt8(index, value, buffer.data)
 }
 
-/**
- * Gets a signed 16-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 32-bit integer representing a signed 16-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt16S = (index, buffer) => {
-  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
-  Bytes.getInt16S(index, buffer.data)
-}
-
-/**
- * Gets an unsigned 16-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 32-bit integer representing an unsigned 16-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt16U = (index, buffer) => {
-  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
-  Bytes.getInt16U(index, buffer.data)
-}
-
-/**
- * Sets a signed 16-bit integer starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setInt16 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
-  Bytes.setInt16(index, value, buffer.data)
-}
-
-/**
- * Appends a signed 16-bit integer to a buffer.
- *
- * @param value: The value to append
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let addInt16 = (value, buffer) => {
+let addInt16help = (value, buffer) => {
   autogrow(_16BIT_LEN, buffer)
   let index = buffer.len
   buffer.len = buffer.len + _16BIT_LEN
-  setInt16(index, value, buffer)
+  Bytes.setInt16(index, value, buffer.data)
 }
 
-/**
- * Gets a signed 32-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A signed 32-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt32 = (index, buffer) => {
-  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
-  Bytes.getInt32(index, buffer.data)
-}
-
-/**
- * Sets a signed 32-bit integer starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setInt32 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
+let addInt32help = (value, buffer) => {
+  autogrow(_32BIT_LEN, buffer)
+  let index = buffer.len
+  buffer.len = buffer.len + _32BIT_LEN
   Bytes.setInt32(index, value, buffer.data)
 }
 
 /**
- * Appends a signed 32-bit integer to a buffer.
- *
- * @param value: The value to append
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
+ * @section Values: Functions for working with the Buffer data type.
  */
-export let addInt32 = (value, buffer) => {
-  autogrow(_32BIT_LEN, buffer)
-  let index = buffer.len
-  buffer.len = buffer.len + _32BIT_LEN
-  setInt32(index, value, buffer)
-}
-
-/**
- * Gets a 32-bit float starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 32-bit float that starts at the given index
- *
- * @since v0.4.0
- */
-export let getFloat32 = (index, buffer) => {
-  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
-  Bytes.getFloat32(index, buffer.data)
-}
-
-/**
- * Sets a 32-bit float starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setFloat32 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
-  Bytes.setFloat32(index, value, buffer.data)
-}
-
-/**
- * Appends a 32-bit float to a buffer.
- *
- * @param value: The value to append
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let addFloat32 = (value, buffer) => {
-  autogrow(_32BIT_LEN, buffer)
-  let index = buffer.len
-  buffer.len = buffer.len + _32BIT_LEN
-  setFloat32(index, value, buffer)
-}
-
-/**
- * Gets a signed 64-bit integer starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A signed 64-bit integer that starts at the given index
- *
- * @since v0.4.0
- */
-export let getInt64 = (index, buffer) => {
-  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
-  Bytes.getInt64(index, buffer.data)
-}
-
-/**
- * Sets a signed 64-bit integer starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setInt64 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
-  Bytes.setInt64(index, value, buffer.data)
-}
-
-/**
- * Appends a signed 64-bit integer to a buffer.
- *
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let addInt64 = (value, buffer) => {
-  autogrow(_64BIT_LEN, buffer)
-  let index = buffer.len
-  buffer.len = buffer.len + _64BIT_LEN
-  setInt64(index, value, buffer)
-}
-
-/**
- * Gets a 64-bit float starting at the given byte index.
- *
- * @param index: The byte index to access
- * @param buffer: The buffer to access
- * @returns A 64-bit float that starts at the given index
- *
- * @since v0.4.0
- */
-export let getFloat64 = (index, buffer) => {
-  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
-  Bytes.getFloat64(index, buffer.data)
-}
-
-/**
- * Sets a 64-bit float starting at the given byte index.
- *
- * @param index: The byte index to update
- * @param value: The value to set
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let setFloat64 = (index, value, buffer) => {
-  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
-  Bytes.setFloat64(index, value, buffer.data)
-}
-
-/**
- * Appends a 64-bit float to a buffer.
- *
- * @param value: The value to append
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-export let addFloat64 = (value, buffer) => {
-  autogrow(_64BIT_LEN, buffer)
-  let index = buffer.len
-  buffer.len = buffer.len + _64BIT_LEN
-  setFloat64(index, value, buffer)
-}
 
 /**
  * Creates a fresh buffer, initially empty.
@@ -547,17 +282,17 @@ export let rec addChar = (char: Char, buffer: Buffer) => {
   match (bytelen) {
     1n => {
       let c = Conv.toInt32(n)
-      Memory.incRef(WasmI32.fromGrain(addInt8))
+      Memory.incRef(WasmI32.fromGrain(addInt8help))
       Memory.incRef(WasmI32.fromGrain(c))
       Memory.incRef(WasmI32.fromGrain(buffer))
-      addInt8(c, buffer)
+      addInt8help(c, buffer)
     },
     2n => {
       let c = Conv.toInt32(n)
-      Memory.incRef(WasmI32.fromGrain(addInt16))
+      Memory.incRef(WasmI32.fromGrain(addInt16help))
       Memory.incRef(WasmI32.fromGrain(c))
       Memory.incRef(WasmI32.fromGrain(buffer))
-      addInt16(c, buffer)
+      addInt16help(c, buffer)
     },
     3n => {
       let (<) = WasmI32.ltU
@@ -567,18 +302,18 @@ export let rec addChar = (char: Char, buffer: Buffer) => {
       let (>>) = WasmI32.shrU
       for (let mut i = 0n; i < 3n; i = i + 1n) {
         let c = Conv.toInt32(n >> (i * 8n) & 0xffn)
-        Memory.incRef(WasmI32.fromGrain(addInt8))
+        Memory.incRef(WasmI32.fromGrain(addInt8help))
         Memory.incRef(WasmI32.fromGrain(c))
         Memory.incRef(WasmI32.fromGrain(buffer))
-        addInt8(c, buffer)
+        addInt8help(c, buffer)
       }
     },
     _ => {
       let c = Conv.toInt32(n)
-      Memory.incRef(WasmI32.fromGrain(addInt32))
+      Memory.incRef(WasmI32.fromGrain(addInt32help))
       Memory.incRef(WasmI32.fromGrain(c))
       Memory.incRef(WasmI32.fromGrain(buffer))
-      addInt32(c, buffer)
+      addInt32help(c, buffer)
     },
   }
 
@@ -766,4 +501,286 @@ export let addBuffer = (srcBuffer, dstBuffer) => {
  */
 export let addBufferSlice = (start, length, srcBuffer, dstBuffer) => {
   addBytesSlice(start, length, srcBuffer.data, dstBuffer)
+}
+
+/**
+ * @section Raw bytes: Functions for working with the raw bytes in a buffer.
+ */
+
+
+/**
+ * Gets a signed 8-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 32-bit integer representing a signed 8-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt8S = (index, buffer) => {
+  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
+  Bytes.getInt8S(index, buffer.data)
+}
+
+/**
+ * Gets an unsigned 8-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 32-bit integer representing an unsigned 8-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt8U = (index, buffer) => {
+  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
+  Bytes.getInt8U(index, buffer.data)
+}
+
+/**
+ * Sets a signed 8-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setInt8 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _8BIT_LEN, buffer)
+  Bytes.setInt8(index, value, buffer.data)
+}
+
+/**
+ * Appends a signed 8-bit integer to a buffer.
+ *
+ * @param value: The value to append
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addInt8 = (value, buffer) => {
+  addInt8help(value, buffer)
+}
+
+/**
+ * Gets a signed 16-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 32-bit integer representing a signed 16-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt16S = (index, buffer) => {
+  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
+  Bytes.getInt16S(index, buffer.data)
+}
+
+/**
+ * Gets an unsigned 16-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 32-bit integer representing an unsigned 16-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt16U = (index, buffer) => {
+  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
+  Bytes.getInt16U(index, buffer.data)
+}
+
+/**
+ * Sets a signed 16-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setInt16 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _16BIT_LEN, buffer)
+  Bytes.setInt16(index, value, buffer.data)
+}
+
+/**
+ * Appends a signed 16-bit integer to a buffer.
+ *
+ * @param value: The value to append
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addInt16 = (value, buffer) => {
+  addInt32help(value, buffer)
+}
+
+/**
+ * Gets a signed 32-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A signed 32-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt32 = (index, buffer) => {
+  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
+  Bytes.getInt32(index, buffer.data)
+}
+
+/**
+ * Sets a signed 32-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setInt32 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
+  Bytes.setInt32(index, value, buffer.data)
+}
+
+/**
+ * Appends a signed 32-bit integer to a buffer.
+ *
+ * @param value: The value to append
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addInt32 = (value, buffer) => {
+  addInt32help(value, buffer)
+}
+
+/**
+ * Gets a 32-bit float starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 32-bit float that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getFloat32 = (index, buffer) => {
+  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
+  Bytes.getFloat32(index, buffer.data)
+}
+
+/**
+ * Sets a 32-bit float starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setFloat32 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _32BIT_LEN, buffer)
+  Bytes.setFloat32(index, value, buffer.data)
+}
+
+/**
+ * Appends a 32-bit float to a buffer.
+ *
+ * @param value: The value to append
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addFloat32 = (value, buffer) => {
+  autogrow(_32BIT_LEN, buffer)
+  let index = buffer.len
+  buffer.len = buffer.len + _32BIT_LEN
+  setFloat32(index, value, buffer)
+}
+
+/**
+ * Gets a signed 64-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A signed 64-bit integer that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getInt64 = (index, buffer) => {
+  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
+  Bytes.getInt64(index, buffer.data)
+}
+
+/**
+ * Sets a signed 64-bit integer starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setInt64 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
+  Bytes.setInt64(index, value, buffer.data)
+}
+
+/**
+ * Appends a signed 64-bit integer to a buffer.
+ *
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addInt64 = (value, buffer) => {
+  autogrow(_64BIT_LEN, buffer)
+  let index = buffer.len
+  buffer.len = buffer.len + _64BIT_LEN
+  setInt64(index, value, buffer)
+}
+
+/**
+ * Gets a 64-bit float starting at the given byte index.
+ *
+ * @param index: The byte index to access
+ * @param buffer: The buffer to access
+ * @returns A 64-bit float that starts at the given index
+ *
+ * @since v0.4.0
+ */
+export let getFloat64 = (index, buffer) => {
+  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
+  Bytes.getFloat64(index, buffer.data)
+}
+
+/**
+ * Sets a 64-bit float starting at the given byte index.
+ *
+ * @param index: The byte index to update
+ * @param value: The value to set
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let setFloat64 = (index, value, buffer) => {
+  checkIsIndexInBounds(index, _64BIT_LEN, buffer)
+  Bytes.setFloat64(index, value, buffer.data)
+}
+
+/**
+ * Appends a 64-bit float to a buffer.
+ *
+ * @param value: The value to append
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addFloat64 = (value, buffer) => {
+  autogrow(_64BIT_LEN, buffer)
+  let index = buffer.len
+  buffer.len = buffer.len + _64BIT_LEN
+  setFloat64(index, value, buffer)
 }

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -613,7 +613,7 @@ export let setInt16 = (index, value, buffer) => {
  * @since v0.4.0
  */
 export let addInt16 = (value, buffer) => {
-  addInt32help(value, buffer)
+  addInt16help(value, buffer)
 }
 
 /**

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -390,9 +390,9 @@ Parameters:
 |`srcBuffer`|`Buffer`|The buffer to append|
 |`dstBuffer`|`Buffer`|The buffer to mutate|
 
-## Raw bytes
+## Binary operations on integers
 
-Functions for working with the raw bytes in a buffer.
+Functions for encoding and decoding integers stored in a buffer.
 
 ### Buffer.**getInt8S**
 

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -19,6 +19,381 @@ import Buffer from "buffer"
 
 Functions for working with the Buffer data type.
 
+### Buffer.**make**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+make : Number -> Buffer
+```
+
+Creates a fresh buffer, initially empty.
+
+The `initialSize` parameter is the initial size of the internal byte sequence that holds the buffer contents.
+That byte sequence is automatically reallocated when more than `initialSize` bytes are stored in the buffer, but shrinks back to `initialSize` characters when reset is called.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`initialSize`|`Number`|The initial size of the buffer|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Buffer`|The new buffer|
+
+### Buffer.**length**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+length : Buffer -> Number
+```
+
+Gets the number of bytes currently contained in a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`buffer`|`Buffer`|The buffer to access|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The length of the buffer in bytes|
+
+### Buffer.**clear**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+clear : Buffer -> Void
+```
+
+Clears data in the buffer and sets its length to zero.
+
+This operation does not resize the underlying byte sequence.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`buffer`|`Buffer`|The buffer to clear|
+
+### Buffer.**reset**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reset : Buffer -> Void
+```
+
+Empty a buffer and deallocate the internal byte sequence holding the buffer contents.
+
+This operation resizes the underlying byte sequence to the initial size of the buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`buffer`|`Buffer`|The buffer to reset|
+
+### Buffer.**truncate**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+truncate : (Number, Buffer) -> Void
+```
+
+Shortens a buffer to the given length.
+
+This operation does not resize the underlying byte sequence.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The number of bytes to truncate the buffer to|
+|`buffer`|`Buffer`|The buffer to truncate|
+
+### Buffer.**toBytes**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toBytes : Buffer -> Bytes
+```
+
+Returns a copy of the current contents of the buffer as a byte sequence.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`buffer`|`Buffer`|The buffer to copy into a byte sequence|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bytes`|A byte sequence made from copied buffer data|
+
+### Buffer.**toBytesSlice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toBytesSlice : (Number, Number, Buffer) -> Bytes
+```
+
+Returns a slice of the current contents of the buffer as a byte sequence.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The start index|
+|`length`|`Number`|The number of bytes to include after the starting index|
+|`buffer`|`Buffer`|The buffer to copy from|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bytes`|A byte sequence with bytes copied from the buffer|
+
+### Buffer.**toString**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toString : Buffer -> String
+```
+
+Returns a copy of the current contents of the buffer as a string.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`buffer`|`Buffer`|The buffer to stringify|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|A string made with data copied from the buffer|
+
+### Buffer.**toStringSlice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toStringSlice : (Number, Number, Buffer) -> String
+```
+
+Returns a copy of a subset of the current contents of the buffer as a string.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The start index|
+|`length`|`Number`|The number of bytes to include after the starting index|
+|`buffer`|`Buffer`|The buffer to copy from|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|A string made with a subset of data copied from the buffer|
+
+### Buffer.**addChar**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addChar : (Char, Buffer) -> Void
+```
+
+Appends the bytes of a char to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`char`|`Char`|The character to append to the buffer|
+|`buffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addBytes**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addBytes : (Bytes, Buffer) -> Void
+```
+
+Appends a byte sequence to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`bytes`|`Bytes`|The byte sequence to append|
+|`buffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addString**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addString : (String, Buffer) -> Void
+```
+
+Appends the bytes of a string to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`string`|`String`|The string to append|
+|`buffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addStringSlice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addStringSlice : (Number, Number, String, Buffer) -> Void
+```
+
+Appends the bytes of a subset of a string to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The char offset into the string|
+|`length`|`Number`|The number of bytes to append|
+|`string`|`String`|The string to append|
+|`buffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addBytesSlice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addBytesSlice : (Number, Number, Bytes, Buffer) -> Void
+```
+
+Appends the bytes of a subset of a byte seuqnece to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The byte offset into the byte sequence|
+|`length`|`Number`|The number of bytes to append|
+|`bytes`|`Bytes`|The byte sequence to append|
+|`buffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addBuffer**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addBuffer : (Buffer, Buffer) -> Void
+```
+
+Appends the bytes of a source buffer to destination buffer.
+
+The source buffer is not mutated by this operation. The destination buffer, however, is mutated.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`srcBuffer`|`Buffer`|The buffer to append|
+|`dstBuffer`|`Buffer`|The buffer to mutate|
+
+### Buffer.**addBufferSlice**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addBufferSlice : (Number, Number, Buffer, Buffer) -> Void
+```
+
+Appends the bytes of a part of a buffer to the end of the buffer
+
+The source buffer is not mutated by this operation. The destination buffer, however, is mutated.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The byte offset into the buffer|
+|`length`|`Number`|The number of bytes to append|
+|`srcBuffer`|`Buffer`|The buffer to append|
+|`dstBuffer`|`Buffer`|The buffer to mutate|
+
+## Raw bytes
+
+Functions for working with the raw bytes in a buffer.
+
 ### Buffer.**getInt8S**
 
 <details disabled>
@@ -472,375 +847,4 @@ Parameters:
 |-----|----|-----------|
 |`value`|`Float64`|The value to append|
 |`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**make**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-make : Number -> Buffer
-```
-
-Creates a fresh buffer, initially empty.
-
-The `initialSize` parameter is the initial size of the internal byte sequence that holds the buffer contents.
-That byte sequence is automatically reallocated when more than `initialSize` bytes are stored in the buffer, but shrinks back to `initialSize` characters when reset is called.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`initialSize`|`Number`|The initial size of the buffer|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Buffer`|The new buffer|
-
-### Buffer.**length**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-length : Buffer -> Number
-```
-
-Gets the number of bytes currently contained in a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`buffer`|`Buffer`|The buffer to access|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Number`|The length of the buffer in bytes|
-
-### Buffer.**clear**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-clear : Buffer -> Void
-```
-
-Clears data in the buffer and sets its length to zero.
-
-This operation does not resize the underlying byte sequence.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`buffer`|`Buffer`|The buffer to clear|
-
-### Buffer.**reset**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-reset : Buffer -> Void
-```
-
-Empty a buffer and deallocate the internal byte sequence holding the buffer contents.
-
-This operation resizes the underlying byte sequence to the initial size of the buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`buffer`|`Buffer`|The buffer to reset|
-
-### Buffer.**truncate**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-truncate : (Number, Buffer) -> Void
-```
-
-Shortens a buffer to the given length.
-
-This operation does not resize the underlying byte sequence.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`length`|`Number`|The number of bytes to truncate the buffer to|
-|`buffer`|`Buffer`|The buffer to truncate|
-
-### Buffer.**toBytes**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-toBytes : Buffer -> Bytes
-```
-
-Returns a copy of the current contents of the buffer as a byte sequence.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`buffer`|`Buffer`|The buffer to copy into a byte sequence|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Bytes`|A byte sequence made from copied buffer data|
-
-### Buffer.**toBytesSlice**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-toBytesSlice : (Number, Number, Buffer) -> Bytes
-```
-
-Returns a slice of the current contents of the buffer as a byte sequence.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`start`|`Number`|The start index|
-|`length`|`Number`|The number of bytes to include after the starting index|
-|`buffer`|`Buffer`|The buffer to copy from|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Bytes`|A byte sequence with bytes copied from the buffer|
-
-### Buffer.**toString**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-toString : Buffer -> String
-```
-
-Returns a copy of the current contents of the buffer as a string.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`buffer`|`Buffer`|The buffer to stringify|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`String`|A string made with data copied from the buffer|
-
-### Buffer.**toStringSlice**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-toStringSlice : (Number, Number, Buffer) -> String
-```
-
-Returns a copy of a subset of the current contents of the buffer as a string.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`start`|`Number`|The start index|
-|`length`|`Number`|The number of bytes to include after the starting index|
-|`buffer`|`Buffer`|The buffer to copy from|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`String`|A string made with a subset of data copied from the buffer|
-
-### Buffer.**addChar**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addChar : (a, Buffer) -> Void
-```
-
-Appends the bytes of a char to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`char`|`a`|The character to append to the buffer|
-|`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addBytes**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addBytes : (Bytes, Buffer) -> Void
-```
-
-Appends a byte sequence to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`bytes`|`Bytes`|The byte sequence to append|
-|`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addString**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addString : (String, Buffer) -> Void
-```
-
-Appends the bytes of a string to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`string`|`String`|The string to append|
-|`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addStringSlice**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addStringSlice : (Number, Number, String, Buffer) -> Void
-```
-
-Appends the bytes of a subset of a string to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`start`|`Number`|The char offset into the string|
-|`length`|`Number`|The number of bytes to append|
-|`string`|`String`|The string to append|
-|`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addBytesSlice**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addBytesSlice : (Number, Number, a, Buffer) -> Void
-```
-
-Appends the bytes of a subset of a byte seuqnece to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`start`|`Number`|The byte offset into the byte sequence|
-|`length`|`Number`|The number of bytes to append|
-|`bytes`|`a`|The byte sequence to append|
-|`buffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addBuffer**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addBuffer : (Buffer, Buffer) -> Void
-```
-
-Appends the bytes of a source buffer to destination buffer.
-
-The source buffer is not mutated by this operation. The destination buffer, however, is mutated.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`srcBuffer`|`Buffer`|The buffer to append|
-|`dstBuffer`|`Buffer`|The buffer to mutate|
-
-### Buffer.**addBufferSlice**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addBufferSlice : (Number, Number, Buffer, Buffer) -> Void
-```
-
-Appends the bytes of a part of a buffer to the end of the buffer
-
-The source buffer is not mutated by this operation. The destination buffer, however, is mutated.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`start`|`Number`|The byte offset into the buffer|
-|`length`|`Number`|The number of bytes to append|
-|`srcBuffer`|`Buffer`|The buffer to append|
-|`dstBuffer`|`Buffer`|The buffer to mutate|
 


### PR DESCRIPTION
I wasn't happy with the way the docs for Buffer are organized on the website, so I reorganized the file and added a new section.