### PR TITLE
chore(stdlib): Fix missing backtick in sys/file docs

### DIFF
--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -529,7 +529,7 @@ export let rec fdRead = (fd: FileDescriptor, size: Number) => {
  * @param fd: The file descriptor to read from
  * @param offset: The position within the file to begin reading
  * @param size: The maximum number of bytes to read from the file descriptor
- * @returns `Ok((contents, numBytes)) of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
+ * @returns `Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise
  */
 export let rec fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   let fdArg = fd

--- a/stdlib/sys/file.md
+++ b/stdlib/sys/file.md
@@ -277,7 +277,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<(String, Number), Exception>`|`Ok((contents, numBytes)) of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+|`Result<(String, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
 
 ### File.**fdWrite**
 


### PR DESCRIPTION
Found this while reviewing the docs on the website.