### PR TITLE
fix(grainfmt): Resolve issues with comments within braces

### DIFF
--- a/compiler/grainformat/debug.re
+++ b/compiler/grainformat/debug.re
@@ -10,10 +10,10 @@ let print_loc_string = (msg: string, loc: Grain_parsing.Location.t) => {
 
   if (startchar >= 0) {
     if (line == endline) {
-      Printf.sprintf("%s %d:%d,%d", msg, line, startchar, endchar);
+      Printf.sprintf("%s %d:%d,%d\n", msg, line, startchar, endchar);
     } else {
       Printf.sprintf(
-        "%s %d:%d - %d:%d",
+        "%s %d:%d - %d:%d\n",
         msg,
         line,
         startchar,
@@ -32,10 +32,10 @@ let print_loc = (msg: string, loc: Grain_parsing.Location.t) => {
 
   if (startchar >= 0) {
     if (line == endline) {
-      Printf.printf("%s %d:%d,%d", msg, line, startchar, endchar);
+      Printf.printf("%s %d:%d,%d\n", msg, line, startchar, endchar);
     } else {
       Printf.printf(
-        "%s %d:%d - %d:%d",
+        "%s %d:%d - %d:%d\n",
         msg,
         line,
         startchar,

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -84,8 +84,7 @@ let is_first_inside_second =
           false;
         };
       } else {
-        false; // true;
-             // ignore the end of line so we catch trailing comments
+        false;
       };
 
     begins_inside && ends_inside;

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -69,7 +69,7 @@ let is_first_inside_second =
     let begins_inside =
       if (raw1l > raw2l) {
         true;
-      } else if (raw1c >= raw2c) {
+      } else if (raw1c >= raw2c && raw1c <= raw2ce) {
         true;
       } else {
         false;
@@ -77,9 +77,16 @@ let is_first_inside_second =
     let ends_inside =
       if (raw1le < raw2le) {
         true;
+      } else if (raw1le == raw2le) {
+        if (raw1ce <= raw2ce) {
+          true;
+        } else {
+          false;
+        };
       } else {
-        true;
-      }; // ignore the end of line so we catch trailing comments
+        false; // true;
+             // ignore the end of line so we catch trailing comments
+      };
 
     begins_inside && ends_inside;
   };
@@ -201,7 +208,6 @@ let partition_comments =
       ([], []),
       all_locations^,
     );
-
   (preceeding, following);
 };
 

--- a/compiler/test/formatter_inputs/brace_comments.gr
+++ b/compiler/test/formatter_inputs/brace_comments.gr
@@ -1,0 +1,17 @@
+match (1) { // fails
+  // fails2
+  1 => "1",
+  _ => "*", // x
+}
+
+if (true) { // block 1
+  // block 2
+  1 // block 2a
+  // block 2b
+} else { // block3
+  // block 4
+  2 // block 5
+  // block 6
+}
+
+let space = ""

--- a/compiler/test/formatter_inputs/enums.gr
+++ b/compiler/test/formatter_inputs/enums.gr
@@ -1,4 +1,4 @@
-export enum Instructions {
+export enum Instructions { // brace trailer
   // leading
   MoveNorth(Number),  // north
   // below north

--- a/compiler/test/formatter_inputs/function_params.gr
+++ b/compiler/test/formatter_inputs/function_params.gr
@@ -1,13 +1,16 @@
-let single_arg = (x) => x
+let single_arg = x => x
 
 let unit_arg = () => 3
 
-let two_args = (x,y) => 4
+let two_args = (x, y) => 4
 
+@disableGC
 export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
-  (fd,
+  (
+    fd,
     iovs,
     iovs_len,
-    nwritten) => {
+    nwritten,
+  ) => {
   0n
 }

--- a/compiler/test/formatter_inputs/function_params.gr
+++ b/compiler/test/formatter_inputs/function_params.gr
@@ -4,13 +4,12 @@ let unit_arg = () => 3
 
 let two_args = (x,y) => 4
 
-@disableGC
-export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+export let fake_write: (int, int, int, string) -> string =
   (
     fd,
     iovs,
     iovs_len,
     nwritten,
   ) => {
-  0n
+  "ok"
 }

--- a/compiler/test/formatter_inputs/function_params.gr
+++ b/compiler/test/formatter_inputs/function_params.gr
@@ -1,8 +1,8 @@
-let single_arg = x => x
+let single_arg = (x) => x
 
 let unit_arg = () => 3
 
-let two_args = (x, y) => 4
+let two_args = (x,y) => 4
 
 @disableGC
 export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =

--- a/compiler/test/formatter_inputs/records.gr
+++ b/compiler/test/formatter_inputs/records.gr
@@ -1,28 +1,65 @@
-record Rec {foo: Number, bar: Number}
-let x = {foo: 4, bar: 9}
+record Rec { foo: Number, bar: Number }
+let x = { foo: 4, bar: 9 }
 
 x.foo + x.bar
 
+record Rec1 { foo2: Number, bar2: Number }
+record Rec2 { baz2: Rec1 }
+let x = { baz2: { foo2: 4, bar2: 9 }, }
+x.baz2.bar2
 
+record Rec3 { foo3: Number, bar3: String, baz3: Bool }
+let { foo3, _ } = { foo3: 4, bar3: "boo", baz3: true }
+foo3
 
-record Rec1 {foo2: Number, bar2: Number}; record Rec2 {baz2: Rec1}; let x = {baz2: {foo2: 4, bar2: 9}}; x.baz2.bar2
+record Long {
+  longField1: Number,
+  longField2: Number,
+  longField3: String,
+  longField4: String,
+  longField5: String,
+}
 
-record Rec3 {foo3: Number, bar3: String, baz3: Bool}; let { foo3, _ } = {foo3: 4, bar3: "boo", baz3: true}; foo3
-
-record Long {longField1: Number, longField2: Number, longField3:String, longField4:String, longField5:String}
-
-record Commented {
+record Commented { // brace comment
   // leading
   name: String, // trail 1
   // under 1
   address: String, /*
   stupid block */
-  age: Number
+  age: Number,
   // trailing
 }
 
 record Bucket<k, v> {
   mut key: k,
   mut value: v,
-  mut nextkey: Option<Bucket<k, v>>
+  mut nextkey: Option<Bucket<k, v>>,
 }
+
+record Commented { // brace comment
+  // leading
+  longlonglongnamenamename1: String, // trail 1
+  // under 1
+  longlonglongnamenamename2: String, /*
+  stupid block */
+  longlonglongnamenamename3: Number,
+  // trailing
+}
+
+let x: Commented = { // comment 1
+  longlonglongnamenamename1: "A",
+  longlonglongnamenamename2: "B",
+  longlonglongnamenamename3: 42,
+} 
+
+let { // a comment 2
+  longlonglongnamenamename1,
+  longlonglongnamenamename2,
+  longlonglongnamenamename3
+} = x
+
+let { // a comment 3
+  l1,
+  l2,
+  l3
+} = x

--- a/compiler/test/formatter_inputs/records.gr
+++ b/compiler/test/formatter_inputs/records.gr
@@ -1,5 +1,5 @@
-record Rec { foo: Number, bar: Number }
-let x = { foo: 4, bar: 9 }
+record Rec {foo: Number, bar: Number}
+let x = {foo: 4, bar: 9}
 
 x.foo + x.bar
 
@@ -12,10 +12,7 @@ record Rec3 { foo3: Number, bar3: String, baz3: Bool }
 let { foo3, _ } = { foo3: 4, bar3: "boo", baz3: true }
 foo3
 
-record Long {
-  longField1: Number,
-  longField2: Number,
-  longField3: String,
+record Long {longField1: Number,longField2: Number,longField3: String,
   longField4: String,
   longField5: String,
 }
@@ -26,7 +23,7 @@ record Commented { // brace comment
   // under 1
   address: String, /*
   stupid block */
-  age: Number,
+  age: Number
   // trailing
 }
 

--- a/compiler/test/formatter_outputs/brace_comments.gr
+++ b/compiler/test/formatter_outputs/brace_comments.gr
@@ -1,0 +1,17 @@
+match (1) { // fails
+  // fails2
+  1 => "1",
+  _ => "*", // x
+}
+
+if (true) { // block 1
+  // block 2
+  1 // block 2a
+  // block 2b
+} else { // block3
+  // block 4
+  2 // block 5
+  // block 6
+}
+
+let space = ""

--- a/compiler/test/formatter_outputs/enums.gr
+++ b/compiler/test/formatter_outputs/enums.gr
@@ -1,4 +1,4 @@
-export enum Instructions {
+export enum Instructions { // brace trailer
   // leading
   MoveNorth(Number), // north
   // below north

--- a/compiler/test/formatter_outputs/function_params.gr
+++ b/compiler/test/formatter_outputs/function_params.gr
@@ -4,13 +4,12 @@ let unit_arg = () => 3
 
 let two_args = (x, y) => 4
 
-@disableGC
-export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+export let fake_write: (int, int, int, string) -> string =
   (
     fd,
     iovs,
     iovs_len,
     nwritten,
   ) => {
-  0n
+  "ok"
 }

--- a/compiler/test/formatter_outputs/function_params.gr
+++ b/compiler/test/formatter_outputs/function_params.gr
@@ -4,6 +4,7 @@ let unit_arg = () => 3
 
 let two_args = (x, y) => 4
 
+@disableGC
 export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
   (
     fd,

--- a/compiler/test/formatter_outputs/records.gr
+++ b/compiler/test/formatter_outputs/records.gr
@@ -20,7 +20,7 @@ record Long {
   longField5: String,
 }
 
-record Commented {
+record Commented { // brace comment
   // leading
   name: String, // trail 1
   // under 1
@@ -35,3 +35,31 @@ record Bucket<k, v> {
   mut value: v,
   mut nextkey: Option<Bucket<k, v>>,
 }
+
+record Commented { // brace comment
+  // leading
+  longlonglongnamenamename1: String, // trail 1
+  // under 1
+  longlonglongnamenamename2: String, /*
+  stupid block */
+  longlonglongnamenamename3: Number,
+  // trailing
+}
+
+let x: Commented = { // comment 1
+  longlonglongnamenamename1: "A",
+  longlonglongnamenamename2: "B",
+  longlonglongnamenamename3: 42,
+}
+
+let { // a comment 2
+  longlonglongnamenamename1,
+  longlonglongnamenamename2,
+  longlonglongnamenamename3
+} = x
+
+let { // a comment 3
+  l1,
+  l2,
+  l3
+} = x

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -28,4 +28,5 @@ describe("formatter", ({test}) => {
   assertFormatOutput("ignores", "ignores");
   assertFormatOutput("list_sugar", "list_sugar");
   assertFormatOutput("values", "values");
+  assertFormatOutput("brace_comments", "brace_comments");
 });


### PR DESCRIPTION
Fixes #884 and other similar code cases where comments follow an opening brace.

Improved record and record pattern printing