### PR TITLE
fix(compiler): Follow proper calling convention when callling stdlib equals in match

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -536,6 +536,7 @@ let call_equal = (wasm_mod, env, args) =>
     wasm_mod,
     get_imported_name(equal_mod, equal_ident),
     [
+      call_incref(wasm_mod, env) @@
       Expression.Global_get.make(
         wasm_mod,
         get_imported_name(equal_mod, equal_closure_ident),

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -106,7 +106,10 @@ pattern matching › constant_match_3
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-          (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          )
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (local.get $2)
@@ -199,7 +202,10 @@ pattern matching › constant_match_3
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-               (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                 (local.get $2)

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -217,7 +217,10 @@ pattern matching › constant_match_2
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-               (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                 (local.get $11)
@@ -276,7 +279,10 @@ pattern matching › constant_match_2
               )
              )
              (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-              (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+              )
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (local.get $12)
@@ -427,7 +433,10 @@ pattern matching › constant_match_2
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                 (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                 )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                   (local.get $13)
@@ -569,7 +578,10 @@ pattern matching › constant_match_2
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                   (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                    (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                   )
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                     (local.get $15)

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -48,7 +48,10 @@ pattern matching › constant_match_1
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-          (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          )
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (local.get $1)
@@ -94,7 +97,10 @@ pattern matching › constant_match_1
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-               (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                 (local.get $1)

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -197,7 +197,10 @@ pattern matching › constant_match_4
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-          (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+          )
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (local.get $10)
@@ -313,7 +316,10 @@ pattern matching › constant_match_4
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-               (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+               )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                 (local.get $3)
@@ -378,7 +384,10 @@ pattern matching › constant_match_4
                  (tuple.extract 0
                   (tuple.make
                    (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                    (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                    )
                     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                      (local.get $13)
@@ -509,7 +518,10 @@ pattern matching › constant_match_4
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/equal_0_equal_0
-                 (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0)
+                 )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                   (local.get $14)

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -36,6 +36,7 @@ let readWholeFile = filename => {
 };
 
 describe("garbage collection", ({test}) => {
+  let assertRun = makeRunner(test);
   let assertFileRun = makeFileRunner(test);
   let assertMemoryLimitedFileRun = makeFileRunner(~num_pages=1, test);
   let assertRunGC = (name, heapSize, prog) =>
@@ -103,5 +104,24 @@ describe("garbage collection", ({test}) => {
     "loop_memory_reclaim",
     "loopMemoryReclaim",
     "OK\n",
+  );
+  assertRun(
+    "match_issue893_internal_equals",
+    {|let f = (n: Number) => {
+      match (n) {
+        0 => {
+          void
+        },
+        _ => {
+          void
+        },
+      }
+    }
+
+    f(1)
+    f(2)
+    f(3)
+    print("4")|},
+    "4\n",
   );
 });


### PR DESCRIPTION
Fixes #893.

@cician You are a lifesaver! Your repro was absolutely perfect and made finding this a breeze.