### PR TITLE
chore(meta): Add GitHub issue forms to allow collecting more structured information.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+---
+name: Bug report.
+description: Create a bug report to help fix a problem with the core Grain language.
+body:
+- type: textarea
+  attributes:
+    label: Description of the bug
+    description: |
+      A description of what the bug is.
+      1. Make sure that you first check if your bug hasn't already been reported. It saves a bit of work on our end.
+      2. Please attach screenshots if they help in understanding the problem better. Don't host your images/videos/GIFs somewhere (e.g. Imgur) and share a link. Directly drag & drop here to avoid navigating to an external link.
+      3. Make sure to format any code samples using triple backticks. If the code sample happens to be large, share a gist/pastebin link instead.
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: In which area of the language did you find a bug ?
+    description: "If you are not sure about this, you can leave it blank."
+    options:
+    - stdlib (Grain standard library)
+    - compiler (Grain core compiler)
+    - runtime (Grain JS runtime)
+    - cli (Grain command line interface)
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: "Please provide detailed steps on how the bug can be reproduced."
+    placeholder: |
+      1. First step.
+      2. Second step.
+      3. Third step.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: "A description of what you expected to happen."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    description: "A description of what actually happened."
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Grain version
+    description: "Run `grain --version` from your shell to find what version of Grain you are running."
+    placeholder: "e.g. 0.4"
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Operating system & version
+    placeholder: "e.g. macOS 10.14, Windows 10, Ubuntu 18.04"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional information
+    description: "You can jot down any additional information you consider relevant to the bug report (This is purely optional)."
+    placeholder: |
+     Examples may include.
+     1. What version of Grain cli are you running ?
+     2. What version of node/yarn are you running ?
+
+     You get the point.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Grain documentation.
+    url: https://github.com/grain-lang/grain-lang.org
+    about: If your issue happens to be with the official Grain documentaion, please head over to the that repo & consider filing an issue/enhancement request over there !
+  - name: Grain VS Code extension/language server.
+    url: https://github.com/grain-lang/grain-language-server
+    about: If your issue happens to be with the official VS Code extension/language server of Grain, please head over to the that repo & consider filing an issue/enhancement request over there !

--- a/.github/ISSUE_TEMPLATE/enhancement_or_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_or_feature_request.yml
@@ -1,0 +1,68 @@
+---
+name: Bug report.
+description: Create a bug report to help fix a problem with the core Grain language.
+body:
+- type: textarea
+  attributes:
+    label: Description of the bug
+    description: |
+      A description of what the bug is.
+      1. Make sure that you first check if your bug hasn't already been reported. It saves a bit of work on our end.
+      2. Please attach screenshots if they help in understanding the problem better. Don't host your images/videos/GIFs somewhere (e.g. Imgur) and share a link. Directly drag & drop here to avoid navigating to an external link.
+      3. Make sure to format any code samples using triple backticks. If the code sample happens to be large, share a gist/pastebin link instead.
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: In which area of the language did you find a bug ?
+    description: "If you are not sure about this, you can leave it blank."
+    options:
+    - stdlib (Grain standard library)
+    - compiler (Grain core compiler)
+    - runtime (Grain JS runtime)
+    - cli (Grain command line interface)
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: "Please provide detailed steps on how the bug can be reproduced."
+    placeholder: |
+      1. First step.
+      2. Second step.
+      3. Third step.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: "A description of what you expected to happen."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    description: "A description of what actually happened."
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Grain version
+    description: "Run `grain --version` from your shell to find what version of Grain you are running."
+    placeholder: "e.g. 0.4"
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Operating system & version
+    placeholder: "e.g. macOS 10.14, Windows 10, Ubuntu 18.04"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional information
+    description: "You can jot down any additional information you consider relevant to the bug report (This is purely optional)."
+    placeholder: |
+     Examples may include.
+     1. What version of Grain cli are you running ?
+     2. What version of node/yarn are you running ?
+
+     You get the point.


### PR DESCRIPTION
This PR adds the ability for to allow for a more structured collection of data via bug reports/enhancement or feature requests using GitHub issue forms.

#### Motivation.
Felt the need for it when submitting https://github.com/grain-lang/grain/issues/892

#### Advantages over not having them at all.

1. It now makes it harder for users to submit bogus bug reports.
2. Formalizes the process of collecting information required for a good bug report and(or) enhancement/feature requests.
3. Reduces the need for maintainers to transfer issues to the right repo, if the user submits an issue not related to the core language (using the links).

Unfortunately, there is not a way for this to be seen from the UI side without first merging, so I have created a dummy repo 
https://github.com/Ultra-Instinct-05/grain_github_issues_demo, as a playground, where anyone can see how these issue forms looks like when a user clicks on `New Issue` on the `Issues` tab.

#### References
1. https://gh-community.github.io/issue-template-feedback/structured/
2. https://docs.github.com/en/enterprise-server@3.0/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser