### PR TITLE
chore(compiler): Disable by default principal type and type name scope compiler warnings

### DIFF
--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -407,10 +407,11 @@ let print_warning = (loc, ppf, w) =>
   print_updating_num_loc_lines(ppf, warning_printer^(loc), w);
 
 let formatter_for_warnings = ref(err_formatter);
-let prerr_warning = (loc, w) => {
-  Grain_utils.Warnings.add_warning(loc, w);
-  print_warning(loc, formatter_for_warnings^, w);
-};
+let prerr_warning = (loc, w) =>
+  if (Grain_utils.Warnings.is_active(w)) {
+    Grain_utils.Warnings.add_warning(loc, w);
+    print_warning(loc, formatter_for_warnings^, w);
+  };
 
 let echo_eof = () => {
   print_newline();

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -137,8 +137,9 @@ let nerrors = ref(0);
 let defaults = [
   LetRecNonFunction(""),
   AmbiguousName([], [], false),
-  NotPrincipal(""),
-  NameOutOfScope("", [], false),
+  // [FIXME] see if we can reenable (grain-lang/grain#681)
+  //NotPrincipal(""),
+  //NameOutOfScope("", [], false),
   StatementType,
   NonreturningStatement,
   AllClausesGuarded,


### PR DESCRIPTION
This PR will allow us to land Regex without exposing users to those compiler warnings. This PR buys us more time to properly investigate #681.