### PR TITLE
fix(cli): Avoid --experimental-wasm-bigint flag on node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        node-version: ["14", "16"]
 
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '14'
+          node-version: ${{ matrix.node-version }}
           check-latest: true
 
       # This configures yarn to use node/npm prefix in our path
@@ -41,7 +42,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: compiler/_export
-          key:  ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
+          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
 
       - name: Import esy cache
         if: steps.esy-cache.outputs.cache-hit == 'true'

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,7 +10,7 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
-if (process.versions.node.startsWith("14.")) {
+if (process.versions.node.startsWith("14.") || process.versions.node.startsWith("15.")) {
   v8.setFlagsFromString("--experimental-wasm-bigint");
 }
 v8.setFlagsFromString("--experimental-wasm-return-call");

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,7 +10,7 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
-if (!process.versions.node.startsWith("16.")) {
+if (process.versions.node.startsWith("14.")) {
   v8.setFlagsFromString("--experimental-wasm-bigint");
 }
 v8.setFlagsFromString("--experimental-wasm-return-call");

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,7 +10,9 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
-v8.setFlagsFromString("--experimental-wasm-bigint");
+if (!process.versions.node.startsWith("16.")) {
+  v8.setFlagsFromString("--experimental-wasm-bigint");
+}
 v8.setFlagsFromString("--experimental-wasm-return-call");
 
 const program = require("commander");

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -10,7 +10,10 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 14, but we should be cautious when updating.
  */
-if (process.versions.node.startsWith("14.") || process.versions.node.startsWith("15.")) {
+if (
+  process.versions.node.startsWith("14.") ||
+  process.versions.node.startsWith("15.")
+) {
   v8.setFlagsFromString("--experimental-wasm-bigint");
 }
 v8.setFlagsFromString("--experimental-wasm-return-call");


### PR DESCRIPTION
This adds an conditional around the `--experimental-wasm-bigint` flag so we don't get a warning in node 16+. I also added node 16 to the test matrix in CI.

Closes #883 (but we should leave #114 open until we don't support node < 16 anymore).