### PR TITLE
fix(grainfmt): handle empty type for foreign exports

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -933,12 +933,10 @@ and print_type =
   | PTyArrow(types, parsed_type) =>
     Doc.concat([
       Doc.group(
-        if (List.length(types) == 0) {
-          Doc.concat([Doc.lparen,Doc.rparen])
-        } else 
-         if (List.length(types) == 1) {
-          print_type(List.hd(types), original_source);
-        } else {
+        switch (List.length(types)) {
+        | 0 => Doc.concat([Doc.lparen, Doc.rparen])
+        | 1 => print_type(List.hd(types), original_source)
+        | _ =>
           Doc.concat([
             Doc.lparen,
             Doc.indent(
@@ -952,7 +950,7 @@ and print_type =
             ),
             Doc.softLine,
             Doc.rparen,
-          ]);
+          ])
         },
       ),
       Doc.space,

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -933,7 +933,10 @@ and print_type =
   | PTyArrow(types, parsed_type) =>
     Doc.concat([
       Doc.group(
-        if (List.length(types) == 1) {
+        if (List.length(types) == 0) {
+          Doc.concat([Doc.lparen,Doc.rparen])
+        } else 
+         if (List.length(types) == 1) {
           print_type(List.hd(types), original_source);
         } else {
           Doc.concat([

--- a/compiler/test/formatter_inputs/imports.gr
+++ b/compiler/test/formatter_inputs/imports.gr
@@ -24,3 +24,5 @@ import * except {
    and
    // just because
  } from "runtime/unsafe/wasmi32"
+
+export foreign wasm promise_results_count: () -> WasmI64 as promiseResultsCount from "env"

--- a/compiler/test/formatter_outputs/imports.gr
+++ b/compiler/test/formatter_outputs/imports.gr
@@ -28,3 +28,5 @@ import * except {
   and
   // just because
 } from "runtime/unsafe/wasmi32"
+
+export foreign wasm promise_results_count: () -> WasmI64 as promiseResultsCount from "env"


### PR DESCRIPTION
Fixes 

export foreign wasm promise_results_count: () -> WasmI64 as promiseResultsCount from "env"

to not break on the empty param types