### PR TITLE
fix(grainfmt): Fix the parens around single arg function params

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1966,19 +1966,13 @@ and print_expression =
           let pat = List.hd(patterns);
 
           switch (pat.ppat_desc) {
-          | PPatConstraint(_) =>
+          | PPatVar(_) => print_pattern(~pat, ~parent_loc, ~original_source)
+          | _ =>
             Doc.concat([
               Doc.lparen,
               print_pattern(~pat, ~parent_loc, ~original_source),
               Doc.rparen,
             ])
-          | PPatTuple(_) =>
-            Doc.concat([
-              Doc.lparen,
-              print_pattern(~pat, ~parent_loc, ~original_source),
-              Doc.rparen,
-            ])
-          | _ => print_pattern(~pat, ~parent_loc, ~original_source)
           };
         };
 

--- a/compiler/test/formatter_inputs/application.gr
+++ b/compiler/test/formatter_inputs/application.gr
@@ -25,3 +25,7 @@ export let unique = array => {
     array,
   )
 }
+
+export let batchActionCreateAccount = ({index}) => {
+  Native.promiseBatchActionCreateAccount(Conv.fromInt64(index))
+}

--- a/compiler/test/formatter_outputs/application.gr
+++ b/compiler/test/formatter_outputs/application.gr
@@ -39,3 +39,7 @@ export let unique = array => {
     array,
   )
 }
+
+export let batchActionCreateAccount = ({ index }) => {
+  Native.promiseBatchActionCreateAccount(Conv.fromInt64(index))
+}


### PR DESCRIPTION
Make sure we keep the parens for single param functions like this:

export let batchActionCreateAccount = ({index}) => {
  Native.promiseBatchActionCreateAccount(Conv.fromInt64(index))
}