### PR TITLE
fix(compiler): Don't warn on exhaustive boolean matches

### DIFF
--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -410,7 +410,9 @@ let formatter_for_warnings = ref(err_formatter);
 let prerr_warning = (loc, w) =>
   if (Grain_utils.Warnings.is_active(w)) {
     Grain_utils.Warnings.add_warning(loc, w);
-    print_warning(loc, formatter_for_warnings^, w);
+    if (Grain_utils.Config.print_warnings^) {
+      print_warning(loc, formatter_for_warnings^, w);
+    };
   };
 
 let echo_eof = () => {

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -699,6 +699,8 @@ let full_match = (closing, env) =>
       /* extensions */
       List.length(env) == c.cstr_consts + c.cstr_nonconsts;
     }
+  | [({pat_desc: TPatConstant(Const_bool(_))}, _), ..._] =>
+    List.length(env) == 2
   | [({pat_desc: TPatArray(_)}, _), ..._]
   | [({pat_desc: TPatConstant(_)}, _), ..._] => false
   | [({pat_desc: TPatTuple(_)}, _), ..._]
@@ -967,11 +969,18 @@ let build_other = (ext, env) =>
       p,
       env,
     )
-  /*| ({pat_desc=(TPatConstant (Const_bool _))} as p,_) :: _ ->
-    build_other_constant
-      (function TPatConstant(Const_bool i) -> i | _ -> assert false)
-      (function i -> TPatConstant(Const_bool i))
-      ??? p env*/
+  | [({pat_desc: TPatConstant(Const_bool(_))} as p, _), ..._] =>
+    build_other_constant(
+      fun
+      | TPatConstant(Const_bool(b)) => b
+      | _ => assert(false),
+      fun
+      | b => TPatConstant(Const_bool(b)),
+      false,
+      (!),
+      p,
+      env,
+    )
   | [({pat_desc: TPatConstant(Const_string(_))} as p, _), ..._] =>
     build_other_constant(
       fun

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -554,6 +554,8 @@ let lsp_mode =
     false,
   );
 
+let print_warnings = internal_opt(true);
+
 /* To be filled in by grainc */
 let base_path = internal_opt("");
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -122,6 +122,10 @@ let safe_string: ref(bool);
 
 let lsp_mode: ref(bool);
 
+/** Internal option to disable printing of warnings. */
+
+let print_warnings: ref(bool);
+
 /*** Configuration Saving/Restoring */
 
 /** Type representing a saved set of configuration options */

--- a/compiler/test/WarningExtensions.re
+++ b/compiler/test/WarningExtensions.re
@@ -1,0 +1,70 @@
+open TestFramework;
+open Rely.MatcherTypes;
+open Grain_utils;
+
+type warningExtensions = {
+  toHaveTriggered: Warnings.t => unit,
+  toHaveTriggeredNoWarnings: unit => unit,
+};
+
+let warningExtensions = ({createMatcher}) => {
+  let pass = (() => "", true);
+  let createTriggeredMatcher =
+    createMatcher(
+      ({formatReceived, formatExpected}, actualThunk, expectedThunk) => {
+      let expected = expectedThunk();
+      let generatedWarnings = Warnings.get_warnings();
+      let warningTriggered =
+        List.exists(((_, warn)) => warn == expected, generatedWarnings);
+
+      if (!warningTriggered) {
+        let receivedWarnings =
+          List.length(generatedWarnings) == 0
+            ? ["No warnings."]
+            : List.map(
+                ((_, warn)) => Warnings.message(warn),
+                generatedWarnings,
+              );
+        let failureMessage =
+          String.concat(
+            "\n",
+            [
+              "Expected warning:",
+              Warnings.message(expected),
+              "\nReceived:",
+              ...receivedWarnings,
+            ],
+          );
+        (() => failureMessage, false);
+      } else {
+        pass;
+      };
+    });
+  let createNotTriggeredMatcher =
+    createMatcher(
+      ({formatReceived, formatExpected}, actualThunk, expectedThunk) => {
+      let generatedWarnings = Warnings.get_warnings();
+      let warningTriggered = List.length(generatedWarnings) > 0;
+
+      if (warningTriggered) {
+        let receivedWarnings =
+          List.map(
+            ((_, warn)) => Warnings.message(warn),
+            generatedWarnings,
+          );
+        let failureMessage =
+          String.concat(
+            "\n",
+            ["Expected no warnings, received:", ...receivedWarnings],
+          );
+        (() => failureMessage, false);
+      } else {
+        pass;
+      };
+    });
+  {
+    toHaveTriggered: warn => createTriggeredMatcher(() => (), () => warn),
+    toHaveTriggeredNoWarnings: () =>
+      createNotTriggeredMatcher(() => (), () => ()),
+  };
+};

--- a/compiler/test/dune
+++ b/compiler/test/dune
@@ -4,7 +4,7 @@
  (name Grain_tests)
  (public_name grain-tests.framework)
  (libraries grain rely.lib)
- (modules TestFramework test_utils runner))
+ (modules TestFramework WarningExtensions test_utils runner))
 
 (executable
  (name test)

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -1,8 +1,15 @@
 open TestFramework;
+open WarningExtensions;
 open Grain.Compile;
 open Grain_utils;
 open Grain_middle_end.Anftree;
 open Grain_middle_end.Anf_helper;
+
+type customMatchers = {warning: warningExtensions};
+
+let customMatchers = createMatcher => {
+  warning: warningExtensions(createMatcher),
+};
 
 let grainfile = name => Filename.concat(test_input_dir, name ++ ".gr");
 let stdlibfile = name => Filename.concat(test_stdlib_dir, name ++ ".gr");
@@ -217,6 +224,26 @@ let makeCompileErrorRunner = (test, name, prog, msg) => {
       expect.string(error).toMatch(msg);
     },
   );
+};
+
+let makeWarningRunner = (test, name, prog, warning) => {
+  test(name, ({expect}) => {
+    Config.preserve_all_configs(() => {
+      Config.print_warnings := false;
+      compile(name, prog);
+      expect.ext.warning.toHaveTriggered(warning);
+    })
+  });
+};
+
+let makeNoWarningRunner = (test, name, prog) => {
+  test(name, ({expect}) => {
+    Config.preserve_all_configs(() => {
+      Config.print_warnings := false;
+      compile(name, prog);
+      expect.ext.warning.toHaveTriggeredNoWarnings();
+    })
+  });
 };
 
 let makeRunner = (test, ~num_pages=?, ~config_fn=?, name, prog, expected) => {

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -1,11 +1,17 @@
 open Grain_tests.TestFramework;
 open Grain_tests.Runner;
+open Grain_utils;
+
+let {describe} =
+  describeConfig |> withCustomMatchers(customMatchers) |> build;
 
 describe("pattern matching", ({test}) => {
   let assertSnapshot = makeSnapshotRunner(test);
   let assertCompileError = makeCompileErrorRunner(test);
   let assertRun = makeRunner(test);
   let assertFileRun = makeFileRunner(test);
+  let assertWarning = makeWarningRunner(test);
+  let assertNoWarning = makeNoWarningRunner(test);
 
   /* Pattern matching on tuples */
   assertRun("tuple_match_1", "print(match ((1,)) { (a,) => a })", "1\n");
@@ -197,4 +203,49 @@ describe("pattern matching", ({test}) => {
     "match ((\"foo\", 5)) { (\"foo\", n) when n == 7 => false, (\"foo\", 9) when true => false, (\"foo\", n) when n == 5 => true, _ => false }",
   );
   assertFileRun("mixed_matching", "mixedPatternMatching", "true\n");
+  assertWarning(
+    "bool_exhaustiveness1",
+    "match (true) {
+       true => print(5),
+     }",
+    Warnings.PartialMatch("false"),
+  );
+  assertWarning(
+    "bool_exhaustiveness2",
+    "match (true) {
+       false => print(5),
+     }",
+    Warnings.PartialMatch("true"),
+  );
+  assertWarning(
+    "bool_exhaustiveness3",
+    "match (true) {
+       true => print(5),
+       true => print(5),
+     }",
+    Warnings.PartialMatch("false"),
+  );
+  assertNoWarning(
+    "bool_exhaustiveness4",
+    "match (true) {
+       false => print(5),
+       true => print(5),
+     }",
+  );
+  assertWarning(
+    "bool_exhaustiveness5",
+    "match (Some(true)) {
+       Some(false) => print(5),
+       None => print(5),
+     }",
+    Warnings.PartialMatch("Some(true)"),
+  );
+  assertNoWarning(
+    "bool_exhaustiveness6",
+    "match (Some(true)) {
+       Some(false) => print(5),
+       Some(true) => print(5),
+       None => print(5),
+     }",
+  );
 });

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -248,4 +248,14 @@ describe("pattern matching", ({test}) => {
        None => print(5),
      }",
   );
+  assertWarning(
+    "bool_exhaustiveness7",
+    "match (true) {
+       true when true => print(5),
+       false => print(5),
+     }",
+    Warnings.PartialMatch(
+      "true\n(However, some guarded clause may match this value.)",
+    ),
+  );
 });


### PR DESCRIPTION
Most of the code here is really new testing support around warnings. Added custom matchers so we can do `expect.ext.warning.toHaveTriggered` and `expect.ext.warning.toHaveTriggeredNoWarnings`, and added some tests around the warning generation for boolean matches.