### PR TITLE
fix(grainfmt) Fixes comments after lbraces and in patterns

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -584,11 +584,11 @@ and print_record_pattern =
     | Closed => Doc.nil
     };
 
-  let braceTrailing = get_trailing_comments_to_end_of_line(patloc);
+  let brace_trailing_comments = get_trailing_comments_to_end_of_line(patloc);
 
   Doc.concat([
     Doc.lbrace,
-    braceTrailing,
+    brace_trailing_comments,
     Doc.indent(
       Doc.concat([
         Doc.line,
@@ -865,10 +865,10 @@ and print_record =
       ~original_source: array(string),
       recloc: Grain_parsing__Location.t,
     ) => {
-  let commentAfterBrace = get_trailing_comments_to_end_of_line(recloc);
+  let comments_after_brace = get_trailing_comments_to_end_of_line(recloc);
   Doc.concat([
     Doc.lbrace,
-    commentAfterBrace,
+    comments_after_brace,
     Doc.indent(
       Doc.concat([
         Doc.line,

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1491,7 +1491,7 @@ and print_expression =
       ])
     | PExpMatch(expression, match_branches) =>
       // need to get comments after { before we process anything else
-      let afterBraceComments =
+      let after_brace_comments =
         get_trailing_comments_to_end_of_line(expression.pexp_loc);
 
       let arg =
@@ -1514,7 +1514,7 @@ and print_expression =
         Doc.concat([
           Doc.concat([Doc.text("match "), arg, Doc.space]),
           Doc.lbrace,
-          afterBraceComments,
+          after_brace_comments,
           Doc.indent(
             Doc.concat([
               Doc.hardLine,
@@ -2391,7 +2391,7 @@ and print_value_bind =
           | _ => Doc.concat([Doc.space, expression])
           };
 
-        let commentsAfterBrace =
+        let comments_after_brace =
           get_trailing_comments_to_end_of_line(vb.pvb_expr.pexp_loc);
         Doc.concat([
           Doc.group(
@@ -2404,7 +2404,7 @@ and print_value_bind =
           Doc.space,
           Doc.equal,
           Doc.group(expressionGrp),
-          commentsAfterBrace,
+          comments_after_brace,
         ]);
       },
       vbs,
@@ -2435,7 +2435,7 @@ let rec print_data =
   let nameloc = data.pdata_name;
   switch (data.pdata_kind) {
   | PDataVariant(constr_declarations) =>
-    let afterNameComments =
+    let after_name_comments =
       get_trailing_comments_to_end_of_line(data.pdata_name.loc);
 
     let decls =
@@ -2520,7 +2520,7 @@ let rec print_data =
           Doc.space;
         },
         Doc.lbrace,
-        afterNameComments,
+        after_name_comments,
         Doc.indent(Doc.concat([Doc.line, joinedDecls])),
         if (!commaTerminated) {
           Doc.ifBreaks(Doc.comma, Doc.nil);
@@ -2533,7 +2533,7 @@ let rec print_data =
     );
 
   | PDataRecord(label_declarations) =>
-    let afterNameComments =
+    let after_name_comments =
       get_trailing_comments_to_end_of_line(data.pdata_name.loc);
 
     let decls =
@@ -2609,7 +2609,7 @@ let rec print_data =
         },
         Doc.concat([
           Doc.lbrace,
-          afterNameComments,
+          after_name_comments,
           Doc.indent(Doc.concat([Doc.line, joinedDecls])),
           if (!commaTerminated) {
             Doc.ifBreaks(Doc.comma, Doc.nil);

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -69,8 +69,14 @@ let is_first_inside_second =
     let begins_inside =
       if (raw1l > raw2l) {
         true;
-      } else if (raw1c >= raw2c && raw1c <= raw2ce) {
-        true;
+      } else if (raw1c >= raw2c) {
+        if (raw2le > raw1le) {
+          true;
+        } else if (raw1ce <= raw2ce) {
+          true;
+        } else {
+          false;
+        };
       } else {
         false;
       };

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -80,18 +80,7 @@ let is_first_inside_second =
       } else {
         false;
       };
-    let ends_inside =
-      if (raw1le < raw2le) {
-        true;
-      } else if (raw1le == raw2le) {
-        if (raw1ce <= raw2ce) {
-          true;
-        } else {
-          false;
-        };
-      } else {
-        false;
-      };
+    let ends_inside = raw2le > raw1le || raw1ce <= raw2ce;
 
     begins_inside && ends_inside;
   };

--- a/compiler/test/formatter_inputs/brace_comments.gr
+++ b/compiler/test/formatter_inputs/brace_comments.gr
@@ -15,3 +15,8 @@ if (true) { // block 1
 }
 
 let space = ""
+
+export let setCounter = val => {
+  // Write the value to memory.
+  Storage.setInt32(key, val)
+}

--- a/compiler/test/formatter_outputs/brace_comments.gr
+++ b/compiler/test/formatter_outputs/brace_comments.gr
@@ -15,3 +15,8 @@ if (true) { // block 1
 }
 
 let space = ""
+
+export let setCounter = val => {
+  // Write the value to memory.
+  Storage.setInt32(key, val)
+}


### PR DESCRIPTION
Fixes issues with comments 

@peblair spotted this didn't reformat

export let setCounter = val => {
  // Write the value to memory.
  Storage.setInt32(key, val)
}

which uncovered some issues with comments in patterns, and comments after the lbrace in other expressions