### PR TITLE
fix(compiler): Remove existing exports when writing universal exports

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -191,6 +191,8 @@ let write_universal_exports =
               [||],
               function_body,
             );
+            // Remove existing Grain export (if any)
+            Export.remove_export(wasm_mod, name);
             ignore @@ Export.add_function_export(wasm_mod, name, name);
           | TSigValue(_)
           | TSigType(_)

--- a/compiler/test/input/wasiPolyfill.gr
+++ b/compiler/test/input/wasiPolyfill.gr
@@ -1,7 +1,22 @@
-import foreign wasm fd_write : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
+import foreign wasm fd_write: (
+  WasmI32,
+  WasmI32,
+  WasmI32,
+  WasmI32
+) -> WasmI32 from "wasi_snapshot_preview1"
 
-export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 = (fd, iovs, iovs_len, nwritten) => {
-    fd_write(fd, iovs, iovs_len, nwritten)
-    fd_write(fd, iovs, iovs_len, nwritten)
-    fd_write(fd, iovs, iovs_len, nwritten)
+export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+  (
+    fd,
+    iovs,
+    iovs_len,
+    nwritten,
+  ) => {
+  fd_write(fd, iovs, iovs_len, nwritten)
+  fd_write(fd, iovs, iovs_len, nwritten)
+  fd_write(fd, iovs, iovs_len, nwritten)
+}
+
+export let args_get: (WasmI32, WasmI32) -> WasmI32 = (a, b) => {
+  76n
 }

--- a/compiler/test/input/wasiPolyfill.gr
+++ b/compiler/test/input/wasiPolyfill.gr
@@ -17,6 +17,6 @@ export let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
   fd_write(fd, iovs, iovs_len, nwritten)
 }
 
-export let args_get: (WasmI32, WasmI32) -> WasmI32 = (a, b) => {
+export let args_get = (a, b) => {
   76n
 }


### PR DESCRIPTION
This never was an issue with the linker since it generates a fresh module (which has no defined exports). It's an issue for the polyfill since it writes exports on an already-exiting module.

Somewhat related: #918 