### PR TITLE
fix(grainfmt): Removed a trailing comma after a spread in a list, and fixed escaped single quote

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -857,7 +857,7 @@ and print_constant = (c: Parsetree.constant) => {
       Printf.sprintf("%s/%s", n, d)
     | PConstBytes(b) => Printf.sprintf("%s", b)
     | PConstChar(c) =>
-      // String.escaped doesn't escape the single quote but we need it to
+      // Special case as a single quote isn't escaped in a string
       if (c == "'") {
         Printf.sprintf("'\\''");
       } else {

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1071,18 +1071,32 @@ and print_application =
   | [first] when prefixop(function_name) =>
     switch (first.pexp_desc) {
     | PExpApp(fn, _) =>
-      Doc.concat([
-        Doc.text(function_name),
-        // Doc.lparen,
-        print_expression(
-          ~parentIsArrow=false,
-          ~endChar=None,
-          ~original_source,
-          ~parent_loc,
-          first,
-        ),
-        //  Doc.rparen,
-      ])
+      let inner_fn = get_function_name(fn);
+      if (infixop(inner_fn)) {
+        Doc.concat([
+          Doc.text(function_name),
+          Doc.lparen,
+          print_expression(
+            ~parentIsArrow=false,
+            ~endChar=None,
+            ~original_source,
+            ~parent_loc,
+            first,
+          ),
+          Doc.rparen,
+        ]);
+      } else {
+        Doc.concat([
+          Doc.text(function_name),
+          print_expression(
+            ~parentIsArrow=false,
+            ~endChar=None,
+            ~original_source,
+            ~parent_loc,
+            first,
+          ),
+        ]);
+      };
 
     | _ =>
       Doc.concat([

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -514,8 +514,6 @@ and resugar_list =
 
   let last_item_was_spread = ref(false);
 
-
-
   let items =
     List.map(
       i =>
@@ -531,7 +529,7 @@ and resugar_list =
               ~parent_loc,
               e,
             ),
-          )
+          );
         | Spread(e) =>
           last_item_was_spread := true;
           Doc.group(
@@ -545,7 +543,7 @@ and resugar_list =
                 e,
               ),
             ]),
-          )
+          );
         },
       processed_list,
     );
@@ -559,8 +557,11 @@ and resugar_list =
             Doc.softLine,
             Doc.join(Doc.concat([Doc.comma, Doc.line]), items),
           ]),
-          if (last_item_was_spread^) Doc.nil else
-             Doc.ifBreaks(Doc.comma, Doc.nil),
+          if (last_item_was_spread^) {
+            Doc.nil;
+          } else {
+            Doc.ifBreaks(Doc.comma, Doc.nil);
+          },
         ]),
       ),
       Doc.softLine,
@@ -1487,7 +1488,7 @@ and print_expression =
           Doc.text("="),
           Doc.indent(
             Doc.concat([
-              Doc.line,
+              Doc.space,
               print_expression(
                 ~parentIsArrow=false,
                 ~endChar=None,

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -885,7 +885,11 @@ and print_constant =
       ~loc: Grain_parsing__Location.t,
       c: Parsetree.constant,
     ) => {
-  Doc.text(get_original_code_snippet(loc, original_source));
+  // we get the original code here to ensure it's well formatted and retains the
+  // approach of the original code, e.g. char format, number format
+  Doc.text(
+    get_original_code_snippet(loc, original_source),
+  );
 }
 
 and print_ident = (ident: Identifier.t) => {

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -857,13 +857,11 @@ and print_constant = (c: Parsetree.constant) => {
       Printf.sprintf("%s/%s", n, d)
     | PConstBytes(b) => Printf.sprintf("%s", b)
     | PConstChar(c) =>
-      // Special case as a single quote isn't escaped in a string
-      if (c == "'") {
-        Printf.sprintf("'\\''");
+      if (String.length(c) > 0) {
+        Printf.sprintf("\'%s\'", Char.escaped(c.[0]));
       } else {
-        Printf.sprintf("'%s'", String.escaped(c));
+        "";
       }
-
     | PConstFloat64(f) => Printf.sprintf("%sd", f)
     | PConstFloat32(f) => Printf.sprintf("%sf", f)
     | PConstInt32(i) => Printf.sprintf("%sl", i)

--- a/compiler/test/formatter_inputs/arrays.gr
+++ b/compiler/test/formatter_inputs/arrays.gr
@@ -21,3 +21,19 @@ let instructions = Array.map(
   },
   String.split("\n", data),
 )
+
+// code snippet to check assignment stays on the same line after =
+let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
+  match(groupN) {
+    Some(groupN) when Array.length(state) > 0 => {
+      let oldSpan = state[groupN]
+      state[groupN] = if (n == 0) None else Some((pos - backAmt, pos))
+      let groupRevert = () => { state[groupN] = oldSpan }
+      callback(groupRevert)
+    },
+    _ => {
+      let groupRevert = () => void
+      callback(groupRevert)
+    }
+  }
+}

--- a/compiler/test/formatter_inputs/list_sugar.gr
+++ b/compiler/test/formatter_inputs/list_sugar.gr
@@ -29,3 +29,5 @@ let list4 = [[1,2],[3,4],[5,6]]
 
 let list5 = [[1,2,3],[3,4,5],[5,6,7]]
 }
+
+let cons = (a, b) => [a, ...b] // <-  some long comment some long comment some long comment some long comment

--- a/compiler/test/formatter_inputs/strings.gr
+++ b/compiler/test/formatter_inputs/strings.gr
@@ -3,3 +3,7 @@ import String from "string"
 let newline = "\n"
 
 let data = String.split("\n", "a long string")
+
+let c = Some('\'')
+
+let d = '\''

--- a/compiler/test/formatter_outputs/arrays.gr
+++ b/compiler/test/formatter_outputs/arrays.gr
@@ -27,11 +27,7 @@ let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
   match (groupN) {
     Some(groupN) when Array.length(state) > 0 => {
       let oldSpan = state[groupN]
-      state[groupN] = if (n == 0) {
-          None
-        } else {
-          Some((pos - backAmt, pos))
-        }
+      state[groupN] = if (n == 0) None else Some((pos - backAmt, pos))
       let groupRevert = () => {
         state[groupN] = oldSpan
       }

--- a/compiler/test/formatter_outputs/arrays.gr
+++ b/compiler/test/formatter_outputs/arrays.gr
@@ -21,3 +21,25 @@ let instructions = Array.map(
   },
   String.split("\n", data),
 )
+
+// code snippet to check assignment stays on the same line after =
+let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
+  match (groupN) {
+    Some(groupN) when Array.length(state) > 0 => {
+      let oldSpan = state[groupN]
+      state[groupN] = if (n == 0) {
+          None
+        } else {
+          Some((pos - backAmt, pos))
+        }
+      let groupRevert = () => {
+        state[groupN] = oldSpan
+      }
+      callback(groupRevert)
+    },
+    _ => {
+      let groupRevert = () => void
+      callback(groupRevert)
+    },
+  }
+}

--- a/compiler/test/formatter_outputs/list_sugar.gr
+++ b/compiler/test/formatter_outputs/list_sugar.gr
@@ -33,3 +33,9 @@ let inaBlock = {
 
   let list5 = [[1, 2, 3], [3, 4, 5], [5, 6, 7]]
 }
+
+let cons = (a, b) =>
+  [
+    a,
+    ...b
+  ] // <-  some long comment some long comment some long comment some long comment

--- a/compiler/test/formatter_outputs/operators.gr
+++ b/compiler/test/formatter_outputs/operators.gr
@@ -10,14 +10,8 @@ let c = false
 
 !b
 
-if (!b) {
-  print("false")
-}
+if (!b) print("false")
 
-if (a && b) {
-  print("true")
-}
+if (a && b) print("true")
 
-if (a && (b || c)) {
-  print("who knows")
-}
+if (a && (b || c)) print("who knows")

--- a/compiler/test/formatter_outputs/spreads.gr
+++ b/compiler/test/formatter_outputs/spreads.gr
@@ -2,11 +2,7 @@ let rec filter = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] =>
-      if (fn(first)) {
-        [first, ...filter(fn, rest)]
-      } else {
-        filter(fn, rest)
-      },
+      if (fn(first)) [first, ...filter(fn, rest)] else filter(fn, rest),
   }
 }
 
@@ -15,11 +11,8 @@ let filteri = (fn, list) => {
     match (list) {
       [] => [],
       [first, ...rest] =>
-        if (fn(first, index)) {
-          [first, ...iter(fn, rest, index + 1)]
-        } else {
-          iter(fn, rest, index + 1)
-        },
+        if (fn(first, index)) [first, ...iter(fn, rest, index + 1)]
+        else iter(fn, rest, index + 1),
     }
   }
   iter(fn, list, 0)
@@ -29,11 +22,7 @@ let rec reject = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] =>
-      if (!(fn(first))) {
-        [first, ...reject(fn, rest)]
-      } else {
-        reject(fn, rest)
-      },
+      if (!fn(first)) [first, ...reject(fn, rest)] else reject(fn, rest),
   }
 }
 

--- a/compiler/test/formatter_outputs/strings.gr
+++ b/compiler/test/formatter_outputs/strings.gr
@@ -3,3 +3,7 @@ import String from "string"
 let newline = "\n"
 
 let data = String.split("\n", "a long string")
+
+let c = Some('\'')
+
+let d = '\''


### PR DESCRIPTION
Adding a comma after a spread in a list was a syntax error

[a,...b,]

Keep array set assignments on the same line as the =

Use constants direct from source to avoid losing any programmer intention regarding structure/format e.g. keep chars specified in the same format, numbers in the same base, etc.