### PR TITLE
chore(ci): Configure release to trigger workflow_dispatch on other repos 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           workflow: Grain Release
           token: ${{ secrets.WORKFLOW_TOKEN }}
           ref: master
-          repo: phated/grain-lang.org
+          repo: grain-lang/grain-lang.org
           tag_input: ${{ needs.release-please.outputs.tag_name }}
 
   dispatch-homebrew:
@@ -126,5 +126,5 @@ jobs:
           workflow: Grain Release
           token: ${{ secrets.WORKFLOW_TOKEN }}
           ref: main
-          repo: phated/homebrew-tap
+          repo: grain-lang/homebrew-tap
           tag_input: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,9 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       upload_url: ${{ steps.release.outputs.upload_url }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2.29.2
+      - uses: GoogleCloudPlatform/release-please-action@v2.33.1
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,3 +100,31 @@ jobs:
           asset_path: ./pkg/grain-linux
           asset_name: grain-linux-x64
           asset_content_type: application/octet-stream
+
+  dispatch-website:
+    needs: [release-please, build-pkg]
+    if: ${{ needs.release-please.outputs.release_created }}
+    name: Dispatch website release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+        with:
+          workflow: Grain Release
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          ref: master
+          repo: phated/grain-lang.org
+          tag_input: ${{ needs.release-please.outputs.tag_name }}
+
+  dispatch-homebrew:
+    needs: [release-please, build-pkg]
+    if: ${{ needs.release-please.outputs.release_created }}
+    name: Dispatch homebrew release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+        with:
+          workflow: Grain Release
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          ref: main
+          repo: phated/homebrew-tap
+          tag_input: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
This adds 2 new jobs to our Release workflow. They initiate a `workflow_dispatch` event to the `Grain Release` workflows added in https://github.com/grain-lang/grain-lang.org/pull/258 and https://github.com/grain-lang/homebrew-tap/pull/5

Running a release now generates this workflow graph:
<img width="1017" alt="Screen Shot 2021-09-28 at 9 13 50 AM" src="https://user-images.githubusercontent.com/992373/135126101-afceaa53-b3d6-4eb6-95cf-6130a1db6884.png">

You can see a trial run from my personal repos:
* Grain release run: https://github.com/phated/grain/actions/runs/1281316653
* Triggered website run: https://github.com/phated/grain-lang.org/actions/runs/1281341528
    * Generated website commit: https://github.com/phated/grain-lang.org/commit/675d3339c362bacc72d23304c0f1a44aa4f69d2f
* Triggered homebrew run: https://github.com/phated/homebrew-tap/actions/runs/1281341560
    * Generated homebrew commit: https://github.com/phated/homebrew-tap/commit/9acb2ddc8b74333d09a49206ef8f3637522d0d6a 