### PR TITLE
feat(compiler)!: Block off 1KiB of heap space as generic swap

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -350,12 +350,14 @@ let lookup_ext_func = (env, modname, itemname) =>
 /** Static runtime values */
 
 // Static pointer to the runtime heap
-// Leaves low 1000 memory unused for Binaryen optimizations
-let runtime_heap_ptr = 0x400;
+// Leaves low 1000 memory unused for Binaryen optimizations,
+// and 0x400-0x800 is reserved for WASI polyfills (which cannot
+// allocate memory)
+let runtime_heap_ptr = 0x800;
 // Start pointer for the runtime heap
-let runtime_heap_start = 0x410;
+let runtime_heap_start = 0x810;
 // Static pointer to runtime type information
-let runtime_type_metadata_ptr = 0x408;
+let runtime_type_metadata_ptr = 0x808;
 
 let get_imported_name = (mod_, name) =>
   Printf.sprintf(

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -163,7 +163,7 @@ enums › adt_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -171,7 +171,7 @@ enums › adt_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (global.set $global_0

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -288,7 +288,7 @@ enums › enum_recursive_data_definition
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -296,7 +296,7 @@ enums › enum_recursive_data_definition
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (global.set $global_0

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -173,7 +173,7 @@ exceptions › exception_4
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -181,7 +181,7 @@ exceptions › exception_4
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (global.set $global_0

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -77,7 +77,7 @@ exceptions › exception_2
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -85,7 +85,7 @@ exceptions › exception_2
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (global.set $global_0

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -107,7 +107,7 @@ functions › func_record_associativity2
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -115,7 +115,7 @@ functions › func_record_associativity2
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -93,7 +93,7 @@ functions › func_record_associativity1
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -101,7 +101,7 @@ functions › func_record_associativity1
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -98,7 +98,7 @@ pattern matching › record_match_3
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -106,7 +106,7 @@ pattern matching › record_match_3
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -86,7 +86,7 @@ pattern matching › adt_match_deep
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -94,7 +94,7 @@ pattern matching › adt_match_deep
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $4

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -94,7 +94,7 @@ pattern matching › record_match_2
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -102,7 +102,7 @@ pattern matching › record_match_2
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -94,7 +94,7 @@ pattern matching › record_match_1
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -102,7 +102,7 @@ pattern matching › record_match_1
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -100,7 +100,7 @@ pattern matching › record_match_4
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -108,7 +108,7 @@ pattern matching › record_match_4
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -91,7 +91,7 @@ pattern matching › record_match_deep
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -99,7 +99,7 @@ pattern matching › record_match_deep
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -90,7 +90,7 @@ records › record_get_multiple
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -98,7 +98,7 @@ records › record_get_multiple
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -71,7 +71,7 @@ records › record_definition_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -79,7 +79,7 @@ records › record_definition_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -71,7 +71,7 @@ records › record_pun
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -79,7 +79,7 @@ records › record_pun
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -94,7 +94,7 @@ records › record_destruct_1
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -102,7 +102,7 @@ records › record_destruct_1
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -100,7 +100,7 @@ records › record_destruct_4
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -108,7 +108,7 @@ records › record_destruct_4
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -71,7 +71,7 @@ records › record_value_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -79,7 +79,7 @@ records › record_value_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -96,7 +96,7 @@ records › record_recursive_data_definition
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -104,7 +104,7 @@ records › record_recursive_data_definition
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_mixed_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_mixed_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -94,7 +94,7 @@ records › record_destruct_2
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -102,7 +102,7 @@ records › record_destruct_2
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -71,7 +71,7 @@ records › record_pun_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -79,7 +79,7 @@ records › record_pun_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -91,7 +91,7 @@ records › record_destruct_deep
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -99,7 +99,7 @@ records › record_destruct_deep
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -98,7 +98,7 @@ records › record_destruct_3
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -106,7 +106,7 @@ records › record_destruct_3
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -99,7 +99,7 @@ records › record_get_multilevel
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -107,7 +107,7 @@ records › record_get_multilevel
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -93,7 +93,7 @@ records › record_multiple_fields_definition_trailing
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -101,7 +101,7 @@ records › record_multiple_fields_definition_trailing
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -77,7 +77,7 @@ records › record_get_2
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -85,7 +85,7 @@ records › record_get_2
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_mixed
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_mixed
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -100,7 +100,7 @@ records › record_destruct_trailing
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -108,7 +108,7 @@ records › record_destruct_trailing
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_mixed_2
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_mixed_2
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -93,7 +93,7 @@ records › record_multiple_fields_both_trailing
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -101,7 +101,7 @@ records › record_multiple_fields_both_trailing
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -71,7 +71,7 @@ records › record_both_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -79,7 +79,7 @@ records › record_both_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_multiple
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_multiple
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_multiple_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_multiple_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -93,7 +93,7 @@ records › record_multiple_fields_value_trailing
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -101,7 +101,7 @@ records › record_multiple_fields_value_trailing
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -79,7 +79,7 @@ records › record_pun_mixed_2_trailing
        )
       )
       (i32.load
-       (i32.const 1032)
+       (i32.const 2056)
       )
      )
      (i32.store offset=4
@@ -87,7 +87,7 @@ records › record_pun_mixed_2_trailing
       (global.get $import__grainEnv_0_moduleRuntimeId_0)
      )
      (i32.store
-      (i32.const 1032)
+      (i32.const 2056)
       (local.get $0)
      )
      (i32.store

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -99,7 +99,7 @@ stdlib › stdlib_equal_20
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -107,7 +107,7 @@ stdlib › stdlib_equal_20
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -99,7 +99,7 @@ stdlib › stdlib_equal_19
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -107,7 +107,7 @@ stdlib › stdlib_equal_19
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -99,7 +99,7 @@ stdlib › stdlib_equal_21
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -107,7 +107,7 @@ stdlib › stdlib_equal_21
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -99,7 +99,7 @@ stdlib › stdlib_equal_22
         )
        )
        (i32.load
-        (i32.const 1032)
+        (i32.const 2056)
        )
       )
       (i32.store offset=4
@@ -107,7 +107,7 @@ stdlib › stdlib_equal_22
        (global.get $import__grainEnv_0_moduleRuntimeId_0)
       )
       (i32.store
-       (i32.const 1032)
+       (i32.const 2056)
        (local.get $0)
       )
       (local.set $1

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -47,7 +47,7 @@ let mut _RUNTIME_TYPE_METADATA_PTR = 0x01n;
 @disableGC
 let initPtr = () => {
   // hack to avoid incRef on this pointer
-  _RUNTIME_TYPE_METADATA_PTR = 0x408n
+  _RUNTIME_TYPE_METADATA_PTR = 0x808n
 }
 initPtr();
 


### PR DESCRIPTION
Currently, there is no way to allocate heap space in WASI polyfills (since they cannot import the `dataStructures.gr` module). To support cases in which some minimal heap use is desired (e.g. the NEAR SDK), this PR blocks off 1KiB of memory (`0x400`-`0x800`) which WASI polyfills can freely write to.

(Technically breaking, since the location of the runtime memory is moved)