### PR TITLE
chore: Update yarn commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ For instructions on how to build Grain from source, please consult the [official
 
 ### Other Commands
 
-To build the standard library:
-
-```bash
-yarn stdlib build
-```
-
 To build the JS runner:
 
 ```bash


### PR DESCRIPTION
We'll probably remove this whole section, but for now we can at least get rid of the outdated command.