### PR TITLE
fix(grainfmt): Format CRLF files without error

### DIFF
--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -38,14 +38,16 @@ let compile_parsed = (filename: option(string)) => {
         while (true) {
           let line = input_line(ic);
 
-          // TODO temporarily trim off the CRLF, but need to output in original format issue #940
-          linesList := linesList^ @ [String.trim(line)];
+          linesList := linesList^ @ [line];
         }
       ) {
       | exn => ()
       };
 
       program_str := String.concat("\n", linesList^);
+
+      // TODO add a new line to the end for where it's in CRLF more
+      program_str := program_str^ ++ "\n";
 
       Grain_utils.Config.base_path := dirname(filenm);
       Compile.compile_string(

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -38,7 +38,8 @@ let compile_parsed = (filename: option(string)) => {
         while (true) {
           let line = input_line(ic);
 
-          linesList := linesList^ @ [line];
+          // TODO temporarily trim off the CRLF, but need to output in original format issue #940
+          linesList := linesList^ @ [String.trim(line)];
         }
       ) {
       | exn => ()

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -46,7 +46,9 @@ let compile_parsed = (filename: option(string)) => {
 
       program_str := String.concat("\n", linesList^);
 
-      // TODO add a new line to the end for where it's in CRLF more
+      // add a new line to the end for where it's in CRLF more
+      // TODO Issue 940 handle CRLF properly
+
       program_str := program_str^ ++ "\n";
 
       Grain_utils.Config.base_path := dirname(filenm);

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -47,8 +47,7 @@ let compile_parsed = (filename: option(string)) => {
       program_str := String.concat("\n", linesList^);
 
       // add a new line to the end for where it's in CRLF more
-      // TODO Issue 940 handle CRLF properly
-
+      // TODO(#940): Handle CRLF properly
       program_str := program_str^ ++ "\n";
 
       Grain_utils.Config.base_path := dirname(filenm);


### PR DESCRIPTION
The reading in of files with CRLF  line endings that left a stray \r character which caused a syntax error
This fixes that issue.   The file is left as a LF file so we need to fix to output in CRLF (see #940)