### PR TITLE
feat: Add npm releases to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       upload_url: ${{ steps.release.outputs.upload_url }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      stdlib_upload_url: ${{ steps.release.outputs.stdlib--upload_url }}
+      stdlib_release_created: ${{ steps.release.outputs.stdlib--release_created }}
+      js-runner_upload_url: ${{ steps.release.outputs.js-runner--upload_url }}
+      js-runner_release_created: ${{ steps.release.outputs.js-runner--release_created }}
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2.33.1
         id: release
@@ -18,11 +22,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: manifest
 
-  build-pkg:
+  prepare-artifacts:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release_created }}
-    name: Build Packaged Grain
+    name: Prepare artifacts
     runs-on: ubuntu-latest
+    outputs:
+      stdlib_download_url: ${{ steps.stdlib-upload.outputs.browser_download_url }}
+      js-runner_download_url: ${{ steps.js-runner-upload.outputs.browser_download_url }}
     steps:
       # Many of these steps are the same as building the compiler for tests
       - name: Setup Node.js
@@ -101,8 +108,46 @@ jobs:
           asset_name: grain-linux-x64
           asset_content_type: application/octet-stream
 
+      - name: Pack stdlib
+        if: ${{ needs.release-please.outputs.stdlib_release_created }}
+        working-directory: ./stdlib
+        # Runs `npm pack` and assigns the filename to an env var we can use later
+        run: |
+          echo "STDLIB_TAR=$(npm pack --json | jq -r '.[0].filename')" >> $GITHUB_ENV
+
+      - name: Upload stdlib
+        id: stdlib-upload
+        if: ${{ needs.release-please.outputs.stdlib_release_created }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release-please.outputs.stdlib_upload_url }}
+          asset_path: ./stdlib/${{ env.STDLIB_TAR }}
+          asset_name: stdlib.tgz
+          asset_content_type: application/octet-stream
+
+      - name: Pack js-runner
+        if: ${{ needs.release-please.outputs.js-runner_release_created }}
+        working-directory: ./js-runner
+        # Runs `npm pack` and assigns the filename to an env var we can use later
+        run: |
+          echo "RUNNER_TAR=$(npm pack --json | jq -r '.[0].filename')" >> $GITHUB_ENV
+
+      - name: Upload js-runner
+        id: js-runner-upload
+        if: ${{ needs.release-please.outputs.js-runner_release_created }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release-please.outputs.js-runner_upload_url }}
+          asset_path: ./js-runner/${{ env.RUNNER_TAR }}
+          asset_name: js-runner.tgz
+          asset_content_type: application/octet-stream
+
   dispatch-website:
-    needs: [release-please, build-pkg]
+    needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.release_created }}
     name: Dispatch website release
     runs-on: ubuntu-latest
@@ -116,7 +161,7 @@ jobs:
           tag_input: ${{ needs.release-please.outputs.tag_name }}
 
   dispatch-homebrew:
-    needs: [release-please, build-pkg]
+    needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.release_created }}
     name: Dispatch homebrew release
     runs-on: ubuntu-latest
@@ -128,3 +173,39 @@ jobs:
           ref: main
           repo: grain-lang/homebrew-tap
           tag_input: ${{ needs.release-please.outputs.tag_name }}
+
+  npm-release-stdlib:
+    needs: [release-please, prepare-artifacts]
+    if: ${{ needs.release-please.outputs.stdlib_release_created }}
+    name: Publish stdlib to npm registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        run: |
+          npm publish ${{ needs.prepare-artifacts.outputs.stdlib_download_url }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE }}
+
+  npm-release-js-runner:
+    needs: [release-please, prepare-artifacts]
+    if: ${{ needs.release-please.outputs.js-runner_release_created }}
+    name: Publish js-runner to npm registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        run: |
+          npm publish ${{ needs.prepare-artifacts.outputs.js-runner_download_url }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE }}


### PR DESCRIPTION
This adds additional jobs to our release workflow to publish `@grain/stdlib` and `@grain/js-runner` to npm if they were bumped as part of a release.

I actually needed to split the logic into 2 parts:
1. While we are building the compiler, we will also now run `npm pack` and uploaded the packed artifacts to the appropriate GitHub release. For example, the `js-runner.tgz` file will be uploaded to the `js-runner-vX.X.X` release on GitHub.
2. After **all** the artifacts are built and uploaded, those artifacts are used to publish to npm in their own steps.

This process is similar to what we do with our binaryen.ml package, but that is packed different due to esy.

Everything added for these npm releases need to be guarded on the "release_created" output for that library, so you'll notice that all of them have something like `if: ${{ needs.release-please.outputs.js-runner_release_created }}` guarding it from running if no release was created.

You can see these different workflows being run on my fork:
* https://github.com/phated/grain/actions/runs/1293191632 published both packages because I made changes in each.
    * Their artifacts were uploaded to respective releases at https://github.com/phated/grain/releases/tag/js-runner-v0.4.2 and https://github.com/phated/grain/releases/tag/stdlib-v0.4.4
    <img width="1029" alt="Screen Shot 2021-09-30 at 6 52 19 PM" src="https://user-images.githubusercontent.com/992373/135553488-f2c04095-60d3-4264-b31e-4404edd21972.png">

* https://github.com/phated/grain/actions/runs/1293243003 only published the `stdlib` package because no changes were made to `js-runner`
    <img width="1027" alt="Screen Shot 2021-09-30 at 6 52 09 PM" src="https://user-images.githubusercontent.com/992373/135553486-1ade9ab6-423c-48f6-8c9e-dd3c44818f46.png">

* https://github.com/phated/grain/actions/runs/1293285946 only published the `js-runner` package because no changes were made to `stdlib`
    <img width="1031" alt="Screen Shot 2021-09-30 at 6 51 56 PM" src="https://user-images.githubusercontent.com/992373/135553483-631210fa-6b4f-4749-ad75-726bfdd97f27.png">

* https://github.com/phated/grain/actions/runs/1293323788 published neither npm package because no changes were made to either.
    <img width="1024" alt="Screen Shot 2021-09-30 at 6 51 42 PM" src="https://user-images.githubusercontent.com/992373/135553479-71abe5e7-65fc-4305-8e0b-311f1b585228.png">



