### PR TITLE
fix(compiler): Ensure cwd directory is normalized on Windows

### DIFF
--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -102,7 +102,9 @@ let realpath = path => {
   | None => None
   | Some(Fp.Absolute(abspath)) => Some(Fp.toString(abspath))
   | Some(Fp.Relative(relpath)) =>
-    Some(Fp.toString(Fp.join(Fp.absoluteExn(Sys.getcwd()), relpath)))
+    let base = Fp.absoluteExn(Grain_utils.Files.get_cwd());
+    let full_path = Fp.join(base, relpath);
+    Some(Fp.toString(full_path));
   };
 };
 

--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -97,59 +97,14 @@ let find_in_path_uncap = (~exts=[], base_dir, path, name) => {
   };
 };
 
-let realpath = path => {
-  switch (Fp.testForPath(path)) {
-  | None => None
-  | Some(Fp.Absolute(abspath)) => Some(Fp.toString(abspath))
-  | Some(Fp.Relative(relpath)) =>
-    let base = Fp.absoluteExn(Grain_utils.Files.get_cwd());
-    let full_path = Fp.join(base, relpath);
-    Some(Fp.toString(full_path));
-  };
-};
-
-let realpath_quick = path => {
-  switch (realpath(path)) {
-  | None => path
-  | Some(rp) => rp
-  };
-};
-
-let smart_cat = (dir, file) => {
-  switch (Fp.absolute(dir)) {
-  | None => Filename.concat(dir, file)
-  | Some(abspath) =>
-    switch (Fp.relative(file)) {
-    | None => Filename.concat(Fp.toString(abspath), file)
-    | Some(relpath) => Fp.toString(Fp.join(abspath, relpath))
-    }
-  };
-};
-
-let canonicalize_relpath = (base_path, unit_name) => {
-  // PRECONDITION: is_relpath(unit_name) == true
-  let abs_base_path =
-    switch (realpath(base_path)) {
-    | None =>
-      failwith(
-        Printf.sprintf(
-          "Internal Grain error; please report! testForPath failed: %s",
-          base_path,
-        ),
-      )
-    | Some(abspath) => abspath
-    };
-  smart_cat(abs_base_path, unit_name);
-};
-
 module PathTbl = {
   type t('a) = Hashtbl.t(string, 'a);
   let create: int => t('a) = Hashtbl.create;
 
   let add: (t('a), (string, string), 'a) => unit =
     (tbl, (dir, unit_name), v) => {
-      let dir = realpath_quick(dir);
-      Hashtbl.add(tbl, smart_cat(dir, unit_name), v);
+      let dir = Grain_utils.Files.realpath_quick(dir);
+      Hashtbl.add(tbl, Grain_utils.Files.smart_cat(dir, unit_name), v);
     };
 
   let find_opt:
@@ -157,7 +112,10 @@ module PathTbl = {
     option('a) =
     (~disable_relpath=false, tbl, base_path, path, unit_name) =>
       if (!disable_relpath && is_relpath(unit_name)) {
-        Hashtbl.find_opt(tbl, canonicalize_relpath(base_path, unit_name));
+        Hashtbl.find_opt(
+          tbl,
+          Grain_utils.Files.canonicalize_relpath(base_path, unit_name),
+        );
       } else {
         List.fold_left(
           (acc, elt) => {
@@ -166,7 +124,9 @@ module PathTbl = {
             | None =>
               Hashtbl.find_opt(
                 tbl,
-                smart_cat(realpath_quick(elt), unit_name),
+                Grain_utils.Files.(
+                  smart_cat(realpath_quick(elt), unit_name)
+                ),
               )
             }
           },

--- a/compiler/src/utils/files.re
+++ b/compiler/src/utils/files.re
@@ -51,7 +51,7 @@ let filename_to_module_name = fname => {
 
 let ensure_parent_directory_exists = fname => {
   // TODO: Use `derelativize` once Fp.t is used everywhere
-  let fullPath =
+  let full_path =
     switch (to_fp(fname)) {
     | Some(Absolute(path)) => path
     | Some(Relative(path)) =>
@@ -67,7 +67,7 @@ let ensure_parent_directory_exists = fname => {
   // No longer swallowing the error because we can handle the CWD case
   // thus we should raise if something is actually wrong
   // TODO: Switch this to return the Result type
-  Fs.mkDirPExn(Fp.dirName(fullPath));
+  Fs.mkDirPExn(Fp.dirName(full_path));
 };
 
 /**
@@ -76,7 +76,7 @@ let ensure_parent_directory_exists = fname => {
   assumed to be relative to the current working directory.
 */
 let derelativize = (~base=?, fname) => {
-  let fullPath =
+  let full_path =
     switch (to_fp(fname)) {
     | Some(Absolute(path)) => path
     | Some(Relative(path)) =>
@@ -105,7 +105,7 @@ let derelativize = (~base=?, fname) => {
       )
     };
 
-  Fp.toString(fullPath);
+  Fp.toString(full_path);
 };
 
 // Recursive readdir

--- a/compiler/test/TestFramework.re
+++ b/compiler/test/TestFramework.re
@@ -19,7 +19,7 @@ let () =
     }
   );
 
-let test_dir = Filename.concat(Sys.getcwd(), "test");
+let test_dir = Filename.concat(Grain_utils.Files.get_cwd(), "test");
 let test_libs_dir = Filename.concat(test_dir, "test-libs");
 let test_input_dir = Filename.concat(test_dir, "input");
 let test_output_dir = Filename.concat(test_dir, "output");


### PR DESCRIPTION
Closes #943

The fix here was using the `Grain_utils.Files.get_cwd()` function which does the separator normalization. I made it in a separate commit than the cleanup for y'all to verify.

I also refactored some of the utils into `Grain_utils.Files` because all Fp utilities should live there (Grain_typed doesn't actually depend on `Fp` so we were relying on transitive deps).