### PR TITLE
fix(grainfmt): Improve formatter performance

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -706,7 +706,11 @@ and print_pattern =
       ~original_source: array(string),
     ) => {
   let (leading_comments, trailing_comments) =
-    Walktree.partition_comments(pat.ppat_loc, Some(parent_loc), false);
+    Walktree.partition_comments(
+      ~range=Some(parent_loc),
+      ~leading_only=false,
+      pat.ppat_loc,
+    );
   Walktree.remove_used_comments(leading_comments, trailing_comments);
 
   let expr_line = get_end_loc_line(pat.ppat_loc);
@@ -1295,7 +1299,7 @@ and get_trailing_comments_to_next_code = (loc: Grain_parsing__Location.t) => {
   // after the lbrace
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, None, false);
+    Walktree.partition_comments(~range=None, ~leading_only=false, loc);
 
   let expr_line = get_loc_line(loc);
 
@@ -1319,7 +1323,11 @@ and get_trailing_comments_to_end_of_block =
   let range = make_to_line_end(block_location);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range), false);
+    Walktree.partition_comments(
+      ~range=Some(range),
+      ~leading_only=false,
+      loc,
+    );
 
   let expr_line = get_end_loc_line(range);
 
@@ -1343,7 +1351,11 @@ and get_trailing_comments_to_end_of_line =
   let range = make_to_line_end(loc);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range), false);
+    Walktree.partition_comments(
+      ~range=Some(range),
+      ~leading_only=false,
+      loc,
+    );
 
   let expr_line = get_end_loc_line(range);
 
@@ -1367,7 +1379,11 @@ and get_trailing_top_level_comments =
   let range = make_to_line_end(loc);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range), false);
+    Walktree.partition_comments(
+      ~range=Some(range),
+      ~leading_only=false,
+      loc,
+    );
 
   let expr_line = get_end_loc_line(range);
 
@@ -1407,7 +1423,11 @@ and print_expression =
       expr: Parsetree.expression,
     ) => {
   let (leading_comments, trailing_comments) =
-    Walktree.partition_comments(expr.pexp_loc, Some(expr.pexp_loc), false);
+    Walktree.partition_comments(
+      ~range=Some(expr.pexp_loc),
+      ~leading_only=false,
+      expr.pexp_loc,
+    );
 
   let expr_line = get_end_loc_line(expr.pexp_loc);
 
@@ -1630,9 +1650,9 @@ and print_expression =
                   (branch: Parsetree.match_branch) => {
                     let (leading_comments, trailing_comments) =
                       Walktree.partition_comments(
+                        ~range=Some(expr.pexp_loc),
+                        ~leading_only=false,
                         branch.pmb_loc,
-                        Some(expr.pexp_loc),
-                        false,
                       );
 
                     let this_line = get_end_loc_line(branch.pmb_loc);
@@ -1757,7 +1777,11 @@ and print_expression =
       Doc.text(originalCode);
     | PExpIf(condition, trueExpr, falseExpr) =>
       let (leading_condition_comments, _trailing_comments) =
-        Walktree.partition_comments(condition.pexp_loc, None, true);
+        Walktree.partition_comments(
+          ~range=None,
+          ~leading_only=true,
+          condition.pexp_loc,
+        );
       Walktree.remove_used_comments(leading_condition_comments, []);
 
       let expr_line = get_end_loc_line(condition.pexp_loc);
@@ -2194,7 +2218,11 @@ and print_expression =
               (e: Parsetree.expression) => {
                 // get the leading comments
                 let (leading_comments, _trailing_comments) =
-                  Walktree.partition_comments(e.pexp_loc, None, true);
+                  Walktree.partition_comments(
+                    ~range=None,
+                    ~leading_only=true,
+                    e.pexp_loc,
+                  );
 
                 let line_end_comments =
                   get_trailing_comments_to_end_of_line(e.pexp_loc);
@@ -2292,9 +2320,9 @@ and print_expression =
       } else {
         let (_leading_comments, trailing_comments) =
           Walktree.partition_comments(
+            ~range=Some(parent_loc),
+            ~leading_only=false,
             expr.pexp_loc,
-            Some(parent_loc),
-            false,
           );
 
         Walktree.remove_used_comments([], trailing_comments);
@@ -2601,9 +2629,9 @@ let rec print_data =
         (d: Grain_parsing__Parsetree.constructor_declaration) => {
           let (leading_comments, trailing_comments) =
             Walktree.partition_comments(
+              ~range=Some(data.pdata_loc),
+              ~leading_only=false,
               d.pcd_loc,
-              Some(data.pdata_loc),
-              false,
             );
 
           let this_line = get_end_loc_line(d.pcd_loc);
@@ -2715,9 +2743,9 @@ let rec print_data =
 
           let (leading_comments, trailing_comments) =
             Walktree.partition_comments(
+              ~range=Some(data.pdata_loc),
+              ~leading_only=false,
               decl.pld_loc,
-              Some(data.pdata_loc),
-              false,
             );
 
           let this_line = get_end_loc_line(decl.pld_loc);
@@ -2858,9 +2886,9 @@ let import_print = (imp: Parsetree.import_declaration) => {
                             };
                           let (_leading_comments, trailing_comments) =
                             Walktree.partition_comments(
+                              ~range=None,
+                              ~leading_only=false,
                               identloc.loc,
-                              None,
-                              false,
                             );
 
                           Walktree.remove_used_comments(
@@ -2932,12 +2960,16 @@ let import_print = (imp: Parsetree.import_declaration) => {
                         let (_leading_comments, trailing_comments) =
                           switch (optloc) {
                           | None =>
-                            Walktree.partition_comments(loc.loc, None, false)
+                            Walktree.partition_comments(
+                              ~range=None,
+                              ~leading_only=false,
+                              loc.loc,
+                            )
                           | Some(alias) =>
                             Walktree.partition_comments(
+                              ~range=None,
+                              ~leading_only=false,
                               alias.loc,
-                              None,
-                              false,
                             )
                           };
                         Walktree.remove_used_comments([], trailing_comments);
@@ -3109,7 +3141,11 @@ let toplevel_print =
   let attributes = data.ptop_attributes;
 
   let (leading_comments, _trailing_comments) =
-    Walktree.partition_comments(data.ptop_loc, None, true);
+    Walktree.partition_comments(
+      ~range=None,
+      ~leading_only=true,
+      data.ptop_loc,
+    );
 
   let line_end_comments = get_trailing_top_level_comments(data.ptop_loc);
 
@@ -3320,7 +3356,12 @@ let reformat_ast =
   let (_leading_comments, trailing_comments) =
     switch (last_stmt^) {
     | None => ([], [])
-    | Some(stmt) => Walktree.partition_comments(stmt.ptop_loc, None, false)
+    | Some(stmt) =>
+      Walktree.partition_comments(
+        ~range=None,
+        ~leading_only=false,
+        stmt.ptop_loc,
+      )
     };
 
   let trailing_comment_docs =

--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -187,7 +187,8 @@ let get_end_loc_line = (loc: Grain_parsing.Location.t) => {
 };
 
 let comment_to_doc = (comment: Parsetree.comment) => {
-  Doc.text(String.trim(Comments.get_comment_source(comment)));
+  let comment_string = Comments.get_comment_source(comment);
+  Doc.text(String.trim(comment_string));
 };
 
 let comment_hardline = (comment: Parsetree.comment) => {
@@ -705,7 +706,7 @@ and print_pattern =
       ~original_source: array(string),
     ) => {
   let (leading_comments, trailing_comments) =
-    Walktree.partition_comments(pat.ppat_loc, Some(parent_loc));
+    Walktree.partition_comments(pat.ppat_loc, Some(parent_loc), false);
   Walktree.remove_used_comments(leading_comments, trailing_comments);
 
   let expr_line = get_end_loc_line(pat.ppat_loc);
@@ -1294,7 +1295,7 @@ and get_trailing_comments_to_next_code = (loc: Grain_parsing__Location.t) => {
   // after the lbrace
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, None);
+    Walktree.partition_comments(loc, None, false);
 
   let expr_line = get_loc_line(loc);
 
@@ -1318,7 +1319,7 @@ and get_trailing_comments_to_end_of_block =
   let range = make_to_line_end(block_location);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range));
+    Walktree.partition_comments(loc, Some(range), false);
 
   let expr_line = get_end_loc_line(range);
 
@@ -1342,7 +1343,7 @@ and get_trailing_comments_to_end_of_line =
   let range = make_to_line_end(loc);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range));
+    Walktree.partition_comments(loc, Some(range), false);
 
   let expr_line = get_end_loc_line(range);
 
@@ -1366,7 +1367,7 @@ and get_trailing_top_level_comments =
   let range = make_to_line_end(loc);
 
   let (_leading_comments, trailing_comments) =
-    Walktree.partition_comments(loc, Some(range));
+    Walktree.partition_comments(loc, Some(range), false);
 
   let expr_line = get_end_loc_line(range);
 
@@ -1406,7 +1407,7 @@ and print_expression =
       expr: Parsetree.expression,
     ) => {
   let (leading_comments, trailing_comments) =
-    Walktree.partition_comments(expr.pexp_loc, Some(expr.pexp_loc));
+    Walktree.partition_comments(expr.pexp_loc, Some(expr.pexp_loc), false);
 
   let expr_line = get_end_loc_line(expr.pexp_loc);
 
@@ -1631,6 +1632,7 @@ and print_expression =
                       Walktree.partition_comments(
                         branch.pmb_loc,
                         Some(expr.pexp_loc),
+                        false,
                       );
 
                     let this_line = get_end_loc_line(branch.pmb_loc);
@@ -1755,7 +1757,7 @@ and print_expression =
       Doc.text(originalCode);
     | PExpIf(condition, trueExpr, falseExpr) =>
       let (leading_condition_comments, _trailing_comments) =
-        Walktree.partition_comments(condition.pexp_loc, None);
+        Walktree.partition_comments(condition.pexp_loc, None, true);
       Walktree.remove_used_comments(leading_condition_comments, []);
 
       let expr_line = get_end_loc_line(condition.pexp_loc);
@@ -2184,6 +2186,7 @@ and print_expression =
         let previous_line = ref(get_loc_line(expr.pexp_loc));
         let after_brace_comments =
           get_trailing_comments_to_end_of_line(expr.pexp_loc);
+
         let block =
           Doc.join(
             Doc.hardLine,
@@ -2191,7 +2194,7 @@ and print_expression =
               (e: Parsetree.expression) => {
                 // get the leading comments
                 let (leading_comments, _trailing_comments) =
-                  Walktree.partition_comments(e.pexp_loc, None);
+                  Walktree.partition_comments(e.pexp_loc, None, true);
 
                 let line_end_comments =
                   get_trailing_comments_to_end_of_line(e.pexp_loc);
@@ -2288,7 +2291,11 @@ and print_expression =
         );
       } else {
         let (_leading_comments, trailing_comments) =
-          Walktree.partition_comments(expr.pexp_loc, Some(parent_loc));
+          Walktree.partition_comments(
+            expr.pexp_loc,
+            Some(parent_loc),
+            false,
+          );
 
         Walktree.remove_used_comments([], trailing_comments);
 
@@ -2593,7 +2600,11 @@ let rec print_data =
       List.map(
         (d: Grain_parsing__Parsetree.constructor_declaration) => {
           let (leading_comments, trailing_comments) =
-            Walktree.partition_comments(d.pcd_loc, Some(data.pdata_loc));
+            Walktree.partition_comments(
+              d.pcd_loc,
+              Some(data.pdata_loc),
+              false,
+            );
 
           let this_line = get_end_loc_line(d.pcd_loc);
 
@@ -2703,7 +2714,11 @@ let rec print_data =
             };
 
           let (leading_comments, trailing_comments) =
-            Walktree.partition_comments(decl.pld_loc, Some(data.pdata_loc));
+            Walktree.partition_comments(
+              decl.pld_loc,
+              Some(data.pdata_loc),
+              false,
+            );
 
           let this_line = get_end_loc_line(decl.pld_loc);
 
@@ -2842,7 +2857,11 @@ let import_print = (imp: Parsetree.import_declaration) => {
                               Doc.nil;
                             };
                           let (_leading_comments, trailing_comments) =
-                            Walktree.partition_comments(identloc.loc, None);
+                            Walktree.partition_comments(
+                              identloc.loc,
+                              None,
+                              false,
+                            );
 
                           Walktree.remove_used_comments(
                             [],
@@ -2912,9 +2931,14 @@ let import_print = (imp: Parsetree.import_declaration) => {
 
                         let (_leading_comments, trailing_comments) =
                           switch (optloc) {
-                          | None => Walktree.partition_comments(loc.loc, None)
+                          | None =>
+                            Walktree.partition_comments(loc.loc, None, false)
                           | Some(alias) =>
-                            Walktree.partition_comments(alias.loc, None)
+                            Walktree.partition_comments(
+                              alias.loc,
+                              None,
+                              false,
+                            )
                           };
                         Walktree.remove_used_comments([], trailing_comments);
 
@@ -3085,7 +3109,7 @@ let toplevel_print =
   let attributes = data.ptop_attributes;
 
   let (leading_comments, _trailing_comments) =
-    Walktree.partition_comments(data.ptop_loc, None);
+    Walktree.partition_comments(data.ptop_loc, None, true);
 
   let line_end_comments = get_trailing_top_level_comments(data.ptop_loc);
 
@@ -3296,7 +3320,7 @@ let reformat_ast =
   let (_leading_comments, trailing_comments) =
     switch (last_stmt^) {
     | None => ([], [])
-    | Some(stmt) => Walktree.partition_comments(stmt.ptop_loc, None)
+    | Some(stmt) => Walktree.partition_comments(stmt.ptop_loc, None, false)
     };
 
   let trailing_comment_docs =

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -121,7 +121,7 @@ let walktree =
 
   let iter_location = (self, location) =>
     if (!List.mem(Code(location), all_locations^)) {
-      all_locations := List.cons(Code(location), all_locations^);
+      all_locations := [Code(location), ...all_locations^];
     };
 
   // put it in the right order ready for the final sort as hopefully

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -122,11 +122,7 @@ let walktree =
   // use a hash table to de-deupe adding locations to the list
   // because the iterator returns the same location multiple times
 
-  // best guess of size, 20 nodes per top level stmt
-
-  let num_nodes = List.length(statements) * 20;
-
-  let locs = Hashtbl.create(num_nodes);
+  let locs = Hashtbl.create(4096); // a reasonable guess
 
   let iter_location = (self, location) => {
     let loc_string = Debug.print_loc_string("", location);

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -119,14 +119,22 @@ let walktree =
 
   all_locations := comment_locations;
 
-  let iter_location = (self, location) =>
-    if (!List.mem(Code(location), all_locations^)) {
+  // use a hash table to de-deupe adding locations to the list
+  // because the iterator returns the same location multiple times
+
+  // best guess of size, 20 nodes per top level stmt
+
+  let num_nodes = List.length(statements) * 20;
+
+  let locs = Hashtbl.create(num_nodes);
+
+  let iter_location = (self, location) => {
+    let loc_string = Debug.print_loc_string("", location);
+    if (!Hashtbl.mem(locs, loc_string)) {
+      Hashtbl.add(locs, loc_string, true);
       all_locations := [Code(location), ...all_locations^];
     };
-
-  // put it in the right order ready for the final sort as hopefully
-  // almost the right order is faster to sort
-  all_locations := List.rev(all_locations^);
+  };
 
   let iterator = {...Ast_iterator.default_iterator, location: iter_location};
 

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -238,6 +238,19 @@ let rec partition_comments_internal =
   };
 };
 
+/*
+  When given a location loc, return the comments before and after that location 
+  bounded by the previous and next nodes in the AST
+
+  range limits that seach to within a particular location in the AST 
+  (useful for finding comments after braces on the same line)
+
+  leading_only is a performance hint.  We iterate through the list to find the node
+  so always do this work anyway.  Sometimes we only need the leading comments
+  so this hints not to do the work to find the trailing ones.
+
+*/
+
 let partition_comments =
     (
       ~range: option(Grain_parsing.Location.t),

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -239,17 +239,17 @@ let rec partition_comments_internal =
 };
 
 /*
-  When given a location loc, return the comments before and after that location 
-  bounded by the previous and next nodes in the AST
+   When given a location loc, return the comments before and after that location
+   bounded by the previous and next nodes in the AST
 
-  range limits that seach to within a particular location in the AST 
-  (useful for finding comments after braces on the same line)
+   range limits that seach to within a particular location in the AST
+   (useful for finding comments after braces on the same line)
 
-  leading_only is a performance hint.  We iterate through the list to find the node
-  so always do this work anyway.  Sometimes we only need the leading comments
-  so this hints not to do the work to find the trailing ones.
+   leading_only is a performance hint.  We iterate through the list to find the node
+   so always do this work anyway.  Sometimes we only need the leading comments
+   so this hints not to do the work to find the trailing ones.
 
-*/
+ */
 
 let partition_comments =
     (

--- a/compiler/grainformat/walktree.re
+++ b/compiler/grainformat/walktree.re
@@ -234,7 +234,7 @@ let rec partition_comments_internal =
               ~leading_only,
               loc,
             );
-          (pre, [c] @ post);
+          (pre, [c, ...post]);
         };
       };
 

--- a/compiler/grainformat/walktree.rei
+++ b/compiler/grainformat/walktree.rei
@@ -27,7 +27,7 @@
 
  */
 let partition_comments:
-  (Grain_parsing.Location.t, option(Grain_parsing.Location.t),bool) =>
+  (Grain_parsing.Location.t, option(Grain_parsing.Location.t), bool) =>
   (
     list(Grain_parsing.Parsetree.comment),
     list(Grain_parsing.Parsetree.comment),

--- a/compiler/grainformat/walktree.rei
+++ b/compiler/grainformat/walktree.rei
@@ -27,7 +27,11 @@
 
  */
 let partition_comments:
-  (Grain_parsing.Location.t, option(Grain_parsing.Location.t), bool) =>
+  (
+    ~range: option(Grain_parsing.Location.t),
+    ~leading_only: bool,
+    Grain_parsing.Location.t
+  ) =>
   (
     list(Grain_parsing.Parsetree.comment),
     list(Grain_parsing.Parsetree.comment),

--- a/compiler/grainformat/walktree.rei
+++ b/compiler/grainformat/walktree.rei
@@ -27,7 +27,7 @@
 
  */
 let partition_comments:
-  (Grain_parsing.Location.t, option(Grain_parsing.Location.t)) =>
+  (Grain_parsing.Location.t, option(Grain_parsing.Location.t),bool) =>
   (
     list(Grain_parsing.Parsetree.comment),
     list(Grain_parsing.Parsetree.comment),

--- a/compiler/test/formatter_inputs/brace_comments.gr
+++ b/compiler/test/formatter_inputs/brace_comments.gr
@@ -16,7 +16,7 @@ if (true) { // block 1
 
 let space = ""
 
-export let setCounter = val => {
+export let rec setCounter = val => {
   // Write the value to memory.
-  Storage.setInt32(key, val)
+  setCounter(val)
 }

--- a/compiler/test/formatter_outputs/brace_comments.gr
+++ b/compiler/test/formatter_outputs/brace_comments.gr
@@ -16,7 +16,7 @@ if (true) { // block 1
 
 let space = ""
 
-export let setCounter = val => {
+export let rec setCounter = val => {
   // Write the value to memory.
-  Storage.setInt32(key, val)
+  setCounter(val)
 }


### PR DESCRIPTION
One trick was simple, use cons instead of appending to an array.  I reverse it in the hope that helps the sort be faster.

Instead of folding over the entire list each time (and skipping) by using recursion I can stop early which speeds up partitions of the AST in the earlier phases when there are lots of non-relevant items in the node list still