### PR TITLE
chore(graindoc): Convert graindoc args to use ppx_deriving_cmdliner

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -36,6 +36,7 @@
     "@opam/fs": "0.0.2",
     "@opam/grain_dypgen": "0.2",
     "@opam/ocamlgraph": ">= 2.0.0",
+    "@opam/ppx_deriving_cmdliner": ">= 0.6.0",
     "@opam/ppx_deriving_yojson": ">= 3.5.2",
     "@opam/ppx_sexp_conv": ">= 0.14.0",
     "@opam/reason": ">= 3.6.2",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2086803ae6beb978f889a207fb067125",
+  "checksum": "a726c3ad97a063d1a3b1159d660522a5",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.11.0@d41d8cd9": {
@@ -589,6 +589,39 @@
         "@opam/ppxlib@opam:0.23.0@b29cda02",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
         "@opam/dune@opam:2.9.1@1e504822"
+      ]
+    },
+    "@opam/ppx_deriving_cmdliner@opam:0.6.0@0ca5b723": {
+      "id": "@opam/ppx_deriving_cmdliner@opam:0.6.0@0ca5b723",
+      "name": "@opam/ppx_deriving_cmdliner",
+      "version": "opam:0.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/5a/5a1050704c477f0ee46001cc2f4fe697#md5:5a1050704c477f0ee46001cc2f4fe697",
+          "archive:https://github.com/hammerlab/ppx_deriving_cmdliner/archive/refs/tags/v0.6.0.tar.gz#md5:5a1050704c477f0ee46001cc2f4fe697"
+        ],
+        "opam": {
+          "name": "ppx_deriving_cmdliner",
+          "version": "0.6.0",
+          "path": "esy.lock/opam/ppx_deriving_cmdliner.0.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/ppxlib@opam:0.23.0@b29cda02",
+        "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.11.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/ppxlib@opam:0.23.0@b29cda02",
+        "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/cmdliner@opam:1.0.4@93208aac"
       ]
     },
     "@opam/ppx_deriving@opam:5.2.1@089e5dd3": {
@@ -1502,6 +1535,7 @@
         "@opam/reason@opam:3.7.0@494dd52d",
         "@opam/ppx_sexp_conv@opam:v0.14.3@8f42b1ac",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
+        "@opam/ppx_deriving_cmdliner@opam:0.6.0@0ca5b723",
         "@opam/ocamlgraph@opam:2.0.0@929b9eba",
         "@opam/grain_dypgen@opam:0.2@4b32567c",
         "@opam/fs@github:facebookexperimental/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",

--- a/compiler/esy.lock/opam/ppx_deriving_cmdliner.0.6.0/opam
+++ b/compiler/esy.lock/opam/ppx_deriving_cmdliner.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: [
+  "Isaac Hodes <isaachodes@gmail.com>"
+  "B. Arman Aksoy <arman@aksoy.org>"
+  "Seb Mondet <seb@mondet.org>"
+  "Nick Zalutskiy <nick@const.fun>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Tom Repetti <trepetti@cs.columbia.edu>"
+  "Marcello Seri <m.seri@rug.nl>"
+]
+homepage: "https://github.com/hammerlab/ppx_deriving_cmdliner"
+bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
+dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
+doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
+license: "MIT"
+tags: ["syntax" "cli"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.05"}
+  "cmdliner"     {>= "1.0.0"}
+  "result"
+  "ppx_deriving" {>= "5.0"}
+  "dune"
+  "ppxlib"       {>= "0.18.0"}
+  "alcotest"     {with-test}
+]
+synopsis: "Cmdliner.Term.t generator"
+description: """
+ppx_deriving_cmdliner is a ppx_deriving plugin that generates
+a Cmdliner Term.t for a record type."""
+url {
+  src:
+    "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/refs/tags/v0.6.0.tar.gz"
+  checksum: "md5=5a1050704c477f0ee46001cc2f4fe697"
+}

--- a/compiler/graindoc/dune
+++ b/compiler/graindoc/dune
@@ -15,7 +15,9 @@
   (:standard
    (:include ./config/flags.sexp)))
  (libraries cmdliner grain grain_diagnostics grain_utils graindoc.docblock
-   binaryen.native dune-build-info))
+   binaryen.native dune-build-info)
+ (preprocess
+  (pps ppx_deriving_cmdliner)))
 
 (rule
  (target graindoc_js.re)
@@ -34,4 +36,6 @@
  (libraries cmdliner grain grain_diagnostics grain_utils graindoc.docblock
    binaryen.js dune-build-info)
  (js_of_ocaml
-  (flags --no-sourcemap --no-extern-fs --quiet)))
+  (flags --no-sourcemap --no-extern-fs --quiet))
+ (preprocess
+  (pps ppx_deriving_cmdliner)))


### PR DESCRIPTION
I've been wanting to explore ppx_deriving_cmdliner for some time because it is really hard for @marcusroberts and I to write cmdliner terms. For this POC, I've converted the `input` and `output` arguments of graindoc (so just the args specific to graindoc, not the internal compiler flags) to use this PPX instead of handwriting everything.

It doesn't remove all the confusion, which usually happens around the `let cmd = { .. }` definition, but this does allow us to have 1 record that contains all our custom options. It also gives us a nice DSL for describing the options and allows us to create modules for custom types (w/ own logic). I'll be using this custom logic to attempt to implement #972

