### PR TITLE
fix(compiler): Ensure main module is included in linker dependency graph

### DIFF
--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -617,6 +617,8 @@ let link_modules = ({asm: wasm_mod, signature}) => {
 
   let main_module = Module_resolution.current_filename^();
   Hashtbl.add(modules, main_module, wasm_mod);
+
+  G.add_vertex(dependency_graph, main_module);
   build_dependency_graph(
     ~base_dir=Filename.dirname(main_module),
     main_module,

--- a/compiler/test/suites/linking.re
+++ b/compiler/test/suites/linking.re
@@ -21,6 +21,17 @@ describe("linking", ({test}) => {
     {|import List from "list"; print(List.map(n => n + 1, [1, 2, 3]))|},
     "[2, 3, 4]\n",
   );
+  assertRun("link_issue_994_no_generated_code", {|0|}, "");
+  assertRun(
+    "link_issue_994_unexported_type",
+    {|record Foo { foo: String }|},
+    "",
+  );
+  assertRun(
+    "link_issue_994_exported_type",
+    {|export record Foo { foo: String }|},
+    "",
+  );
   // --wasi-polyfill
   assertWasiPolyfillRun(
     "test/input/wasiPolyfill.gr",


### PR DESCRIPTION
Fixes #994

If a module has no dependencies at the WebAssembly level (that is, the Grain files it depends on don't produce any code (only types, etc.), the module doesn't use any of the values from imported modules, and/or it manages to even not depend on the runtime) it fails linking. Most things depend on the runtime, but really simple programs can get into this state.

This is because vertices are added to the linker's dependency graph implicitly when edges between modules are created, and if there are no dependencies, no edges are created, so the main module itself isn't included in the graph. This causes a `Not_found` to occur in the linker when it tries to write universal exports because the (empty) hash for the module's exports was not created.

This PR just initializes the dependency graph to a single node of the main module.