### PR TITLE
chore(compiler): Update vscode script to use a custom template on non-Windows

### DIFF
--- a/.vscode/setup-ocaml-lsp.js
+++ b/.vscode/setup-ocaml-lsp.js
@@ -21,7 +21,7 @@ if (process.platform === 'win32') {
   console.log("NOTE: It looks like you are using Windows. You'll need to install esy globally using `npm i -g esy`");
 
   output[ocamlsandbox] = {
-    "root": "${compilerPath}",
+    "root": `${compilerPath}`,
     "kind": "esy"
   };
 } else {

--- a/.vscode/setup-ocaml-lsp.js
+++ b/.vscode/setup-ocaml-lsp.js
@@ -3,16 +3,32 @@ const path = require('path');
 
 const settingsPath = path.join(__dirname, 'settings.json');
 
-const compilerPath = path.join(__dirname, '../compiler');
+const ocamlsandbox = "ocaml.sandbox";
 
-const output = `{
-  "ocaml.sandbox": {
-    "root": "${compilerPath}",
-    "kind": "esy"
-  },
+const output = {
   "files.associations": {
     "*.dyp": "ocaml.ocamllex"
   }
-}`;
+};
 
-fs.writeFileSync(settingsPath, output);
+// On Mac and Linux, we can use our yarn trick
+// but on Windows, they don't run vscode in the correct directory
+// Ref https://github.com/microsoft/vscode/issues/43237
+if (process.platform === 'win32') {
+  const compilerPath = path.join(__dirname, '../compiler');
+
+  // This also means that Windows needs to have esy installed globally
+  console.log("NOTE: It looks like you are using Windows. You'll need to install esy globally using `npm i -g esy`");
+
+  output[ocamlsandbox] = {
+    "root": "${compilerPath}",
+    "kind": "esy"
+  };
+} else {
+  output[ocamlsandbox] = {
+    "kind": "custom",
+    "template": "yarn --silent workspace @grain/compiler run --silent esy b $prog $args"
+  };
+}
+
+fs.writeFileSync(settingsPath, JSON.stringify(output, null, 2));

--- a/.vscode/setup-ocaml-lsp.js
+++ b/.vscode/setup-ocaml-lsp.js
@@ -1,33 +1,36 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const settingsPath = path.join(__dirname, 'settings.json');
+const settingsPath = path.join(__dirname, "settings.json");
 
 const ocamlsandbox = "ocaml.sandbox";
 
 const output = {
   "files.associations": {
-    "*.dyp": "ocaml.ocamllex"
-  }
+    "*.dyp": "ocaml.ocamllex",
+  },
 };
 
 // On Mac and Linux, we can use our yarn trick
 // but on Windows, they don't run vscode in the correct directory
 // Ref https://github.com/microsoft/vscode/issues/43237
-if (process.platform === 'win32') {
-  const compilerPath = path.join(__dirname, '../compiler');
+if (process.platform === "win32") {
+  const compilerPath = path.join(__dirname, "../compiler");
 
   // This also means that Windows needs to have esy installed globally
-  console.log("NOTE: It looks like you are using Windows. You'll need to install esy globally using `npm i -g esy`");
+  console.log(
+    "NOTE: It looks like you are using Windows. You'll need to install esy globally using `npm i -g esy`"
+  );
 
   output[ocamlsandbox] = {
-    "root": `${compilerPath}`,
-    "kind": "esy"
+    root: `${compilerPath}`,
+    kind: "esy",
   };
 } else {
   output[ocamlsandbox] = {
-    "kind": "custom",
-    "template": "yarn --silent workspace @grain/compiler run --silent esy b $prog $args"
+    kind: "custom",
+    template:
+      "yarn --silent workspace @grain/compiler run --silent esy b $prog $args",
   };
 }
 


### PR DESCRIPTION
In vscode-ocaml-platform v1.0.0, they added a configuration option to specify a "custom" template for finding the ocamllsp in your sandbox. Before this, we needed to have a special script that found the absolute path to `grain/compiler` and labeled that as the esy sandbox. However, with this "custom" template, we can actually defer the lookup to `yarn` and our local `esy` command.

I've removed the "vscode" script and the file it executed and then committed a workspace `settings.json` file that implements the custom command that I got working. We need to test this on windows still 😭

cc @cician - Can you try this out in your environments (without a global esy installed)?