### PR TITLE
fix(compiler): Allow modules to re-export imported types containing generics

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -968,11 +968,11 @@ let rec find_module_descr = (path, filename, env) => {
     try(IdTbl.find_same(id, env.components)) {
     | Not_found =>
       let (_, unit_source, _) = get_unit();
-      let filename = Option.value(~default=Ident.name(id), filename);
-      if (Ident.persistent(id) && !(filename == unit_source)) {
-        find_pers_struct(~loc=Location.dummy_loc, filename).ps_comps;
-      } else {
-        raise(Not_found);
+      switch (filename) {
+      | Some(filename)
+          when Ident.persistent(id) && !(filename == unit_source) =>
+        find_pers_struct(~loc=Location.dummy_loc, filename).ps_comps
+      | _ => raise(Not_found)
       };
     }
   | PExternal(m, s, pos) =>

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -161,4 +161,13 @@ describe("records", ({test}) => {
       bar.foo = Some(foo)
     |},
   );
+  assertRun(
+    "export_import_record_issue_665",
+    {|
+      import { Foo } from "data"
+      export enum Bar { Baz(Foo<Number>) }
+      print(Baz({ bar: 1 }))
+    |},
+    "Baz(<record value>)\n",
+  );
 });

--- a/compiler/test/test-libs/data.gr
+++ b/compiler/test/test-libs/data.gr
@@ -1,0 +1,1 @@
+export record Foo<a> { bar: a }


### PR DESCRIPTION
Fixes #665

It seems that when we didn't have a filename for a module, we were using it's identifier as a filepath. However, if we raise `Not_found`, the compiler can generally sort out the type you want.