### PR TITLE
chore: Add -slim Dockerfile and update Docker workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@ script/node_modules
 **/*.log
 _build/
 */_build/
+cli/bin/*.exe
 .installed-pkgs
 notes.org
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ script/node_modules
 _build/
 */_build/
 cli/bin/*.exe
+cli/bin/*.bc.js
 .installed-pkgs
 notes.org
 node_modules/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,30 +1,105 @@
-name: Publish Docker image (HEAD)
+name: Publish Docker images
 on:
   push:
-    branches: [main]
-    tags: ["v*.*.*"]
+    branches: main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag of release"
+        required: true
 jobs:
-  push_to_registries:
-    name: Push Docker image to multiple registries
+  push_base_image:
+    name: Push base Docker image to multiple registries
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      # TODO: Re-implement with v2 Docker GitHub Actions
-      # - name: Push to Docker Hub
-      #   uses: docker/build-push-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
-      #     repository: grainlang/grain
-      #     tag_with_ref: true
+      - name: Parse tag
+        # This step converts Grain tags into standard semver, i.e. grain-v1.2.3 -> v1.2.3
+        id: vars
+        if: ${{ github.event.inputs.tag }}
+        run: GITHUB_TAG=${{ github.event.inputs.tag }}; echo ::set-output name=tag::${GITHUB_TAG#grain-}
 
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
+          images: |
+            grainlang/grain
+            ghcr.io/grain-lang/grain
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}},value=${{ steps.vars.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: grain-lang/grain/grain
-          tag_with_ref: true
+
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_slim_image:
+    name: Push slim Docker image to multiple registries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Parse tag
+        # This step converts Grain tags into standard semver, i.e. grain-v1.2.3 -> v1.2.3
+        id: vars
+        if: ${{ github.event.inputs.tag }}
+        run: GITHUB_TAG=${{ github.event.inputs.tag }}; echo ::set-output name=tag::${GITHUB_TAG#grain-}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          flavor: |
+            suffix=-slim,onlatest=true
+          images: |
+            grainlang/grain
+            ghcr.io/grain-lang/grain
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}},value=${{ steps.vars.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push slim image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-slim
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v3.6.0
         with:
           images: |
             grainlang/grain
@@ -34,20 +34,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.10.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.10.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.7.0
         with:
           context: .
           file: Dockerfile
@@ -70,7 +70,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v3.6.0
         with:
           flavor: |
             suffix=-slim,onlatest=true
@@ -83,20 +83,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.10.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.10.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push slim image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.7.0
         with:
           context: .
           file: Dockerfile-slim

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -100,6 +100,6 @@ jobs:
         with:
           context: .
           file: Dockerfile-slim
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,20 @@ jobs:
           repo: grain-lang/homebrew-tap
           tag_input: ${{ needs.release-please.outputs.tag_name }}
 
+  dispatch-docker:
+    needs: [release-please, prepare-artifacts]
+    if: ${{ needs.release-please.outputs.release_created }}
+    name: Dispatch Docker builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+        with:
+          workflow: Publish Docker images
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          ref: main
+          repo: grain-lang/grain
+          tag_input: ${{ needs.release-please.outputs.tag_name }}
+
   npm-release-stdlib:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.stdlib_release_created }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,84 +1,19 @@
-FROM buildpack-deps:focal
+# This Dockerfile constructs an environment in which the Grain compiler can be built and used.
 
-# Taken from https://github.com/nodejs/docker-node/blob/31246f5f779cafa0930a1db04bd00d875d6a940d/14/buster/Dockerfile
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+FROM node:16
 
-ENV NODE_VERSION 14.16.1
-
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  # gpg keys listed at https://github.com/nodejs/node#release-keys
-  && set -ex \
-  && for key in \
-    4ED778F539E3634C779C87C6D7062848A1AB005C \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-    108F52B48DB57BB0CC439B2997B01419BD92F80A \
-    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
-  ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  # smoke tests
-  && node --version \
-  && npm --version
-
-ENV YARN_VERSION 1.22.5
-
-RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  # smoke test
-  && yarn --version
-
-# This Dockerfile constructs an environment in which Grain is built and can be used.
 LABEL name="Grain"
 LABEL description="Grain CLI"
 LABEL vcs-url="https://github.com/grain-lang/grain"
-LABEL maintainer="philip@grain-lang.org"
+LABEL maintainer="team@grain-lang.org"
 
 COPY . /grain
 
 WORKDIR /grain
 
-RUN yarn --pure-lockfile
-RUN yarn compiler build
+# Build the compiler and CLI
+RUN yarn --pure-lockfile && \
+    yarn compiler build
 
 # Set up container environment
 WORKDIR /

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,0 +1,36 @@
+# This Dockerfile constructs a minimal environment in which Grain programs can be compiled.
+# The environment is only meant to build Grain programs, not develop the compiler.
+
+FROM node:16-slim
+
+LABEL name="Grain"
+LABEL description="Grain CLI"
+LABEL vcs-url="https://github.com/grain-lang/grain"
+LABEL maintainer="team@grain-lang.org"
+
+COPY . /grain
+
+WORKDIR /grain
+
+# Build the compiler and CLI
+RUN apt-get update && \
+    # Install necessary build tools to build the Grain compiler
+    apt-get install git curl zlib1g build-essential -y && \
+    # Install all JavaScript dependencies
+    yarn --pure-lockfile && \
+    # Build the Grain compiler
+    yarn compiler build && \
+    # Remove all node modules and only install modules necessary to run the CLI (no dev dependencies)
+    yarn cache clean && \
+    rm -rf node_modules && \
+    NODE_ENV=production yarn --pure-lockfile && \
+    # Remove all esy build files
+    rm -rf compiler/_esy && \
+    rm -rf ~/.esy && \
+    # Remove all of the build tooling and apt lists
+    apt-get remove build-essential -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up container environment
+WORKDIR /
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Closes #1007
Closes #1010 

This PR updates the `docker/build-push-action` GitHub action to v2 (which allows us to publish to DockerHub again) and adds a new `Dockerfile-slim` which provides a minimal environment that can compile Grain programs. The slim version is about 10x smaller!

![image](https://user-images.githubusercontent.com/7244034/142298890-493d6b05-8651-42c1-ac4c-0875a16cce9b.png)

You can see a [successful run of the GitHub workflow](https://github.com/grain-lang/grain/runs/4243823185?check_suite_focus=true), [images published on DockerHub](https://hub.docker.com/repository/docker/grainlang/grain/tags?page=1&ordering=last_updated&name=oscar-docker), and [on the GitHub Container Registry](https://github.com/grain-lang/grain/pkgs/container/grain). Note that we previously were (accidentally) publishing on GHCR as `grain-lang/grain/grain` rather than `grain-lang/grain`.

In addition to the push on `main`, there's also a `workflow_dispatch` event that gets triggered on release. Shoutout to @phated for making it easy for me to figure out how to do that 😤 

You can see that the tag is handled properly via [this workflow](https://github.com/ospencer/grain/runs/4244964750?check_suite_focus=true) (and that it's ignored on `main` via [this workflow](https://github.com/ospencer/grain/runs/4244950280?check_suite_focus=true)), but I've also got some screenshots here to save you some clicks:

For the standard image:
![image](https://user-images.githubusercontent.com/7244034/142300612-308561c7-3038-4180-9f10-0e98c98091d1.png)

For the slim image:
![image](https://user-images.githubusercontent.com/7244034/142300673-1b607f71-bd82-4096-9c12-400ba05ddc58.png)

When just running on a push to `main`:
![image](https://user-images.githubusercontent.com/7244034/142300752-8a52b622-1711-4082-aa26-5c960d1edf61.png)

The docker metadata action is quite nice, as you can see that it will also handle having a release tag (i.e. `grain:0.4.4`) and also a tag for the minor for automatic patch updates (i.e. `grain:0.4`).

Besides that, the main Dockerfile was simplified quite a bit. The slim version is similar, but it has to manually install some packages and then does a bunch of cleanup.