### PR TITLE
fix(compiler): Fix memory leaks when loading from heap values

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -2553,18 +2553,25 @@ let rec compile_store = (wasm_mod, env, binds) => {
     let process_bind = ((b, instr), acc) => {
       let store_bind = arg =>
         compile_bind(~action=BindSet(arg), wasm_mod, env, b);
-      let get_bind = compile_bind(~action=BindGet, wasm_mod, env, b);
       let compiled_instr =
         switch (instr.instr_desc) {
         // special logic here for letrec
         | MAllocate(MClosure(cdata)) =>
+          let get_bind =
+            compile_bind(
+              ~action=BindGet,
+              ~skip_incref=true,
+              wasm_mod,
+              env,
+              b,
+            );
           allocate_closure(
             wasm_mod,
             env,
             ~lambda=get_bind,
             ~skip_patching=true,
             cdata,
-          )
+          );
         | MReturnCallIndirect(_)
         | MReturnCallKnown(_)
         | MCallIndirect(_)

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1108,6 +1108,10 @@ let error_if_true = (wasm_mod, env, cond, err, args) =>
   );
 
 let compile_tuple_op = (~is_box=false, wasm_mod, env, tup_imm, op) => {
+  // We skip the incref here as this is akin to using a swap slot (the
+  // reference we create here cannot escape, so there isn't a need to add an
+  // incref/decref pair). Since it won't live in a local, it wouldn't be
+  // cleaned up automatically anyway.
   let tup = () => compile_imm(~skip_incref=true, wasm_mod, env, tup_imm);
   switch (op) {
   | MTupleGet(idx) =>
@@ -1176,6 +1180,10 @@ let compile_array_op = (wasm_mod, env, arr_imm, op) => {
   let get_swap = n => get_swap(wasm_mod, env, n);
   let set_swap = n => set_swap(wasm_mod, env, n);
   let get_arr_value = () =>
+    // We skip the incref here as this is akin to using a swap slot (the
+    // reference we create here cannot escape, so there isn't a need to add an
+    // incref/decref pair). Since it won't live in a local, it wouldn't be
+    // cleaned up automatically anyway.
     compile_imm(~skip_incref=true, wasm_mod, env, arr_imm);
   switch (op) {
   | MArrayGet(idx_imm) =>
@@ -1396,6 +1404,10 @@ let compile_array_op = (wasm_mod, env, arr_imm, op) => {
 };
 
 let compile_adt_op = (wasm_mod, env, adt_imm, op) => {
+  // We skip the incref here as this is akin to using a swap slot (the
+  // reference we create here cannot escape, so there isn't a need to add an
+  // incref/decref pair). Since it won't live in a local, it wouldn't be
+  // cleaned up automatically anyway.
   let adt = compile_imm(~skip_incref=true, wasm_mod, env, adt_imm);
   switch (op) {
   | MAdtGet(idx) =>
@@ -1411,6 +1423,10 @@ let compile_adt_op = (wasm_mod, env, adt_imm, op) => {
 };
 
 let compile_record_op = (wasm_mod, env, rec_imm, op) => {
+  // We skip the incref here as this is akin to using a swap slot (the
+  // reference we create here cannot escape, so there isn't a need to add an
+  // incref/decref pair). Since it won't live in a local, it wouldn't be
+  // cleaned up automatically anyway.
   let record = () => compile_imm(~skip_incref=true, wasm_mod, env, rec_imm);
   switch (op) {
   | MRecordGet(idx) =>
@@ -2557,6 +2573,10 @@ let rec compile_store = (wasm_mod, env, binds) => {
         switch (instr.instr_desc) {
         // special logic here for letrec
         | MAllocate(MClosure(cdata)) =>
+          // We skip the incref here as this is akin to using a swap slot (the
+          // reference we create here cannot escape, so there isn't a need to add an
+          // incref/decref pair). Since it won't live in a local, it wouldn't be
+          // cleaned up automatically anyway.
           let get_bind =
             compile_bind(
               ~action=BindGet,

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -28,49 +28,6 @@ arrays › array_access
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 5)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (if
        (i32.lt_s
         (i32.const 0)
@@ -80,9 +37,48 @@ arrays › array_access
           (local.tee $2
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 20)
+                     )
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (i32.const 5)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=8
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=12
+                  (local.get $0)
+                  (i32.const 5)
+                 )
+                 (i32.store offset=16
+                  (local.get $0)
+                  (i32.const 7)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
              )
              (i32.const 0)
             )

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -28,49 +28,6 @@ arrays › array_access4
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 5)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (if
        (i32.lt_s
         (local.tee $1
@@ -82,9 +39,48 @@ arrays › array_access4
           (local.tee $2
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 20)
+                     )
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (i32.const 5)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=8
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=12
+                  (local.get $0)
+                  (i32.const 5)
+                 )
+                 (i32.store offset=16
+                  (local.get $0)
+                  (i32.const 7)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
              )
              (i32.const 0)
             )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -28,49 +28,6 @@ arrays › array_access2
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 5)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (if
        (i32.lt_s
         (local.tee $1
@@ -82,9 +39,48 @@ arrays › array_access2
           (local.tee $2
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 20)
+                     )
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (i32.const 5)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=8
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=12
+                  (local.get $0)
+                  (i32.const 5)
+                 )
+                 (i32.store offset=16
+                  (local.get $0)
+                  (i32.const 7)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
              )
              (i32.const 0)
             )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -28,49 +28,6 @@ arrays › array_access3
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 5)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (if
        (i32.lt_s
         (local.tee $1
@@ -82,9 +39,48 @@ arrays › array_access3
           (local.tee $2
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 20)
+                     )
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (i32.const 5)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=8
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=12
+                  (local.get $0)
+                  (i32.const 5)
+                 )
+                 (i32.store offset=16
+                  (local.get $0)
+                  (i32.const 7)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
              )
              (i32.const 0)
             )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -28,49 +28,6 @@ arrays › array_access5
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 5)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (if
        (i32.lt_s
         (local.tee $1
@@ -82,9 +39,48 @@ arrays › array_access5
           (local.tee $2
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+             (local.tee $3
+              (tuple.extract 0
+               (tuple.make
+                (block (result i32)
+                 (i32.store
+                  (local.tee $0
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                      (i32.const 20)
+                     )
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                  (i32.const 5)
+                 )
+                 (i32.store offset=4
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=8
+                  (local.get $0)
+                  (i32.const 3)
+                 )
+                 (i32.store offset=12
+                  (local.get $0)
+                  (i32.const 5)
+                 )
+                 (i32.store offset=16
+                  (local.get $0)
+                  (i32.const 7)
+                 )
+                 (local.get $0)
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (i32.const 0)
+                )
+               )
+              )
              )
              (i32.const 0)
             )

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -110,11 +110,11 @@ basic functionality › func_shadow
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -153,24 +153,13 @@ basic functionality › func_shadow
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $2)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (local.set $4
+      (local.set $3
        (tuple.extract 0
         (tuple.make
          (call $foo_1155
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $2)
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -191,13 +180,18 @@ basic functionality › func_shadow
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (global.get $import_pervasives_1164_print_1165)
             )
-            (local.get $0)
+            (tuple.extract 0
+             (tuple.make
+              (local.get $1)
+              (local.get $0)
+             )
+            )
            )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $4)
+          (local.get $3)
          )
          (i32.load offset=8
           (local.get $0)
@@ -205,7 +199,7 @@ basic functionality › func_shadow
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -247,24 +241,13 @@ basic functionality › func_shadow
         )
        )
       )
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $3)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (local.set $0
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (call $foo_1157
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -275,28 +258,45 @@ basic functionality › func_shadow
        )
       )
       (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $1
+       (local.tee $0
         (tuple.extract 0
          (tuple.make
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (global.get $import_pervasives_1164_print_1165)
           )
-          (local.get $1)
+          (tuple.extract 0
+           (tuple.make
+            (local.get $2)
+            (local.get $0)
+           )
+          )
          )
         )
        )
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $0)
+        (local.get $4)
        )
        (i32.load offset=8
-        (local.get $1)
+        (local.get $0)
        )
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $3)
    )
   )
   (drop
@@ -314,22 +314,10 @@ basic functionality › func_shadow
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (i32.const 0)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -74,17 +74,6 @@ basic functionality › block_no_expression
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $f_1155
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -92,7 +81,12 @@ basic functionality › block_no_expression
        )
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -445,52 +445,48 @@ basic functionality › pattern_match_unsafe_wasm
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 1)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 1)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -204,11 +204,11 @@ basic functionality › func_shadow_and_indirect_call
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -247,24 +247,13 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $2)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (call $foo_1155
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $2)
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -285,13 +274,18 @@ basic functionality › func_shadow_and_indirect_call
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (global.get $import_pervasives_1169_print_1170)
             )
-            (local.get $0)
+            (tuple.extract 0
+             (tuple.make
+              (local.get $1)
+              (local.get $0)
+             )
+            )
            )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
+          (local.get $4)
          )
          (i32.load offset=8
           (local.get $0)
@@ -299,7 +293,7 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -341,24 +335,13 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $3)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (local.set $6
+      (local.set $5
        (tuple.extract 0
         (tuple.make
          (call $foo_1157
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -379,13 +362,18 @@ basic functionality › func_shadow_and_indirect_call
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (global.get $import_pervasives_1169_print_1170)
             )
-            (local.get $0)
+            (tuple.extract 0
+             (tuple.make
+              (local.get $2)
+              (local.get $0)
+             )
+            )
            )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $6)
+          (local.get $5)
          )
          (i32.load offset=8
           (local.get $0)
@@ -393,7 +381,7 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $4
+      (local.set $3
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -435,24 +423,13 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $4)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (local.set $0
+      (local.set $6
        (tuple.extract 0
         (tuple.make
          (call $foo_1159
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $4)
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -466,19 +443,24 @@ basic functionality › func_shadow_and_indirect_call
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $0)
+              (local.get $6)
              )
-             (local.get $1)
+             (tuple.extract 0
+              (tuple.make
+               (local.get $3)
+               (local.get $0)
+              )
+             )
             )
            )
           )
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -489,14 +471,14 @@ basic functionality › func_shadow_and_indirect_call
        )
       )
       (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $1
+       (local.tee $0
         (tuple.extract 0
          (tuple.make
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (global.get $import_pervasives_1169_print_1170)
           )
-          (local.get $1)
+          (local.get $0)
          )
         )
        )
@@ -505,12 +487,24 @@ basic functionality › func_shadow_and_indirect_call
         (local.get $7)
        )
        (i32.load offset=8
-        (local.get $1)
+        (local.get $0)
        )
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $4)
    )
   )
   (drop
@@ -540,18 +534,6 @@ basic functionality › func_shadow_and_indirect_call
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $7)
    )
   )
@@ -561,7 +543,7 @@ basic functionality › func_shadow_and_indirect_call
     (i32.const 0)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -117,10 +117,7 @@ boxes › box_subtraction1
        )
       )
       (i32.store offset=8
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $1)
-       )
+       (local.get $1)
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -130,10 +127,7 @@ boxes › box_subtraction1
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
         )

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -122,10 +122,7 @@ boxes › box_multiplication2
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -135,10 +132,7 @@ boxes › box_multiplication2
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -122,10 +122,7 @@ boxes › box_division2
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -135,10 +132,7 @@ boxes › box_division2
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -122,10 +122,7 @@ boxes › box_addition2
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -135,10 +132,7 @@ boxes › box_addition2
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -117,10 +117,7 @@ boxes › box_division1
        )
       )
       (i32.store offset=8
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $1)
-       )
+       (local.get $1)
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -130,10 +127,7 @@ boxes › box_division1
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
         )

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -122,10 +122,7 @@ boxes › box_subtraction2
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -135,10 +132,7 @@ boxes › box_subtraction2
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -117,10 +117,7 @@ boxes › box_addition1
        )
       )
       (i32.store offset=8
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $1)
-       )
+       (local.get $1)
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -130,10 +127,7 @@ boxes › box_addition1
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
         )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -117,10 +117,7 @@ boxes › box_multiplication1
        )
       )
       (i32.store offset=8
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $1)
-       )
+       (local.get $1)
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -130,10 +127,7 @@ boxes › box_multiplication1
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
         )

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -23,37 +23,33 @@ boxes › test_set_extra1
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1160_box_1161)
+      (i32.store offset=8
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call_indirect (type $i32_i32_=>_i32)
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (global.get $import_pervasives_1160_box_1161)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 3)
+           (i32.load offset=8
+            (local.get $0)
+           )
           )
-          (i32.const 3)
-          (i32.load offset=8
-           (local.get $0)
+          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+           (i32.const 0)
           )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
          )
         )
-       )
-      )
-      (i32.store offset=8
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $1)
        )
        (tuple.extract 0
         (tuple.make
@@ -61,10 +57,7 @@ boxes › test_set_extra1
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
         )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -216,10 +216,7 @@ enums › adt_trailing
      (local.set $0
       (tuple.extract 0
        (tuple.make
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (global.get $global_0)
-        )
+        (global.get $global_0)
         (local.get $0)
        )
       )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -387,10 +387,7 @@ enums › enum_recursive_data_definition
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $global_1)
-         )
+         (global.get $global_1)
          (local.get $0)
         )
        )
@@ -486,10 +483,7 @@ enums › enum_recursive_data_definition
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $global_3)
-         )
+         (global.get $global_3)
          (local.get $0)
         )
        )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -226,10 +226,7 @@ exceptions › exception_4
      (local.set $0
       (tuple.extract 0
        (tuple.make
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (global.get $global_0)
-        )
+        (global.get $global_0)
         (local.get $0)
        )
       )

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -9,10 +9,8 @@ exports › let_rec_export
  (elem $elem (global.get $import__grainEnv_0_relocBase_0) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_0 (mut i32) (i32.const 0))
  (global $global_2 i32 (i32.const 1))
@@ -79,10 +77,7 @@ exports › let_rec_export
     )
     (tuple.extract 0
      (tuple.make
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $global_0)
-      )
+      (global.get $global_0)
       (local.get $0)
      )
     )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -74,17 +74,6 @@ functions › dup_func
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $foo_1159
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -92,7 +81,12 @@ functions › dup_func
        )
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -85,52 +85,48 @@ functions › shorthand_4
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -91,17 +91,6 @@ functions › shorthand_1
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $foo_1155
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -110,7 +99,12 @@ functions › shorthand_1
        (i32.const 3)
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -40,10 +40,7 @@ functions › lam_destructure_5
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -59,10 +56,7 @@ functions › lam_destructure_5
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -78,10 +72,7 @@ functions › lam_destructure_5
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -97,10 +88,7 @@ functions › lam_destructure_5
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -116,10 +104,7 @@ functions › lam_destructure_5
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -357,52 +342,48 @@ functions › lam_destructure_5
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 3)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -80,17 +80,6 @@ functions › lambda_pat_any
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
@@ -103,7 +92,12 @@ functions › lambda_pat_any
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
                (i32.const 16)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -162,52 +162,48 @@ functions › curried_func
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $1
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $2)
+          (local.tee $2
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -91,17 +91,6 @@ functions › app_1
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $lam_lambda_1158
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -110,7 +99,12 @@ functions › app_1
        (i32.const 3)
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -91,17 +91,6 @@ functions › shorthand_3
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $foo_1155
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -110,7 +99,12 @@ functions › shorthand_3
        (i32.const 3)
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -36,10 +36,7 @@ functions › lam_destructure_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -55,10 +52,7 @@ functions › lam_destructure_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -74,10 +68,7 @@ functions › lam_destructure_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -212,52 +203,48 @@ functions › lam_destructure_3
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -39,10 +39,7 @@ functions › lam_destructure_7
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -58,10 +55,7 @@ functions › lam_destructure_7
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -77,10 +71,7 @@ functions › lam_destructure_7
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -96,10 +87,7 @@ functions › lam_destructure_7
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -115,10 +103,7 @@ functions › lam_destructure_7
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -308,52 +293,48 @@ functions › lam_destructure_7
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -85,52 +85,48 @@ functions › shorthand_2
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -36,10 +36,7 @@ functions › lam_destructure_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -55,10 +52,7 @@ functions › lam_destructure_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -74,10 +68,7 @@ functions › lam_destructure_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -212,52 +203,48 @@ functions › lam_destructure_4
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -39,10 +39,7 @@ functions › lam_destructure_8
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -58,10 +55,7 @@ functions › lam_destructure_8
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -77,10 +71,7 @@ functions › lam_destructure_8
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -96,10 +87,7 @@ functions › lam_destructure_8
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -115,10 +103,7 @@ functions › lam_destructure_8
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -308,52 +293,48 @@ functions › lam_destructure_8
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -80,17 +80,6 @@ functions › lam_destructure_1
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
@@ -103,7 +92,12 @@ functions › lam_destructure_1
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
                (i32.const 16)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -80,17 +80,6 @@ functions › lam_destructure_2
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
@@ -103,7 +92,12 @@ functions › lam_destructure_2
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
                (i32.const 16)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -156,17 +156,6 @@ functions › func_record_associativity2
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
@@ -179,7 +168,12 @@ functions › func_record_associativity2
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
                (i32.const 20)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )
@@ -271,10 +265,7 @@ functions › func_record_associativity2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -290,10 +281,7 @@ functions › func_record_associativity2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $4)
-           )
+           (local.get $4)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -94,52 +94,48 @@ functions › fn_trailing_comma
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 3)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -40,10 +40,7 @@ functions › lam_destructure_6
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -59,10 +56,7 @@ functions › lam_destructure_6
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -78,10 +72,7 @@ functions › lam_destructure_6
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -97,10 +88,7 @@ functions › lam_destructure_6
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -116,10 +104,7 @@ functions › lam_destructure_6
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -357,52 +342,48 @@ functions › lam_destructure_6
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-               (i32.const 20)
-              )
-              (i32.const 0)
-             )
-            )
-           )
-           (i32.const 7)
-          )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $import__grainEnv_0_relocBase_0)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 1)
-          )
-          (local.get $0)
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (i32.store offset=16
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $1)
+          (local.tee $1
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $0
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $0)
+               (i32.const 3)
+              )
+              (i32.store offset=8
+               (local.get $0)
+               (global.get $import__grainEnv_0_relocBase_0)
+              )
+              (i32.store offset=12
+               (local.get $0)
+               (i32.const 1)
+              )
+              (local.get $0)
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
           (local.get $0)
          )

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -142,17 +142,6 @@ functions › func_record_associativity1
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
@@ -165,7 +154,12 @@ functions › func_record_associativity1
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
                (i32.const 20)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )
@@ -208,10 +202,7 @@ functions › func_record_associativity1
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -220,10 +220,7 @@ loops › loop2
              (tuple.make
               (block (result i32)
                (i32.store offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $2)
-                )
+                (local.get $2)
                 (tuple.extract 0
                  (tuple.make
                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -233,10 +230,7 @@ loops › loop2
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                    (i32.load offset=8
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
+                    (local.get $2)
                    )
                   )
                  )
@@ -313,10 +307,7 @@ loops › loop2
             )
            )
            (i32.store offset=8
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
-            )
+            (local.get $3)
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -326,10 +317,7 @@ loops › loop2
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
              )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -98,17 +98,6 @@ optimizations › trs1
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $1)
-         )
-         (local.get $0)
-        )
-       )
-      )
       (call $f1_1155
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -118,7 +107,12 @@ optimizations › trs1
        (i32.const 5)
       )
      )
-     (local.get $0)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $1)
+       (local.get $0)
+      )
+     )
     )
    )
   )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -90,20 +90,14 @@ optimizations › test_dead_branch_elimination_5
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
            (tuple.extract 0
             (tuple.make
              (i32.const 7)
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $2)
-               )
+               (local.get $2)
               )
              )
             )
@@ -123,20 +117,14 @@ optimizations › test_dead_branch_elimination_5
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (i32.const 9)
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=8
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -169,10 +169,7 @@ pattern matching › record_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -188,10 +185,7 @@ pattern matching › record_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -97,7 +97,7 @@ pattern matching › adt_match_deep
        (i32.const 1032)
        (local.get $0)
       )
-      (local.set $4
+      (local.set $3
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -146,44 +146,40 @@ pattern matching › adt_match_deep
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $2
+         (i32.load offset=12
+          (local.tee $4
            (tuple.extract 0
             (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1176_[...]_1177)
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $2
+               (tuple.extract 0
+                (tuple.make
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_pervasives_1176_[...]_1177)
+                 )
+                 (local.get $0)
+                )
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $3)
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (global.get $import_pervasives_1174_[]_1175)
+              )
+              (i32.load offset=8
+               (local.get $2)
+              )
              )
-             (local.get $0)
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
             )
            )
-          )
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $4)
-          )
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (global.get $import_pervasives_1174_[]_1175)
-          )
-          (i32.load offset=8
-           (local.get $2)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $0)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -201,7 +197,7 @@ pattern matching › adt_match_deep
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
+             (local.get $0)
             )
             (i32.const 3)
            )
@@ -237,7 +233,7 @@ pattern matching › adt_match_deep
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $3)
+                  (local.get $0)
                  )
                  (i32.const 1)
                 )
@@ -300,10 +296,7 @@ pattern matching › adt_match_deep
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $0)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -317,10 +310,7 @@ pattern matching › adt_match_deep
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=16
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $6)
-            )
+            (local.get $6)
            )
           )
          )
@@ -336,6 +326,12 @@ pattern matching › adt_match_deep
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $4)
    )
   )
@@ -343,12 +339,6 @@ pattern matching › adt_match_deep
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -42,7 +42,7 @@ pattern matching › tuple_match_deep4
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $13
+      (local.set $12
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -73,7 +73,7 @@ pattern matching › tuple_match_deep4
         )
        )
       )
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -103,7 +103,7 @@ pattern matching › tuple_match_deep4
            (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $13)
+            (local.get $12)
            )
           )
           (local.get $0)
@@ -118,29 +118,22 @@ pattern matching › tuple_match_deep4
       (local.set $11
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $12
-       (tuple.extract 0
-        (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
+          (local.tee $13
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (i32.load offset=12
+               (local.get $4)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -158,7 +151,7 @@ pattern matching › tuple_match_deep4
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $12)
+             (local.get $11)
             )
             (i32.const 3)
            )
@@ -173,7 +166,7 @@ pattern matching › tuple_match_deep4
         )
        )
       )
-      (local.set $7
+      (local.set $8
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -185,32 +178,25 @@ pattern matching › tuple_match_deep4
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $7
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $11)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
            (local.set $1
             (tuple.extract 0
              (tuple.make
               (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $7)
+               (local.tee $8
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $13)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
+                )
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -252,15 +238,24 @@ pattern matching › tuple_match_deep4
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $2
+             (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $7)
+                (i32.load offset=12
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $8)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
                   )
                  )
                 )
@@ -271,23 +266,7 @@ pattern matching › tuple_match_deep4
                )
               )
              )
-             (local.set $6
-              (tuple.extract 0
-               (tuple.make
-                (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $8
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -295,7 +274,7 @@ pattern matching › tuple_match_deep4
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -314,37 +293,30 @@ pattern matching › tuple_match_deep4
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $9
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $4)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -390,7 +362,7 @@ pattern matching › tuple_match_deep4
                )
               )
               (block (result i32)
-               (local.set $4
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -398,7 +370,7 @@ pattern matching › tuple_match_deep4
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -419,7 +391,7 @@ pattern matching › tuple_match_deep4
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -466,7 +438,7 @@ pattern matching › tuple_match_deep4
            )
           )
           (block (result i32)
-           (local.set $7
+           (local.set $8
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -474,7 +446,7 @@ pattern matching › tuple_match_deep4
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $12)
+                  (local.get $11)
                  )
                  (i32.const 1)
                 )
@@ -493,7 +465,7 @@ pattern matching › tuple_match_deep4
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
+              (local.get $8)
              )
              (i32.const 31)
             )
@@ -504,7 +476,7 @@ pattern matching › tuple_match_deep4
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $7)
+          (local.get $8)
          )
         )
        )
@@ -527,7 +499,7 @@ pattern matching › tuple_match_deep4
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $8)
                      )
                      (i32.const 1)
                     )
@@ -548,10 +520,7 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -567,10 +536,7 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -586,15 +552,44 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
                 )
                )
               )
@@ -605,53 +600,12 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $6)
-                )
-               )
-              )
-             )
-             (local.set $8
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $8)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
                 )
                )
               )
@@ -662,10 +616,7 @@ pattern matching › tuple_match_deep4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -696,7 +647,7 @@ pattern matching › tuple_match_deep4
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -730,7 +681,7 @@ pattern matching › tuple_match_deep4
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $8)
+                  (local.get $7)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -762,7 +713,7 @@ pattern matching › tuple_match_deep4
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -777,10 +728,7 @@ pattern matching › tuple_match_deep4
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -796,10 +744,7 @@ pattern matching › tuple_match_deep4
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -815,10 +760,7 @@ pattern matching › tuple_match_deep4
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -828,45 +770,39 @@ pattern matching › tuple_match_deep4
              )
             )
            )
-           (local.set $6
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $6)
+               (local.get $5)
               )
              )
             )
            )
-           (local.set $8
+           (local.set $7
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $8)
+               (local.get $7)
               )
              )
             )
            )
-           (local.set $4
+           (local.set $6
             (tuple.extract 0
              (tuple.make
               (call_indirect (type $i32_i32_i32_=>_i32)
@@ -883,11 +819,11 @@ pattern matching › tuple_match_deep4
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -895,7 +831,7 @@ pattern matching › tuple_match_deep4
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
+               (local.get $6)
               )
              )
             )
@@ -915,7 +851,7 @@ pattern matching › tuple_match_deep4
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $6)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -934,10 +870,7 @@ pattern matching › tuple_match_deep4
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=12
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -953,10 +886,7 @@ pattern matching › tuple_match_deep4
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
+              (local.get $1)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -972,10 +902,7 @@ pattern matching › tuple_match_deep4
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=8
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1016,10 +943,7 @@ pattern matching › tuple_match_deep4
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
+         (local.get $4)
         )
        )
       )
@@ -1031,13 +955,19 @@ pattern matching › tuple_match_deep4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $13)
+    (local.get $12)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $13)
    )
   )
   (drop
@@ -1049,19 +979,13 @@ pattern matching › tuple_match_deep4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $12)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $14)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $8)
    )
   )
   (drop
@@ -1085,19 +1009,19 @@ pattern matching › tuple_match_deep4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -101,44 +101,40 @@ pattern matching › adt_match_4
         )
        )
       )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1218_[...]_1219)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (i32.const 9)
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
-          )
-          (i32.load offset=8
-           (local.get $0)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (local.set $9
        (tuple.extract 0
         (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+          (local.tee $4
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (tuple.extract 0
+                (tuple.make
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_pervasives_1218_[...]_1219)
+                 )
+                 (local.get $0)
+                )
+               )
+              )
+              (i32.const 9)
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $11)
+              )
+              (i32.load offset=8
+               (local.get $0)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -171,7 +167,7 @@ pattern matching › adt_match_4
         )
        )
       )
-      (local.set $4
+      (local.set $5
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -183,15 +179,24 @@ pattern matching › adt_match_4
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $4
+           (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
+              (i32.load offset=12
+               (local.tee $5
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $4)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
                 )
                )
               )
@@ -202,23 +207,7 @@ pattern matching › adt_match_4
              )
             )
            )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $4)
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (local.set $5
+           (local.set $3
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -226,7 +215,7 @@ pattern matching › adt_match_4
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
+                  (local.get $1)
                  )
                  (i32.const 3)
                 )
@@ -245,37 +234,30 @@ pattern matching › adt_match_4
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $1
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $7
+             (local.set $6
               (tuple.extract 0
                (tuple.make
                 (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $5)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -293,7 +275,7 @@ pattern matching › adt_match_4
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $7)
+                    (local.get $6)
                    )
                    (i32.const 3)
                   )
@@ -317,32 +299,25 @@ pattern matching › adt_match_4
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $1)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $13
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                   (local.tee $7
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -388,7 +363,7 @@ pattern matching › adt_match_4
                )
               )
               (block (result i32)
-               (local.set $6
+               (local.set $7
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -396,7 +371,7 @@ pattern matching › adt_match_4
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $6)
                      )
                      (i32.const 1)
                     )
@@ -417,7 +392,7 @@ pattern matching › adt_match_4
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $6)
+                  (local.get $7)
                  )
                  (i32.const 31)
                 )
@@ -426,7 +401,7 @@ pattern matching › adt_match_4
              )
             )
             (block (result i32)
-             (local.set $1
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -434,7 +409,7 @@ pattern matching › adt_match_4
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $2)
+                    (local.get $1)
                    )
                    (i32.const 1)
                   )
@@ -455,7 +430,7 @@ pattern matching › adt_match_4
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.const 31)
               )
@@ -464,7 +439,7 @@ pattern matching › adt_match_4
            )
           )
           (block (result i32)
-           (local.set $4
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -491,7 +466,7 @@ pattern matching › adt_match_4
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $5)
              )
              (i32.const 31)
             )
@@ -502,7 +477,7 @@ pattern matching › adt_match_4
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $4)
+          (local.get $5)
          )
         )
        )
@@ -525,7 +500,7 @@ pattern matching › adt_match_4
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $4)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -540,54 +515,13 @@ pattern matching › adt_match_4
                )
               )
              )
-             (local.set $2
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $2)
-                )
-               )
-              )
-             )
-             (local.set $5
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $5)
-                )
-               )
-              )
-             )
              (local.set $1
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                 (i32.load offset=24
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -597,21 +531,50 @@ pattern matching › adt_match_4
                )
               )
              )
-             (local.set $7
+             (local.set $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=24
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $7)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
                 )
                )
               )
@@ -622,10 +585,7 @@ pattern matching › adt_match_4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -635,7 +595,7 @@ pattern matching › adt_match_4
                )
               )
              )
-             (local.set $6
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (call_indirect (type $i32_i32_i32_=>_i32)
@@ -656,7 +616,7 @@ pattern matching › adt_match_4
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $7)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -664,7 +624,7 @@ pattern matching › adt_match_4
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $6)
+                 (local.get $7)
                 )
                )
               )
@@ -684,53 +644,15 @@ pattern matching › adt_match_4
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.load offset=8
                 (local.get $0)
                )
-              )
-             )
-            )
-           )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $2)
-              )
-             )
-            )
-           )
-           (local.set $5
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $2)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $5)
               )
              )
             )
@@ -740,16 +662,45 @@ pattern matching › adt_match_4
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+               (i32.load offset=24
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (local.get $1)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $1)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $2
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $4)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $2)
               )
              )
             )
@@ -769,11 +720,11 @@ pattern matching › adt_match_4
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
+              (local.get $2)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.load offset=8
               (local.get $0)
@@ -786,10 +737,7 @@ pattern matching › adt_match_4
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=20
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
-            )
+            (local.get $4)
            )
           )
          )
@@ -817,7 +765,7 @@ pattern matching › adt_match_4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
+    (local.get $4)
    )
   )
   (drop
@@ -835,18 +783,6 @@ pattern matching › adt_match_4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $5)
    )
   )
@@ -859,7 +795,19 @@ pattern matching › adt_match_4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $6)
    )
   )
   (drop
@@ -871,7 +819,7 @@ pattern matching › adt_match_4
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $6)
+    (local.get $7)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -200,10 +200,7 @@ pattern matching › record_match_2
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=20
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $2)
-        )
+        (local.get $2)
        )
       )
      )

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -78,10 +78,7 @@ pattern matching › guarded_match_2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -125,10 +125,7 @@ pattern matching › tuple_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -144,10 +141,7 @@ pattern matching › tuple_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -163,10 +157,7 @@ pattern matching › tuple_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -182,10 +173,7 @@ pattern matching › tuple_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -201,10 +189,7 @@ pattern matching › tuple_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -200,10 +200,7 @@ pattern matching › record_match_1
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $2)
-        )
+        (local.get $2)
        )
       )
      )

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -127,10 +127,7 @@ pattern matching › constant_match_2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -146,10 +143,7 @@ pattern matching › constant_match_2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -165,10 +159,7 @@ pattern matching › constant_match_2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -330,10 +321,7 @@ pattern matching › constant_match_2
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=16
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -349,10 +337,7 @@ pattern matching › constant_match_2
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -475,10 +460,7 @@ pattern matching › constant_match_2
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=16
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -494,10 +476,7 @@ pattern matching › constant_match_2
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -171,10 +171,7 @@ pattern matching › record_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=24
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -190,10 +187,7 @@ pattern matching › record_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -209,10 +203,7 @@ pattern matching › record_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -44,7 +44,7 @@ pattern matching › tuple_match_deep6
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $13
+      (local.set $12
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -75,7 +75,7 @@ pattern matching › tuple_match_deep6
         )
        )
       )
-      (local.set $14
+      (local.set $13
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -93,7 +93,7 @@ pattern matching › tuple_match_deep6
           (i32.const 11)
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $13)
+           (local.get $12)
           )
           (i32.load offset=8
            (local.get $0)
@@ -106,7 +106,7 @@ pattern matching › tuple_match_deep6
         )
        )
       )
-      (local.set $15
+      (local.set $14
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -124,7 +124,7 @@ pattern matching › tuple_match_deep6
           (i32.const 9)
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $14)
+           (local.get $13)
           )
           (i32.load offset=8
            (local.get $0)
@@ -137,7 +137,7 @@ pattern matching › tuple_match_deep6
         )
        )
       )
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -167,7 +167,7 @@ pattern matching › tuple_match_deep6
            (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $15)
+            (local.get $14)
            )
           )
           (local.get $0)
@@ -182,29 +182,22 @@ pattern matching › tuple_match_deep6
       (local.set $11
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $12
-       (tuple.extract 0
-        (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
+          (local.tee $15
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (i32.load offset=12
+               (local.get $4)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -222,7 +215,7 @@ pattern matching › tuple_match_deep6
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $12)
+             (local.get $11)
             )
             (i32.const 3)
            )
@@ -237,7 +230,7 @@ pattern matching › tuple_match_deep6
         )
        )
       )
-      (local.set $7
+      (local.set $8
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -249,32 +242,25 @@ pattern matching › tuple_match_deep6
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $7
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $11)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
            (local.set $1
             (tuple.extract 0
              (tuple.make
               (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $7)
+               (local.tee $8
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $15)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
+                )
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -316,15 +302,24 @@ pattern matching › tuple_match_deep6
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $2
+             (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $7)
+                (i32.load offset=12
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $8)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
                   )
                  )
                 )
@@ -335,23 +330,7 @@ pattern matching › tuple_match_deep6
                )
               )
              )
-             (local.set $6
-              (tuple.extract 0
-               (tuple.make
-                (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $8
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -359,7 +338,7 @@ pattern matching › tuple_match_deep6
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -378,37 +357,30 @@ pattern matching › tuple_match_deep6
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $9
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $4)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -454,7 +426,7 @@ pattern matching › tuple_match_deep6
                )
               )
               (block (result i32)
-               (local.set $4
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -462,7 +434,7 @@ pattern matching › tuple_match_deep6
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -483,7 +455,7 @@ pattern matching › tuple_match_deep6
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -530,7 +502,7 @@ pattern matching › tuple_match_deep6
            )
           )
           (block (result i32)
-           (local.set $7
+           (local.set $8
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -538,7 +510,7 @@ pattern matching › tuple_match_deep6
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $12)
+                  (local.get $11)
                  )
                  (i32.const 1)
                 )
@@ -557,7 +529,7 @@ pattern matching › tuple_match_deep6
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
+              (local.get $8)
              )
              (i32.const 31)
             )
@@ -568,7 +540,7 @@ pattern matching › tuple_match_deep6
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $7)
+          (local.get $8)
          )
         )
        )
@@ -591,7 +563,7 @@ pattern matching › tuple_match_deep6
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $8)
                      )
                      (i32.const 1)
                     )
@@ -612,10 +584,7 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -631,10 +600,7 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -650,15 +616,44 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
                 )
                )
               )
@@ -669,53 +664,12 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $6)
-                )
-               )
-              )
-             )
-             (local.set $8
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $8)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
                 )
                )
               )
@@ -726,10 +680,7 @@ pattern matching › tuple_match_deep6
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -760,7 +711,7 @@ pattern matching › tuple_match_deep6
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -794,7 +745,7 @@ pattern matching › tuple_match_deep6
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $8)
+                  (local.get $7)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -826,7 +777,7 @@ pattern matching › tuple_match_deep6
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -841,10 +792,7 @@ pattern matching › tuple_match_deep6
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -860,10 +808,7 @@ pattern matching › tuple_match_deep6
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -879,10 +824,7 @@ pattern matching › tuple_match_deep6
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -892,45 +834,39 @@ pattern matching › tuple_match_deep6
              )
             )
            )
-           (local.set $6
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $6)
+               (local.get $5)
               )
              )
             )
            )
-           (local.set $8
+           (local.set $7
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $8)
+               (local.get $7)
               )
              )
             )
            )
-           (local.set $4
+           (local.set $6
             (tuple.extract 0
              (tuple.make
               (call_indirect (type $i32_i32_i32_=>_i32)
@@ -947,11 +883,11 @@ pattern matching › tuple_match_deep6
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -959,7 +895,7 @@ pattern matching › tuple_match_deep6
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
+               (local.get $6)
               )
              )
             )
@@ -979,7 +915,7 @@ pattern matching › tuple_match_deep6
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $6)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -998,10 +934,7 @@ pattern matching › tuple_match_deep6
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=12
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1017,10 +950,7 @@ pattern matching › tuple_match_deep6
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
+              (local.get $1)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1036,10 +966,7 @@ pattern matching › tuple_match_deep6
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=8
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1080,16 +1007,19 @@ pattern matching › tuple_match_deep6
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
+         (local.get $4)
         )
        )
       )
      )
      (local.get $0)
     )
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $12)
    )
   )
   (drop
@@ -1107,13 +1037,13 @@ pattern matching › tuple_match_deep6
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $15)
+    (local.get $4)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
+    (local.get $15)
    )
   )
   (drop
@@ -1125,19 +1055,13 @@ pattern matching › tuple_match_deep6
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $12)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $16)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $8)
    )
   )
   (drop
@@ -1161,19 +1085,19 @@ pattern matching › tuple_match_deep6
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -114,10 +114,7 @@ pattern matching › tuple_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -133,10 +130,7 @@ pattern matching › tuple_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -152,10 +146,7 @@ pattern matching › tuple_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -40,7 +40,7 @@ pattern matching › tuple_match_deep3
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -85,29 +85,22 @@ pattern matching › tuple_match_deep3
       (local.set $11
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $12
-       (tuple.extract 0
-        (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
+          (local.tee $12
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (i32.load offset=12
+               (local.get $4)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -125,7 +118,7 @@ pattern matching › tuple_match_deep3
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $12)
+             (local.get $11)
             )
             (i32.const 3)
            )
@@ -140,7 +133,7 @@ pattern matching › tuple_match_deep3
         )
        )
       )
-      (local.set $7
+      (local.set $8
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -152,32 +145,25 @@ pattern matching › tuple_match_deep3
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $7
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $11)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
            (local.set $1
             (tuple.extract 0
              (tuple.make
               (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $7)
+               (local.tee $8
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $12)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
+                )
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -219,15 +205,24 @@ pattern matching › tuple_match_deep3
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $2
+             (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $7)
+                (i32.load offset=12
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $8)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
                   )
                  )
                 )
@@ -238,23 +233,7 @@ pattern matching › tuple_match_deep3
                )
               )
              )
-             (local.set $6
-              (tuple.extract 0
-               (tuple.make
-                (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $8
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -262,7 +241,7 @@ pattern matching › tuple_match_deep3
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -281,37 +260,30 @@ pattern matching › tuple_match_deep3
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $9
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $4)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -357,7 +329,7 @@ pattern matching › tuple_match_deep3
                )
               )
               (block (result i32)
-               (local.set $4
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -365,7 +337,7 @@ pattern matching › tuple_match_deep3
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -386,7 +358,7 @@ pattern matching › tuple_match_deep3
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -433,7 +405,7 @@ pattern matching › tuple_match_deep3
            )
           )
           (block (result i32)
-           (local.set $7
+           (local.set $8
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -441,7 +413,7 @@ pattern matching › tuple_match_deep3
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $12)
+                  (local.get $11)
                  )
                  (i32.const 1)
                 )
@@ -460,7 +432,7 @@ pattern matching › tuple_match_deep3
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
+              (local.get $8)
              )
              (i32.const 31)
             )
@@ -471,7 +443,7 @@ pattern matching › tuple_match_deep3
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $7)
+          (local.get $8)
          )
         )
        )
@@ -494,7 +466,7 @@ pattern matching › tuple_match_deep3
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $8)
                      )
                      (i32.const 1)
                     )
@@ -515,10 +487,7 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -534,10 +503,7 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -553,15 +519,44 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
                 )
                )
               )
@@ -572,53 +567,12 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $6)
-                )
-               )
-              )
-             )
-             (local.set $8
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $8)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
                 )
                )
               )
@@ -629,10 +583,7 @@ pattern matching › tuple_match_deep3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -663,7 +614,7 @@ pattern matching › tuple_match_deep3
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -697,7 +648,7 @@ pattern matching › tuple_match_deep3
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $8)
+                  (local.get $7)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -729,7 +680,7 @@ pattern matching › tuple_match_deep3
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -744,10 +695,7 @@ pattern matching › tuple_match_deep3
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -763,10 +711,7 @@ pattern matching › tuple_match_deep3
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -782,10 +727,7 @@ pattern matching › tuple_match_deep3
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -795,45 +737,39 @@ pattern matching › tuple_match_deep3
              )
             )
            )
-           (local.set $6
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $6)
+               (local.get $5)
               )
              )
             )
            )
-           (local.set $8
+           (local.set $7
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $8)
+               (local.get $7)
               )
              )
             )
            )
-           (local.set $4
+           (local.set $6
             (tuple.extract 0
              (tuple.make
               (call_indirect (type $i32_i32_i32_=>_i32)
@@ -850,11 +786,11 @@ pattern matching › tuple_match_deep3
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -862,7 +798,7 @@ pattern matching › tuple_match_deep3
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
+               (local.get $6)
               )
              )
             )
@@ -882,7 +818,7 @@ pattern matching › tuple_match_deep3
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $6)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -901,10 +837,7 @@ pattern matching › tuple_match_deep3
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=12
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -920,10 +853,7 @@ pattern matching › tuple_match_deep3
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
+              (local.get $1)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -939,10 +869,7 @@ pattern matching › tuple_match_deep3
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=8
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -983,10 +910,7 @@ pattern matching › tuple_match_deep3
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
+         (local.get $4)
         )
        )
       )
@@ -998,13 +922,7 @@ pattern matching › tuple_match_deep3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $11)
+    (local.get $4)
    )
   )
   (drop
@@ -1016,13 +934,19 @@ pattern matching › tuple_match_deep3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $13)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $8)
    )
   )
   (drop
@@ -1046,19 +970,19 @@ pattern matching › tuple_match_deep3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -39,10 +39,7 @@ pattern matching › adt_match_1
        (tuple.extract 0
         (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (global.get $import_pervasives_1209_[]_1210)
-          )
+          (global.get $import_pervasives_1209_[]_1210)
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
@@ -74,7 +71,7 @@ pattern matching › adt_match_1
         )
        )
       )
-      (local.set $3
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -86,15 +83,24 @@ pattern matching › adt_match_1
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $3
+           (local.set $0
             (tuple.extract 0
              (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (global.get $import_pervasives_1209_[]_1210)
+              (i32.load offset=12
+               (local.tee $4
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (global.get $import_pervasives_1209_[]_1210)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
                 )
                )
               )
@@ -105,23 +111,7 @@ pattern matching › adt_match_1
              )
             )
            )
-           (local.set $1
-            (tuple.extract 0
-             (tuple.make
-              (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $3)
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (local.set $4
+           (local.set $3
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -129,7 +119,7 @@ pattern matching › adt_match_1
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
+                  (local.get $0)
                  )
                  (i32.const 3)
                 )
@@ -148,37 +138,30 @@ pattern matching › adt_match_1
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $3)
              )
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $0
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $6
+             (local.set $5
               (tuple.extract 0
                (tuple.make
                 (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $0)
+                 (local.tee $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $4)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -196,7 +179,7 @@ pattern matching › adt_match_1
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -220,32 +203,25 @@ pattern matching › adt_match_1
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $5
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $0)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $10
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $5)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $1)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -291,7 +267,7 @@ pattern matching › adt_match_1
                )
               )
               (block (result i32)
-               (local.set $5
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -299,7 +275,7 @@ pattern matching › adt_match_1
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -320,7 +296,7 @@ pattern matching › adt_match_1
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $5)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -329,7 +305,7 @@ pattern matching › adt_match_1
              )
             )
             (block (result i32)
-             (local.set $0
+             (local.set $1
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -337,7 +313,7 @@ pattern matching › adt_match_1
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $1)
+                    (local.get $0)
                    )
                    (i32.const 1)
                   )
@@ -358,7 +334,7 @@ pattern matching › adt_match_1
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $0)
+                (local.get $1)
                )
                (i32.const 31)
               )
@@ -367,7 +343,7 @@ pattern matching › adt_match_1
            )
           )
           (block (result i32)
-           (local.set $3
+           (local.set $4
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -394,7 +370,7 @@ pattern matching › adt_match_1
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $3)
+              (local.get $4)
              )
              (i32.const 31)
             )
@@ -405,7 +381,7 @@ pattern matching › adt_match_1
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $3)
+          (local.get $4)
          )
         )
        )
@@ -428,7 +404,7 @@ pattern matching › adt_match_1
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $3)
+                      (local.get $4)
                      )
                      (i32.const 1)
                     )
@@ -443,54 +419,13 @@ pattern matching › adt_match_1
                )
               )
              )
-             (local.set $1
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (global.get $import_pervasives_1209_[]_1210)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $1)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
-                )
-               )
-              )
-             )
              (local.set $0
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $4)
-                  )
+                 (i32.load offset=24
+                  (global.get $import_pervasives_1209_[]_1210)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -500,21 +435,50 @@ pattern matching › adt_match_1
                )
               )
              )
-             (local.set $6
+             (local.set $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=24
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (local.set $1
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $6)
+                 (local.get $1)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $0)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
                 )
                )
               )
@@ -525,10 +489,7 @@ pattern matching › adt_match_1
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (global.get $import_pervasives_1209_[]_1210)
-                  )
+                  (global.get $import_pervasives_1209_[]_1210)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -538,7 +499,7 @@ pattern matching › adt_match_1
                )
               )
              )
-             (local.set $5
+             (local.set $6
               (tuple.extract 0
                (tuple.make
                 (call_indirect (type $i32_i32_i32_=>_i32)
@@ -559,7 +520,7 @@ pattern matching › adt_match_1
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $6)
+                  (local.get $5)
                  )
                  (i32.load offset=8
                   (local.get $2)
@@ -567,7 +528,7 @@ pattern matching › adt_match_1
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $5)
+                 (local.get $6)
                 )
                )
               )
@@ -587,53 +548,15 @@ pattern matching › adt_match_1
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $5)
+                (local.get $6)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $0)
+                (local.get $1)
                )
                (i32.load offset=8
                 (local.get $2)
                )
-              )
-             )
-            )
-           )
-           (local.set $1
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (global.get $import_pervasives_1209_[]_1210)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $1)
-              )
-             )
-            )
-           )
-           (local.set $4
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
               )
              )
             )
@@ -643,16 +566,45 @@ pattern matching › adt_match_1
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (global.get $import_pervasives_1209_[]_1210)
-                )
+               (i32.load offset=24
+                (global.get $import_pervasives_1209_[]_1210)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (local.get $0)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $0)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $1
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (global.get $import_pervasives_1209_[]_1210)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $1)
               )
              )
             )
@@ -672,11 +624,11 @@ pattern matching › adt_match_1
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $0)
+              (local.get $1)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $3)
              )
              (i32.load offset=8
               (local.get $2)
@@ -689,10 +641,7 @@ pattern matching › adt_match_1
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=20
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1209_[]_1210)
-            )
+            (global.get $import_pervasives_1209_[]_1210)
            )
           )
          )
@@ -720,18 +669,6 @@ pattern matching › adt_match_1
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $4)
    )
   )
@@ -744,7 +681,19 @@ pattern matching › adt_match_1
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $6)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
    )
   )
   (drop
@@ -756,7 +705,7 @@ pattern matching › adt_match_1
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
+    (local.get $6)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -263,10 +263,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -282,10 +279,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -301,10 +295,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $4)
-           )
+           (local.get $4)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -320,10 +311,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -339,10 +327,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
+           (local.get $5)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -358,10 +343,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
+           (local.get $5)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -377,10 +359,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -396,10 +375,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -415,10 +391,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $4)
-           )
+           (local.get $4)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -434,10 +407,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -453,10 +423,7 @@ pattern matching › tuple_match_deep2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -203,10 +203,7 @@ pattern matching › record_match_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -219,10 +216,7 @@ pattern matching › record_match_deep
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $3)
-        )
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -80,10 +80,7 @@ pattern matching › guarded_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -99,10 +96,7 @@ pattern matching › guarded_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -78,10 +78,7 @@ pattern matching › guarded_match_1
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -37,44 +37,40 @@ pattern matching › adt_match_2
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1214_[...]_1215)
-             )
-             (i32.const 0)
-            )
-           )
-          )
-          (i32.const 5)
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (global.get $import_pervasives_1212_[]_1213)
-          )
-          (i32.load offset=8
-           (local.get $0)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (local.set $9
        (tuple.extract 0
         (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+          (local.tee $4
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (tuple.extract 0
+                (tuple.make
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_pervasives_1214_[...]_1215)
+                 )
+                 (i32.const 0)
+                )
+               )
+              )
+              (i32.const 5)
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (global.get $import_pervasives_1212_[]_1213)
+              )
+              (i32.load offset=8
+               (local.get $0)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -107,7 +103,7 @@ pattern matching › adt_match_2
         )
        )
       )
-      (local.set $4
+      (local.set $5
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -119,15 +115,24 @@ pattern matching › adt_match_2
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $4
+           (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
+              (i32.load offset=12
+               (local.tee $5
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $4)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
                 )
                )
               )
@@ -138,23 +143,7 @@ pattern matching › adt_match_2
              )
             )
            )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $4)
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (local.set $5
+           (local.set $3
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -162,7 +151,7 @@ pattern matching › adt_match_2
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
+                  (local.get $1)
                  )
                  (i32.const 3)
                 )
@@ -181,37 +170,30 @@ pattern matching › adt_match_2
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $1
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $7
+             (local.set $6
               (tuple.extract 0
                (tuple.make
                 (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $5)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -229,7 +211,7 @@ pattern matching › adt_match_2
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $7)
+                    (local.get $6)
                    )
                    (i32.const 3)
                   )
@@ -253,32 +235,25 @@ pattern matching › adt_match_2
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $1)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $11
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                   (local.tee $7
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -324,7 +299,7 @@ pattern matching › adt_match_2
                )
               )
               (block (result i32)
-               (local.set $6
+               (local.set $7
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -332,7 +307,7 @@ pattern matching › adt_match_2
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $6)
                      )
                      (i32.const 1)
                     )
@@ -353,7 +328,7 @@ pattern matching › adt_match_2
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $6)
+                  (local.get $7)
                  )
                  (i32.const 31)
                 )
@@ -362,7 +337,7 @@ pattern matching › adt_match_2
              )
             )
             (block (result i32)
-             (local.set $1
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -370,7 +345,7 @@ pattern matching › adt_match_2
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $2)
+                    (local.get $1)
                    )
                    (i32.const 1)
                   )
@@ -391,7 +366,7 @@ pattern matching › adt_match_2
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.const 31)
               )
@@ -400,7 +375,7 @@ pattern matching › adt_match_2
            )
           )
           (block (result i32)
-           (local.set $4
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -427,7 +402,7 @@ pattern matching › adt_match_2
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $5)
              )
              (i32.const 31)
             )
@@ -438,7 +413,7 @@ pattern matching › adt_match_2
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $4)
+          (local.get $5)
          )
         )
        )
@@ -461,7 +436,7 @@ pattern matching › adt_match_2
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $4)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -476,54 +451,13 @@ pattern matching › adt_match_2
                )
               )
              )
-             (local.set $2
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $2)
-                )
-               )
-              )
-             )
-             (local.set $5
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $5)
-                )
-               )
-              )
-             )
              (local.set $1
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                 (i32.load offset=24
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -533,21 +467,50 @@ pattern matching › adt_match_2
                )
               )
              )
-             (local.set $7
+             (local.set $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=24
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $7)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
                 )
                )
               )
@@ -558,10 +521,7 @@ pattern matching › adt_match_2
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -571,7 +531,7 @@ pattern matching › adt_match_2
                )
               )
              )
-             (local.set $6
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (call_indirect (type $i32_i32_i32_=>_i32)
@@ -592,7 +552,7 @@ pattern matching › adt_match_2
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $7)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -600,7 +560,7 @@ pattern matching › adt_match_2
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $6)
+                 (local.get $7)
                 )
                )
               )
@@ -620,53 +580,15 @@ pattern matching › adt_match_2
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.load offset=8
                 (local.get $0)
                )
-              )
-             )
-            )
-           )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $2)
-              )
-             )
-            )
-           )
-           (local.set $5
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $2)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $5)
               )
              )
             )
@@ -676,16 +598,45 @@ pattern matching › adt_match_2
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+               (i32.load offset=24
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (local.get $1)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $1)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $2
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $4)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $2)
               )
              )
             )
@@ -705,11 +656,11 @@ pattern matching › adt_match_2
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
+              (local.get $2)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.load offset=8
               (local.get $0)
@@ -722,10 +673,7 @@ pattern matching › adt_match_2
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=20
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
-            )
+            (local.get $4)
            )
           )
          )
@@ -741,7 +689,7 @@ pattern matching › adt_match_2
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
+    (local.get $4)
    )
   )
   (drop
@@ -759,18 +707,6 @@ pattern matching › adt_match_2
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $5)
    )
   )
@@ -783,7 +719,19 @@ pattern matching › adt_match_2
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $6)
    )
   )
   (drop
@@ -795,7 +743,7 @@ pattern matching › adt_match_2
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $6)
+    (local.get $7)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -80,10 +80,7 @@ pattern matching › guarded_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -99,10 +96,7 @@ pattern matching › guarded_match_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -69,44 +69,40 @@ pattern matching › adt_match_3
         )
        )
       )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1216_[...]_1217)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (i32.const 9)
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $10)
-          )
-          (i32.load offset=8
-           (local.get $0)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (local.set $9
        (tuple.extract 0
         (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+          (local.tee $4
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (tuple.extract 0
+                (tuple.make
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_pervasives_1216_[...]_1217)
+                 )
+                 (local.get $0)
+                )
+               )
+              )
+              (i32.const 9)
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $10)
+              )
+              (i32.load offset=8
+               (local.get $0)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -139,7 +135,7 @@ pattern matching › adt_match_3
         )
        )
       )
-      (local.set $4
+      (local.set $5
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -151,15 +147,24 @@ pattern matching › adt_match_3
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $4
+           (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
+              (i32.load offset=12
+               (local.tee $5
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $4)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
                 )
                )
               )
@@ -170,23 +175,7 @@ pattern matching › adt_match_3
              )
             )
            )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $4)
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (local.set $5
+           (local.set $3
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -194,7 +183,7 @@ pattern matching › adt_match_3
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
+                  (local.get $1)
                  )
                  (i32.const 3)
                 )
@@ -213,37 +202,30 @@ pattern matching › adt_match_3
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $1
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $7
+             (local.set $6
               (tuple.extract 0
                (tuple.make
                 (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $5)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -261,7 +243,7 @@ pattern matching › adt_match_3
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $7)
+                    (local.get $6)
                    )
                    (i32.const 3)
                   )
@@ -285,32 +267,25 @@ pattern matching › adt_match_3
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $1)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $12
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                   (local.tee $7
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -356,7 +331,7 @@ pattern matching › adt_match_3
                )
               )
               (block (result i32)
-               (local.set $6
+               (local.set $7
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -364,7 +339,7 @@ pattern matching › adt_match_3
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $6)
                      )
                      (i32.const 1)
                     )
@@ -385,7 +360,7 @@ pattern matching › adt_match_3
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $6)
+                  (local.get $7)
                  )
                  (i32.const 31)
                 )
@@ -394,7 +369,7 @@ pattern matching › adt_match_3
              )
             )
             (block (result i32)
-             (local.set $1
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -402,7 +377,7 @@ pattern matching › adt_match_3
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $2)
+                    (local.get $1)
                    )
                    (i32.const 1)
                   )
@@ -423,7 +398,7 @@ pattern matching › adt_match_3
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.const 31)
               )
@@ -432,7 +407,7 @@ pattern matching › adt_match_3
            )
           )
           (block (result i32)
-           (local.set $4
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -459,7 +434,7 @@ pattern matching › adt_match_3
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $5)
              )
              (i32.const 31)
             )
@@ -470,7 +445,7 @@ pattern matching › adt_match_3
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $4)
+          (local.get $5)
          )
         )
        )
@@ -493,7 +468,7 @@ pattern matching › adt_match_3
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $4)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -508,54 +483,13 @@ pattern matching › adt_match_3
                )
               )
              )
-             (local.set $2
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $2)
-                )
-               )
-              )
-             )
-             (local.set $5
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $5)
-                )
-               )
-              )
-             )
              (local.set $1
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                 (i32.load offset=24
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -565,21 +499,50 @@ pattern matching › adt_match_3
                )
               )
              )
-             (local.set $7
+             (local.set $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=24
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $7)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
                 )
                )
               )
@@ -590,10 +553,7 @@ pattern matching › adt_match_3
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -603,7 +563,7 @@ pattern matching › adt_match_3
                )
               )
              )
-             (local.set $6
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (call_indirect (type $i32_i32_i32_=>_i32)
@@ -624,7 +584,7 @@ pattern matching › adt_match_3
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $7)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -632,7 +592,7 @@ pattern matching › adt_match_3
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $6)
+                 (local.get $7)
                 )
                )
               )
@@ -652,53 +612,15 @@ pattern matching › adt_match_3
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.load offset=8
                 (local.get $0)
                )
-              )
-             )
-            )
-           )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $2)
-              )
-             )
-            )
-           )
-           (local.set $5
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $2)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $5)
               )
              )
             )
@@ -708,16 +630,45 @@ pattern matching › adt_match_3
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+               (i32.load offset=24
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (local.get $1)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $1)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $2
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $4)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $2)
               )
              )
             )
@@ -737,11 +688,11 @@ pattern matching › adt_match_3
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
+              (local.get $2)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.load offset=8
               (local.get $0)
@@ -754,10 +705,7 @@ pattern matching › adt_match_3
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=20
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
-            )
+            (local.get $4)
            )
           )
          )
@@ -779,7 +727,7 @@ pattern matching › adt_match_3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
+    (local.get $4)
    )
   )
   (drop
@@ -797,18 +745,6 @@ pattern matching › adt_match_3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $5)
    )
   )
@@ -821,7 +757,19 @@ pattern matching › adt_match_3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $6)
    )
   )
   (drop
@@ -833,7 +781,7 @@ pattern matching › adt_match_3
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $6)
+    (local.get $7)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -133,44 +133,40 @@ pattern matching › adt_match_5
         )
        )
       )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1220_[...]_1221)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (i32.const 9)
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $12)
-          )
-          (i32.load offset=8
-           (local.get $0)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
       (local.set $9
        (tuple.extract 0
         (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $3)
+          (local.tee $4
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (tuple.extract 0
+                (tuple.make
+                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                  (global.get $import_pervasives_1220_[...]_1221)
+                 )
+                 (local.get $0)
+                )
+               )
+              )
+              (i32.const 9)
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -203,7 +199,7 @@ pattern matching › adt_match_5
         )
        )
       )
-      (local.set $4
+      (local.set $5
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -215,15 +211,24 @@ pattern matching › adt_match_5
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $4
+           (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
+              (i32.load offset=12
+               (local.tee $5
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $4)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
                 )
                )
               )
@@ -234,23 +239,7 @@ pattern matching › adt_match_5
              )
             )
            )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $4)
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
-           (local.set $5
+           (local.set $3
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -258,7 +247,7 @@ pattern matching › adt_match_5
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
+                  (local.get $1)
                  )
                  (i32.const 3)
                 )
@@ -277,37 +266,30 @@ pattern matching › adt_match_5
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $1
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $4)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $7
+             (local.set $6
               (tuple.extract 0
                (tuple.make
                 (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $1)
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $5)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
+                  )
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -325,7 +307,7 @@ pattern matching › adt_match_5
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $7)
+                    (local.get $6)
                    )
                    (i32.const 3)
                   )
@@ -349,32 +331,25 @@ pattern matching › adt_match_5
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $6
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $1)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $14
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                   (local.tee $7
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -420,7 +395,7 @@ pattern matching › adt_match_5
                )
               )
               (block (result i32)
-               (local.set $6
+               (local.set $7
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -428,7 +403,7 @@ pattern matching › adt_match_5
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $6)
                      )
                      (i32.const 1)
                     )
@@ -449,7 +424,7 @@ pattern matching › adt_match_5
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $6)
+                  (local.get $7)
                  )
                  (i32.const 31)
                 )
@@ -458,7 +433,7 @@ pattern matching › adt_match_5
              )
             )
             (block (result i32)
-             (local.set $1
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -466,7 +441,7 @@ pattern matching › adt_match_5
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $2)
+                    (local.get $1)
                    )
                    (i32.const 1)
                   )
@@ -487,7 +462,7 @@ pattern matching › adt_match_5
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.const 31)
               )
@@ -496,7 +471,7 @@ pattern matching › adt_match_5
            )
           )
           (block (result i32)
-           (local.set $4
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -523,7 +498,7 @@ pattern matching › adt_match_5
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $5)
              )
              (i32.const 31)
             )
@@ -534,7 +509,7 @@ pattern matching › adt_match_5
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $4)
+          (local.get $5)
          )
         )
        )
@@ -557,7 +532,7 @@ pattern matching › adt_match_5
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $4)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -572,54 +547,13 @@ pattern matching › adt_match_5
                )
               )
              )
-             (local.set $2
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $2)
-                )
-               )
-              )
-             )
-             (local.set $5
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $5)
-                )
-               )
-              )
-             )
              (local.set $1
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                 (i32.load offset=24
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -629,21 +563,50 @@ pattern matching › adt_match_5
                )
               )
              )
-             (local.set $7
+             (local.set $3
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=24
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $3)
+                )
+               )
+              )
+             )
+             (local.set $2
               (tuple.extract 0
                (tuple.make
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $7)
+                 (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $6
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $1)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $6)
                 )
                )
               )
@@ -654,10 +617,7 @@ pattern matching › adt_match_5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -667,7 +627,7 @@ pattern matching › adt_match_5
                )
               )
              )
-             (local.set $6
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (call_indirect (type $i32_i32_i32_=>_i32)
@@ -688,7 +648,7 @@ pattern matching › adt_match_5
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $7)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -696,7 +656,7 @@ pattern matching › adt_match_5
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $6)
+                 (local.get $7)
                 )
                )
               )
@@ -716,53 +676,15 @@ pattern matching › adt_match_5
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
+                (local.get $2)
                )
                (i32.load offset=8
                 (local.get $0)
                )
-              )
-             )
-            )
-           )
-           (local.set $2
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $2)
-              )
-             )
-            )
-           )
-           (local.set $5
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $2)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $5)
               )
              )
             )
@@ -772,16 +694,45 @@ pattern matching › adt_match_5
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+               (i32.load offset=24
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                (local.get $1)
+              )
+             )
+            )
+           )
+           (local.set $3
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $1)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $3)
+              )
+             )
+            )
+           )
+           (local.set $2
+            (tuple.extract 0
+             (tuple.make
+              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+               (i32.load offset=20
+                (local.get $4)
+               )
+              )
+              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+               (local.get $2)
               )
              )
             )
@@ -801,11 +752,11 @@ pattern matching › adt_match_5
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $1)
+              (local.get $2)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.load offset=8
               (local.get $0)
@@ -818,10 +769,7 @@ pattern matching › adt_match_5
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (i32.load offset=20
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $3)
-            )
+            (local.get $4)
            )
           )
          )
@@ -855,7 +803,7 @@ pattern matching › adt_match_5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $3)
+    (local.get $4)
    )
   )
   (drop
@@ -873,18 +821,6 @@ pattern matching › adt_match_5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $5)
    )
   )
@@ -897,7 +833,19 @@ pattern matching › adt_match_5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $6)
    )
   )
   (drop
@@ -909,7 +857,7 @@ pattern matching › adt_match_5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $6)
+    (local.get $7)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -43,7 +43,7 @@ pattern matching › tuple_match_deep5
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $13
+      (local.set $12
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -74,7 +74,7 @@ pattern matching › tuple_match_deep5
         )
        )
       )
-      (local.set $14
+      (local.set $13
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -92,7 +92,7 @@ pattern matching › tuple_match_deep5
           (i32.const 9)
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $13)
+           (local.get $12)
           )
           (i32.load offset=8
            (local.get $0)
@@ -105,7 +105,7 @@ pattern matching › tuple_match_deep5
         )
        )
       )
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -135,7 +135,7 @@ pattern matching › tuple_match_deep5
            (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $14)
+            (local.get $13)
            )
           )
           (local.get $0)
@@ -150,29 +150,22 @@ pattern matching › tuple_match_deep5
       (local.set $11
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $12
-       (tuple.extract 0
-        (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
+          (local.tee $14
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (i32.load offset=12
+               (local.get $4)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -190,7 +183,7 @@ pattern matching › tuple_match_deep5
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $12)
+             (local.get $11)
             )
             (i32.const 3)
            )
@@ -205,7 +198,7 @@ pattern matching › tuple_match_deep5
         )
        )
       )
-      (local.set $7
+      (local.set $8
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -217,32 +210,25 @@ pattern matching › tuple_match_deep5
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $7
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $11)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
            (local.set $1
             (tuple.extract 0
              (tuple.make
               (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $7)
+               (local.tee $8
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $14)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
+                )
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -284,15 +270,24 @@ pattern matching › tuple_match_deep5
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $2
+             (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $7)
+                (i32.load offset=12
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $8)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
                   )
                  )
                 )
@@ -303,23 +298,7 @@ pattern matching › tuple_match_deep5
                )
               )
              )
-             (local.set $6
-              (tuple.extract 0
-               (tuple.make
-                (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $8
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -327,7 +306,7 @@ pattern matching › tuple_match_deep5
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -346,37 +325,30 @@ pattern matching › tuple_match_deep5
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $9
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $4)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -422,7 +394,7 @@ pattern matching › tuple_match_deep5
                )
               )
               (block (result i32)
-               (local.set $4
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -430,7 +402,7 @@ pattern matching › tuple_match_deep5
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -451,7 +423,7 @@ pattern matching › tuple_match_deep5
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -498,7 +470,7 @@ pattern matching › tuple_match_deep5
            )
           )
           (block (result i32)
-           (local.set $7
+           (local.set $8
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -506,7 +478,7 @@ pattern matching › tuple_match_deep5
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $12)
+                  (local.get $11)
                  )
                  (i32.const 1)
                 )
@@ -525,7 +497,7 @@ pattern matching › tuple_match_deep5
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
+              (local.get $8)
              )
              (i32.const 31)
             )
@@ -536,7 +508,7 @@ pattern matching › tuple_match_deep5
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $7)
+          (local.get $8)
          )
         )
        )
@@ -559,7 +531,7 @@ pattern matching › tuple_match_deep5
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $8)
                      )
                      (i32.const 1)
                     )
@@ -580,10 +552,7 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -599,10 +568,7 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -618,15 +584,44 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
                 )
                )
               )
@@ -637,53 +632,12 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $6)
-                )
-               )
-              )
-             )
-             (local.set $8
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $8)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
                 )
                )
               )
@@ -694,10 +648,7 @@ pattern matching › tuple_match_deep5
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -728,7 +679,7 @@ pattern matching › tuple_match_deep5
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -762,7 +713,7 @@ pattern matching › tuple_match_deep5
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $8)
+                  (local.get $7)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -794,7 +745,7 @@ pattern matching › tuple_match_deep5
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -809,10 +760,7 @@ pattern matching › tuple_match_deep5
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -828,10 +776,7 @@ pattern matching › tuple_match_deep5
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -847,10 +792,7 @@ pattern matching › tuple_match_deep5
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -860,45 +802,39 @@ pattern matching › tuple_match_deep5
              )
             )
            )
-           (local.set $6
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $6)
+               (local.get $5)
               )
              )
             )
            )
-           (local.set $8
+           (local.set $7
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $8)
+               (local.get $7)
               )
              )
             )
            )
-           (local.set $4
+           (local.set $6
             (tuple.extract 0
              (tuple.make
               (call_indirect (type $i32_i32_i32_=>_i32)
@@ -915,11 +851,11 @@ pattern matching › tuple_match_deep5
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -927,7 +863,7 @@ pattern matching › tuple_match_deep5
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
+               (local.get $6)
               )
              )
             )
@@ -947,7 +883,7 @@ pattern matching › tuple_match_deep5
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $6)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -966,10 +902,7 @@ pattern matching › tuple_match_deep5
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=12
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -985,10 +918,7 @@ pattern matching › tuple_match_deep5
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
+              (local.get $1)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1004,10 +934,7 @@ pattern matching › tuple_match_deep5
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=8
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1048,10 +975,7 @@ pattern matching › tuple_match_deep5
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
+         (local.get $4)
         )
        )
       )
@@ -1063,7 +987,19 @@ pattern matching › tuple_match_deep5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $13)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $4)
    )
   )
   (drop
@@ -1075,19 +1011,7 @@ pattern matching › tuple_match_deep5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $11)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $12)
    )
   )
   (drop
@@ -1099,7 +1023,7 @@ pattern matching › tuple_match_deep5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $8)
    )
   )
   (drop
@@ -1123,19 +1047,19 @@ pattern matching › tuple_match_deep5
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -126,10 +126,7 @@ pattern matching › constant_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -145,10 +142,7 @@ pattern matching › constant_match_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=8
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -280,10 +274,7 @@ pattern matching › constant_match_4
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -299,10 +290,7 @@ pattern matching › constant_match_4
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -447,10 +435,7 @@ pattern matching › constant_match_4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -466,10 +451,7 @@ pattern matching › constant_match_4
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -45,7 +45,7 @@ pattern matching › tuple_match_deep7
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $13
+      (local.set $12
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -76,7 +76,7 @@ pattern matching › tuple_match_deep7
         )
        )
       )
-      (local.set $14
+      (local.set $13
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -92,6 +92,37 @@ pattern matching › tuple_match_deep7
            )
           )
           (i32.const 13)
+          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+           (local.get $12)
+          )
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $14
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (global.get $import_pervasives_1243_[...]_1244)
+             )
+             (local.get $0)
+            )
+           )
+          )
+          (i32.const 11)
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (local.get $13)
@@ -122,7 +153,7 @@ pattern matching › tuple_match_deep7
             )
            )
           )
-          (i32.const 11)
+          (i32.const 9)
           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
            (local.get $14)
@@ -138,38 +169,7 @@ pattern matching › tuple_match_deep7
         )
        )
       )
-      (local.set $16
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (global.get $import_pervasives_1243_[...]_1244)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (i32.const 9)
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $15)
-          )
-          (i32.load offset=8
-           (local.get $0)
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $5
+      (local.set $4
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -199,7 +199,7 @@ pattern matching › tuple_match_deep7
            (local.get $0)
            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $16)
+            (local.get $15)
            )
           )
           (local.get $0)
@@ -214,29 +214,22 @@ pattern matching › tuple_match_deep7
       (local.set $11
        (tuple.extract 0
         (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $5)
-           )
-          )
-         )
-         (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $12
-       (tuple.extract 0
-        (tuple.make
          (i32.load offset=12
-          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-           (local.get $11)
+          (local.tee $16
+           (tuple.extract 0
+            (tuple.make
+             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+              (i32.load offset=12
+               (local.get $4)
+              )
+             )
+             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+              (i32.const 0)
+             )
+            )
+           )
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -254,7 +247,7 @@ pattern matching › tuple_match_deep7
            (i32.eq
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (local.get $12)
+             (local.get $11)
             )
             (i32.const 3)
            )
@@ -269,7 +262,7 @@ pattern matching › tuple_match_deep7
         )
        )
       )
-      (local.set $7
+      (local.set $8
        (tuple.extract 0
         (tuple.make
          (if (result i32)
@@ -281,32 +274,25 @@ pattern matching › tuple_match_deep7
            (i32.const 31)
           )
           (block (result i32)
-           (local.set $7
-            (tuple.extract 0
-             (tuple.make
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $11)
-                )
-               )
-              )
-              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (i32.const 0)
-              )
-             )
-            )
-           )
            (local.set $1
             (tuple.extract 0
              (tuple.make
               (i32.load offset=12
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $7)
+               (local.tee $8
+                (tuple.extract 0
+                 (tuple.make
+                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                   (i32.load offset=24
+                    (local.get $16)
+                   )
+                  )
+                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                   (i32.const 0)
+                  )
+                 )
+                )
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -348,15 +334,24 @@ pattern matching › tuple_match_deep7
              (i32.const 31)
             )
             (block (result i32)
-             (local.set $2
+             (local.set $5
               (tuple.extract 0
                (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $7)
+                (i32.load offset=12
+                 (local.tee $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                     (i32.load offset=24
+                      (local.get $8)
+                     )
+                    )
+                    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                     (i32.const 0)
+                    )
+                   )
                   )
                  )
                 )
@@ -367,23 +362,7 @@ pattern matching › tuple_match_deep7
                )
               )
              )
-             (local.set $6
-              (tuple.extract 0
-               (tuple.make
-                (i32.load offset=12
-                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $2)
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (i32.const 0)
-                )
-               )
-              )
-             )
-             (local.set $8
+             (local.set $7
               (tuple.extract 0
                (tuple.make
                 (i32.or
@@ -391,7 +370,7 @@ pattern matching › tuple_match_deep7
                   (i32.eq
                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $6)
+                    (local.get $5)
                    )
                    (i32.const 3)
                   )
@@ -410,37 +389,30 @@ pattern matching › tuple_match_deep7
               (i32.shr_u
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (i32.const 31)
               )
               (block (result i32)
-               (local.set $4
-                (tuple.extract 0
-                 (tuple.make
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (i32.load offset=24
-                    (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                     (local.get $2)
-                    )
-                   )
-                  )
-                  (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                   (i32.const 0)
-                  )
-                 )
-                )
-               )
                (local.set $9
                 (tuple.extract 0
                  (tuple.make
                   (i32.load offset=12
-                   (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                    (local.get $4)
+                   (local.tee $6
+                    (tuple.extract 0
+                     (tuple.make
+                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                       (i32.load offset=24
+                        (local.get $2)
+                       )
+                      )
+                      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                       (i32.const 0)
+                      )
+                     )
+                    )
                    )
                   )
                   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -486,7 +458,7 @@ pattern matching › tuple_match_deep7
                )
               )
               (block (result i32)
-               (local.set $4
+               (local.set $6
                 (tuple.extract 0
                  (tuple.make
                   (i32.or
@@ -494,7 +466,7 @@ pattern matching › tuple_match_deep7
                     (i32.eq
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $6)
+                      (local.get $5)
                      )
                      (i32.const 1)
                     )
@@ -515,7 +487,7 @@ pattern matching › tuple_match_deep7
                 (i32.shr_u
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.const 31)
                 )
@@ -562,7 +534,7 @@ pattern matching › tuple_match_deep7
            )
           )
           (block (result i32)
-           (local.set $7
+           (local.set $8
             (tuple.extract 0
              (tuple.make
               (i32.or
@@ -570,7 +542,7 @@ pattern matching › tuple_match_deep7
                 (i32.eq
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $12)
+                  (local.get $11)
                  )
                  (i32.const 1)
                 )
@@ -589,7 +561,7 @@ pattern matching › tuple_match_deep7
             (i32.shr_u
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $7)
+              (local.get $8)
              )
              (i32.const 31)
             )
@@ -600,7 +572,7 @@ pattern matching › tuple_match_deep7
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-          (local.get $7)
+          (local.get $8)
          )
         )
        )
@@ -623,7 +595,7 @@ pattern matching › tuple_match_deep7
                     (i32.shr_s
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (local.get $7)
+                      (local.get $8)
                      )
                      (i32.const 1)
                     )
@@ -644,10 +616,7 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=12
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -663,10 +632,7 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -682,15 +648,44 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=24
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
+                  (local.get $3)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $2)
+                )
+               )
+              )
+             )
+             (local.set $5
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $2)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $5)
+                )
+               )
+              )
+             )
+             (local.set $7
+              (tuple.extract 0
+               (tuple.make
+                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+                 (i32.load offset=20
+                  (local.get $3)
+                 )
+                )
+                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+                 (local.get $7)
                 )
                )
               )
@@ -701,53 +696,12 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $2)
-                  )
+                  (local.get $1)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
                  (local.get $6)
-                )
-               )
-              )
-             )
-             (local.set $8
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $3)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $8)
-                )
-               )
-              )
-             )
-             (local.set $4
-              (tuple.extract 0
-               (tuple.make
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (i32.load offset=20
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $1)
-                  )
-                 )
-                )
-                (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-                 (local.get $4)
                 )
                )
               )
@@ -758,10 +712,7 @@ pattern matching › tuple_match_deep7
                 (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                  (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                  (i32.load offset=8
-                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                   (local.get $5)
-                  )
+                  (local.get $4)
                  )
                 )
                 (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -792,7 +743,7 @@ pattern matching › tuple_match_deep7
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $4)
+                  (local.get $6)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -826,7 +777,7 @@ pattern matching › tuple_match_deep7
                  )
                  (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                   (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                  (local.get $8)
+                  (local.get $7)
                  )
                  (i32.load offset=8
                   (local.get $0)
@@ -858,7 +809,7 @@ pattern matching › tuple_match_deep7
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -873,10 +824,7 @@ pattern matching › tuple_match_deep7
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=12
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -892,10 +840,7 @@ pattern matching › tuple_match_deep7
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -911,10 +856,7 @@ pattern matching › tuple_match_deep7
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $3)
-                )
+                (local.get $3)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -924,45 +866,39 @@ pattern matching › tuple_match_deep7
              )
             )
            )
-           (local.set $6
+           (local.set $5
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $1)
-                )
+                (local.get $1)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $6)
+               (local.get $5)
               )
              )
             )
            )
-           (local.set $8
+           (local.set $7
             (tuple.extract 0
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
                (i32.load offset=8
-                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                 (local.get $5)
-                )
+                (local.get $4)
                )
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $8)
+               (local.get $7)
               )
              )
             )
            )
-           (local.set $4
+           (local.set $6
             (tuple.extract 0
              (tuple.make
               (call_indirect (type $i32_i32_i32_=>_i32)
@@ -979,11 +915,11 @@ pattern matching › tuple_match_deep7
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $8)
+                (local.get $7)
                )
                (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                 (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $6)
+                (local.get $5)
                )
                (i32.load offset=8
                 (local.get $0)
@@ -991,7 +927,7 @@ pattern matching › tuple_match_deep7
               )
               (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-               (local.get $4)
+               (local.get $6)
               )
              )
             )
@@ -1011,7 +947,7 @@ pattern matching › tuple_match_deep7
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-              (local.get $4)
+              (local.get $6)
              )
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
@@ -1030,10 +966,7 @@ pattern matching › tuple_match_deep7
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=12
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1049,10 +982,7 @@ pattern matching › tuple_match_deep7
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=20
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $1)
-              )
+              (local.get $1)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1068,10 +998,7 @@ pattern matching › tuple_match_deep7
             (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
              (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
              (i32.load offset=8
-              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (local.get $5)
-              )
+              (local.get $4)
              )
             )
             (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -1112,16 +1039,19 @@ pattern matching › tuple_match_deep7
        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (local.get $5)
-         )
+         (local.get $4)
         )
        )
       )
      )
      (local.get $0)
     )
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $12)
    )
   )
   (drop
@@ -1145,13 +1075,13 @@ pattern matching › tuple_match_deep7
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $16)
+    (local.get $4)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $5)
+    (local.get $16)
    )
   )
   (drop
@@ -1163,19 +1093,13 @@ pattern matching › tuple_match_deep7
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $12)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $17)
    )
   )
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $7)
+    (local.get $8)
    )
   )
   (drop
@@ -1199,19 +1123,19 @@ pattern matching › tuple_match_deep7
   (drop
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (local.get $4)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -157,10 +157,7 @@ records › record_get_multiple
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -176,10 +173,7 @@ records › record_get_multiple
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -200,10 +200,7 @@ records › record_destruct_1
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $2)
-        )
+        (local.get $2)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -171,10 +171,7 @@ records › record_destruct_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -190,10 +187,7 @@ records › record_destruct_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -209,10 +203,7 @@ records › record_destruct_4
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=24
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -240,10 +240,7 @@ records › record_recursive_data_definition
         (tuple.make
          (block (result i32)
           (i32.store offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -253,10 +250,7 @@ records › record_recursive_data_definition
              (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
               (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
               (i32.load offset=16
-               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                (local.get $1)
-               )
+               (local.get $1)
               )
              )
             )
@@ -302,10 +296,7 @@ records › record_recursive_data_definition
        )
       )
       (i32.store offset=16
-       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-        (local.get $2)
-       )
+       (local.get $2)
        (tuple.extract 0
         (tuple.make
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
@@ -315,10 +306,7 @@ records › record_recursive_data_definition
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
         )

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -200,10 +200,7 @@ records › record_destruct_2
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=20
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $2)
-        )
+        (local.get $2)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -203,10 +203,7 @@ records › record_destruct_deep
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -219,10 +216,7 @@ records › record_destruct_deep
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $3)
-        )
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -169,10 +169,7 @@ records › record_destruct_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -188,10 +185,7 @@ records › record_destruct_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -215,10 +215,7 @@ records › record_get_multilevel
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $2)
-           )
+           (local.get $2)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -231,10 +228,7 @@ records › record_get_multilevel
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=20
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $3)
-        )
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -137,10 +137,7 @@ records › record_get_2
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $1)
-        )
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -171,10 +171,7 @@ records › record_destruct_trailing
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=16
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -190,10 +187,7 @@ records › record_destruct_trailing
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=20
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -209,10 +203,7 @@ records › record_destruct_trailing
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=24
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $1)
-           )
+           (local.get $1)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -155,10 +155,7 @@ tuples › nested_tup_3
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -171,10 +168,7 @@ tuples › nested_tup_3
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $4)
-        )
+        (local.get $4)
        )
       )
      )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -151,10 +151,7 @@ tuples › nested_tup_1
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $3)
-        )
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -73,10 +73,7 @@ tuples › big_tup_access
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=16
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $1)
-        )
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -155,10 +155,7 @@ tuples › nested_tup_2
          (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
           (i32.load offset=12
-           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-            (local.get $3)
-           )
+           (local.get $3)
           )
          )
          (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
@@ -171,10 +168,7 @@ tuples › nested_tup_2
       (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
        (i32.load offset=12
-        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-         (local.get $4)
-        )
+        (local.get $4)
        )
       )
      )


### PR DESCRIPTION
Closes #962 
Closes #1002 
Closes #1003

@cician ~~Could you confirm that this change fixes those issues? Would love an extra set of eyes 🙂~~ thanks again for checking!

Record/array/tuple access are all functionally the same. The issue here was that our GC convention calls for any load to cause an incRef, and we load the record to load a value from it. We weren't decRefing after, which caused the leak. Instead of adding a decRef call, since these accesses are isolated, I just removed the incRef on the load.

The closures fix is essentially the same, though slightly more complicated to find since the leak happens during backpatching. The closure was just allocated, so there's no need to incRef and decRef it.