### PR TITLE
fix(compiler): Properly apply bindings when executing match guard

### DIFF
--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -379,7 +379,7 @@ module MatchTreeCompiler = {
       (Comp.imm(~allocation_type=StackAllocated(WasmI32), Imm.trap()), [])
     /* Optimizations to avoid unneeded destructuring: */
     | Explode(_, Leaf(_) as inner)
-    | Explode(_, Guard(_) as inner)
+    | Explode(_, Guard(_, Leaf(_) | Fail, Leaf(_) | Fail) as inner)
     | Explode(_, Fail as inner) =>
       compile_tree_help(inner, values, expr, helpI)
     | Explode(matrix_type, rest) =>

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -11,7 +11,7 @@ pattern matching › constant_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $import_GRAIN$MODULE$runtime/equal_0_GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1204_==_1205 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $import_pervasives_1197_==_1198 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $import_GRAIN$MODULE$runtime/gc_0_malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
@@ -234,7 +234,7 @@ pattern matching › constant_match_4
              (tuple.make
               (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-               (global.get $import_pervasives_1204_==_1205)
+               (global.get $import_pervasives_1197_==_1198)
               )
               (local.get $0)
              )
@@ -555,7 +555,7 @@ pattern matching › constant_match_4
                     (tuple.make
                      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
                       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-                      (global.get $import_pervasives_1204_==_1205)
+                      (global.get $import_pervasives_1197_==_1198)
                      )
                      (local.get $0)
                     )

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -185,6 +185,16 @@ describe("pattern matching", ({test}) => {
      print(value)",
     "79\n",
   );
+  assertRun(
+    "guarded_match_10",
+    "let value = match ([1, 2, 3]) {
+       [a, b, ...rest] when false => 42,
+       [a, b, c, ...rest] when true => 24,
+       _ => 79
+     }
+     print(value)",
+    "24\n",
+  );
   // Constant patterns
   assertSnapshot(
     "constant_match_1",


### PR DESCRIPTION
Closes #1023 

We were over-optimizing an Explode case—the continuation for when a guard fails needs the bindings that `Explode` introduces.