### PR TITLE
fix(stdlib): Array rotate with generic elements and for empty arrays

### DIFF
--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -391,3 +391,7 @@ assert arr7 == [> ]
 let arr8 = [> "a", "b", "c"]
 Array.rotate(1, arr8)
 assert arr8 == [> "c", "a", "b"]
+
+let arr9 = [> ]
+Array.rotate(1, arr9)
+assert arr9 == [> ]

--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -383,3 +383,11 @@ assert arr5 == [> 3, 4, 5, 1, 2]
 let arr6 = [> 1, 2, 3, 4, 5]
 Array.rotate(-54, arr6) 
 assert arr6 == [> 5, 1, 2, 3, 4]
+
+let arr7 = [> ] : (Array<Number>)
+Array.rotate(1, arr7)
+assert arr7 == [> ]
+
+let arr8 = [> "a", "b", "c"]
+Array.rotate(1, arr8)
+assert arr8 == [> "c", "a", "b"]

--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -361,7 +361,7 @@ assert result == void
 
 // Array.rotate
 let arr1 = [> 1, 2, 3, 4, 5]
-Array.rotate(0, arr1) 
+Array.rotate(0, arr1)
 assert arr1 == [> 1, 2, 3, 4, 5]
 
 let arr2 = [> 1, 2, 3, 4, 5]
@@ -377,11 +377,11 @@ Array.rotate(5, arr4)
 assert arr4 == [> 1, 2, 3, 4, 5]
 
 let arr5 = [> 1, 2, 3, 4, 5]
-Array.rotate(48, arr5) 
+Array.rotate(48, arr5)
 assert arr5 == [> 3, 4, 5, 1, 2]
 
 let arr6 = [> 1, 2, 3, 4, 5]
-Array.rotate(-54, arr6) 
+Array.rotate(-54, arr6)
 assert arr6 == [> 5, 1, 2, 3, 4]
 
 let arr7 = [> ] : (Array<Number>)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -922,11 +922,10 @@ export let rotate = (n, arr) => {
   let arrLen = length(arr)
   let k = n % arrLen
   let mut d = -1
-  let mut temp = 0
   let mut j  = 0
   for (let mut i = 0; i < gcd(arrLen, k); i += 1) {
     j = i
-    temp = arr[i]
+    let temp = arr[i]
     while (true) {
       d = (j - k) % arrLen
       if (d == i) {

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -920,21 +920,23 @@ export let rotate = (n, arr) => {
   }
 
   let arrLen = length(arr)
-  let k = n % arrLen
-  let mut d = -1
-  let mut j  = 0
-  for (let mut i = 0; i < gcd(arrLen, k); i += 1) {
-    j = i
-    let temp = arr[i]
-    while (true) {
-      d = (j - k) % arrLen
-      if (d == i) {
-        break
+  if (arrLen > 0) {
+    let k = n % arrLen
+    let mut d = -1
+    let mut j  = 0
+    for (let mut i = 0; i < gcd(arrLen, k); i += 1) {
+      j = i
+      let temp = arr[i]
+      while (true) {
+        d = (j - k) % arrLen
+        if (d == i) {
+          break
+        }
+        let newVal = arr[d]
+        arr[j] = newVal
+        j = d
       }
-      let newVal = arr[d]
-      arr[j] = newVal
-      j = d
+      arr[j] = temp
     }
-    arr[j] = temp
   }
 }

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -1057,7 +1057,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotate : (Number, Array<Number>) -> Void
+rotate : (Number, Array<a>) -> Void
 ```
 
 Rotates an array by n elements to the right, in place.
@@ -1070,7 +1070,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`n`|`Number`|The number of elements to rotate by|
-|`arr`|`Array<Number>`|The array to be rotated|
+|`arr`|`Array<a>`|The array to be rotated|
 
 Examples:
 


### PR DESCRIPTION
This PR changes slightly the `Array.rotate` function to accept arrays with any types of elements. This theoretically changes the signature of the function, but I'm assuming the intention form the start was to make it generic.

Additionally calling rotate on an empty array becomes a no-op instead of failing with a runtime error.