### PR TITLE
feat(compiler): Allow @externalName attribute for foreign names

### DIFF
--- a/compiler/grainformat/reformat.re
+++ b/compiler/grainformat/reformat.re
@@ -1462,8 +1462,30 @@ and print_attributes = attributes =>
       Doc.join(
         Doc.space,
         List.map(
-          (a: Location.loc(string)) =>
-            Doc.concat([Doc.text("@"), Doc.text(a.txt)]),
+          ((a: Location.loc(string), args: list(Location.loc(string)))) => {
+            switch (args) {
+            | [] => Doc.concat([Doc.text("@"), Doc.text(a.txt)])
+            | _ =>
+              Doc.concat([
+                Doc.text("@"),
+                Doc.text(a.txt),
+                Doc.text("("),
+                Doc.join(
+                  Doc.concat([Doc.comma, Doc.space]),
+                  List.map(
+                    (b: Location.loc(string)) =>
+                      Doc.concat([
+                        Doc.text("\""),
+                        Doc.text(b.txt),
+                        Doc.text("\""),
+                      ]),
+                    args,
+                  ),
+                ),
+                Doc.text(")"),
+              ])
+            }
+          },
           attributes,
         ),
       ),

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3409,7 +3409,7 @@ let compile_main = (wasm_mod, env, prog) => {
 
 let compile_functions = (wasm_mod, env, {functions} as prog) => {
   let handle_attrs = ({attrs} as func) =>
-    if (List.mem(Disable_gc, attrs)) {
+    if (List.mem(Typedtree.Disable_gc, attrs)) {
       Config.preserve_config(() => {
         Config.no_gc := true;
         compile_function(wasm_mod, env, func);

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -15,11 +15,7 @@ type tag_type = Value_tags.tag_type;
 type heap_tag_type = Value_tags.heap_tag_type;
 
 [@deriving sexp]
-type attributes = list(attribute)
-
-[@deriving sexp]
-and attribute =
-  | Disable_gc;
+type attributes = Typedtree.attributes;
 
 type grain_error = Runtime_errors.grain_error;
 let (prim1_of_sexp, sexp_of_prim1) = (

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -666,17 +666,6 @@ let next_global = (~exported=false, id, ty) => {
   Printf.sprintf("global_%d", ret);
 };
 
-let transl_attributes = attrs => {
-  List.map(
-    ({txt}) =>
-      switch (txt) {
-      | "disableGC" => Disable_gc
-      | _ => failwith("impossible by well-formedness")
-      },
-    attrs,
-  );
-};
-
 let rec compile_comp = (~id=?, env, c) => {
   let desc =
     switch (c.comp_desc) {
@@ -825,7 +814,7 @@ let rec compile_comp = (~id=?, env, c) => {
             env,
             args,
             body,
-            transl_attributes(c.comp_attributes),
+            c.comp_attributes,
             c.comp_loc,
           ),
         ),

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -7,7 +7,7 @@ type str = loc(string);
 type loc = Location.t;
 type env = Env.t;
 type ident = Ident.t;
-type attributes = Asttypes.attributes;
+type attributes = Typedtree.attributes;
 
 let default_loc = Location.dummy_loc;
 let default_env = Env.empty;

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -7,7 +7,7 @@ type str = loc(string);
 type loc = Location.t;
 type env = Env.t;
 type ident = Ident.t;
-type attributes = Asttypes.attributes;
+type attributes = Typedtree.attributes;
 
 module Imm: {
   let mk: (~loc: loc=?, ~env: env=?, imm_expression_desc) => imm_expression;

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -245,15 +245,7 @@ module ClearLocationsArg: Anf_mapper.MapArgument = {
 
   let leave_imm_expression = i => {...i, imm_loc: Location.dummy_loc};
 
-  let leave_comp_expression = c => {
-    ...c,
-    comp_loc: Location.dummy_loc,
-    comp_attributes:
-      List.map(
-        attr => {...attr, Asttypes.loc: Location.dummy_loc},
-        c.comp_attributes,
-      ),
-  };
+  let leave_comp_expression = c => {...c, comp_loc: Location.dummy_loc};
 
   let leave_anf_expression = a => {...a, anf_loc: Location.dummy_loc};
 };

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -14,7 +14,7 @@ type global_flag =
 type loc('a) = Location.loc('a);
 
 [@deriving sexp]
-type attributes = Asttypes.attributes;
+type attributes = Typedtree.attributes;
 
 type analysis = ..;
 

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -15,7 +15,7 @@ type global_flag =
 type loc('a) = Location.loc('a);
 
 [@deriving sexp]
-type attributes = Asttypes.attributes;
+type attributes = Typedtree.attributes;
 
 [@deriving sexp]
 type partial = Typedtree.partial = | Partial | Total;

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -1421,6 +1421,18 @@ let rec transl_anf_statement =
       | Exported => Global
       | Nonexported => Nonglobal
       };
+    let external_name =
+      switch (
+        List.find_opt(
+          fun
+          | External_name(_) => true
+          | _ => false,
+          attributes,
+        )
+      ) {
+      | Some(External_name(name)) => name
+      | _ => desc.tvd_name.txt
+      };
     switch (desc.tvd_desc.ctyp_type.desc) {
     | TTyArrow(_) =>
       let (argsty, retty) =
@@ -1438,7 +1450,7 @@ let rec transl_anf_statement =
             ~global,
             desc.tvd_id,
             desc.tvd_mod.txt,
-            desc.tvd_name.txt,
+            external_name,
             FunctionShape(argsty, retty),
           ),
         ],
@@ -1452,7 +1464,7 @@ let rec transl_anf_statement =
             ~global,
             desc.tvd_id,
             desc.tvd_mod.txt,
-            desc.tvd_name.txt,
+            external_name,
             GlobalShape(ty),
           ),
         ],

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -1422,17 +1422,14 @@ let rec transl_anf_statement =
       | Nonexported => Nonglobal
       };
     let external_name =
-      switch (
-        List.find_opt(
+      List.fold_left(
+        name =>
           fun
-          | External_name(_) => true
-          | _ => false,
-          attributes,
-        )
-      ) {
-      | Some(External_name(name)) => name
-      | _ => desc.tvd_name.txt
-      };
+          | External_name(name) => name
+          | _ => name,
+        desc.tvd_name.txt,
+        attributes,
+      );
     switch (desc.tvd_desc.ctyp_type.desc) {
     | TTyArrow(_) =>
       let (argsty, retty) =

--- a/compiler/src/parsing/ast_iterator.re
+++ b/compiler/src/parsing/ast_iterator.re
@@ -30,7 +30,13 @@ module Cnst = {
 module E = {
   let iter = (sub, {pexp_desc: desc, pexp_attributes: attrs, pexp_loc: loc}) => {
     sub.location(sub, loc);
-    List.iter(iter_loc(sub), attrs);
+    List.iter(
+      ((attr, args)) => {
+        iter_loc(sub, attr);
+        List.iter(iter_loc(sub), args);
+      },
+      attrs,
+    );
     switch (desc) {
     | PExpId(i) => iter_loc(sub, i)
     | PExpConstant(c) => sub.constant(sub, c)
@@ -288,7 +294,13 @@ module VD = {
 module TL = {
   let iter = (sub, {ptop_desc: desc, ptop_attributes: attrs, ptop_loc: loc}) => {
     sub.location(sub, loc);
-    List.iter(iter_loc(sub), attrs);
+    List.iter(
+      ((attr, args)) => {
+        iter_loc(sub, attr);
+        List.iter(iter_loc(sub), args);
+      },
+      attrs,
+    );
     switch (desc) {
     | PTopImport(id) => sub.import(sub, id)
     | PTopExport(ex) => sub.export(sub, ex)

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -32,7 +32,12 @@ module E = {
   let map = (sub, {pexp_desc: desc, pexp_attributes: attrs, pexp_loc: loc}) => {
     open Exp;
     let loc = sub.location(sub, loc);
-    let attributes = List.map(map_loc(sub), attrs);
+    let attributes =
+      List.map(
+        ((attr, args)) =>
+          (map_loc(sub, attr), List.map(map_loc(sub), args)),
+        attrs,
+      );
     switch (desc) {
     | PExpId(i) => ident(~loc, ~attributes, map_loc(sub, i))
     | PExpConstant(c) => constant(~loc, ~attributes, sub.constant(sub, c))
@@ -336,7 +341,12 @@ module TL = {
   let map = (sub, {ptop_desc: desc, ptop_attributes: attrs, ptop_loc: loc}) => {
     open Top;
     let loc = sub.location(sub, loc);
-    let attributes = List.map(map_loc(sub), attrs);
+    let attributes =
+      List.map(
+        ((attr, args)) =>
+          (map_loc(sub, attr), List.map(map_loc(sub), args)),
+        attrs,
+      );
     switch (desc) {
     | PTopImport(decls) =>
       Top.import(~loc, ~attributes, sub.import(sub, decls))

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -85,4 +85,4 @@ let mknoloc = Location.mknoloc;
 
 /** Addtional expression information that may affect compilation. */
 [@deriving (sexp, yojson)]
-type attributes = list(loc(string));
+type attributes = list((loc(string), list(loc(string))));

--- a/compiler/src/parsing/parser.dyp
+++ b/compiler/src/parsing/parser.dyp
@@ -414,7 +414,7 @@ lam_expr :
   | ID thickarrow block_or_expr { Exp.lambda ~loc:(symbol_rloc dyp) [Pat.var ~loc:(rhs_loc dyp 1) (mkstr dyp $1)] $3 }
 
 attributes :
-  | [AT id_str eols? { $2 }]* { $1 }
+  | [AT id_str [lparen STRING rparen { Location.mkloc $2 (symbol_rloc dyp) }]? eols? { $2, Option.to_list $3 }]* { $1 }
 
 let_expr :
   | attributes LET REC value_binds { Exp.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Recursive Immutable $4 }
@@ -570,9 +570,9 @@ toplevel_stmt :
   | attributes LET value_binds { Top.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonexported Nonrecursive Immutable $3 }
   | attributes LET REC MUT value_binds { Top.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonexported Recursive Mutable $5 }
   | attributes LET MUT value_binds { Top.let_ ~loc:(symbol_rloc dyp) ~attributes:$1 Nonexported Nonrecursive Mutable $4 }
+  | attributes IMPORT foreign_stmt { Top.foreign ~loc:(symbol_rloc dyp) ~attributes:$1 Nonexported $3 }
   | expr { Top.expr ~loc:(symbol_rloc dyp) $1 }
   | import_stmt { Top.import ~loc:(symbol_rloc dyp) $1 }
-  | IMPORT foreign_stmt { Top.foreign ~loc:(symbol_rloc dyp) Nonexported $2 }
   | data_declaration_stmts { Top.data ~loc:(symbol_rloc dyp) $1 }
   | export_stmt { $1 }
   | primitive_stmt { Top.primitive ~loc:(symbol_rloc dyp) Nonexported $1 }

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -429,6 +429,7 @@ let disallowed_attributes = (errs, super) => {
     switch (List.find_opt((({txt}, _)) => txt == "externalName", attrs)) {
     | Some(({txt, loc}, _)) =>
       switch (desc) {
+      | PTopForeign(_)
       | PTopLet(
           _,
           _,
@@ -441,13 +442,29 @@ let disallowed_attributes = (errs, super) => {
               },
             },
           ],
-        )
-      | PTopForeign(_) => ()
+        ) =>
+        ()
+      | PTopLet(_, _, _, [_]) =>
+        errs :=
+          [
+            AttributeDisallowed(
+              "`externalName` cannot be used with a destructuring pattern.",
+              loc,
+            ),
+          ]
+      | PTopLet(_, _, _, [_, _, ..._]) =>
+        errs :=
+          [
+            AttributeDisallowed(
+              "`externalName` cannot be used on a `let` with multiple bindings.",
+              loc,
+            ),
+          ]
       | _ =>
         errs :=
           [
             AttributeDisallowed(
-              "`externalName` is only allowed on `foreign` statements and let bindings of a single name.",
+              "`externalName` is only allowed on `foreign` statements and `let` bindings.",
               loc,
             ),
           ]

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -18,6 +18,8 @@ type wferr =
   | NoLetRecMut(Location.t)
   | RationalZeroDenominator(Location.t)
   | UnknownAttribute(string, Location.t)
+  | InvalidAttributeArity(string, int, Location.t)
+  | AttributeDisallowed(string, Location.t)
   | LoopControlOutsideLoop(string, Location.t);
 
 exception Error(wferr);
@@ -66,6 +68,14 @@ let prepare_error =
         errorf(~loc, "Rational numbers may not have a denominator of zero.")
       | UnknownAttribute(attr, loc) =>
         errorf(~loc, "Unknown attribute `%s`.", attr)
+      | InvalidAttributeArity(attr, arity, loc) =>
+        switch (arity) {
+        | 0 => errorf(~loc, "Attribute `%s` expects no arguments.", attr)
+        | 1 => errorf(~loc, "Attribute `%s` expects one argument.", attr)
+        | _ =>
+          errorf(~loc, "Attribute `%s` expects %d arguments.", attr, arity)
+        }
+      | AttributeDisallowed(msg, loc) => errorf(~loc, "%s", msg)
       | LoopControlOutsideLoop(control, loc) =>
         errorf(~loc, "`%s` statement used outside of a loop.", control)
     )
@@ -367,27 +377,83 @@ let no_zero_denominator_rational = (errs, super) => {
   {errs, iterator};
 };
 
-let known_attributes = ["disableGC"];
+type known_attribute = {
+  name: string,
+  arity: int,
+};
 
-let no_unknown_attributes = (errs, super) => {
+let known_attributes = [
+  {name: "disableGC", arity: 0},
+  {name: "externalName", arity: 1},
+];
+
+let valid_attributes = (errs, super) => {
+  let iter_attributes = (({txt, loc}, args)) => {
+    switch (List.find_opt(({name}) => name == txt, known_attributes)) {
+    | Some({arity}) when List.length(args) != arity =>
+      errs := [InvalidAttributeArity(txt, arity, loc), ...errs^]
+    | None => errs := [UnknownAttribute(txt, loc), ...errs^]
+    | _ => ()
+    };
+  };
+
   let iter_expr = (self, {pexp_attributes: attrs} as e) => {
-    List.iter(
-      ({txt, loc}) =>
-        if (!List.mem(txt, known_attributes)) {
-          errs := [UnknownAttribute(txt, loc), ...errs^];
-        },
-      attrs,
-    );
+    List.iter(iter_attributes, attrs);
     super.expr(self, e);
   };
   let iter_toplevel = (self, {ptop_attributes: attrs} as top) => {
-    List.iter(
-      ({txt, loc}) =>
-        if (!List.mem(txt, known_attributes)) {
-          errs := [UnknownAttribute(txt, loc), ...errs^];
-        },
-      attrs,
-    );
+    List.iter(iter_attributes, attrs);
+    super.toplevel(self, top);
+  };
+  let iterator = {...super, expr: iter_expr, toplevel: iter_toplevel};
+  {errs, iterator};
+};
+
+let disallowed_attributes = (errs, super) => {
+  let iter_expr = (self, {pexp_desc: desc, pexp_attributes: attrs} as e) => {
+    switch (List.find_opt((({txt}, _)) => txt == "externalName", attrs)) {
+    | Some(({txt, loc}, _)) =>
+      errs :=
+        [
+          AttributeDisallowed(
+            "`externalName` is only allowed on top-level let bindings and `foreign` statements.",
+            loc,
+          ),
+        ]
+    | None => ()
+    };
+    super.expr(self, e);
+  };
+  let iter_toplevel =
+      (self, {ptop_desc: desc, ptop_attributes: attrs} as top) => {
+    switch (List.find_opt((({txt}, _)) => txt == "externalName", attrs)) {
+    | Some(({txt, loc}, _)) =>
+      switch (desc) {
+      | PTopLet(
+          _,
+          _,
+          _,
+          [
+            {
+              pvb_pat: {
+                ppat_desc:
+                  PPatVar(_) | PPatConstraint({ppat_desc: PPatVar(_)}, _),
+              },
+            },
+          ],
+        )
+      | PTopForeign(_) => ()
+      | _ =>
+        errs :=
+          [
+            AttributeDisallowed(
+              "`externalName` is only allowed on `foreign` statements and let bindings of a single name.",
+              loc,
+            ),
+          ]
+      }
+    | None => ()
+    };
     super.toplevel(self, top);
   };
   let iterator = {...super, expr: iter_expr, toplevel: iter_toplevel};
@@ -434,7 +500,8 @@ let well_formedness_checks = [
   only_functions_oh_rhs_letrec,
   no_letrec_mut,
   no_zero_denominator_rational,
-  no_unknown_attributes,
+  valid_attributes,
+  disallowed_attributes,
   no_loop_control_statement_outside_of_loop,
 ];
 

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -1406,7 +1406,7 @@ let transl_prim = (env, desc) => {
     | Not_found => failwith("This primitive does not exist.")
     };
 
-  let diable_gc = [Location.mknoloc("disableGC")];
+  let diable_gc = [(Location.mknoloc("disableGC"), [])];
 
   let value =
     switch (prim) {

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -563,7 +563,7 @@ and type_expect_ =
     (~in_function=?, ~recarg=Rejected, env, sexp, ty_expected_explained) => {
   let {ty: ty_expected, explanation} = ty_expected_explained;
   let loc = sexp.pexp_loc;
-  let attributes = sexp.pexp_attributes;
+  let attributes = Typetexp.type_attributes(sexp.pexp_attributes);
   /* Record the expression type before unifying it with the expected type */
   let with_explanation = with_explanation(explanation);
   let rue = exp => {

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -26,14 +26,7 @@ let exp_is_wasm_unsafe = ({exp_type: {desc}}) => {
 };
 
 let is_marked_disable_gc = attrs => {
-  List.exists(
-    ({txt}) =>
-      switch (txt) {
-      | "disableGC" => true
-      | _ => false
-      },
-    attrs,
-  );
+  List.mem(Disable_gc, attrs);
 };
 
 let make_bool_stack = () => {

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -21,6 +21,15 @@ open Types;
 let sexp_locs_disabled = _ => ! Grain_utils.Config.sexp_locs_enabled^;
 
 type loc('a) = Location.loc('a);
+
+[@deriving sexp]
+type attributes = list(attribute)
+
+[@deriving sexp]
+and attribute =
+  | Disable_gc
+  | External_name(string);
+
 [@deriving sexp]
 type partial =
   | Partial

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -22,6 +22,15 @@ open Types;
 let sexp_locs_disabled: 'a => bool;
 
 type loc('a) = Location.loc('a);
+
+[@deriving sexp]
+type attributes = list(attribute)
+
+[@deriving sexp]
+and attribute =
+  | Disable_gc
+  | External_name(string);
+
 type partial =
   | Partial
   | Total;

--- a/compiler/src/typed/typetexp.re
+++ b/compiler/src/typed/typetexp.re
@@ -589,7 +589,7 @@ let type_attributes = attrs => {
       switch (txt, args) {
       | ("disableGC", []) => Disable_gc
       | ("externalName", [{txt}]) => External_name(txt)
-      | _ => failwith("impossible by well-formedness")
+      | _ => failwith("type_attributes: impossible by well-formedness")
       },
     attrs,
   );

--- a/compiler/src/typed/typetexp.re
+++ b/compiler/src/typed/typetexp.re
@@ -583,6 +583,18 @@ let fold_modules = fold_persistent(Env.fold_modules);
 let fold_constructors = fold_descr(Env.fold_constructors, d => d.cstr_name);
 let fold_modtypes = fold_simple(Env.fold_modtypes);
 
+let type_attributes = attrs => {
+  List.map(
+    (({txt}, args)) =>
+      switch (txt, args) {
+      | ("disableGC", []) => Disable_gc
+      | ("externalName", [{txt}]) => External_name(txt)
+      | _ => failwith("impossible by well-formedness")
+      },
+    attrs,
+  );
+};
+
 let report_error = (env, ppf) =>
   fun
   | Unbound_type_variable(name) =>

--- a/compiler/src/typed/typetexp.rei
+++ b/compiler/src/typed/typetexp.rei
@@ -110,5 +110,7 @@ let lookup_module:
 let find_modtype:
   (Env.t, Location.t, Identifier.t) => (Path.t, modtype_declaration);
 
+let type_attributes: Asttypes.attributes => Typedtree.attributes;
+
 let unbound_label_error: (Env.t, Location.loc(Identifier.t)) => 'a;
 let unbound_constructor_error: (Env.t, Location.loc(Identifier.t)) => 'a;

--- a/compiler/test/suites/foreigns.re
+++ b/compiler/test/suites/foreigns.re
@@ -1,0 +1,52 @@
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+
+describe("foreigns", ({test}) => {
+  test("external_name", ({expect}) => {
+    let name = "external_name";
+    let outfile = wasmfile(name);
+    ignore @@
+    compile(
+      name,
+      {|
+      @externalName("env.foo")
+      import foreign wasm foo: Number -> Number from "env"
+
+      @externalName("__foo%%!")
+      export let bar = () => foo(1)
+      |},
+    );
+    let ic = open_in_bin(outfile);
+    let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
+    close_in(ic);
+    let import_sections =
+      List.find_map(
+        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
+          switch (sec) {
+          | {sec_type: Import(exports)} => Some(exports)
+          | _ => None
+          },
+        sections,
+      );
+    let export_sections =
+      List.find_map(
+        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
+          switch (sec) {
+          | {sec_type: Export(exports)} => Some(exports)
+          | _ => None
+          },
+        sections,
+      );
+    expect.option(import_sections).toBeSome();
+    expect.list(Option.get(import_sections)).toContainEqual((
+      WasmFunction,
+      "env",
+      "env.foo",
+    ));
+    expect.option(export_sections).toBeSome();
+    expect.list(Option.get(export_sections)).toContainEqual((
+      WasmFunction,
+      "__foo%%!",
+    ));
+  })
+});

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -398,7 +398,7 @@ describe("optimizations", ({test}) => {
             foo,
             Comp.lambda(
               ~name=Ident.name(foo),
-              ~attributes=[Grain_parsing.Asttypes.mknoloc("disableGC")],
+              ~attributes=[Disable_gc],
               [
                 (arg, HeapAllocated),
                 (arg, HeapAllocated),
@@ -472,7 +472,7 @@ describe("optimizations", ({test}) => {
             foo,
             Comp.lambda(
               ~name=Ident.name(foo),
-              ~attributes=[Grain_parsing.Asttypes.mknoloc("disableGC")],
+              ~attributes=[Disable_gc],
               [],
               (
                 AExp.seq(
@@ -553,7 +553,7 @@ describe("optimizations", ({test}) => {
             foo,
             Comp.lambda(
               ~name=Ident.name(foo),
-              ~attributes=[Grain_parsing.Asttypes.mknoloc("disableGC")],
+              ~attributes=[Disable_gc],
               [],
               (
                 AExp.seq(


### PR DESCRIPTION
This PR adds the ability to specify any UTF-8 string (not just valid Grain identifiers) to use as an external identifier when importing a foreign value or exporting one:

```
@externalName("env.foo")
import foreign wasm foo: Number -> Number from "env"

@externalName("__bar%%!")
export let bar = () => foo(1)
```

This is to allow importing/exporting any foreign value WebAssembly supports.