### PR TITLE
fix(compiler): Fix counting of stack size

### DIFF
--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -235,8 +235,6 @@ and comp_count_vars = c =>
   | CSwitch(_, bs, _) =>
     List.fold_left(tuple_max, tuple_zero) @@
     List.map(((_, b)) => anf_count_vars(b), bs)
-  | CApp(_, args, _) => (List.length(args), 0, 0, 0)
-  | CAppBuiltin(_, _, args) => (List.length(args), 0, 0, 0)
   | _ => tuple_zero
   };
 

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo4
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const -33)
-      (i32.const 35)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const -33)
+     (i32.const 35)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › land4
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $import_pervasives_1158_&_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › land4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_&_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_&_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lxor1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $import_pervasives_1158_^_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lxor1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_^_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_^_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lor1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $import_pervasives_1158_|_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lor1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_|_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_|_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo6
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo6
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 35)
-      (i32.const 35)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 35)
+     (i32.const 35)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -85,18 +85,6 @@ basic functionality › precedence3
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lsl1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $import_pervasives_1158_<<_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lsl1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_<<_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_<<_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 15)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 15)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -205,18 +205,6 @@ basic functionality › comp22
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › land1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $import_pervasives_1158_&_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › land1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_&_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_&_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -18,45 +18,36 @@ basic functionality › orshort2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1157_print_1158)
-            )
-            (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1157_print_1158)
            )
+           (i32.const 0)
           )
          )
-         (i32.const 3)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 3)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (i32.const 2147483646)
      )
-     (local.get $0)
+     (i32.const 2147483646)
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -85,18 +85,6 @@ basic functionality › precedence4
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lsl2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $import_pervasives_1158_<<_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lsl2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_<<_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_<<_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › comp17
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $import_pervasives_1156_isnt_1157 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › comp17
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1156_isnt_1157)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1156_isnt_1157)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 2147483646)
-      (i32.const -2)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 2147483646)
+     (i32.const -2)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › complex2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1160_print_1161 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › complex2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1160_print_1161)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1160_print_1161)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -206,18 +206,6 @@ basic functionality › comp20
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lor3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $import_pervasives_1158_|_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lor3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_|_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_|_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › decr_3
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $import_pervasives_1157_decr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › decr_3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_decr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_decr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -311,12 +311,6 @@ basic functionality › func_shadow
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo5
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo5
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 35)
-      (i32.const -33)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 35)
+     (i32.const -33)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › binop6
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › binop6
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 19)
-      (i32.const 11)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 19)
+     (i32.const 11)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lor2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $import_pervasives_1158_|_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lor2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_|_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_|_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › land2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $import_pervasives_1158_&_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › land2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_&_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_&_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › asr1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $import_pervasives_1158_>>_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › asr1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_>>_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_>>_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 359)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 359)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -205,18 +205,6 @@ basic functionality › comp21
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lxor3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $import_pervasives_1158_^_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lxor3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_^_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_^_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › incr_3
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $import_pervasives_1157_incr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › incr_3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_incr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_incr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const -1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const -1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lxor2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $import_pervasives_1158_^_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lxor2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_^_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_^_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 3)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 3)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › if_one_sided
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $import_pervasives_1161_print_1162 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › if_one_sided
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1161_print_1162)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1161_print_1162)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lxor4
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $import_pervasives_1158_^_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lxor4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_^_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_^_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -18,45 +18,36 @@ basic functionality › complex1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1168_print_1169)
-            )
-            (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1168_print_1169)
            )
+           (i32.const 0)
           )
          )
-         (i32.const 7)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 7)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (i32.const -5)
      )
-     (local.get $0)
+     (i32.const -5)
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lsr2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $import_pervasives_1158_>>>_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lsr2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_>>>_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_>>>_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -20,155 +20,146 @@ basic functionality › toplevel_statements
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1167_print_1168)
-            )
-            (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1167_print_1168)
            )
+           (i32.const 0)
           )
          )
-         (i32.const 3)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 3)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1167_print_1168)
-            )
-            (local.get $0)
+     )
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1167_print_1168)
            )
+           (local.get $0)
           )
          )
-         (i32.const 5)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 5)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1167_print_1168)
-            )
-            (local.get $0)
+     )
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1167_print_1168)
            )
+           (local.get $0)
           )
          )
-         (i32.const 7)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 7)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1167_print_1168)
-            )
-            (local.get $0)
+     )
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1167_print_1168)
            )
+           (local.get $0)
           )
          )
-         (i32.const 9)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 9)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1167_print_1168)
-            )
-            (local.get $0)
+     )
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1167_print_1168)
            )
+           (local.get $0)
           )
          )
-         (i32.const 11)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 11)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (i32.store
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
-           (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
-           (i32.const 16)
-          )
-          (local.get $0)
+     )
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $import_GRAIN$MODULE$runtime/gc_0_malloc_0
+          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$malloc_0)
+          (i32.const 16)
          )
+         (local.get $0)
         )
        )
-       (i32.const 1)
       )
-      (i32.store offset=4
-       (local.get $0)
-       (i32.const 3)
-      )
-      (i64.store offset=8
-       (local.get $0)
-       (i64.const 7303014)
-      )
+      (i32.const 1)
+     )
+     (i32.store offset=4
       (local.get $0)
+      (i32.const 3)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 7303014)
      )
      (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lsr1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $import_pervasives_1158_>>>_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lsr1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_>>>_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_>>>_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 15)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 15)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › incr_1
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $import_pervasives_1157_incr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › incr_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_incr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_incr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 5)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 5)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › incr_2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $import_pervasives_1157_incr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › incr_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_incr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_incr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const -33)
-      (i32.const -7)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const -33)
+     (i32.const -7)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › lor4
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $import_pervasives_1158_|_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › lor4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_|_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_|_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 1)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 1)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › int64_pun_1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $import_pervasives_1158_*_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › int64_pun_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_*_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_*_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 19999999)
-      (i32.const 199999999)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 19999999)
+     (i32.const 199999999)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › decr_1
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $import_pervasives_1157_decr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › decr_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_decr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_decr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 5)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 5)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -18,45 +18,36 @@ basic functionality › andshort1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (drop
-       (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-        (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-        (call_indirect (type $i32_i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-             (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-             (global.get $import_pervasives_1157_print_1158)
-            )
-            (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (drop
+      (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
+       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
+       (call_indirect (type $i32_i32_=>_i32)
+        (local.tee $0
+         (tuple.extract 0
+          (tuple.make
+           (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+            (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+            (global.get $import_pervasives_1157_print_1158)
            )
+           (i32.const 0)
           )
          )
-         (i32.const 3)
-         (i32.load offset=8
-          (local.get $0)
-         )
+        )
+        (i32.const 3)
+        (i32.load offset=8
+         (local.get $0)
         )
        )
       )
-      (i32.const 2147483646)
      )
-     (local.get $0)
+     (i32.const 2147483646)
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const -33)
-      (i32.const 9)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const -33)
+     (i32.const 9)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › land3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $import_pervasives_1158_&_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › land3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_&_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_&_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › comp18
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $import_pervasives_1158_isnt_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › comp18
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_isnt_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_isnt_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 9)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 9)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › asr2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $import_pervasives_1158_>>_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › asr2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_>>_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_>>_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 1)
-      (i32.const 3)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 1)
+     (i32.const 3)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › modulo2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $import_pervasives_1158_%_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › modulo2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_%_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_%_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 35)
-      (i32.const -7)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 35)
+     (i32.const -7)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -7,10 +7,8 @@ basic functionality › decr_2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $import_pervasives_1157_decr_1158 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -18,37 +16,28 @@ basic functionality › decr_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1157_decr_1158)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1157_decr_1158)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -206,18 +206,6 @@ basic functionality › comp19
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › int64_pun_2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $import_pervasives_1158_-_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,44 +17,29 @@ basic functionality › int64_pun_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_pervasives_1158_-_1159)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_pervasives_1158_-_1159)
         )
+        (i32.const 0)
        )
       )
-      (i32.const -199999997)
-      (i32.const 1999999999)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const -199999997)
+     (i32.const 1999999999)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -537,12 +537,6 @@ basic functionality › func_shadow_and_indirect_call
     (local.get $7)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -157,12 +157,6 @@ boxes › box_subtraction1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -196,12 +196,6 @@ boxes › box_multiplication2
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -196,12 +196,6 @@ boxes › box_division2
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -196,12 +196,6 @@ boxes › box_addition2
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -157,12 +157,6 @@ boxes › box_division1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -196,12 +196,6 @@ boxes › box_subtraction2
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -157,12 +157,6 @@ boxes › box_addition1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -157,12 +157,6 @@ boxes › box_multiplication1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -715,12 +715,6 @@ enums › enum_recursive_data_definition
     (local.get $6)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -7,11 +7,9 @@ exports › export9
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $import_exportStar_1166_z_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ exports › export9
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_z_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_z_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -88,18 +88,6 @@ exports › export8
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -64,18 +64,6 @@ functions › shorthand_4
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -153,12 +141,6 @@ functions › shorthand_4
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -114,12 +114,6 @@ functions › shorthand_1
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -319,18 +319,6 @@ functions › lam_destructure_5
     (local.get $11)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -511,18 +499,6 @@ functions › lam_destructure_5
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -147,12 +147,6 @@ functions › lambda_pat_any
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -140,18 +140,6 @@ functions › curried_func
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -263,12 +251,6 @@ functions › curried_func
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $1)

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -114,12 +114,6 @@ functions › app_1
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -114,12 +114,6 @@ functions › shorthand_3
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -181,18 +181,6 @@ functions › lam_destructure_3
     (local.get $6)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -323,12 +311,6 @@ functions › lam_destructure_3
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -270,18 +270,6 @@ functions › lam_destructure_7
     (local.get $9)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -461,12 +449,6 @@ functions › lam_destructure_7
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -64,18 +64,6 @@ functions › shorthand_2
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -153,12 +141,6 @@ functions › shorthand_2
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -181,18 +181,6 @@ functions › lam_destructure_4
     (local.get $6)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -323,12 +311,6 @@ functions › lam_destructure_4
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -270,18 +270,6 @@ functions › lam_destructure_8
     (local.get $9)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $2)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -461,12 +449,6 @@ functions › lam_destructure_8
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -147,12 +147,6 @@ functions › lam_destructure_1
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -147,12 +147,6 @@ functions › lam_destructure_2
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -73,18 +73,6 @@ functions › fn_trailing_comma
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -163,18 +151,6 @@ functions › fn_trailing_comma
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -319,18 +319,6 @@ functions › lam_destructure_6
     (local.get $11)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
@@ -511,18 +499,6 @@ functions › lam_destructure_6
    (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
     (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
@@ -1,18 +1,16 @@
 imports › import_all_constructor
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1165_Empty_1166 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $import_tlists_1167_Cons_1168 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -20,47 +18,32 @@ imports › import_all_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1167_Cons_1168)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1167_Cons_1168)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 5)
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1165_Empty_1166)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 5)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1165_Empty_1166)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -88,12 +88,6 @@ imports › import_alias_multiple_constructor
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -7,11 +7,9 @@ imports › import_alias_multiple
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1166_x_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_alias_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_x_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_x_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
@@ -7,11 +7,9 @@ imports › import_some_multiple_trailing
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1166_x_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_some_multiple_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_x_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_x_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -7,11 +7,9 @@ imports › import_some_multiple
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1166_x_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_some_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_x_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_x_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -82,12 +82,6 @@ imports › import_relative_path4
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
@@ -1,18 +1,16 @@
 imports › import_some_constructor
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1165_Empty_1166 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $import_tlists_1167_Cons_1168 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -20,47 +18,32 @@ imports › import_some_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1167_Cons_1168)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1167_Cons_1168)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1165_Empty_1166)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1165_Empty_1166)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -7,11 +7,9 @@ imports › import_module2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1166_x_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_module2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_x_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_x_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
@@ -1,18 +1,16 @@
 imports › import_same_module_unify2
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1165_Empty_1166 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $import_tlists_1167_Cons_1168 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -20,47 +18,32 @@ imports › import_same_module_unify2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1167_Cons_1168)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1167_Cons_1168)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1165_Empty_1166)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1165_Empty_1166)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
@@ -1,18 +1,16 @@
 imports › import_same_module_unify
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1167_Empty_1168 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $import_tlists_1169_Cons_1170 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -20,47 +18,32 @@ imports › import_same_module_unify
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1169_Cons_1170)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1169_Cons_1170)
         )
+        (i32.const 0)
        )
       )
-      (i32.const 11)
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1167_Empty_1168)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (i32.const 11)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1167_Empty_1168)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -7,11 +7,9 @@ imports › import_all_except_multiple_constructor
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1164_Empty_1165 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $import_tlists_1166_sum_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_all_except_multiple_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1166_sum_1167)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1166_sum_1167)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1164_Empty_1165)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1164_Empty_1165)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
+++ b/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
@@ -7,11 +7,9 @@ imports › import_some_multiple_trailing2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1166_x_1167 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $import_exportStar_1168_y_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_some_multiple_trailing2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_exportStar_1168_y_1169)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_exportStar_1168_y_1169)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1166_x_1167)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1166_x_1167)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -7,11 +7,9 @@ imports › import_alias_constructor
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1164_Empty_1165 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $import_tlists_1166_sum_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -19,40 +17,31 @@ imports › import_alias_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1166_sum_1167)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1166_sum_1167)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1164_Empty_1165)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1164_Empty_1165)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
@@ -1,19 +1,17 @@
 imports › import_muliple_modules
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $import__grainEnv_0_relocBase_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $import_tlists_1174_Empty_1175 (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $import_exportStar_1176_x_1177 (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $import_tlists_1178_Cons_1179 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $import_GRAIN$MODULE$runtime/gc_0_incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -21,50 +19,35 @@ imports › import_muliple_modules
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-          (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-          (global.get $import_tlists_1178_Cons_1179)
-         )
-         (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (call_indirect (type $i32_i32_i32_=>_i32)
+     (local.tee $0
+      (tuple.extract 0
+       (tuple.make
+        (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+         (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+         (global.get $import_tlists_1178_Cons_1179)
         )
+        (i32.const 0)
        )
       )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_exportStar_1176_x_1177)
-      )
-      (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
-       (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
-       (global.get $import_tlists_1174_Empty_1175)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (local.get $0)
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_exportStar_1176_x_1177)
+     )
+     (call $import_GRAIN$MODULE$runtime/gc_0_incRef_0
+      (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$incRef_0)
+      (global.get $import_tlists_1174_Empty_1175)
+     )
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -88,12 +88,6 @@ imports › import_some_mixed
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -120,12 +120,6 @@ let mut › let-mut_division1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $1)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -124,12 +124,6 @@ let mut › let-mut3
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -120,12 +120,6 @@ let mut › let-mut_multiplication1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $1)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -120,12 +120,6 @@ let mut › let-mut_subtraction1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $1)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -120,12 +120,6 @@ let mut › let-mut_addition1
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $1)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -164,18 +164,6 @@ lists › list_spread
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -126,18 +126,6 @@ lists › list1_trailing_space
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -126,18 +126,6 @@ lists › list1_trailing
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -406,24 +406,6 @@ loops › loop2
     (i32.const 0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -301,24 +301,6 @@ loops › loop5
     (i32.const 0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -190,24 +190,6 @@ loops › loop3
     (i32.const 0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $1)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -302,24 +302,6 @@ loops › loop4
     (i32.const 0)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -122,18 +122,6 @@ optimizations › trs1
     (local.get $1)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -264,18 +264,6 @@ optimizations › test_dead_branch_elimination_5
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -242,18 +242,6 @@ pattern matching › record_match_3
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -1042,18 +1042,6 @@ pattern matching › tuple_match_deep4
     (local.get $15)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -350,18 +350,6 @@ pattern matching › tuple_match_deep
     (local.get $9)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -306,18 +306,6 @@ pattern matching › record_match_4
     (local.get $5)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -1118,18 +1118,6 @@ pattern matching › tuple_match_deep6
     (local.get $17)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -1003,18 +1003,6 @@ pattern matching › tuple_match_deep3
     (local.get $14)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -758,18 +758,6 @@ pattern matching › tuple_match_deep2
     (local.get $21)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -1080,18 +1080,6 @@ pattern matching › tuple_match_deep5
     (local.get $16)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -730,12 +730,6 @@ pattern matching › constant_match_4
     (local.get $16)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -1156,18 +1156,6 @@ pattern matching › tuple_match_deep7
     (local.get $18)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -230,18 +230,6 @@ records › record_get_multiple
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -306,18 +306,6 @@ records › record_destruct_4
     (local.get $5)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -242,18 +242,6 @@ records › record_destruct_3
     (local.get $3)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -306,18 +306,6 @@ records › record_destruct_trailing
     (local.get $5)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -347,18 +347,6 @@ stdlib › stdlib_equal_20
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -138,18 +138,6 @@ stdlib › stdlib_equal_18
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -146,18 +146,6 @@ stdlib › stdlib_equal_1
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -126,18 +126,6 @@ stdlib › stdlib_cons
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -347,18 +347,6 @@ stdlib › stdlib_equal_19
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -138,18 +138,6 @@ stdlib › stdlib_equal_16
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -162,18 +162,6 @@ stdlib › stdlib_equal_12
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -347,18 +347,6 @@ stdlib › stdlib_equal_21
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -134,18 +134,6 @@ stdlib › stdlib_equal_15
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -134,18 +134,6 @@ stdlib › stdlib_equal_14
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -282,18 +282,6 @@ stdlib › stdlib_equal_3
     (local.get $6)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -142,18 +142,6 @@ stdlib › stdlib_equal_11
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -134,18 +134,6 @@ stdlib › stdlib_equal_9
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -146,18 +146,6 @@ stdlib › stdlib_equal_2
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -347,18 +347,6 @@ stdlib › stdlib_equal_22
     (local.get $4)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -138,18 +138,6 @@ stdlib › stdlib_equal_10
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -130,18 +130,6 @@ stdlib › stdlib_equal_13
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -130,18 +130,6 @@ stdlib › stdlib_equal_8
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -138,18 +138,6 @@ stdlib › stdlib_equal_17
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -138,18 +138,6 @@ strings › concat
     (local.get $2)
    )
   )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
-  (drop
-   (call $import_GRAIN$MODULE$runtime/gc_0_decRefIgnoreZeros_0
-    (global.get $import_GRAIN$MODULE$runtime/gc_0_GRAIN$EXPORT$decRefIgnoreZeros_0)
-    (i32.const 0)
-   )
-  )
   (local.get $0)
  )
  (func $_start (; has Stack IR ;)


### PR DESCRIPTION
@jozanza Noticed that we were incorrectly considering the arguments to functions as a factor in the stack size (in our case, the number of locals the function needs). Arguments at this stage are always constants or are pulled from a local—no new locals are needed.

We were inflating the stack with unused slots, which resulted in extra (useless) calls to `decRefIgnoreZeros`. You'll notice that every removal of a `decRefIgnoreZeros` in the snapshots is a Binaryen-optimized `decRefIgnoreZeros(0)` 🎉 

~~I believe this is why `decRefIgnoreZeros` was introduced in the first place, so now we can consider removing it.~~ The `ignoreZeros` part is about the ref count.

Great find @jozanza!