### PR TITLE
fix(graindoc): Ensure value_description is resolved to outcome before printing

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -27,9 +27,16 @@ let title_for_api = (~module_name, ident: Ident.t) => {
   Format.asprintf("%s.**%a**", module_name, Printtyp.ident, ident);
 };
 
-let types_for_function = (vd: Types.value_description) => {
+let types_for_function = (~ident, vd: Types.value_description) => {
   switch (Ctype.repr(vd.val_type).desc) {
-  | TTyArrow(args, returns, _) => (Some(args), Some(returns))
+  | TTyArrow(_) =>
+    switch (Printtyp.tree_of_value_description(ident, vd)) {
+    | Osig_value({oval_type: Otyp_arrow(args, returns)}) => (
+        Some(args),
+        Some(returns),
+      )
+    | _ => failwith("types_for_function: impossible via implementation")
+    }
   | _ => (None, None)
   };
 };
@@ -38,11 +45,14 @@ let lookup_type_expr = (~idx, type_exprs) => {
   Option.bind(type_exprs, te => List.nth_opt(te, idx));
 };
 
-let string_of_type_expr = type_expr => {
-  let to_string = type_expr => {
-    Format.asprintf("%a", Printtyp.type_expr, type_expr);
+let string_of_type_expr = out_type => {
+  let printer = (ppf, out_type) => {
+    Oprint.out_type^(ppf, out_type);
   };
-  Option.map(to_string, type_expr);
+  let to_string = out_type => {
+    Format.asprintf("%a", printer, out_type);
+  };
+  Option.map(to_string, out_type);
 };
 
 let for_value_description = (~ident: Ident.t, vd: Types.value_description) => {
@@ -58,7 +68,7 @@ let for_value_description = (~ident: Ident.t, vd: Types.value_description) => {
     | None => (None, [])
     };
 
-  let (args, returns) = types_for_function(vd);
+  let (args, returns) = types_for_function(~ident, vd);
   // This replaces the default `None` for `attr_type` on `Param` and `Returns` attributes
   let apply_types: (int, Comments.Attribute.t) => Comments.Attribute.t =
     (idx, attr) => {

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -371,7 +371,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Array<a>`|The new array with mapped values|
+|`Array<b>`|The new array with mapped values|
 
 ### Array.**mapi**
 
@@ -398,7 +398,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Array<a>`|The new array with mapped values|
+|`Array<b>`|The new array with mapped values|
 
 ### Array.**reduce**
 
@@ -425,7 +425,7 @@ Parameters:
 |-----|----|-----------|
 |`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
-|`array`|`Array<a>`|The array to iterate|
+|`array`|`Array<b>`|The array to iterate|
 
 Returns:
 
@@ -465,7 +465,7 @@ Parameters:
 |-----|----|-----------|
 |`fn`|`(a, b, Number) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
-|`array`|`Array<a>`|The array to iterate|
+|`array`|`Array<b>`|The array to iterate|
 
 Returns:
 
@@ -500,7 +500,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Array<a>`|The new array|
+|`Array<b>`|The new array|
 
 ### Array.**every**
 

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -121,13 +121,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> Result<b, c>`|The function to call on the value of an `Ok` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`result`|`Result<a, c>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<a, b>`|A new Result produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise|
+|`Result<b, c>`|A new Result produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise|
 
 ### Result.**flatMapErr**
 
@@ -147,13 +147,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> Result<b, c>`|The function to call on the value of an `Err` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`result`|`Result<b, a>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<a, b>`|A new Result produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise|
+|`Result<b, c>`|A new Result produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise|
 
 ### Result.**map**
 
@@ -173,13 +173,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`result`|`Result<a, c>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<a, b>`|A new `Ok` variant produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise|
+|`Result<b, c>`|A new `Ok` variant produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise|
 
 ### Result.**mapErr**
 
@@ -199,13 +199,13 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> b`|The function to call on the value of an `Err` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`result`|`Result<c, a>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<a, b>`|A new `Err` variant produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise|
+|`Result<c, b>`|A new `Err` variant produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise|
 
 ### Result.**mapWithDefault**
 
@@ -226,14 +226,14 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`def`|`a`|A fallback value for an `Err` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`def`|`b`|A fallback value for an `Err` variant|
+|`result`|`Result<a, c>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`a`|The value produced by the mapping function if the result is of the `Ok` variant or the default value otherwise|
+|`b`|The value produced by the mapping function if the result is of the `Ok` variant or the default value otherwise|
 
 ### Result.**mapWithDefaultFn**
 
@@ -255,14 +255,14 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fnOk`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`fnErr`|`a -> b`|The function to call on the value of an `Err` variant|
-|`result`|`Result<a, b>`|The result to map|
+|`fnErr`|`c -> b`|The function to call on the value of an `Err` variant|
+|`result`|`Result<a, c>`|The result to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`a`|The value produced by one of the mapping functions|
+|`b`|The value produced by one of the mapping functions|
 
 ### Result.**or**
 
@@ -336,8 +336,8 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fnOk`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`fnErr`|`a -> b`|The function to call on the value of an `Err` variant|
-|`result`|`Result<a, b>`|The result to inspect|
+|`fnErr`|`c -> d`|The function to call on the value of an `Err` variant|
+|`result`|`Result<a, c>`|The result to inspect|
 
 ### Result.**peekOk**
 
@@ -357,7 +357,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`result`|`Result<a, b>`|The result to inspect|
+|`result`|`Result<a, c>`|The result to inspect|
 
 ### Result.**peekErr**
 
@@ -377,7 +377,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fn`|`a -> b`|The function to call on the value of an `Err` variant|
-|`result`|`Result<a, b>`|The result to inspect|
+|`result`|`Result<c, a>`|The result to inspect|
 
 ### Result.**expect**
 

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -249,7 +249,7 @@ Parameters:
 |-----|----|-----------|
 |`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`init`|`a`|The initial value to use for the accumulator on the first iteration|
-|`set`|`Set<a>`|The set to iterate|
+|`set`|`Set<b>`|The set to iterate|
 
 Returns:
 


### PR DESCRIPTION
Remember when I posted #1069 and said that I thought it was going to be hard to fix? Well, I fixed it.

Closes #1069

@ospencer do you think this is a good semantic title? I also wonder if everything should be resolved to outcome types when they are plucked out of `signature_items` 🤔 