### PR TITLE
feat(compiler): Inline all primitives

### DIFF
--- a/compiler/src/middle_end/analyze_inline_wasm.re
+++ b/compiler/src/middle_end/analyze_inline_wasm.re
@@ -1,11 +1,11 @@
+// This module still exists to support the --no-bulk-memory flag.
+
 open Anftree;
 open Anf_iterator;
 open Grain_typed;
 open Grain_utils;
 
 type inline_type =
-  | WasmPrim1(prim1)
-  | WasmPrim2(prim2)
   | WasmPrimN(primn);
 
 type analysis +=
@@ -37,205 +37,15 @@ let get_primitive = prim =>
   Option.bind(prim, prim => {
     Translprim.(
       switch (PrimMap.find_opt(prim_map, prim)) {
-      | Some(Primitive1(prim)) => Some(WasmPrim1(prim))
-      | Some(Primitive2(prim)) => Some(WasmPrim2(prim))
       | Some(PrimitiveN(prim)) => Some(WasmPrimN(prim))
-      | None => None
+      | _ => None
       }
     )
   });
 
-let get_primitive_i32 = id => {
-  let prim =
-    switch (id) {
-    | "fromGrain" => Some("@wasm.fromGrain")
-    | "toGrain" => Some("@wasm.toGrain")
-    | "load" => Some("@wasm.load_int32")
-    | "load8S" => Some("@wasm.load_8_s_int32")
-    | "load8U" => Some("@wasm.load_8_u_int32")
-    | "load16S" => Some("@wasm.load_16_s_int32")
-    | "load16U" => Some("@wasm.load_16_u_int32")
-    | "store" => Some("@wasm.store_int32")
-    | "store8" => Some("@wasm.store_8_int32")
-    | "store16" => Some("@wasm.store_16_int32")
-    | "clz" => Some("@wasm.clz_int32")
-    | "ctz" => Some("@wasm.ctz_int32")
-    | "popcnt" => Some("@wasm.popcnt_int32")
-    | "eqz" => Some("@wasm.eq_z_int32")
-    | "add" => Some("@wasm.add_int32")
-    | "sub" => Some("@wasm.sub_int32")
-    | "mul" => Some("@wasm.mul_int32")
-    | "divS" => Some("@wasm.div_s_int32")
-    | "divU" => Some("@wasm.div_u_int32")
-    | "remS" => Some("@wasm.rem_s_int32")
-    | "remU" => Some("@wasm.rem_u_int32")
-    | "and" => Some("@wasm.and_int32")
-    | "or" => Some("@wasm.or_int32")
-    | "xor" => Some("@wasm.xor_int32")
-    | "shl" => Some("@wasm.shl_int32")
-    | "shrU" => Some("@wasm.shr_u_int32")
-    | "shrS" => Some("@wasm.shr_s_int32")
-    | "rotl" => Some("@wasm.rot_l_int32")
-    | "rotr" => Some("@wasm.rot_r_int32")
-    | "eq" => Some("@wasm.eq_int32")
-    | "ne" => Some("@wasm.ne_int32")
-    | "ltS" => Some("@wasm.lt_s_int32")
-    | "ltU" => Some("@wasm.lt_u_int32")
-    | "leS" => Some("@wasm.le_s_int32")
-    | "leU" => Some("@wasm.le_u_int32")
-    | "gtS" => Some("@wasm.gt_s_int32")
-    | "gtU" => Some("@wasm.gt_u_int32")
-    | "geS" => Some("@wasm.ge_s_int32")
-    | "geU" => Some("@wasm.ge_u_int32")
-    | "wrapI64" => Some("@wasm.wrap_int64")
-    | "truncF32S" => Some("@wasm.trunc_s_float32_to_int32")
-    | "truncF32U" => Some("@wasm.trunc_u_float32_to_int32")
-    | "truncF64S" => Some("@wasm.trunc_s_float64_to_int32")
-    | "truncF64U" => Some("@wasm.trunc_u_float64_to_int32")
-    | "reinterpretF32" => Some("@wasm.reinterpret_float32")
-    | "extendS8" => Some("@wasm.extend_s8_int32")
-    | "extendS16" => Some("@wasm.extend_s16_int32")
-    | _ => None
-    };
-
-  get_primitive(prim);
-};
-let get_primitive_i64 = id => {
-  let prim =
-    switch (id) {
-    | "load" => Some("@wasm.load_int64")
-    | "load8S" => Some("@wasm.load_8_s_int64")
-    | "load8U" => Some("@wasm.load_8_u_int64")
-    | "load16S" => Some("@wasm.load_16_s_int64")
-    | "load16U" => Some("@wasm.load_16_u_int64")
-    | "load32S" => Some("@wasm.load_32_s_int64")
-    | "load32U" => Some("@wasm.load_32_u_int64")
-    | "store" => Some("@wasm.store_int64")
-    | "store8" => Some("@wasm.store_8_int64")
-    | "store16" => Some("@wasm.store_16_int64")
-    | "store32" => Some("@wasm.store_32_int64")
-    | "clz" => Some("@wasm.clz_int64")
-    | "ctz" => Some("@wasm.ctz_int64")
-    | "popcnt" => Some("@wasm.popcnt_int64")
-    | "eqz" => Some("@wasm.eq_z_int64")
-    | "add" => Some("@wasm.add_int64")
-    | "sub" => Some("@wasm.sub_int64")
-    | "mul" => Some("@wasm.mul_int64")
-    | "divS" => Some("@wasm.div_s_int64")
-    | "divU" => Some("@wasm.div_u_int64")
-    | "remS" => Some("@wasm.rem_s_int64")
-    | "remU" => Some("@wasm.rem_u_int64")
-    | "and" => Some("@wasm.and_int64")
-    | "or" => Some("@wasm.or_int64")
-    | "xor" => Some("@wasm.xor_int64")
-    | "shl" => Some("@wasm.shl_int64")
-    | "shrU" => Some("@wasm.shr_u_int64")
-    | "shrS" => Some("@wasm.shr_s_int64")
-    | "rotl" => Some("@wasm.rot_l_int64")
-    | "rotr" => Some("@wasm.rot_r_int64")
-    | "eq" => Some("@wasm.eq_int64")
-    | "ne" => Some("@wasm.ne_int64")
-    | "ltS" => Some("@wasm.lt_s_int64")
-    | "ltU" => Some("@wasm.lt_u_int64")
-    | "leS" => Some("@wasm.le_s_int64")
-    | "leU" => Some("@wasm.le_u_int64")
-    | "gtS" => Some("@wasm.gt_s_int64")
-    | "gtU" => Some("@wasm.gt_u_int64")
-    | "geS" => Some("@wasm.ge_s_int64")
-    | "geU" => Some("@wasm.ge_u_int64")
-    | "extendI32S" => Some("@wasm.extend_s_int32")
-    | "extendI32U" => Some("@wasm.extend_u_int32")
-    | "truncF32S" => Some("@wasm.trunc_s_float32_to_int64")
-    | "truncF32U" => Some("@wasm.trunc_u_float32_to_int64")
-    | "truncF64S" => Some("@wasm.trunc_s_float64_to_int64")
-    | "truncF64U" => Some("@wasm.trunc_u_float64_to_int64")
-    | "reinterpretF64" => Some("@wasm.reinterpret_float64")
-    | "extendS8" => Some("@wasm.extend_s8_int64")
-    | "extendS16" => Some("@wasm.extend_s16_int64")
-    | "extendS32" => Some("@wasm.extend_s32_int64")
-    | _ => None
-    };
-
-  get_primitive(prim);
-};
-let get_primitive_f32 = id => {
-  let prim =
-    switch (id) {
-    | "load" => Some("@wasm.load_float32")
-    | "store" => Some("@wasm.store_float32")
-    | "neg" => Some("@wasm.neg_float32")
-    | "abs" => Some("@wasm.abs_float32")
-    | "ceil" => Some("@wasm.ceil_float32")
-    | "floor" => Some("@wasm.floor_float32")
-    | "trunc" => Some("@wasm.trunc_float32")
-    | "nearest" => Some("@wasm.nearest_float32")
-    | "sqrt" => Some("@wasm.sqrt_float32")
-    | "add" => Some("@wasm.add_float32")
-    | "sub" => Some("@wasm.sub_float32")
-    | "mul" => Some("@wasm.mul_float32")
-    | "div" => Some("@wasm.div_float32")
-    | "copySign" => Some("@wasm.copy_sign_float32")
-    | "min" => Some("@wasm.min_float32")
-    | "max" => Some("@wasm.max_float32")
-    | "eq" => Some("@wasm.eq_float32")
-    | "ne" => Some("@wasm.ne_float32")
-    | "lt" => Some("@wasm.lt_float32")
-    | "le" => Some("@wasm.le_float32")
-    | "gt" => Some("@wasm.gt_float32")
-    | "ge" => Some("@wasm.ge_float32")
-    | "reinterpretI32" => Some("@wasm.reinterpret_int32")
-    | "convertI32S" => Some("@wasm.convert_s_int32_to_float32")
-    | "convertI32U" => Some("@wasm.convert_u_int32_to_float32")
-    | "convertI64S" => Some("@wasm.convert_s_int64_to_float32")
-    | "convertI64U" => Some("@wasm.convert_u_int64_to_float32")
-    | "demoteF64" => Some("@wasm.demote_float64")
-    | _ => None
-    };
-
-  get_primitive(prim);
-};
-let get_primitive_f64 = id => {
-  let prim =
-    switch (id) {
-    | "load" => Some("@wasm.load_float64")
-    | "store" => Some("@wasm.store_float64")
-    | "neg" => Some("@wasm.neg_float64")
-    | "abs" => Some("@wasm.abs_float64")
-    | "ceil" => Some("@wasm.ceil_float64")
-    | "floor" => Some("@wasm.floor_float64")
-    | "trunc" => Some("@wasm.trunc_float64")
-    | "nearest" => Some("@wasm.nearest_float64")
-    | "sqrt" => Some("@wasm.sqrt_float64")
-    | "add" => Some("@wasm.add_float64")
-    | "sub" => Some("@wasm.sub_float64")
-    | "mul" => Some("@wasm.mul_float64")
-    | "div" => Some("@wasm.div_float64")
-    | "copySign" => Some("@wasm.copy_sign_float64")
-    | "min" => Some("@wasm.min_float64")
-    | "max" => Some("@wasm.max_float64")
-    | "eq" => Some("@wasm.eq_float64")
-    | "ne" => Some("@wasm.ne_float64")
-    | "lt" => Some("@wasm.lt_float64")
-    | "le" => Some("@wasm.le_float64")
-    | "gt" => Some("@wasm.gt_float64")
-    | "ge" => Some("@wasm.ge_float64")
-    | "reinterpretI64" => Some("@wasm.reinterpret_int64")
-    | "convertI32S" => Some("@wasm.convert_s_int32_to_float64")
-    | "convertI32U" => Some("@wasm.convert_u_int32_to_float64")
-    | "convertI64S" => Some("@wasm.convert_s_int64_to_float64")
-    | "convertI64U" => Some("@wasm.convert_u_int64_to_float64")
-    | "promoteF32" => Some("@wasm.promote_float32")
-    | _ => None
-    };
-
-  get_primitive(prim);
-};
 let get_primitive_memory = id => {
   let prim =
     switch (id) {
-    | "grow" => Some("@wasm.memory_grow")
-    | "size" => Some("@wasm.memory_size")
-    | "compare" => Some("@wasm.memory_compare")
     | "copy" when Config.bulk_memory^ => Some("@wasm.memory_copy")
     | "fill" when Config.bulk_memory^ => Some("@wasm.memory_fill")
     | _ => None
@@ -249,30 +59,6 @@ let analyze = ({imports, body, analyses}) => {
   mod_has_inlineable_wasm := false;
   let process_import = ({imp_use_id, imp_desc}) => {
     switch (imp_desc) {
-    | GrainValue("runtime/unsafe/wasmi32", name) =>
-      mod_has_inlineable_wasm := true;
-      switch (get_primitive_i32(name)) {
-      | Some(prim) => set_inlineable_wasm(imp_use_id, prim)
-      | None => ()
-      };
-    | GrainValue("runtime/unsafe/wasmi64", name) =>
-      mod_has_inlineable_wasm := true;
-      switch (get_primitive_i64(name)) {
-      | Some(prim) => set_inlineable_wasm(imp_use_id, prim)
-      | None => ()
-      };
-    | GrainValue("runtime/unsafe/wasmf32", name) =>
-      mod_has_inlineable_wasm := true;
-      switch (get_primitive_f32(name)) {
-      | Some(prim) => set_inlineable_wasm(imp_use_id, prim)
-      | None => ()
-      };
-    | GrainValue("runtime/unsafe/wasmf64", name) =>
-      mod_has_inlineable_wasm := true;
-      switch (get_primitive_f64(name)) {
-      | Some(prim) => set_inlineable_wasm(imp_use_id, prim)
-      | None => ()
-      };
     | GrainValue("runtime/unsafe/memory", name) =>
       mod_has_inlineable_wasm := true;
       switch (get_primitive_memory(name)) {

--- a/compiler/src/middle_end/analyze_inline_wasm.rei
+++ b/compiler/src/middle_end/analyze_inline_wasm.rei
@@ -2,8 +2,6 @@ open Anftree;
 open Grain_typed;
 
 type inline_type =
-  | WasmPrim1(prim1)
-  | WasmPrim2(prim2)
   | WasmPrimN(primn);
 
 let mod_has_inlineable_wasm: ref(bool);

--- a/compiler/src/middle_end/optimize_inline_wasm.re
+++ b/compiler/src/middle_end/optimize_inline_wasm.re
@@ -1,3 +1,5 @@
+// This module still exists to support the --no-bulk-memory flag.
+
 open Anftree;
 open Grain_typed;
 open Analyze_inline_wasm;
@@ -7,28 +9,11 @@ module IWArg: Anf_mapper.MapArgument = {
 
   let leave_comp_expression = ({comp_desc: desc} as c) => {
     switch (desc) {
-    | CApp(({imm_desc: ImmId(id)}, _), [arg1], _)
-        when has_inline_wasm_type(id) =>
-      let prim1 =
-        switch (get_inline_wasm_type(id)) {
-        | WasmPrim1(prim1) => prim1
-        | _ => failwith("internal: WasmPrim1 was not found")
-        };
-      {...c, comp_desc: CPrim1(prim1, arg1)};
-    | CApp(({imm_desc: ImmId(id)}, _), [arg1, arg2], _)
-        when has_inline_wasm_type(id) =>
-      let prim2 =
-        switch (get_inline_wasm_type(id)) {
-        | WasmPrim2(prim2) => prim2
-        | _ => failwith("internal: WasmPrim2 was not found")
-        };
-      {...c, comp_desc: CPrim2(prim2, arg1, arg2)};
     | CApp(({imm_desc: ImmId(id)}, _), args, _)
         when has_inline_wasm_type(id) =>
       let primn =
         switch (get_inline_wasm_type(id)) {
         | WasmPrimN(primn) => primn
-        | _ => failwith("internal: WasmPrimN was not found")
         };
       {...c, comp_desc: CPrimN(primn, args)};
     | _ => c

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -7,12 +7,13 @@ basic functionality › comp22
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $gimport_pervasives_[] (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $gimport_pervasives_[...] (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $gimport_pervasives_isnt (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -33,22 +34,30 @@ basic functionality › comp22
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 3)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -94,22 +103,30 @@ basic functionality › comp22
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (local.get $0)
              )
-             (local.get $0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 3)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -7,12 +7,12 @@ basic functionality › comp21
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $gimport_pervasives_[] (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $gimport_pervasives_[...] (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$is\" (global $gimport_pervasives_is (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -33,22 +33,30 @@ basic functionality › comp21
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 3)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -94,22 +102,30 @@ basic functionality › comp21
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (local.get $0)
              )
-             (local.get $0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 3)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -152,29 +168,21 @@ basic functionality › comp21
         )
        )
       )
-      (call_indirect (type $i32_i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_is)
-          )
-          (local.get $0)
+      (i32.or
+       (i32.shl
+        (i32.eq
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $2)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $4)
          )
         )
+        (i32.const 31)
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
-       )
-       (i32.load offset=8
-        (local.get $0)
-       )
+       (i32.const 2147483646)
       )
      )
      (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -11,7 +11,6 @@ basic functionality › comp19
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $gimport_pervasives_[] (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $gimport_pervasives_[...] (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$is\" (global $gimport_pervasives_is (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -153,29 +152,21 @@ basic functionality › comp19
         )
        )
       )
-      (call_indirect (type $i32_i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_is)
-          )
-          (local.get $0)
+      (i32.or
+       (i32.shl
+        (i32.eq
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $2)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $4)
          )
         )
+        (i32.const 31)
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
-       )
-       (i32.load offset=8
-        (local.get $0)
-       )
+       (i32.const 2147483646)
       )
      )
      (local.get $0)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_subtraction1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -31,22 +31,30 @@ boxes › box_subtraction1
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -58,24 +66,10 @@ boxes › box_subtraction1
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_multiplication2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $gimport_pervasives_* (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -32,22 +32,30 @@ boxes › box_multiplication2
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -59,24 +67,10 @@ boxes › box_multiplication2
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -147,24 +141,10 @@ boxes › box_multiplication2
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_division2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $gimport_pervasives_/ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -32,22 +32,30 @@ boxes › box_division2
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 153)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 153)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -59,24 +67,10 @@ boxes › box_division2
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -147,24 +141,10 @@ boxes › box_division2
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_addition2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -32,22 +32,30 @@ boxes › box_addition2
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -59,24 +67,10 @@ boxes › box_addition2
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -147,24 +141,10 @@ boxes › box_addition2
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_division1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $gimport_pervasives_/ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -31,22 +31,30 @@ boxes › box_division1
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 153)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 153)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -58,24 +66,10 @@ boxes › box_division1
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_subtraction2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -32,22 +32,30 @@ boxes › box_subtraction2
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -59,24 +67,10 @@ boxes › box_subtraction2
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -147,24 +141,10 @@ boxes › box_subtraction2
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $1)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_addition1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -31,22 +31,30 @@ boxes › box_addition1
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -58,24 +66,10 @@ boxes › box_addition1
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -7,11 +7,11 @@ boxes › box_multiplication1
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $gimport_pervasives_* (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -31,22 +31,30 @@ boxes › box_multiplication1
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -58,24 +66,10 @@ boxes › box_multiplication1
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -4,12 +4,10 @@ boxes › test_set_extra1
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -27,22 +25,30 @@ boxes › test_set_extra1
        (local.tee $1
         (tuple.extract 0
          (tuple.make
-          (call_indirect (type $i32_i32_=>_i32)
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (global.get $gimport_pervasives_box)
+          (block (result i32)
+           (i32.store
+            (local.tee $0
+             (tuple.extract 0
+              (tuple.make
+               (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                (i32.const 12)
+               )
+               (i32.const 0)
               )
-              (i32.const 0)
              )
             )
+            (i32.const 8)
            )
-           (i32.const 3)
-           (i32.load offset=8
+           (i32.store offset=4
             (local.get $0)
+            (i32.const 1)
            )
+           (i32.store offset=8
+            (local.get $0)
+            (i32.const 3)
+           )
+           (local.get $0)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -4,12 +4,11 @@ let mut › let-mut3
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -29,22 +28,30 @@ let mut › let-mut3
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 9)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 9)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -81,24 +88,10 @@ let mut › let-mut3
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -7,13 +7,13 @@ loops › loop2
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $gimport_pervasives_> (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -37,22 +37,30 @@ loops › loop2
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 25)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 25)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -64,22 +72,30 @@ loops › loop2
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (local.get $0)
              )
-             (local.get $0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 1)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 1)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -96,24 +112,10 @@ loops › loop2
            (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call_indirect (type $i32_i32_=>_i32)
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                   (global.get $gimport_pervasives_unbox)
-                  )
-                  (local.get $0)
-                 )
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (local.get $2)
-               )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (i32.load offset=8
-                (local.get $0)
+                (local.get $2)
                )
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -157,24 +159,10 @@ loops › loop2
            (local.set $1
             (tuple.extract 0
              (tuple.make
-              (call_indirect (type $i32_i32_=>_i32)
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                   (global.get $gimport_pervasives_unbox)
-                  )
-                  (local.get $0)
-                 )
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (local.get $2)
-               )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (i32.load offset=8
-                (local.get $0)
+                (local.get $2)
                )
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -248,24 +236,10 @@ loops › loop2
            (local.set $5
             (tuple.extract 0
              (tuple.make
-              (call_indirect (type $i32_i32_=>_i32)
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                   (global.get $gimport_pervasives_unbox)
-                  )
-                  (local.get $0)
-                 )
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (local.get $3)
-               )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (i32.load offset=8
-                (local.get $0)
+                (local.get $3)
                )
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -333,24 +307,10 @@ loops › loop2
         )
        )
       )
-      (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_unbox)
-          )
-          (local.get $0)
-         )
-        )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
-       )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $0)
+        (local.get $3)
        )
       )
      )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -7,11 +7,11 @@ optimizations › test_dead_branch_elimination_5
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$unbox\" (global $gimport_pervasives_unbox (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$box\" (global $gimport_pervasives_box (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
@@ -31,25 +31,33 @@ optimizations › test_dead_branch_elimination_5
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 3)
-          (i32.load offset=8
-           (local.get $1)
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -58,25 +66,33 @@ optimizations › test_dead_branch_elimination_5
         )
        )
       )
-      (local.set $1
+      (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_box)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 12)
+              )
+              (local.get $0)
              )
-             (local.get $1)
             )
            )
+           (i32.const 8)
           )
-          (i32.const 5)
-          (i32.load offset=8
+          (i32.store offset=4
            (local.get $0)
+           (i32.const 1)
           )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 5)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
@@ -90,14 +106,14 @@ optimizations › test_dead_branch_elimination_5
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (local.get $2)
+           (local.get $1)
            (tuple.extract 0
             (tuple.make
              (i32.const 7)
              (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
               (i32.load offset=8
-               (local.get $2)
+               (local.get $1)
               )
              )
             )
@@ -117,14 +133,14 @@ optimizations › test_dead_branch_elimination_5
         (tuple.make
          (block (result i32)
           (i32.store offset=8
-           (local.get $1)
+           (local.get $2)
            (tuple.extract 0
             (tuple.make
              (i32.const 9)
              (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
               (i32.load offset=8
-               (local.get $1)
+               (local.get $2)
               )
              )
             )
@@ -142,24 +158,10 @@ optimizations › test_dead_branch_elimination_5
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -172,24 +174,10 @@ optimizations › test_dead_branch_elimination_5
       (local.set $4
        (tuple.extract 0
         (tuple.make
-         (call_indirect (type $i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_unbox)
-             )
-             (local.get $0)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $2)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
@@ -231,13 +219,13 @@ optimizations › test_dead_branch_elimination_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -3,14 +3,11 @@ stdlib › stdlib_equal_1
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRefIgnoreZeros\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRefIgnoreZeros (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$is\" (global $gimport_pervasives_is (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRefIgnoreZeros\" (func $wimport_GRAIN$MODULE$runtime/gc_decRefIgnoreZeros (param i32 i32) (result i32)))
@@ -105,29 +102,21 @@ stdlib › stdlib_equal_1
         )
        )
       )
-      (call_indirect (type $i32_i32_i32_=>_i32)
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_is)
-          )
-          (local.get $0)
+      (i32.or
+       (i32.shl
+        (i32.eq
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $1)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $2)
          )
         )
+        (i32.const 31)
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
-       )
-       (i32.load offset=8
-        (local.get $0)
-       )
+       (i32.const 2147483646)
       )
      )
      (local.get $0)


### PR DESCRIPTION
Right now we only inline some primitives. This PR inlines them all. This also allows us to mostly remove the `inline_wasm` optimization, but we can't completely get rid of it because of `--no-bulk-memory`—we could, but that means we'd need to write the polyfill implementations of `memory_fill` and `memory_copy` in pure wasm in the compiler (which I didn't want to do right now 😅).