### PR TITLE
feat(stdlib): Add sign function to Number module

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -134,3 +134,9 @@ assert Result.isErr(Number.parseInt("zzzzz", 37))
 assert Result.isErr(Number.parseInt("zzzzz", 9223372036854775807))
 assert Result.isErr(Number.parseInt("10", 1.23))
 assert Result.isErr(Number.parseInt("10", 2/3))
+
+// Number.sign
+assert Number.sign(-10000) == -1
+assert Number.sign(22222) == 1
+assert Number.sign(0) == 0
+assert Number.sign(-0) == 0

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -1,5 +1,6 @@
 import Number from "number"
 import Result from "result"
+import Float64 from "float64"
 
 // add
 assert Number.add(25, 5) == 30
@@ -138,5 +139,7 @@ assert Result.isErr(Number.parseInt("10", 2/3))
 // Number.sign
 assert Number.sign(-10000) == -1
 assert Number.sign(22222) == 1
-assert Number.sign(0) == 0
-assert Number.sign(-0) == 0
+// TODO(#693): Replace with Infinity literal when it exists
+assert 1 / Number.sign(0.0) == Float64.toNumber(Float64.infinity)
+// TODO(#693): Replace with -Infinity literal when it exists
+assert 1 / Number.sign(-0.0) == Number.neg(Float64.toNumber(Float64.infinity))

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -94,7 +94,7 @@ export let rec sqrt = (x: Number) => {
  *
  * @example Number.sign(-10000) == -1
  * @example Number.sign(222222) == 1
- * @example Number.sign(-0.0) == -0.0
+ * @example Number.sign(0) == 0
  */
 export let sign = x => {
   match (x) {

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -87,6 +87,24 @@ export let rec sqrt = (x: Number) => {
 }
 
 /**
+ * Determine the positivity or negativity of a Number.
+ *
+ * @param x: The number to inspect
+ * @returns `-1` if the number is negative, `1` if positive, or +/-`0` otherwise
+ *
+ * @example Math.sign(-10000) == -1
+ * @example Math.sign(222222) == 1
+ * @example Math.sign(-0) == -0
+ */
+export let sign = x => {
+  match (x) {
+    x when x < 0 => -1,
+    x when x > 0 => 1,
+    _ => 0 * x,
+  }
+}
+
+/**
  * Returns the smaller of its operands.
  *
  * @param x: The first operand

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -92,9 +92,9 @@ export let rec sqrt = (x: Number) => {
  * @param x: The number to inspect
  * @returns `-1` if the number is negative, `1` if positive, or +/-`0` otherwise
  *
- * @example Math.sign(-10000) == -1
- * @example Math.sign(222222) == 1
- * @example Math.sign(-0.0) == -0.0
+ * @example Number.sign(-10000) == -1
+ * @example Number.sign(222222) == 1
+ * @example Number.sign(-0.0) == -0.0
  */
 export let sign = x => {
   match (x) {

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -90,7 +90,7 @@ export let rec sqrt = (x: Number) => {
  * Determine the positivity or negativity of a Number.
  *
  * @param x: The number to inspect
- * @returns `-1` if the number is negative, `1` if positive, or +/-`0` otherwise
+ * @returns `-1` if the number is negative, `1` if positive, or `0` otherwise; signedness of `-0.0` is preserved
  *
  * @example Number.sign(-10000) == -1
  * @example Number.sign(222222) == 1

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -94,7 +94,7 @@ export let rec sqrt = (x: Number) => {
  *
  * @example Math.sign(-10000) == -1
  * @example Math.sign(222222) == 1
- * @example Math.sign(-0) == -0
+ * @example Math.sign(-0.0) == -0.0
  */
 export let sign = x => {
   match (x) {

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -173,7 +173,7 @@ Math.sign(222222) == 1
 ```
 
 ```grain
-Math.sign(-0) == -0
+Math.sign(-0.0) == -0.0
 ```
 
 ### Number.**min**

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -160,20 +160,20 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|`-1` if the number is negative, `1` if positive, or +/-`0` otherwise|
+|`Number`|`-1` if the number is negative, `1` if positive, or `0` otherwise; signedness of `-0.0` is preserved|
 
 Examples:
 
 ```grain
-Math.sign(-10000) == -1
+Number.sign(-10000) == -1
 ```
 
 ```grain
-Math.sign(222222) == 1
+Number.sign(222222) == 1
 ```
 
 ```grain
-Math.sign(-0.0) == -0.0
+Number.sign(0) == 0
 ```
 
 ### Number.**min**

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -142,6 +142,40 @@ Returns:
 |----|-----------|
 |`Number`|The square root of the operand|
 
+### Number.**sign**
+
+```grain
+sign : Number -> Number
+```
+
+Determine the positivity or negativity of a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Number`|The number to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|`-1` if the number is negative, `1` if positive, or +/-`0` otherwise|
+
+Examples:
+
+```grain
+Math.sign(-10000) == -1
+```
+
+```grain
+Math.sign(222222) == 1
+```
+
+```grain
+Math.sign(-0) == -0
+```
+
 ### Number.**min**
 
 <details disabled>


### PR DESCRIPTION
This adds the `Number.sign(x)` function, similar to the [`Math.sign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign) function in JavaScript. It even accounts for the `-0` case by multiplying the `0` result by the input number (you can see it working in the tests).

Opening as a draft, just to make sure we are good with the implementation.

Ref #1017