### PR TITLE
chore(cli): Advertise the "-o" option in the help of the doc command.

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -211,6 +211,7 @@ program
 program
   .command("doc <file>")
   .description("generate documentation for a grain file")
+  .option("-o <filename>", "output filename")
   .action(
     wrapAction(function (file, options, program) {
       doc(file, program);


### PR DESCRIPTION
The help for graindoc didn't list the `-o` option.