### PR TITLE
chore: Update copyright & license year

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ yarn run
 
 This will display an interactive session where you can select the project and command you want.
 
-Copyright ©️ 2017-2021 Philip Blair, Oscar Spencer, & contributors.
+Copyright ©️ 2017-22 Philip Blair, Oscar Spencer, & contributors.

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ yarn run
 
 This will display an interactive session where you can select the project and command you want.
 
-Copyright ©️ 2017-22 Philip Blair, Oscar Spencer, & contributors.
+Copyright ©️ 2017-2022 Philip Blair, Oscar Spencer, & contributors.

--- a/js-runner/LICENSE
+++ b/js-runner/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2022 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stdlib/LICENSE
+++ b/stdlib/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2022 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates 2021 to 2022 in the license and copyright.