### PR TITLE
fix(grainfmt): Indent function application args when adding parens

### DIFF
--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -1732,12 +1732,7 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, left_expr, Doc.rparen]);
         } else {
-          Doc.concat([
-            Doc.lparen,
-            Doc.indent(Doc.concat([Doc.softLine, left_expr])),
-            Doc.softLine,
-            Doc.rparen,
-          ]);
+          Doc.concat([Doc.lparen, Doc.indent(left_expr), Doc.rparen]);
         };
       } else {
         left_expr;
@@ -1748,12 +1743,7 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, right_expr, Doc.rparen]);
         } else {
-          Doc.concat([
-            Doc.lparen,
-            Doc.indent(Doc.concat([Doc.softLine, right_expr])),
-            Doc.softLine,
-            Doc.rparen,
-          ]);
+          Doc.concat([Doc.lparen, Doc.indent(right_expr), Doc.rparen]);
         };
       } else {
         right_expr;

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -1729,14 +1729,22 @@ and print_infix_application =
 
     let wrapped_left =
       if (left_needs_parens) {
-        Doc.concat([Doc.lparen, Doc.indent(left_expr), Doc.rparen]);
+        if (Doc.willBreak(right_expr)) {
+          Doc.concat([Doc.lparen, left_expr, Doc.rparen]);
+        } else {
+          Doc.concat([Doc.lparen, Doc.indent(left_expr), Doc.rparen]);
+        };
       } else {
         left_expr;
       };
 
     let wrapped_right =
       if (right_needs_parens) {
-        Doc.concat([Doc.lparen, Doc.indent(right_expr), Doc.rparen]);
+        if (Doc.willBreak(right_expr)) {
+          Doc.concat([Doc.lparen, right_expr, Doc.rparen]);
+        } else {
+          Doc.concat([Doc.lparen, Doc.indent(right_expr), Doc.rparen]);
+        };
       } else {
         right_expr;
       };

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -1732,7 +1732,12 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, left_expr, Doc.rparen]);
         } else {
-          Doc.concat([Doc.lparen, Doc.indent(Doc.concat([Doc.softLine,left_expr])), Doc.softLine, Doc.rparen]);
+          Doc.concat([
+            Doc.lparen,
+            Doc.indent(Doc.concat([Doc.softLine, left_expr])),
+            Doc.softLine,
+            Doc.rparen,
+          ]);
         };
       } else {
         left_expr;
@@ -1743,7 +1748,12 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, right_expr, Doc.rparen]);
         } else {
-          Doc.concat([Doc.lparen, Doc.indent(Doc.concat([Doc.softLine,right_expr])), Doc.softLine, Doc.rparen]);
+          Doc.concat([
+            Doc.lparen,
+            Doc.indent(Doc.concat([Doc.softLine, right_expr])),
+            Doc.softLine,
+            Doc.rparen,
+          ]);
         };
       } else {
         right_expr;

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -1732,7 +1732,7 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, left_expr, Doc.rparen]);
         } else {
-          Doc.concat([Doc.lparen, Doc.indent(left_expr), Doc.rparen]);
+          Doc.concat([Doc.lparen, Doc.indent(Doc.concat([Doc.softLine,left_expr])), Doc.softLine, Doc.rparen]);
         };
       } else {
         left_expr;
@@ -1743,7 +1743,7 @@ and print_infix_application =
         if (Doc.willBreak(right_expr)) {
           Doc.concat([Doc.lparen, right_expr, Doc.rparen]);
         } else {
-          Doc.concat([Doc.lparen, Doc.indent(right_expr), Doc.rparen]);
+          Doc.concat([Doc.lparen, Doc.indent(Doc.concat([Doc.softLine,right_expr])), Doc.softLine, Doc.rparen]);
         };
       } else {
         right_expr;

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -1729,14 +1729,14 @@ and print_infix_application =
 
     let wrapped_left =
       if (left_needs_parens) {
-        Doc.concat([Doc.lparen, left_expr, Doc.rparen]);
+        Doc.concat([Doc.lparen, Doc.indent(left_expr), Doc.rparen]);
       } else {
         left_expr;
       };
 
     let wrapped_right =
       if (right_needs_parens) {
-        Doc.concat([Doc.lparen, right_expr, Doc.rparen]);
+        Doc.concat([Doc.lparen, Doc.indent(right_expr), Doc.rparen]);
       } else {
         right_expr;
       };

--- a/compiler/test/formatter_inputs/application_indenting.gr
+++ b/compiler/test/formatter_inputs/application_indenting.gr
@@ -1,0 +1,26 @@
+let flagsToWasmVal = (flag, i) => {
+      let riiiiiiightsInheriting = Module64.load(structPtr, 16n)
+      (riiiiiiightsInheriting &
+      1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)) >
+      0N
+    }
+
+
+let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
+  let mut lastp = buffer + len - 1n
+  let mut digit = Module32.load8U(lastp, 0n)
+  let mut rest = rest
+  while (
+    Module64.ltU(rest, wp_w) &&
+    Module64.geU(Module64.sub(delta, rest), ten_kappa) &&
+    (Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
+    Module64.gtU(
+      Module64.sub(wp_w, rest),
+      Module64.sub(Module64.add(rest, ten_kappa), wp_w)
+    ))
+  ) {
+    digit -= 1n
+    rest = Module64.add(rest, ten_kappa)
+  }
+  Module32.store8(lastp, digit, 0n)
+}

--- a/compiler/test/formatter_outputs/application_indenting.gr
+++ b/compiler/test/formatter_outputs/application_indenting.gr
@@ -1,0 +1,25 @@
+let flagsToWasmVal = (flag, i) => {
+  let riiiiiiightsInheriting = Module64.load(structPtr, 16n)
+  (riiiiiiightsInheriting &
+    1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)) >
+  0N
+}
+
+let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
+  let mut lastp = buffer + len - 1n
+  let mut digit = Module32.load8U(lastp, 0n)
+  let mut rest = rest
+  while (
+    Module64.ltU(rest, wp_w) &&
+    Module64.geU(Module64.sub(delta, rest), ten_kappa) &&
+    (Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
+      Module64.gtU(
+        Module64.sub(wp_w, rest),
+        Module64.sub(Module64.add(rest, ten_kappa), wp_w)
+      ))
+  ) {
+    digit -= 1n
+    rest = Module64.add(rest, ten_kappa)
+  }
+  Module32.store8(lastp, digit, 0n)
+}

--- a/compiler/test/formatter_outputs/application_indenting.gr
+++ b/compiler/test/formatter_outputs/application_indenting.gr
@@ -1,7 +1,9 @@
 let flagsToWasmVal = (flag, i) => {
   let riiiiiiightsInheriting = Module64.load(structPtr, 16n)
-  (riiiiiiightsInheriting &
-    1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)) >
+  (
+    riiiiiiightsInheriting &
+    1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)
+  ) >
   0N
 }
 
@@ -12,11 +14,13 @@ let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
   while (
     Module64.ltU(rest, wp_w) &&
     Module64.geU(Module64.sub(delta, rest), ten_kappa) &&
-    (Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
+    (
+      Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
       Module64.gtU(
         Module64.sub(wp_w, rest),
         Module64.sub(Module64.add(rest, ten_kappa), wp_w)
-      ))
+      )
+    )
   ) {
     digit -= 1n
     rest = Module64.add(rest, ten_kappa)

--- a/compiler/test/formatter_outputs/application_indenting.gr
+++ b/compiler/test/formatter_outputs/application_indenting.gr
@@ -1,9 +1,7 @@
 let flagsToWasmVal = (flag, i) => {
   let riiiiiiightsInheriting = Module64.load(structPtr, 16n)
-  (
-    riiiiiiightsInheriting &
-    1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)
-  ) >
+  (riiiiiiightsInheriting &
+    1N << Module64.extendI32U(Module32.fromGrain(i) >> 1n)) >
   0N
 }
 
@@ -14,13 +12,11 @@ let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
   while (
     Module64.ltU(rest, wp_w) &&
     Module64.geU(Module64.sub(delta, rest), ten_kappa) &&
-    (
-      Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
+    (Module64.ltU(Module64.add(rest, ten_kappa), wp_w) ||
       Module64.gtU(
         Module64.sub(wp_w, rest),
         Module64.sub(Module64.add(rest, ten_kappa), wp_w)
-      )
-    )
+      ))
   ) {
     digit -= 1n
     rest = Module64.add(rest, ten_kappa)

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -6,6 +6,7 @@ describe("formatter", ({test}) => {
   assertFormatOutput("aliases", "aliases");
   assertFormatOutput("application", "application");
   assertFormatOutput("application2", "application2");
+  assertFormatOutput("application_indenting", "application_indenting");
   assertFormatOutput("function_params", "function_params");
   assertFormatOutput("variants", "variants");
   assertFormatOutput("matches", "matches");

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -1105,10 +1105,10 @@ let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
     WasmI64.ltU(rest, wp_w) &&
     WasmI64.geU(WasmI64.sub(delta, rest), ten_kappa) &&
     (WasmI64.ltU(WasmI64.add(rest, ten_kappa), wp_w) ||
-    WasmI64.gtU(
-      WasmI64.sub(wp_w, rest),
-      WasmI64.sub(WasmI64.add(rest, ten_kappa), wp_w)
-    ))
+      WasmI64.gtU(
+        WasmI64.sub(wp_w, rest),
+        WasmI64.sub(WasmI64.add(rest, ten_kappa), wp_w)
+      ))
   ) {
     digit -= 1n
     rest = WasmI64.add(rest, ten_kappa)

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -1104,11 +1104,13 @@ let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
   while (
     WasmI64.ltU(rest, wp_w) &&
     WasmI64.geU(WasmI64.sub(delta, rest), ten_kappa) &&
-    (WasmI64.ltU(WasmI64.add(rest, ten_kappa), wp_w) ||
+    (
+      WasmI64.ltU(WasmI64.add(rest, ten_kappa), wp_w) ||
       WasmI64.gtU(
         WasmI64.sub(wp_w, rest),
         WasmI64.sub(WasmI64.add(rest, ten_kappa), wp_w)
-      ))
+      )
+    )
   ) {
     digit -= 1n
     rest = WasmI64.add(rest, ten_kappa)

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1634,8 +1634,10 @@ let rec decodeRangeHelp =
           let codeWord = if (w1 >= 0xD800n && w1 <= 0xDBFFn) {
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
-            let w2 = (WasmI32.load8U(bytesPtr, 2n) << 8n |
-                WasmI32.load8U(bytesPtr, 3n)) &
+            let w2 = (
+                WasmI32.load8U(bytesPtr, 2n) << 8n |
+                WasmI32.load8U(bytesPtr, 3n)
+              ) &
               0x03FFn
             let codeWord = w1 + w2 + 0x10000n
             // no problems, so go past both code words
@@ -1657,8 +1659,10 @@ let rec decodeRangeHelp =
           let codeWord = if (w1 >= 0xD800n && w1 <= 0xDBFFn) {
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
-            let w2 = (WasmI32.load8U(bytesPtr, 3n) << 8n |
-                WasmI32.load8U(bytesPtr, 2n)) &
+            let w2 = (
+                WasmI32.load8U(bytesPtr, 3n) << 8n |
+                WasmI32.load8U(bytesPtr, 2n)
+              ) &
               0x03FFn
             //let uPrime = codePoint - 0x10000n
             //let w1 = ((uPrime & 0b11111111110000000000n) >>> 10n) + 0xD800n // High surrogate

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1251,16 +1251,16 @@ let rec encodeHelp = (string: String, encoding: Encoding, includeBom: Bool) => {
   Memory.incRef(WasmI32.fromGrain((+)))
   let size = encodedLength(string, encoding) +
     (if (includeBom) {
-        match (encoding) {
-          UTF8 => 3,
-          UTF16_LE => 2,
-          UTF16_BE => 2,
-          UTF32_LE => 4,
-          UTF32_BE => 4,
-        }
-      } else {
-        0
-      })
+      match (encoding) {
+        UTF8 => 3,
+        UTF16_LE => 2,
+        UTF16_BE => 2,
+        UTF32_LE => 4,
+        UTF32_BE => 4,
+      }
+    } else {
+      0
+    })
   let (>>>) = WasmI32.shrU
   let bytes = WasmI32.toGrain(allocateBytes(WasmI32.fromGrain(size) >>> 1n))
   Memory.incRef(WasmI32.fromGrain(encodeAtHelp))

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1634,10 +1634,8 @@ let rec decodeRangeHelp =
           let codeWord = if (w1 >= 0xD800n && w1 <= 0xDBFFn) {
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
-            let w2 = (
-                WasmI32.load8U(bytesPtr, 2n) << 8n |
-                WasmI32.load8U(bytesPtr, 3n)
-              ) &
+            let w2 = (WasmI32.load8U(bytesPtr, 2n) << 8n |
+                WasmI32.load8U(bytesPtr, 3n)) &
               0x03FFn
             let codeWord = w1 + w2 + 0x10000n
             // no problems, so go past both code words
@@ -1659,10 +1657,8 @@ let rec decodeRangeHelp =
           let codeWord = if (w1 >= 0xD800n && w1 <= 0xDBFFn) {
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
-            let w2 = (
-                WasmI32.load8U(bytesPtr, 3n) << 8n |
-                WasmI32.load8U(bytesPtr, 2n)
-              ) &
+            let w2 = (WasmI32.load8U(bytesPtr, 3n) << 8n |
+                WasmI32.load8U(bytesPtr, 2n)) &
               0x03FFn
             //let uPrime = codePoint - 0x10000n
             //let w1 = ((uPrime & 0b11111111110000000000n) >>> 10n) + 0xD800n // High surrogate

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1251,16 +1251,16 @@ let rec encodeHelp = (string: String, encoding: Encoding, includeBom: Bool) => {
   Memory.incRef(WasmI32.fromGrain((+)))
   let size = encodedLength(string, encoding) +
     (if (includeBom) {
-      match (encoding) {
-        UTF8 => 3,
-        UTF16_LE => 2,
-        UTF16_BE => 2,
-        UTF32_LE => 4,
-        UTF32_BE => 4,
-      }
-    } else {
-      0
-    })
+        match (encoding) {
+          UTF8 => 3,
+          UTF16_LE => 2,
+          UTF16_BE => 2,
+          UTF32_LE => 4,
+          UTF32_BE => 4,
+        }
+      } else {
+        0
+      })
   let (>>>) = WasmI32.shrU
   let bytes = WasmI32.toGrain(allocateBytes(WasmI32.fromGrain(size) >>> 1n))
   Memory.incRef(WasmI32.fromGrain(encodeAtHelp))
@@ -1635,7 +1635,7 @@ let rec decodeRangeHelp =
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
             let w2 = (WasmI32.load8U(bytesPtr, 2n) << 8n |
-              WasmI32.load8U(bytesPtr, 3n)) &
+                WasmI32.load8U(bytesPtr, 3n)) &
               0x03FFn
             let codeWord = w1 + w2 + 0x10000n
             // no problems, so go past both code words
@@ -1658,7 +1658,7 @@ let rec decodeRangeHelp =
             // high surrogate. next character is low srurrogate
             let w1 = (w1 & 0x03FFn) << 10n
             let w2 = (WasmI32.load8U(bytesPtr, 3n) << 8n |
-              WasmI32.load8U(bytesPtr, 2n)) &
+                WasmI32.load8U(bytesPtr, 2n)) &
               0x03FFn
             //let uPrime = codePoint - 0x10000n
             //let w1 = ((uPrime & 0b11111111110000000000n) >>> 10n) + 0xD800n // High surrogate

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -903,8 +903,10 @@ export let rec fdStats = (fd: FileDescriptor) => {
 
     let flagsToWasmVal = (flag, i) => {
       let rightsInheriting = WasmI64.load(structPtr, 16n)
-      (rightsInheriting &
-      1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n)) >
+      (
+        rightsInheriting &
+        1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n)
+      ) >
       0N
     }
     Memory.incRef(WasmI32.fromGrain(List.filteri))

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -903,10 +903,8 @@ export let rec fdStats = (fd: FileDescriptor) => {
 
     let flagsToWasmVal = (flag, i) => {
       let rightsInheriting = WasmI64.load(structPtr, 16n)
-      (
-        rightsInheriting &
-        1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n)
-      ) >
+      (rightsInheriting &
+        1N << WasmI64.extendI32U(WasmI32.fromGrain(i) >> 1n)) >
       0N
     }
     Memory.incRef(WasmI32.fromGrain(List.filteri))


### PR DESCRIPTION
Fixes #1087 

Add indenting when adding parens around function application arguments for better layout.

Added tests and reformatted the stdlib with the change