### PR TITLE
fix(compiler): Move lsp flag into grainc to remove it as a recompilation flag

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -138,8 +138,8 @@ let compile_file = (name, outfile_arg) => {
 
 /* add a wrapper so we can switch to LSP mode based on cli config */
 
-let compile_wrapper = (name, outfile_arg) =>
-  if (Grain_utils.Config.lsp_mode^) {
+let compile_wrapper = (lsp_mode, name, outfile_arg) =>
+  if (lsp_mode) {
     compile_string(name);
   } else {
     compile_file(name, outfile_arg);
@@ -189,6 +189,11 @@ let output_filename = {
   );
 };
 
+let lsp_mode = {
+  let doc = "Generate lsp errors and warnings only";
+  Arg.(value & flag(info(["lsp"], ~doc)));
+};
+
 let cmd = {
   let doc = sprintf("Compile Grain programs");
   let version =
@@ -200,6 +205,7 @@ let cmd = {
     Term.(
       ret(
         Grain_utils.Config.with_cli_options(compile_wrapper)
+        $ lsp_mode
         $ input_filename
         $ output_filename,
       )

--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -43,6 +43,7 @@ let compile_string = name => {
       {
         let compile_state =
           Compile.compile_string(
+            ~is_root_file=true,
             ~hook=stop_after_typed_well_formed,
             ~name,
             program_str^,

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -26,7 +26,11 @@ let compile_parsed = (filename: option(string)) => {
 
       program_str := String.concat("\n", linesList^);
 
-      Compile.compile_string(~hook=stop_after_parse, ~name="", program_str^);
+      Compile.compile_string(
+        ~is_root_file=true,
+        ~hook=stop_after_parse,
+        program_str^,
+      );
     | Some(filenm) =>
       // need to read the source file in case we want to use the content
       // for formatter-ignore or decision making
@@ -52,6 +56,7 @@ let compile_parsed = (filename: option(string)) => {
 
       Grain_utils.Config.base_path := dirname(filenm);
       Compile.compile_string(
+        ~is_root_file=true,
         ~hook=stop_after_parse,
         ~name=filenm,
         program_str^,

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -1,13 +1,19 @@
+type digestable =
+  | Digestable
+  | NotDigestable;
+
 type config_opt =
-  | Opt((ref('a), 'a)): config_opt;
+  | Opt((ref('a), 'a, digestable)): config_opt;
 
 type saved_config_opt =
-  | SavedOpt((ref('a), 'a)): saved_config_opt;
+  | SavedOpt((ref('a), 'a, digestable)): saved_config_opt;
 
 type digestable_opt =
   | DigestableOpt('a): digestable_opt;
 
 type config = list(saved_config_opt);
+
+let empty: config = [];
 
 /* Here we model the API provided by cmdliner without introducing
    an explicit dependency on it (that's left to grainc). */
@@ -30,10 +36,10 @@ type config_spec =
 let opts: ref(list(config_opt)) = (ref([]): ref(list(config_opt)));
 let specs: ref(list(config_spec)) = (ref([]): ref(list(config_spec)));
 
-let internal_opt: 'a. 'a => ref('a) =
-  v => {
+let internal_opt: 'a. ('a, digestable) => ref('a) =
+  (v, digestable) => {
     let cur = ref(v);
-    opts := [Opt((cur, v)), ...opts^];
+    opts := [Opt((cur, v, digestable)), ...opts^];
     cur;
   };
 
@@ -97,7 +103,7 @@ let opt:
     ~conv as c,
     v,
   ) => {
-    let cur = internal_opt(v);
+    let cur = internal_opt(v, Digestable);
     specs :=
       [
         Spec(
@@ -137,7 +143,7 @@ let toggle_flag:
   ) =>
   ref(bool) = (
   (~docs=?, ~docv=?, ~doc=?, ~env_docs=?, ~env_doc=?, ~env=?, ~names, default) => {
-    let cur = internal_opt(default);
+    let cur = internal_opt(default, Digestable);
     specs :=
       [
         Spec(
@@ -183,21 +189,21 @@ let toggle_flag:
 let save_config = () => {
   let single_save =
     fun
-    | Opt((cur, _)) => SavedOpt((cur, cur^));
+    | Opt((cur, _, digestable)) => SavedOpt((cur, cur^, digestable));
   List.map(single_save, opts^);
 };
 
 let restore_config = {
   let single_restore =
     fun
-    | SavedOpt((ptr, value)) => ptr := value;
+    | SavedOpt((ptr, value, _)) => ptr := value;
   List.iter(single_restore);
 };
 
 let reset_config = () => {
   let single_reset =
     fun
-    | Opt((cur, default)) => cur := default;
+    | Opt((cur, default, _)) => cur := default;
   List.iter(single_reset, opts^);
 };
 
@@ -214,7 +220,14 @@ let get_root_config_digest = () => {
   | Some(dgst) => dgst
   | None =>
     let config_opts =
-      List.map((SavedOpt((_, opt))) => DigestableOpt(opt), root_config^);
+      root_config^
+      |> List.filter((SavedOpt((_, _, digestable))) =>
+           switch (digestable) {
+           | Digestable => true
+           | NotDigestable => false
+           }
+         )
+      |> List.map((SavedOpt((_, opt, _))) => DigestableOpt(opt));
     let config = Marshal.to_bytes(config_opts, []);
     let ret = Digest.to_hex(Digest.bytes(config));
     root_config_digest := Some(ret);
@@ -547,10 +560,10 @@ let elide_type_info =
 let source_map =
   toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
 
-let print_warnings = internal_opt(true);
+let print_warnings = internal_opt(true, NotDigestable);
 
 /* To be filled in by grainc */
-let base_path = internal_opt("");
+let base_path = internal_opt("", NotDigestable);
 
 let with_base_path = (path, func) => {
   let old_base_path = base_path^;

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -547,13 +547,6 @@ let elide_type_info =
 let source_map =
   toggle_flag(~names=["source-map"], ~doc="Generate source maps", false);
 
-let lsp_mode =
-  toggle_flag(
-    ~names=["lsp"],
-    ~doc="Generate lsp errors and warnings only",
-    false,
-  );
-
 let print_warnings = internal_opt(true);
 
 /* To be filled in by grainc */

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -126,10 +126,10 @@ let print_warnings: ref(bool);
 
 /** Type representing a saved set of configuration options */
 
-type saved_config_opt =
-  | SavedOpt((ref('a), 'a)): saved_config_opt;
+type config;
 
-type config = list(saved_config_opt);
+/** An empty config */
+let empty: config;
 
 /** The current configuration for all programs */
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -118,10 +118,6 @@ let source_map: ref(bool);
 
 let safe_string: ref(bool);
 
-/** Just output errors and warnings for LSP mode. */
-
-let lsp_mode: ref(bool);
-
 /** Internal option to disable printing of warnings. */
 
 let print_warnings: ref(bool);

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -42,7 +42,7 @@ let read_stream = cstream => {
 let compile = (~num_pages=?, ~config_fn=?, ~hook=?, name, prog) => {
   Config.preserve_all_configs(() => {
     Config.with_config(
-      [],
+      Config.empty,
       () => {
         switch (config_fn) {
         | Some(fn) => fn()
@@ -65,7 +65,7 @@ let compile = (~num_pages=?, ~config_fn=?, ~hook=?, name, prog) => {
 let compile_file = (~num_pages=?, ~config_fn=?, ~hook=?, filename, outfile) => {
   Config.preserve_all_configs(() => {
     Config.with_config(
-      [],
+      Config.empty,
       () => {
         switch (config_fn) {
         | Some(fn) => fn()

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -24,7 +24,7 @@ describe("optimizations", ({test}) => {
     test(outfile, ({expect}) => {
       Grain_utils.Config.preserve_all_configs(() => {
         Config.with_config(
-          [],
+          Config.empty,
           () => {
             switch (config_fn) {
             | None => ()


### PR DESCRIPTION
Closes #1094

This removes the `--lsp` flag from `Grain_utils.Config` and adds it to grainc directly. This avoids using it as a flag that triggers a full recompile of every dependency.

You can see the drastic difference if you compile the JS version and use `time grain test.gr` while adjusting code with the LSP enabled.