### PR TITLE
feat(compiler)!: Stack-allocated Chars

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -172,7 +172,6 @@ type wasm_op =
 
 type prim0 =
   Parsetree.prim0 =
-    | AllocateChar
     | AllocateInt32
     | AllocateInt64
     | AllocateFloat32
@@ -194,6 +193,8 @@ type prim1 =
     | BytesSize
     | TagSimpleNumber
     | UntagSimpleNumber
+    | TagChar
+    | UntagChar
     | Not
     | Box
     | Unbox

--- a/compiler/src/codegen/value_tags.re
+++ b/compiler/src/codegen/value_tags.re
@@ -4,7 +4,6 @@ open Sexplib.Conv;
 [@deriving sexp]
 type heap_tag_type =
   | StringType
-  | CharType
   | ADTType
   | RecordType
   | ArrayType
@@ -16,26 +15,24 @@ type heap_tag_type =
 let tag_val_of_heap_tag_type =
   fun
   | StringType => 1
-  | CharType => 2
-  | ADTType => 3
-  | RecordType => 4
-  | ArrayType => 5
-  | BoxedNumberType => 6
-  | LambdaType => 7
-  | TupleType => 8
-  | BytesType => 9;
+  | ADTType => 2
+  | RecordType => 3
+  | ArrayType => 4
+  | BoxedNumberType => 5
+  | LambdaType => 6
+  | TupleType => 7
+  | BytesType => 8;
 
 let heap_tag_type_of_tag_val =
   fun
   | 1 => StringType
-  | 2 => CharType
-  | 3 => ADTType
-  | 4 => RecordType
-  | 5 => ArrayType
-  | 6 => BoxedNumberType
-  | 7 => LambdaType
-  | 8 => TupleType
-  | 9 => BytesType
+  | 2 => ADTType
+  | 3 => RecordType
+  | 4 => ArrayType
+  | 5 => BoxedNumberType
+  | 6 => LambdaType
+  | 7 => TupleType
+  | 8 => BytesType
   | x => failwith(Printf.sprintf("Unknown tag type: %d", x));
 
 [@deriving sexp]
@@ -67,18 +64,5 @@ let boxed_number_tag_type_of_tag_val =
 type tag_type =
   | NumberTagType
   | ConstTagType
+  | CharTagType
   | GenericHeapType(option(heap_tag_type));
-
-let and_mask_of_tag_type =
-  fun
-  | NumberTagType => 0b0001
-  | ConstTagType => 0b0111
-  | GenericHeapType(_) => 0b0111;
-
-let tag_val_of_tag_type =
-  fun
-  | NumberTagType => 0b0001
-  | ConstTagType => 0b0110
-  | GenericHeapType(_) => 0b0000;
-
-let shift_amount_of_tag_type = tt => 31 - tag_val_of_tag_type(tt);

--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -44,8 +44,7 @@ let rec analyze_comp_expression =
     | CImmExpr({imm_desc: ImmTrap}) => false
     | CImmExpr(_) => true
     | CPrim0(
-        AllocateChar | AllocateInt32 | AllocateInt64 | AllocateFloat32 |
-        AllocateFloat64 |
+        AllocateInt32 | AllocateInt64 | AllocateFloat32 | AllocateFloat64 |
         AllocateRational,
       ) =>
       true
@@ -60,6 +59,8 @@ let rec analyze_comp_expression =
         BytesSize |
         TagSimpleNumber |
         UntagSimpleNumber |
+        TagChar |
+        UntagChar |
         Not |
         Box |
         Unbox |

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -158,7 +158,6 @@ type wasm_op =
 
 type prim0 =
   Parsetree.prim0 =
-    | AllocateChar
     | AllocateInt32
     | AllocateInt64
     | AllocateFloat32
@@ -180,6 +179,8 @@ type prim1 =
     | BytesSize
     | TagSimpleNumber
     | UntagSimpleNumber
+    | TagChar
+    | UntagChar
     | Not
     | Box
     | Unbox

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -159,7 +159,6 @@ type wasm_op =
 
 type prim0 =
   Parsetree.prim0 =
-    | AllocateChar
     | AllocateInt32
     | AllocateInt64
     | AllocateFloat32
@@ -181,6 +180,8 @@ type prim1 =
     | BytesSize
     | TagSimpleNumber
     | UntagSimpleNumber
+    | TagChar
+    | UntagChar
     | Not
     | Box
     | Unbox

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -303,7 +303,6 @@ type wasm_op =
 /** Zero-argument operators */
 [@deriving (sexp, yojson)]
 type prim0 =
-  | AllocateChar
   | AllocateInt32
   | AllocateInt64
   | AllocateFloat32
@@ -326,6 +325,8 @@ type prim1 =
   | BytesSize
   | TagSimpleNumber
   | UntagSimpleNumber
+  | TagChar
+  | UntagChar
   | Not
   | Box
   | Unbox

--- a/compiler/src/typed/builtin_types.re
+++ b/compiler/src/typed/builtin_types.re
@@ -174,7 +174,7 @@ let initial_env = (add_type, empty_env) =>
   |> add_type(ident_bool, decl_bool)
   |> add_type(ident_box, decl_box)
   |> add_type(ident_string, decl_abstr(path_string))
-  |> add_type(ident_char, decl_abstr(path_char))
+  |> add_type(ident_char, decl_abstr_imm(WasmI32, path_char))
   |> add_type(ident_void, decl_void)
   |> add_type(ident_array, decl_array)
   |> add_type(ident_fd, decl_abstr(path_fd))

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -44,7 +44,6 @@ let prim_map =
       ("@heap.base", PrimitiveConstant(HeapBase)),
       ("@heap.start", PrimitiveConstant(HeapStart)),
       ("@heap.type_metadata", PrimitiveConstant(HeapTypeMetadata)),
-      ("@allocate.char", Primitive0(AllocateChar)),
       ("@allocate.int32", Primitive0(AllocateInt32)),
       ("@allocate.int64", Primitive0(AllocateInt64)),
       ("@allocate.float32", Primitive0(AllocateFloat32)),
@@ -63,6 +62,8 @@ let prim_map =
       ("@bytes.size", Primitive1(BytesSize)),
       ("@tag.simple_number", Primitive1(TagSimpleNumber)),
       ("@untag.simple_number", Primitive1(UntagSimpleNumber)),
+      ("@tag.char", Primitive1(TagChar)),
+      ("@untag.char", Primitive1(UntagChar)),
       ("@not", Primitive1(Not)),
       ("@box", Primitive1(Box)),
       ("@unbox", Primitive1(Unbox)),
@@ -1499,8 +1500,7 @@ let transl_prim = (env, desc) => {
       (Exp.constant(~loc, ~attributes=disable_gc, value), attrs);
     | Primitive0(
         (
-          AllocateChar | AllocateInt32 | AllocateInt64 | AllocateFloat32 |
-          AllocateFloat64 |
+          AllocateInt32 | AllocateInt64 | AllocateFloat32 | AllocateFloat64 |
           AllocateRational
         ) as p,
       ) => (

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -100,7 +100,6 @@ let grain_type_of_wasm_prim_type =
 
 let prim0_type =
   fun
-  | AllocateChar
   | AllocateInt32
   | AllocateInt64
   | AllocateFloat32
@@ -125,6 +124,8 @@ let prim1_type =
       Builtin_types.type_number,
       Builtin_types.type_wasmi32,
     )
+  | TagChar => (Builtin_types.type_wasmi32, Builtin_types.type_char)
+  | UntagChar => (Builtin_types.type_char, Builtin_types.type_wasmi32)
   | Not => (Builtin_types.type_bool, Builtin_types.type_bool)
   | Box
   | BoxBind => {

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -177,7 +177,6 @@ type wasm_op =
 
 type prim0 =
   Parsetree.prim0 =
-    | AllocateChar
     | AllocateInt32
     | AllocateInt64
     | AllocateFloat32
@@ -199,6 +198,8 @@ type prim1 =
     | BytesSize
     | TagSimpleNumber
     | UntagSimpleNumber
+    | TagChar
+    | UntagChar
     | Not
     | Box
     | Unbox

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -176,7 +176,6 @@ type wasm_op =
 
 type prim0 =
   Parsetree.prim0 =
-    | AllocateChar
     | AllocateInt32
     | AllocateInt64
     | AllocateFloat32
@@ -198,6 +197,8 @@ type prim1 =
     | BytesSize
     | TagSimpleNumber
     | UntagSimpleNumber
+    | TagChar
+    | UntagChar
     | Not
     | Box
     | Unbox

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -43,7 +43,7 @@ arrays › array_access
             )
            )
           )
-          (i32.const 5)
+          (i32.const 4)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
@@ -29,7 +29,7 @@ arrays › array1_trailing
         )
        )
       )
-      (i32.const 5)
+      (i32.const 4)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -43,7 +43,7 @@ arrays › array_access4
             )
            )
           )
-          (i32.const 5)
+          (i32.const 4)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -43,7 +43,7 @@ arrays › array_access2
             )
            )
           )
-          (i32.const 5)
+          (i32.const 4)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -43,7 +43,7 @@ arrays › array_access3
             )
            )
           )
-          (i32.const 5)
+          (i32.const 4)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -43,7 +43,7 @@ arrays › array_access5
             )
            )
           )
-          (i32.const 5)
+          (i32.const 4)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
@@ -29,7 +29,7 @@ arrays › array3
         )
        )
       )
-      (i32.const 5)
+      (i32.const 4)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
@@ -29,7 +29,7 @@ arrays › array1_trailing_space
         )
        )
       )
-      (i32.const 5)
+      (i32.const 4)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -47,7 +47,7 @@ basic functionality › comp22
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -116,7 +116,7 @@ basic functionality › comp22
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › int64_1
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › heap_number_i64_wrapper
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -130,7 +130,7 @@ basic functionality › func_shadow
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -215,7 +215,7 @@ basic functionality › func_shadow
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -50,7 +50,7 @@ basic functionality › block_no_expression
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -40,7 +40,7 @@ basic functionality › pattern_match_unsafe_wasm
            )
           )
          )
-         (i32.const 7)
+         (i32.const 6)
         )
         (i32.store offset=4
          (local.get $0)
@@ -430,7 +430,7 @@ basic functionality › pattern_match_unsafe_wasm
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › division1
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -46,7 +46,7 @@ basic functionality › comp21
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -115,7 +115,7 @@ basic functionality › comp21
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › int32_1
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › heap_number_i32_wrapper_max
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
@@ -29,7 +29,7 @@ basic functionality › heap_number_i32_wrapper
         )
        )
       )
-      (i32.const 6)
+      (i32.const 5)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -126,7 +126,7 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (i32.const 7)
+       (i32.const 6)
       )
       (i32.store offset=4
        (local.get $1)
@@ -224,7 +224,7 @@ basic functionality › func_shadow_and_indirect_call
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -309,7 +309,7 @@ basic functionality › func_shadow_and_indirect_call
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -397,7 +397,7 @@ basic functionality › func_shadow_and_indirect_call
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_subtraction1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_multiplication2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_division2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_addition2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_division1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_subtraction2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_addition1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -44,7 +44,7 @@ boxes › box_multiplication1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -38,7 +38,7 @@ boxes › test_set_extra1
               )
              )
             )
-            (i32.const 8)
+            (i32.const 7)
            )
            (i32.store offset=4
             (local.get $0)

--- a/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
+++ b/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
@@ -2,49 +2,18 @@ chars › char4
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const 65)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 522)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.259e330c.0.snapshot
+++ b/compiler/test/__snapshots__/chars.259e330c.0.snapshot
@@ -2,49 +2,18 @@ chars › char2
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const 65)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 522)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
+++ b/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
@@ -2,49 +2,18 @@ chars › char8
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const 11050210)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 80194)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.51010573.0.snapshot
+++ b/compiler/test/__snapshots__/chars.51010573.0.snapshot
@@ -2,49 +2,18 @@ chars › char7
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const -1098080272)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 1022450)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
+++ b/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
@@ -2,49 +2,18 @@ chars › char6
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const -1349345296)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 1025402)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
+++ b/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
@@ -2,49 +2,18 @@ chars › char5
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const 65)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 522)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
+++ b/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
@@ -2,49 +2,18 @@ chars › char3
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (block (result i32)
-     (i32.store
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-          (i32.const 8)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (i32.const 2)
-     )
-     (i32.store offset=4
-      (local.get $0)
-      (i32.const 65)
-     )
-     (local.get $0)
-    )
-    (local.get $0)
-   )
-  )
+  (i32.const 522)
  )
  (func $_start (; has Stack IR ;)
-  (drop
-   (call $_gmain)
-  )
+  (nop)
  )
  ;; custom section \"cmi\", size 237
 )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -41,7 +41,7 @@ enums › adt_trailing
          )
         )
        )
-       (i32.const 3)
+       (i32.const 2)
       )
       (i32.store offset=4
        (local.get $2)
@@ -181,7 +181,7 @@ enums › adt_trailing
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)
@@ -228,7 +228,7 @@ enums › adt_trailing
             )
            )
           )
-          (i32.const 3)
+          (i32.const 2)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -48,7 +48,7 @@ enums › enum_recursive_data_definition
          )
         )
        )
-       (i32.const 3)
+       (i32.const 2)
       )
       (i32.store offset=4
        (local.get $3)
@@ -127,7 +127,7 @@ enums › enum_recursive_data_definition
          )
         )
        )
-       (i32.const 3)
+       (i32.const 2)
       )
       (i32.store offset=4
        (local.get $3)
@@ -315,7 +315,7 @@ enums › enum_recursive_data_definition
              )
             )
            )
-           (i32.const 3)
+           (i32.const 2)
           )
           (i32.store offset=4
            (local.get $0)
@@ -361,7 +361,7 @@ enums › enum_recursive_data_definition
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -408,7 +408,7 @@ enums › enum_recursive_data_definition
              )
             )
            )
-           (i32.const 3)
+           (i32.const 2)
           )
           (i32.store offset=4
            (local.get $0)
@@ -454,7 +454,7 @@ enums › enum_recursive_data_definition
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -42,7 +42,7 @@ exceptions › exception_4
          )
         )
        )
-       (i32.const 3)
+       (i32.const 2)
       )
       (i32.store offset=4
        (local.get $3)
@@ -191,7 +191,7 @@ exceptions › exception_4
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)
@@ -238,7 +238,7 @@ exceptions › exception_4
             )
            )
           )
-          (i32.const 3)
+          (i32.const 2)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -104,7 +104,7 @@ exceptions › exception_2
             )
            )
           )
-          (i32.const 3)
+          (i32.const 2)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -50,7 +50,7 @@ exports › let_rec_export
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -50,7 +50,7 @@ functions › dup_func
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -86,7 +86,7 @@ functions › shorthand_4
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -67,7 +67,7 @@ functions › shorthand_1
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -338,7 +338,7 @@ functions › lam_destructure_5
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -382,7 +382,7 @@ functions › lam_destructure_5
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -425,7 +425,7 @@ functions › lam_destructure_5
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -57,7 +57,7 @@ functions › lambda_pat_any
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -39,7 +39,7 @@ functions › curried_func
          )
         )
        )
-       (i32.const 7)
+       (i32.const 6)
       )
       (i32.store offset=4
        (local.get $2)
@@ -155,7 +155,7 @@ functions › curried_func
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -68,7 +68,7 @@ functions › app_1
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -67,7 +67,7 @@ functions › shorthand_3
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -203,7 +203,7 @@ functions › lam_destructure_3
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -247,7 +247,7 @@ functions › lam_destructure_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -291,7 +291,7 @@ functions › lam_destructure_7
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -335,7 +335,7 @@ functions › lam_destructure_7
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -374,7 +374,7 @@ functions › lam_destructure_7
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -86,7 +86,7 @@ functions › shorthand_2
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -203,7 +203,7 @@ functions › lam_destructure_4
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -250,7 +250,7 @@ functions › lam_destructure_4
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -291,7 +291,7 @@ functions › lam_destructure_8
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -338,7 +338,7 @@ functions › lam_destructure_8
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -377,7 +377,7 @@ functions › lam_destructure_8
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -57,7 +57,7 @@ functions › lam_destructure_1
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -57,7 +57,7 @@ functions › lam_destructure_2
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -132,7 +132,7 @@ functions › func_record_associativity2
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -176,7 +176,7 @@ functions › func_record_associativity2
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -225,7 +225,7 @@ functions › func_record_associativity2
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -95,7 +95,7 @@ functions › fn_trailing_comma
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -338,7 +338,7 @@ functions › lam_destructure_6
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -385,7 +385,7 @@ functions › lam_destructure_6
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -428,7 +428,7 @@ functions › lam_destructure_6
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -118,7 +118,7 @@ functions › func_record_associativity1
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $0)
@@ -162,7 +162,7 @@ functions › func_record_associativity1
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -38,7 +38,7 @@ let mut › let-mut3
             )
            )
           )
-          (i32.const 8)
+          (i32.const 7)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -40,7 +40,7 @@ let mut › let-mut2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -79,7 +79,7 @@ let mut › let-mut2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -50,7 +50,7 @@ loops › loop2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -85,7 +85,7 @@ loops › loop2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -74,7 +74,7 @@ optimizations › trs1
             )
            )
           )
-          (i32.const 7)
+          (i32.const 6)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -45,7 +45,7 @@ optimizations › test_dead_branch_elimination_5
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -80,7 +80,7 @@ optimizations › test_dead_branch_elimination_5
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -125,7 +125,7 @@ pattern matching › record_match_3
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -112,7 +112,7 @@ pattern matching › adt_match_deep
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -88,7 +88,7 @@ pattern matching › tuple_match_deep4
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -156,7 +156,7 @@ pattern matching › record_match_2
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -43,7 +43,7 @@ pattern matching › guarded_match_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -50,7 +50,7 @@ pattern matching › tuple_match_deep
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -89,7 +89,7 @@ pattern matching › tuple_match_deep
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -156,7 +156,7 @@ pattern matching › record_match_1
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -86,7 +86,7 @@ pattern matching › constant_match_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -127,7 +127,7 @@ pattern matching › record_match_4
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -44,7 +44,7 @@ pattern matching › constant_match_1
              )
             )
            )
-           (i32.const 6)
+           (i32.const 5)
           )
           (i32.store offset=4
            (local.get $0)
@@ -119,7 +119,7 @@ pattern matching › constant_match_1
                             )
                            )
                           )
-                          (i32.const 6)
+                          (i32.const 5)
                          )
                          (i32.store offset=4
                           (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -152,7 +152,7 @@ pattern matching › tuple_match_deep6
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -78,7 +78,7 @@ pattern matching › tuple_match_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -165,7 +165,7 @@ pattern matching › tuple_match_3
          )
         )
        )
-       (i32.const 8)
+       (i32.const 7)
       )
       (i32.store offset=4
        (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -55,7 +55,7 @@ pattern matching › tuple_match_deep3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -62,7 +62,7 @@ pattern matching › tuple_match_deep2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -101,7 +101,7 @@ pattern matching › tuple_match_deep2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -147,7 +147,7 @@ pattern matching › tuple_match_deep2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -189,7 +189,7 @@ pattern matching › tuple_match_deep2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -231,7 +231,7 @@ pattern matching › tuple_match_deep2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -118,7 +118,7 @@ pattern matching › record_match_deep
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -164,7 +164,7 @@ pattern matching › record_match_deep
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -45,7 +45,7 @@ pattern matching › guarded_match_4
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -43,7 +43,7 @@ pattern matching › guarded_match_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -45,7 +45,7 @@ pattern matching › guarded_match_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -120,7 +120,7 @@ pattern matching › tuple_match_deep5
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -91,7 +91,7 @@ pattern matching › constant_match_4
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -184,7 +184,7 @@ pattern matching › tuple_match_deep7
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -117,7 +117,7 @@ records › record_get_multiple
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -94,7 +94,7 @@ records › record_definition_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -94,7 +94,7 @@ records › record_pun
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -156,7 +156,7 @@ records › record_destruct_1
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -127,7 +127,7 @@ records › record_destruct_4
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -94,7 +94,7 @@ records › record_value_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -122,7 +122,7 @@ records › record_recursive_data_definition
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -171,7 +171,7 @@ records › record_recursive_data_definition
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_mixed_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -156,7 +156,7 @@ records › record_destruct_2
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -94,7 +94,7 @@ records › record_pun_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -118,7 +118,7 @@ records › record_destruct_deep
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -164,7 +164,7 @@ records › record_destruct_deep
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -125,7 +125,7 @@ records › record_destruct_3
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -126,7 +126,7 @@ records › record_get_multilevel
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -176,7 +176,7 @@ records › record_get_multilevel
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -151,7 +151,7 @@ records › record_multiple_fields_definition_trailing
          )
         )
        )
-       (i32.const 4)
+       (i32.const 3)
       )
       (i32.store offset=4
        (local.get $0)

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -104,7 +104,7 @@ records › record_get_2
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_mixed
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -127,7 +127,7 @@ records › record_destruct_trailing
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_mixed_2
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -151,7 +151,7 @@ records › record_multiple_fields_both_trailing
          )
         )
        )
-       (i32.const 4)
+       (i32.const 3)
       )
       (i32.store offset=4
        (local.get $0)

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -94,7 +94,7 @@ records › record_both_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_multiple
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_multiple_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -151,7 +151,7 @@ records › record_multiple_fields_value_trailing
          )
         )
        )
-       (i32.const 4)
+       (i32.const 3)
       )
       (i32.store offset=4
        (local.get $0)

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -102,7 +102,7 @@ records › record_pun_mixed_2_trailing
         )
        )
       )
-      (i32.const 4)
+      (i32.const 3)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -161,7 +161,7 @@ stdlib › stdlib_equal_20
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -253,7 +253,7 @@ stdlib › stdlib_equal_20
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -40,7 +40,7 @@ stdlib › stdlib_equal_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -79,7 +79,7 @@ stdlib › stdlib_equal_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -161,7 +161,7 @@ stdlib › stdlib_equal_19
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -253,7 +253,7 @@ stdlib › stdlib_equal_19
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_12
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)
@@ -90,7 +90,7 @@ stdlib › stdlib_equal_12
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -161,7 +161,7 @@ stdlib › stdlib_equal_21
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -253,7 +253,7 @@ stdlib › stdlib_equal_21
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_11
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)
@@ -82,7 +82,7 @@ stdlib › stdlib_equal_11
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_9
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)
@@ -74,7 +74,7 @@ stdlib › stdlib_equal_9
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -82,7 +82,7 @@ stdlib › stdlib_equal_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -161,7 +161,7 @@ stdlib › stdlib_equal_22
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)
@@ -253,7 +253,7 @@ stdlib › stdlib_equal_22
              )
             )
            )
-           (i32.const 4)
+           (i32.const 3)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_10
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)
@@ -78,7 +78,7 @@ stdlib › stdlib_equal_10
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -43,7 +43,7 @@ stdlib › stdlib_equal_8
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)
@@ -74,7 +74,7 @@ stdlib › stdlib_equal_8
              )
             )
            )
-           (i32.const 5)
+           (i32.const 4)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -42,7 +42,7 @@ tuples › nested_tup_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -81,7 +81,7 @@ tuples › nested_tup_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -120,7 +120,7 @@ tuples › nested_tup_3
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -41,7 +41,7 @@ tuples › nested_tup_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -80,7 +80,7 @@ tuples › nested_tup_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -119,7 +119,7 @@ tuples › nested_tup_1
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/tuples.2f6e820d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2f6e820d.0.snapshot
@@ -29,7 +29,7 @@ tuples › singleton_tup_annotation
         )
        )
       )
-      (i32.const 8)
+      (i32.const 7)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/tuples.843a836f.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.843a836f.0.snapshot
@@ -29,7 +29,7 @@ tuples › singleton_tup
         )
        )
       )
-      (i32.const 8)
+      (i32.const 7)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
@@ -29,7 +29,7 @@ tuples › tup1_trailing
         )
        )
       )
-      (i32.const 8)
+      (i32.const 7)
      )
      (i32.store offset=4
       (local.get $0)

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -38,7 +38,7 @@ tuples › big_tup_access
             )
            )
           )
-          (i32.const 8)
+          (i32.const 7)
          )
          (i32.store offset=4
           (local.get $0)

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -42,7 +42,7 @@ tuples › nested_tup_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -81,7 +81,7 @@ tuples › nested_tup_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)
@@ -120,7 +120,7 @@ tuples › nested_tup_2
              )
             )
            )
-           (i32.const 8)
+           (i32.const 7)
           )
           (i32.store offset=4
            (local.get $0)

--- a/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
@@ -29,7 +29,7 @@ tuples › tup1_trailing_space
         )
        )
       )
-      (i32.const 8)
+      (i32.const 7)
      )
      (i32.store offset=4
       (local.get $0)

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -14,6 +14,7 @@ import Exception from "runtime/exception"
 import Int32 from "int32"
 import Bytes from "bytes"
 import String from "string"
+import Char from "char"
 import { coerceNumberToWasmI32 } from "runtime/numbers"
 
 record Buffer {
@@ -60,30 +61,6 @@ let autogrow = (len, buf) => {
     let growBy = newSize - currentSize
 
     buf.data = Bytes.resize(0, growBy, buf.data)
-  }
-}
-
-/* Gets the pointer for a char's bytes following the char's tag */
-@unsafe
-let rec getCharAsWasmI32 = char => {
-  let c = WasmI32.fromGrain(char)
-  WasmI32.load(c, 4n)
-}
-
-/* Gets the UTF-8 byte length of a char */
-@unsafe
-let rec getCharByteLength = byte => {
-  let (+) = WasmI32.add
-  let (&) = WasmI32.and
-  let (==) = WasmI32.eq
-  if ((byte & 0x80n) == 0x00n) {
-    1n
-  } else if ((byte & 0xF0n) == 0xF0n) {
-    4n
-  } else if ((byte & 0xE0n) == 0xE0n) {
-    3n
-  } else {
-    2n
   }
 }
 
@@ -264,45 +241,6 @@ export let toStringSlice = (start, length, buffer) => {
 }
 
 /**
- * Appends the bytes of a char to a buffer.
- *
- * @param char: The character to append to the buffer
- * @param buffer: The buffer to mutate
- *
- * @since v0.4.0
- */
-@unsafe
-export let addChar = (char: Char, buffer: Buffer) => {
-  let n = getCharAsWasmI32(char)
-  let bytelen = getCharByteLength(n)
-  match (bytelen) {
-    1n => {
-      let c = Conv.toInt32(n)
-      addInt8help(c, buffer)
-    },
-    2n => {
-      let c = Conv.toInt32(n)
-      addInt16help(c, buffer)
-    },
-    3n => {
-      let (<) = WasmI32.ltU
-      let (+) = WasmI32.add
-      let (*) = WasmI32.mul
-      let (&) = WasmI32.and
-      let (>>) = WasmI32.shrU
-      for (let mut i = 0n; i < 3n; i += 1n) {
-        let c = Conv.toInt32(n >> i * 8n & 0xffn)
-        addInt8help(c, buffer)
-      }
-    },
-    _ => {
-      let c = Conv.toInt32(n)
-      addInt32help(c, buffer)
-    },
-  }
-}
-
-/**
  * Appends a byte sequence to a buffer.
  *
  * @param bytes: The byte sequence to append
@@ -346,6 +284,18 @@ export let addString = (string, buffer) => {
   appendBytes(0n, off, len, src, dst)
 
   buffer.len = buffer.len + bytelen
+}
+
+/**
+ * Appends the bytes of a char to a buffer.
+ *
+ * @param char: The character to append to the buffer
+ * @param buffer: The buffer to mutate
+ *
+ * @since v0.4.0
+ */
+export let addChar = (char, buffer) => {
+  addString(Char.toString(char), buffer)
 }
 
 /**

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -9,11 +9,12 @@
  */
 
 import WasmI32 from "runtime/unsafe/wasmi32"
-import Memory from "runtime/unsafe/memory"
 import Errors from "runtime/unsafe/errors"
+import Tags from "runtime/unsafe/tags"
 import {
   tagSimpleNumber,
-  allocateChar,
+  tagChar,
+  untagChar,
   allocateString,
 } from "runtime/dataStructures"
 
@@ -58,71 +59,13 @@ export let isValid = charCode => {
  * 
  * @since 0.3.0
  */
-@disableGC
-export let rec code = (char: Char) => {
-  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
+@unsafe
+export let code = (char: Char) => {
+  let usv = untagChar(char)
 
-  let char = WasmI32.fromGrain(char)
-
-  let (+) = WasmI32.add
-  let (==) = WasmI32.eq
-  let (>=) = WasmI32.geU
-  let (<=) = WasmI32.leU
-  let (<<) = WasmI32.shl
-  let (&) = WasmI32.and
-  let (|) = WasmI32.or
-
-  let mut codePoint = 0n
-  let mut bytesSeen = 0n
-  let mut bytesNeeded = 0n
-  let mut lowerBoundary = 0x80n
-  let mut upperBoundary = 0xBFn
-
-  let mut offset = 0n
-
-  let mut result = 0n
-
-  while (true) {
-    let byte = WasmI32.load8U(char + offset, 4n)
-    offset += 1n
-    if (bytesNeeded == 0n) {
-      if (byte >= 0x00n && byte <= 0x7Fn) {
-        result = byte
-        break
-      } else if (byte >= 0xC2n && byte <= 0xDFn) {
-        bytesNeeded = 1n
-        codePoint = byte & 0x1Fn
-      } else if (byte >= 0xE0n && byte <= 0xEFn) {
-        if (byte == 0xE0n) lowerBoundary = 0xA0n
-        if (byte == 0xEDn) upperBoundary = 0x9Fn
-        bytesNeeded = 2n
-        codePoint = byte & 0xFn
-      } else if (byte >= 0xF0n && byte <= 0xF4n) {
-        if (byte == 0xF0n) lowerBoundary = 0x90n
-        if (byte == 0xF4n) upperBoundary = 0x8Fn
-        bytesNeeded = 3n
-        codePoint = byte & 0x7n
-      } else {
-        throw MalformedUtf8
-      }
-      continue
-    }
-    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
-      throw MalformedUtf8
-    }
-    lowerBoundary = 0x80n
-    upperBoundary = 0xBFn
-    codePoint = codePoint << 6n | byte & 0x3Fn
-    bytesSeen += 1n
-    if (bytesSeen == bytesNeeded) {
-      result = codePoint
-      break
-    }
-  }
-
-  Memory.decRef(char)
-  Memory.decRef(WasmI32.fromGrain(code))
-  tagSimpleNumber(result)
+  // This could save an instruction by combining the two tagging operations,
+  // though we stick with tagSimpleNumber for simplicity.
+  tagSimpleNumber(usv)
 }
 
 /**
@@ -134,62 +77,26 @@ export let rec code = (char: Char) => {
  * 
  * @since 0.3.0
  */
-@disableGC
-export let rec fromCode = (usv: Number) => {
-  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-encoder
-
-  let (+) = WasmI32.add
+@unsafe
+export let fromCode = (usv: Number) => {
   let (-) = WasmI32.sub
-  let (*) = WasmI32.mul
-  let (==) = WasmI32.eq
-  let (>) = WasmI32.gtU
-  let (<=) = WasmI32.leU
-  let (<) = WasmI32.ltU
-  let (>>>) = WasmI32.shrU
-  let (&) = WasmI32.and
-  let (|) = WasmI32.or
+  let (<<) = WasmI32.shl
 
-  let usv = WasmI32.fromGrain(usv)
-  if ((usv & 1n) == 0n) {
+  if (!isValid(usv)) {
     throw InvalidArgument("Invalid character code")
   }
 
-  let usv = usv >>> 1n
-  let result = if (usv < 0x80n) {
-    let char = allocateChar()
-    WasmI32.store8(char, usv, 4n)
-    WasmI32.toGrain(char): Char
-  } else {
-    let mut count = 0n
-    let mut offset = 0n
-    if (usv <= 0x07FFn) {
-      count = 1n
-      offset = 0xC0n
-    } else if (usv <= 0xFFFFn) {
-      count = 2n
-      offset = 0xE0n
-    } else {
-      count = 3n
-      offset = 0xF0n
-    }
-    let char = allocateChar()
-    WasmI32.store8(char, (usv >>> 6n * count) + offset, 4n)
+  // usv is now guaranteed to be a simple number
+  let usv = WasmI32.fromGrain(usv)
 
-    let mut n = 0n
-    while (count > 0n) {
-      n += 1n
-      let temp = usv >>> 6n * (count - 1n)
-      WasmI32.store8(char + n, 0x80n | temp & 0x3Fn, 4n)
-      count -= 1n
-    }
+  // Here we use a math trick to avoid fully untagging and retagging.
+  // Simple numbers are represented as 2n + 1 and chars are represented as
+  // 8n + 2. Quick reminder that shifting left is the equivalent of multiplying
+  // by 2, and that _GRAIN_CHAR_TAG_TYPE is equal to 2:
+  // 4(2n + 1) - 2 = 8n + 2
+  let char = (usv << 2n) - Tags._GRAIN_CHAR_TAG_TYPE
 
-    WasmI32.toGrain(char): Char
-  }
-
-  // We've asserted that the original `code` was a stack allocated number so
-  // no need to decRef it
-  Memory.decRef(WasmI32.fromGrain(fromCode))
-  result
+  WasmI32.toGrain(char): Char
 }
 
 /**
@@ -240,27 +147,50 @@ export let pred = char => {
  * 
  * @since 0.3.0
  */
-@disableGC
-export let rec toString = (char: Char) => {
+@unsafe
+export let toString = (char: Char) => {
   let (+) = WasmI32.add
+  let (-) = WasmI32.sub
+  let (*) = WasmI32.mul
   let (&) = WasmI32.and
-  let (==) = WasmI32.eq
+  let (|) = WasmI32.or
+  let (>>>) = WasmI32.shrU
+  let (<) = WasmI32.ltU
+  let (>) = WasmI32.gtU
+  let (<=) = WasmI32.leU
 
-  let char = WasmI32.fromGrain(char)
-  let byte = WasmI32.load8U(char, 4n)
-  let n = if ((byte & 0x80n) == 0x00n) {
-    1n
-  } else if ((byte & 0xF0n) == 0xF0n) {
-    4n
-  } else if ((byte & 0xE0n) == 0xE0n) {
-    3n
+  let usv = untagChar(char)
+
+  let result = if (usv < 0x80n) {
+    let string = allocateString(1n)
+    WasmI32.store8(string, usv, 8n)
+    WasmI32.toGrain(string): String
   } else {
-    2n
+    let mut count = 0n
+    let mut offset = 0n
+    if (usv <= 0x07FFn) {
+      count = 1n
+      offset = 0xC0n
+    } else if (usv <= 0xFFFFn) {
+      count = 2n
+      offset = 0xE0n
+    } else {
+      count = 3n
+      offset = 0xF0n
+    }
+    let string = allocateString(count + 1n)
+    WasmI32.store8(string, (usv >>> 6n * count) + offset, 8n)
+
+    let mut n = 0n
+    while (count > 0n) {
+      n += 1n
+      let temp = usv >>> 6n * (count - 1n)
+      WasmI32.store8(string + n, 0x80n | temp & 0x3Fn, 8n)
+      count -= 1n
+    }
+
+    WasmI32.toGrain(string): String
   }
-  let str = allocateString(n)
-  Memory.copy(str + 8n, char + 4n, n)
-  let ret = WasmI32.toGrain(str): String
-  Memory.decRef(WasmI32.fromGrain(char))
-  Memory.decRef(WasmI32.fromGrain(toString))
-  ret
+
+  result
 }

--- a/stdlib/hash.gr
+++ b/stdlib/hash.gr
@@ -119,22 +119,6 @@ let rec hashOne = (val, depth) => {
         if (rem != 0n) hashRemaining(rem)
         finalize(length)
       },
-      t when t == Tags._GRAIN_CHAR_HEAP_TAG => {
-        let word = WasmI32.load(heapPtr, 4n)
-        // little-endian byte order
-        let byte = word & 0xFFn
-        let mut shift = 0n
-        if ((byte & 0x80n) == 0x00n) {
-          shift = 24n
-        } else if ((byte & 0xF0n) == 0xF0n) {
-          shift = 0n
-        } else if ((byte & 0xE0n) == 0xE0n) {
-          shift = 8n
-        } else {
-          shift = 16n
-        }
-        hash32(word << shift)
-      },
       t when t == Tags._GRAIN_ADT_HEAP_TAG => {
         // moduleId
         hash32(WasmI32.load(heapPtr, 4n))
@@ -216,13 +200,8 @@ let rec hashOne = (val, depth) => {
         hash32(heapPtr)
       },
     }
-  } else if (val == WasmI32.fromGrain(true)) {
-    hash32(val)
-  } else if (val == WasmI32.fromGrain(false)) {
-    hash32(val)
-  } else if (val == WasmI32.fromGrain(void)) {
-    hash32(val)
   } else {
+    // Handle non-heap values: booleans, chars, void, etc.
     hash32(val)
   }
 }

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -36,14 +36,6 @@ export primitive allocateBytes: WasmI32 -> WasmI32 = "@allocate.bytes"
 @unsafe
 export primitive allocateString: WasmI32 -> WasmI32 = "@allocate.string"
 
-/**
- * Allocates a new Grain char.
- *
- * @returns The pointer to the char
- */
-@unsafe
-export primitive allocateChar: () -> WasmI32 = "@allocate.char"
-
 // INT32/INT64
 
 /**
@@ -175,3 +167,21 @@ export primitive tagSimpleNumber: WasmI32 -> Number = "@tag.simple_number"
  */
 @unsafe
 export primitive untagSimpleNumber: Number -> WasmI32 = "@untag.simple_number"
+
+/**
+ * Tag a char.
+ *
+ * @param num: The usv to tag
+ * @returns The tagged char
+ */
+@unsafe
+export primitive tagChar: WasmI32 -> Char = "@tag.char"
+
+/**
+ * Untag a char.
+ *
+ * @param num: The char to untag
+ * @returns The untagged usv
+ */
+@unsafe
+export primitive untagChar: Char -> WasmI32 = "@untag.char"

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -158,22 +158,6 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
         result
       }
     },
-    t when t == Tags._GRAIN_CHAR_HEAP_TAG => {
-      let byte = WasmI32.load8U(xptr, 4n)
-      let n = if ((byte & 0x80n) == 0x00n) {
-        1n
-      } else if ((byte & 0xF0n) == 0xF0n) {
-        4n
-      } else if ((byte & 0xE0n) == 0xE0n) {
-        3n
-      } else {
-        2n
-      }
-      // WebAssembly is little-endian, so bytes are in reverse order
-      let x = WasmI32.load(xptr, 4n) << (4n - n) * 8n
-      let y = WasmI32.load(yptr, 4n) << (4n - n) * 8n
-      x == y
-    },
     t when t == Tags._GRAIN_TUPLE_HEAP_TAG => {
       let xsize = WasmI32.load(xptr, 4n)
       let ysize = WasmI32.load(yptr, 4n)

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -7,6 +7,7 @@ import WasmI32, {
   divS as (/),
   shl as (<<),
   shrS as (>>),
+  shrU as (>>>),
   and as (&),
   or as (|),
   eq as (==),
@@ -206,24 +207,9 @@ let escape = (ptr, isString) => {
 
   let _SEQ_QUOTE = if (isString) _SEQ_DQUOTE else _SEQ_SQUOTE
 
-  let size = if (isString) {
-    WasmI32.load(ptr, 4n)
-  } else {
-    let byte = WasmI32.load8U(ptr, 4n)
+  let size = WasmI32.load(ptr, 4n)
 
-    // Calculate number of bytes via utf-8 encoding
-    if ((byte & 0x80n) == 0x00n) {
-      1n
-    } else if ((byte & 0xF0n) == 0xF0n) {
-      4n
-    } else if ((byte & 0xE0n) == 0xE0n) {
-      3n
-    } else {
-      2n
-    }
-  }
-
-  let startOffset = if (isString) 8n else 4n
+  let startOffset = 8n
   let stringOffset = 8n
 
   let mut newSize = 2n // extra space for quote characters
@@ -285,8 +271,42 @@ let escapeString = (s: String) => {
 }
 
 @unsafe
-let escapeChar = (c: Char) => {
-  escape(WasmI32.fromGrain(c), false)
+let escapeChar = (s: String) => {
+  escape(WasmI32.fromGrain(s), false)
+}
+
+@unsafe
+let usvToString = usv => {
+  if (usv < 0x80n) {
+    let string = allocateString(1n)
+    WasmI32.store8(string, usv, 8n)
+    WasmI32.toGrain(string): String
+  } else {
+    let mut count = 0n
+    let mut offset = 0n
+    if (usv <= 0x07FFn) {
+      count = 1n
+      offset = 0xC0n
+    } else if (usv <= 0xFFFFn) {
+      count = 2n
+      offset = 0xE0n
+    } else {
+      count = 3n
+      offset = 0xF0n
+    }
+    let string = allocateString(count + 1n)
+    WasmI32.store8(string, (usv >>> 6n * count) + offset, 8n)
+
+    let mut n = 0n
+    while (count > 0n) {
+      n += 1n
+      let temp = usv >>> 6n * (count - 1n)
+      WasmI32.store8(string + n, 0x80n | temp & 0x3Fn, 8n)
+      count -= 1n
+    }
+
+    WasmI32.toGrain(string): String
+  }
 }
 
 @unsafe
@@ -346,27 +366,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       }
 
       WasmI32.toGrain(str): String
-    },
-    t when t == Tags._GRAIN_CHAR_HEAP_TAG => {
-      if (toplevel) {
-        let byte = WasmI32.load8U(ptr, 4n)
-        let numBytes = if ((byte & 0x80n) == 0x00n) {
-          1n
-        } else if ((byte & 0xF0n) == 0xF0n) {
-          4n
-        } else if ((byte & 0xE0n) == 0xE0n) {
-          3n
-        } else {
-          2n
-        }
-        let str = allocateString(numBytes)
-        Memory.copy(str + 8n, ptr + 4n, numBytes)
-        WasmI32.toGrain(str): String
-      } else {
-        // We incRef ptr so we can reuse it via WasmI32.toGrain
-        Memory.incRef(ptr)
-        escapeChar(WasmI32.toGrain(ptr))
-      }
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
       // [ <value type tag>, <module_tag>, <type_tag>, <variant_tag>, <arity>, elts ... ]
@@ -548,16 +547,26 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
-  } else if ((grainValue & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
-    heapValueToString(grainValue, extraIndents, toplevel)
-  } else if (grainValue == WasmI32.fromGrain(true)) {
-    "true"
-  } else if (grainValue == WasmI32.fromGrain(false)) {
-    "false"
-  } else if (grainValue == WasmI32.fromGrain(void)) {
-    "void"
   } else {
-    "<unknown value>"
+    let tag = grainValue & 7n
+    if (tag == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
+      heapValueToString(grainValue, extraIndents, toplevel)
+    } else if (tag == Tags._GRAIN_CHAR_TAG_TYPE) {
+      let string = usvToString(grainValue >> 3n)
+      if (toplevel) {
+        string
+      } else {
+        escapeChar(string)
+      }
+    } else if (grainValue == WasmI32.fromGrain(true)) {
+      "true"
+    } else if (grainValue == WasmI32.fromGrain(false)) {
+      "false"
+    } else if (grainValue == WasmI32.fromGrain(void)) {
+      "void"
+    } else {
+      "<unknown value>"
+    }
   }
 }, listToString = (ptr, extraIndents) => {
   let mut cur = ptr

--- a/stdlib/runtime/unsafe/tags.gr
+++ b/stdlib/runtime/unsafe/tags.gr
@@ -1,6 +1,7 @@
 /* grainc-flags --compilation-mode=runtime */
 
 export let _GRAIN_NUMBER_TAG_TYPE = 0b0001n
+export let _GRAIN_CHAR_TAG_TYPE = 0b0010n
 export let _GRAIN_CONST_TAG_TYPE = 0b0110n
 export let _GRAIN_GENERIC_HEAP_TAG_TYPE = 0b0000n
 
@@ -8,14 +9,13 @@ export let _GRAIN_NUMBER_TAG_MASK = 0b0001n
 export let _GRAIN_GENERIC_TAG_MASK = 0b0111n
 
 export let _GRAIN_STRING_HEAP_TAG = 1n
-export let _GRAIN_CHAR_HEAP_TAG = 2n
-export let _GRAIN_ADT_HEAP_TAG = 3n
-export let _GRAIN_RECORD_HEAP_TAG = 4n
-export let _GRAIN_ARRAY_HEAP_TAG = 5n
-export let _GRAIN_BOXED_NUM_HEAP_TAG = 6n
-export let _GRAIN_LAMBDA_HEAP_TAG = 7n
-export let _GRAIN_TUPLE_HEAP_TAG = 8n
-export let _GRAIN_BYTES_HEAP_TAG = 9n
+export let _GRAIN_ADT_HEAP_TAG = 2n
+export let _GRAIN_RECORD_HEAP_TAG = 3n
+export let _GRAIN_ARRAY_HEAP_TAG = 4n
+export let _GRAIN_BOXED_NUM_HEAP_TAG = 5n
+export let _GRAIN_LAMBDA_HEAP_TAG = 6n
+export let _GRAIN_TUPLE_HEAP_TAG = 7n
+export let _GRAIN_BYTES_HEAP_TAG = 8n
 
 // Boxed number types
 export let _GRAIN_FLOAT32_BOXED_NUM_TAG = 1n

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -12,8 +12,9 @@ import Exception from "runtime/exception"
 import Conv from "runtime/unsafe/conv"
 import {
   tagSimpleNumber,
+  tagChar,
+  untagChar,
   allocateArray,
-  allocateChar,
   allocateString,
   allocateBytes,
 } from "runtime/dataStructures"
@@ -32,6 +33,8 @@ export enum Encoding {
   UTF32_BE,
   UTF32_LE,
 }
+
+exception MalformedUnicode
 
 /**
  * @section Values: Functions for working with the String data type.
@@ -189,6 +192,66 @@ export let rec indexOf = (search: String, string: String) => {
   ret
 }
 
+@disableGC
+let getCodePoint = (ptr: WasmI32) => {
+  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
+  let (+) = WasmI32.add
+  let (==) = WasmI32.eq
+  let (>=) = WasmI32.geU
+  let (<=) = WasmI32.leU
+  let (<<) = WasmI32.shl
+  let (&) = WasmI32.and
+  let (|) = WasmI32.or
+
+  let mut codePoint = 0n
+  let mut bytesSeen = 0n
+  let mut bytesNeeded = 0n
+  let mut lowerBoundary = 0x80n
+  let mut upperBoundary = 0xBFn
+
+  let mut offset = 0n
+
+  let mut result = 0n
+
+  while (true) {
+    let byte = WasmI32.load8U(ptr + offset, 0n)
+    offset += 1n
+    if (bytesNeeded == 0n) {
+      if (byte >= 0x00n && byte <= 0x7Fn) {
+        result = byte
+        break
+      } else if (byte >= 0xC2n && byte <= 0xDFn) {
+        bytesNeeded = 1n
+        codePoint = byte & 0x1Fn
+      } else if (byte >= 0xE0n && byte <= 0xEFn) {
+        if (byte == 0xE0n) lowerBoundary = 0xA0n
+        if (byte == 0xEDn) upperBoundary = 0x9Fn
+        bytesNeeded = 2n
+        codePoint = byte & 0xFn
+      } else if (byte >= 0xF0n && byte <= 0xF4n) {
+        if (byte == 0xF0n) lowerBoundary = 0x90n
+        if (byte == 0xF4n) upperBoundary = 0x8Fn
+        bytesNeeded = 3n
+        codePoint = byte & 0x7n
+      } else {
+        throw MalformedUnicode
+      }
+      continue
+    }
+    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
+      throw MalformedUnicode
+    }
+    lowerBoundary = 0x80n
+    upperBoundary = 0xBFn
+    codePoint = codePoint << 6n | byte & 0x3Fn
+    bytesSeen += 1n
+    if (bytesSeen == bytesNeeded) {
+      result = codePoint
+      break
+    }
+  }
+  result
+}
 /**
  * Get the character at the position in the input string.
  *
@@ -221,14 +284,17 @@ export let rec charAt = (position, string: String) => {
   let (<) = WasmI32.ltU
   let (==) = WasmI32.eq
   let size = WasmI32.fromGrain(wasmSafeByteLength(string)) >>> 1n
-  let len = WasmI32.fromGrain(wasmSafeLength(string)) >>> 1n
   let position = WasmI32.fromGrain(position) >>> 1n
   let string = WasmI32.fromGrain(string)
   let mut ptr = string + 8n
   let end = ptr + size
   let mut counter = 0n
-  let mut result = 0n
+  let mut result = WasmI32.toGrain(0n): Char
   while (ptr < end) {
+    if (counter == position) {
+      result = tagChar(getCodePoint(ptr))
+      break
+    }
     let byte = WasmI32.load8U(ptr, 0n)
     let n = if ((byte & 0x80n) == 0x00n) {
       1n
@@ -239,22 +305,15 @@ export let rec charAt = (position, string: String) => {
     } else {
       2n
     }
-    if (counter == position) {
-      let c = allocateChar()
-      Memory.copy(c + 4n, ptr, n)
-      result = c
-      break
-    }
     counter += 1n
     ptr += n
   }
-  if (result == 0n) {
+  if (WasmI32.eqz(WasmI32.fromGrain(result))) {
     fail "charAt: should be impossible (please report)"
   }
-  let ret = WasmI32.toGrain(result): Char
   Memory.decRef(WasmI32.fromGrain(string))
   Memory.decRef(WasmI32.fromGrain(charAt))
-  ret
+  result
 }
 
 @disableGC
@@ -289,9 +348,7 @@ let explodeHelp = (s: String, chars) => {
     }
 
     let c = if (chars) {
-      let c = allocateChar()
-      Memory.copy(c + 4n, ptr, n)
-      c
+      WasmI32.fromGrain(tagChar(getCodePoint(ptr)))
     } else {
       let s = allocateString(n)
       Memory.copy(s + 8n, ptr, n)
@@ -337,32 +394,34 @@ export let rec explode = string => {
  *
  * @since v0.3.0
  */
-@disableGC
+@unsafe
 export let rec implode = (arr: Array<Char>) => {
   let (+) = WasmI32.add
-  let (==) = WasmI32.eq
+  let (-) = WasmI32.sub
+  let (*) = WasmI32.mul
   let (<) = WasmI32.ltU
+  let (>) = WasmI32.gtU
+  let (<=) = WasmI32.leU
   let (<<) = WasmI32.shl
+  let (>>>) = WasmI32.shrU
   let (&) = WasmI32.and
+  let (|) = WasmI32.or
 
-  let arr = WasmI32.fromGrain(arr)
-
-  let arrLength = WasmI32.load(arr, 4n)
+  let arrLength = WasmI32.load(WasmI32.fromGrain(arr), 4n)
 
   let mut stringByteLength = 0n
 
   for (let mut i = 0n; i < arrLength; i += 1n) {
-    let char = WasmI32.load(arr + (i << 2n), 8n)
-    let byte = WasmI32.load8U(char, 4n)
+    let usv = untagChar(arr[tagSimpleNumber(i)])
 
-    let n = if ((byte & 0x80n) == 0x00n) {
+    let n = if (usv <= 0x7Fn) {
       1n
-    } else if ((byte & 0xF0n) == 0xF0n) {
-      4n
-    } else if ((byte & 0xE0n) == 0xE0n) {
+    } else if (usv <= 0x07FFn) {
+      2n
+    } else if (usv <= 0xFFFFn) {
       3n
     } else {
-      2n
+      4n
     }
 
     stringByteLength += n
@@ -372,27 +431,37 @@ export let rec implode = (arr: Array<Char>) => {
   let mut offset = 8n
 
   for (let mut i = 0n; i < arrLength; i += 1n) {
-    let char = WasmI32.load(arr + (i << 2n), 8n)
-    let byte = WasmI32.load8U(char, 4n)
+    let usv = untagChar(arr[tagSimpleNumber(i)])
 
-    let n = if ((byte & 0x80n) == 0x00n) {
-      1n
-    } else if ((byte & 0xF0n) == 0xF0n) {
-      4n
-    } else if ((byte & 0xE0n) == 0xE0n) {
-      3n
+    if (usv < 0x7Fn) {
+      WasmI32.store8(str + offset, usv, 0n)
+      offset += 1n
     } else {
-      2n
-    }
+      let mut count = 0n
+      let mut marker = 0n
+      if (usv <= 0x07FFn) {
+        count = 1n
+        marker = 0xC0n
+      } else if (usv <= 0xFFFFn) {
+        count = 2n
+        marker = 0xE0n
+      } else {
+        count = 3n
+        marker = 0xF0n
+      }
+      WasmI32.store8(str + offset, (usv >>> 6n * count) + marker, 0n)
+      offset += 1n
 
-    Memory.copy(str + offset, char + 4n, n)
-    offset += n
+      while (count > 0n) {
+        let temp = usv >>> 6n * (count - 1n)
+        WasmI32.store8(str + offset, 0x80n | temp & 0x3Fn, 0n)
+        count -= 1n
+        offset += 1n
+      }
+    }
   }
 
-  let ret = WasmI32.toGrain(str): String
-  Memory.decRef(WasmI32.fromGrain(arr))
-  Memory.decRef(WasmI32.fromGrain(implode))
-  ret
+  WasmI32.toGrain(str): String
 }
 
 // Helper to get the length in constant time without depending on Array
@@ -878,69 +947,6 @@ let encodedLength = (s: String, encoding) => {
     UTF16_LE => utf16Length(s),
     UTF8 => wasmSafeByteLength(s),
   }
-}
-
-exception MalformedUnicode
-
-@disableGC
-let getCodePoint = (ptr: WasmI32) => {
-  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
-  let (+) = WasmI32.add
-  let (==) = WasmI32.eq
-  let (>=) = WasmI32.geU
-  let (<=) = WasmI32.leU
-  let (<<) = WasmI32.shl
-  let (&) = WasmI32.and
-  let (|) = WasmI32.or
-
-  let mut codePoint = 0n
-  let mut bytesSeen = 0n
-  let mut bytesNeeded = 0n
-  let mut lowerBoundary = 0x80n
-  let mut upperBoundary = 0xBFn
-
-  let mut offset = 0n
-
-  let mut result = 0n
-
-  while (true) {
-    let byte = WasmI32.load8U(ptr + offset, 0n)
-    offset += 1n
-    if (bytesNeeded == 0n) {
-      if (byte >= 0x00n && byte <= 0x7Fn) {
-        result = byte
-        break
-      } else if (byte >= 0xC2n && byte <= 0xDFn) {
-        bytesNeeded = 1n
-        codePoint = byte & 0x1Fn
-      } else if (byte >= 0xE0n && byte <= 0xEFn) {
-        if (byte == 0xE0n) lowerBoundary = 0xA0n
-        if (byte == 0xEDn) upperBoundary = 0x9Fn
-        bytesNeeded = 2n
-        codePoint = byte & 0xFn
-      } else if (byte >= 0xF0n && byte <= 0xF4n) {
-        if (byte == 0xF0n) lowerBoundary = 0x90n
-        if (byte == 0xF4n) upperBoundary = 0x8Fn
-        bytesNeeded = 3n
-        codePoint = byte & 0x7n
-      } else {
-        throw MalformedUnicode
-      }
-      continue
-    }
-    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
-      throw MalformedUnicode
-    }
-    lowerBoundary = 0x80n
-    upperBoundary = 0xBFn
-    codePoint = codePoint << 6n | byte & 0x3Fn
-    bytesSeen += 1n
-    if (bytesSeen == bytesNeeded) {
-      result = codePoint
-      break
-    }
-  }
-  result: WasmI32
 }
 
 // hack to avoid incRef on this pointer


### PR DESCRIPTION
This PR changes the implementation of chars to use an i32 on the stack rather than a heap object.

Details can be seen in the updated data_representations doc, but the gist is that a char is now just a Unicode scalar shifted left by 3 and the last 3 bits set to `010`. Things like `Char.code`/`Char.fromCode` are much simpler, while things like printing/conversion to a string got more complex.