### PR TITLE
feat(graindoc)!: Add --current-version flag, required for since/history attributes

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -211,6 +211,7 @@ program
 program
   .command("doc <file>")
   .description("generate documentation for a grain file")
+  .forwardOption("--current-version <version>", "provide a version to use as current when generating markdown for `@since` and `@history` attributes")
   .action(
     wrapAction(function (file, options, program) {
       doc(file, program);

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -266,7 +266,7 @@ Returns:
 ### Array.**cycle**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.4.4</code></summary>
 No other changes yet.
 </details>
 
@@ -1030,7 +1030,7 @@ Returns:
 ### Array.**sort**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
 No other changes yet.
 </details>
 
@@ -1052,7 +1052,7 @@ Parameters:
 ### Array.**rotate**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -459,7 +459,7 @@ Returns:
 ### Number.**parseInt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/option.md
+++ b/stdlib/option.md
@@ -533,7 +533,7 @@ No other changes yet.
 </details>
 
 ```grain
-( or ) : (Option<a>, Option<a>) -> Option<a>
+or : (Option<a>, Option<a>) -> Option<a>
 ```
 
 Behaves like a logical OR (`||`) where the first Option is only returned if it is the `Some` variant and falling back to the second Option in all other cases.

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -272,7 +272,7 @@ No other changes yet.
 </details>
 
 ```grain
-( or ) : (Result<a, b>, Result<a, b>) -> Result<a, b>
+or : (Result<a, b>, Result<a, b>) -> Result<a, b>
 ```
 
 Behaves like a logical OR (`||`) where the first Result is only returned if it is the `Ok` variant and falling back to the second Result in all other cases.

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -266,7 +266,7 @@ String.implode([> 'H', 'e', 'l', 'l', 'o']) == "Hello"
 ### String.**reverse**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
 No other changes yet.
 </details>
 


### PR DESCRIPTION
Closes #1110 

This adds a `--current-version` flag to the `grain doc` command line. If your docs are using `@since` or `@history`, this flag is required (thus breaking) because we need (want?) a version to compare so we can insert `next` into the generated markdown if the docs are being generated before a release is made.