### PR TITLE
chore: Remove explicit exit 0 in native executables

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -218,5 +218,5 @@ let cmd = {
 let () =
   switch (Term.eval(cmd)) {
   | `Error(_) => exit(1)
-  | _ => exit(0)
+  | _ => ()
   };

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -279,5 +279,5 @@ let cmd = {
 let () =
   switch (Term.eval(cmd)) {
   | `Error(_) => exit(1)
-  | _ => exit(0)
+  | _ => ()
   };

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -208,5 +208,5 @@ let cmd = {
 let () =
   switch (Term.eval(cmd)) {
   | `Error(_) => exit(1)
-  | _ => exit(0)
+  | _ => ()
   };


### PR DESCRIPTION
The process should exit successfully with code 0 upon a successful cmdliner run. Having an explicit `exit(0)` here caused weirdness in some browser hacking I was working on.