### PR TITLE
feat(stdlib): Added Bytes.clear function. Avoid allocation in Buffer.clear

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -142,7 +142,7 @@ export let length = buffer => buffer.len
  * @since v0.4.0
  */
 export let clear = buffer => {
-  Bytes.fill(0x0l, buffer.data)
+  Bytes.clear(buffer.data)
   buffer.len = 0
 }
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -324,10 +324,10 @@ export let rec clear = (bytes: Bytes) => {
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(bytes)
   let size = getSize(src)
-  let ret = Memory.fill(src + _VALUE_OFFSET, 0n, size)
+  Memory.fill(src + _VALUE_OFFSET, 0n, size)
   Memory.decRef(WasmI32.fromGrain(bytes))
   Memory.decRef(WasmI32.fromGrain(clear))
-  ret
+  void
 }
 
 /**

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -319,15 +319,12 @@ export let fill = (value: Int32, bytes: Bytes) => {
  *
  * @since v0.5.0
  */
-@disableGC
-export let rec clear = (bytes: Bytes) => {
+@unsafe
+export let clear = (bytes: Bytes) => {
   let (+) = WasmI32.add
   let src = WasmI32.fromGrain(bytes)
   let size = getSize(src)
   Memory.fill(src + _VALUE_OFFSET, 0n, size)
-  Memory.decRef(WasmI32.fromGrain(bytes))
-  Memory.decRef(WasmI32.fromGrain(clear))
-  void
 }
 
 /**

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -313,7 +313,7 @@ export let fill = (value: Int32, bytes: Bytes) => {
 }
 
 /**
- * Replaces all bytes in a byte sequnce with value zero.
+ * Replaces all bytes in a byte sequence with zeroes.
  *
  * @param bytes: The byte sequence to clear
  *

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -317,7 +317,7 @@ export let fill = (value: Int32, bytes: Bytes) => {
  *
  * @param bytes: The byte sequence to clear
  *
- * @since v0.3.2
+ * @since v0.5.0
  */
 @disableGC
 export let rec clear = (bytes: Bytes) => {

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -313,6 +313,24 @@ export let fill = (value: Int32, bytes: Bytes) => {
 }
 
 /**
+ * Replaces all bytes in a byte sequnce with value zero.
+ *
+ * @param bytes: The byte sequence to clear
+ *
+ * @since v0.3.2
+ */
+@disableGC
+export let rec clear = (bytes: Bytes) => {
+  let (+) = WasmI32.add
+  let src = WasmI32.fromGrain(bytes)
+  let size = getSize(src)
+  let ret = Memory.fill(src + _VALUE_OFFSET, 0n, size)
+  Memory.decRef(WasmI32.fromGrain(bytes))
+  Memory.decRef(WasmI32.fromGrain(clear))
+  ret
+}
+
+/**
  * @section Binary operations on integers: Functions for encoding and decoding integers stored in a byte sequence.
  */
 

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -281,6 +281,25 @@ Parameters:
 |`value`|`Int32`|The value replacing each byte|
 |`bytes`|`Bytes`|The byte sequence to update|
 
+### Bytes.**clear**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+clear : Bytes -> Void
+```
+
+Replaces all bytes in a byte sequence with zeroes.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`bytes`|`Bytes`|The byte sequence to clear|
+
 ## Binary operations on integers
 
 Functions for encoding and decoding integers stored in a byte sequence.


### PR DESCRIPTION
This PR adds a simple function `clear` to the Bytes module and uses it in `Buffer.clear` instead if `Bytes.fill`. This avoids allocating an instance of Int32 on the heap for each call to `Buffer.clear`.