### PR TITLE
fix(stdlib): Buffer.autogrow was making unnecessary intermediate resizes of the buffer.

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -56,6 +56,7 @@ let autogrow = (len, buf) => {
     let mut newSize = if (currentSize > 0) {
       currentSize
     } else {
+      // Make sure bytes of 0 length grow too
       4
     }
 

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -49,11 +49,23 @@ let getSize = ptr => WasmI32.load(ptr, _SIZE_OFFSET)
 
 /* Doubles the size of buffer's underlying byte sequence, if the given size is larger than the size of a buffer's underlying byte sequence */
 let autogrow = (len, buf) => {
-  while (buf.len + len > Bytes.length(buf.data)) {
-    let mut n = Bytes.length(buf.data)
-    if (n == 0) n = 4
-    // Make sure bytes of 0 length grow too
-    buf.data = Bytes.resize(0, n, buf.data)
+  let requiredMinimumSize = buf.len + len
+  let currentSize = Bytes.length(buf.data)
+
+  if (requiredMinimumSize > currentSize) {
+    let mut newSize = if (currentSize > 0) {
+      currentSize
+    } else {
+      4
+    }
+
+    while (newSize < requiredMinimumSize) {
+      newSize *= 2
+    }
+
+    let growBy = newSize - currentSize
+
+    buf.data = Bytes.resize(0, growBy, buf.data)
   }
 }
 


### PR DESCRIPTION
In some cases Buffer.autogrow was making unnecessary intermediate resizes of the buffer. In particular when adding a big chunk of data at once.