### PR TITLE
fix(stdlib): Buffer.toBytes should not expose the raw instance of Bytes used by the buffer.

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -228,12 +228,7 @@ export let rec truncate = (length, buffer) => {
  * @since v0.4.0
  */
 export let toBytes = buffer => {
-  let len = Bytes.length(buffer.data)
-  if (buffer.len == len) {
-    buffer.data
-  } else {
-    Bytes.slice(0, buffer.len, buffer.data)
-  }
+  Bytes.slice(0, buffer.len, buffer.data)
 }
 
 /**


### PR DESCRIPTION
This PR simply changes `Buffer.toBytes` to actually always make a copy like stated in its graindoc comment. Returning the underlying instance of Bytes could lead to nasty unexpected bugs.

I'm not sure if we want a way to access the underlying raw Bytes instance or not. It may be handy in some performance critical scenarios. If so, I think it should be a separate function and warn the consumer of the API of risks.