### PR TITLE
feat(compiler)!: Improved long running LSP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,11 @@ cli/bin/graindoc.exe
 cli/bin/graindoc_js.bc.js
 cli/bin/grainformat.exe
 cli/bin/grainformat_js.bc.js
+cli/bin/grainlsp.exe
+cli/bin/grainlsp_js.bc.js
+
+# LSP log file
+
+./lsp_debug.log
 
 .DS_Store

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -96,8 +96,42 @@ function execGrainformat(
   );
 }
 
+function getGrainlsp() {
+  const grainlsp = path.join(__dirname, "grainlsp.exe");
+
+  // TODO: Maybe make an installable path & check it?
+  if (process.pkg || !fs.existsSync(grainformat)) {
+    const node = process.execPath;
+    const grainlsp_js = path.join(__dirname, "grainlsp.js");
+    return `"${node}" ${grainlsp_js}`;
+  }
+
+  return `${grainlsp}`;
+}
+
+const grainlsp = getGrainlsp();
+
+function execGrainlsp(
+  program,
+  execOpts = { stdio: "pipe" }
+) {
+  const flags = [];
+  const options = program.opts();
+  program.options.forEach((option) => {
+    if (!option.forward) return;
+    const flag = option.toFlag(options);
+    if (flag) flags.push(flag);
+  });
+
+  return execSync(
+    `${grainlsp} ${flags.join(" ")} `,
+    execOpts
+  );
+}
+
 module.exports = {
   grainc: execGrainc,
   graindoc: execGraindoc,
   grainformat: execGrainformat,
+  grainlsp: execGrainlsp,
 };

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -116,7 +116,9 @@ function execGrainlsp(
   execOpts = { stdio: "pipe" }
 ) {
   const flags = [];
-  const options = program.opts();
+
+  const options = program.parent.options.concat(program.options);
+  const opts = { ...program.parent.opts(), ...program.opts() };
   program.options.forEach((option) => {
     if (!option.forward) return;
     const flag = option.toFlag(options);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -202,13 +202,13 @@ program
   });
 
 program
-  .command("lsp <file>")
-  .description("check a grain file for LSP")
+  .command("lsp")
+  .description("start the Grain LSP server")
   .action(
-    wrapAction(function (file) {
+    wrapAction(function (options,program) {
       // The lsp subcommand inherits all options of the
       // top level grain command
-      lsp(file, program);
+      lsp(program);
     })
   );
 

--- a/cli/bin/grainlsp.js
+++ b/cli/bin/grainlsp.js
@@ -1,0 +1,6 @@
+// A wrapper around grainlsp_js.bc.js that prepares the `pkg` env
+const preparePkg = require("./pkg");
+
+preparePkg();
+
+require("./grainlsp_js.bc.js");

--- a/cli/bin/lsp.js
+++ b/cli/bin/lsp.js
@@ -1,9 +1,6 @@
 const exec = require("./exec");
 
-// call the compiler, passing stdio through so the compiler gets the source code on stdin
-// and we get the compiler output in stdout
-// we still take the file name so we have it available
+module.exports = function (program) {
 
-module.exports = (file, program) => {
-  exec.grainc(`--lsp ${file}`, program, { stdio: "inherit" });
+  exec.grainlsp( program, { stdio: "inherit" });
 };

--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,157 +1,263 @@
 (lang dune 2.3)
+
 (name grain)
+
 (version 0.4.6)
+
 (using menhir 2.0)
 
 ; Flip this to `true` when we want to generate opam files again
+
 (generate_opam_files false)
 
 (license LGPL-3.0)
+
 (authors "Philip Blair" "Oscar Spencer")
+
 (maintainers "philip@grain-lang.org" "oscar@grain-lang.org")
-(source (github grain-lang/grain))
+
+(source
+ (github grain-lang/grain))
+
 (homepage "https://grain-lang.org")
+
 (documentation "https://grain-lang.org/docs/")
 
 ; These aren't used currently but left in for reference when we generate opam files again
-(package
-  (name grain)
-  (synopsis "The core Grain language compiler library")
-  (depends
-    (reason (>= 3.6.0))
-    (conf-openssl (>= 2))
-    (dune-build-info (>= 2.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))
-    (grain_typed (>= 0))
-    (grain_middle_end (>= 0))
-    (grain_diagnostics (>= 0))
-    (grain_codegen (>= 0))))
 
 (package
-  (name grainc)
-  (synopsis "The core Grain language compiler CLI")
-  (depends
-    (reason (>= 3.6.0))
-    (js_of_ocaml-compiler (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+ (name grain)
+ (synopsis "The core Grain language compiler library")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (conf-openssl
+   (>= 2))
+  (dune-build-info
+   (>= 2.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (cmdliner
+   (>= 1.0.2))
+  (grain_utils
+   (>= 0))
+  (grain_parsing
+   (>= 0))
+  (grain_typed
+   (>= 0))
+  (grain_middle_end
+   (>= 0))
+  (grain_diagnostics
+   (>= 0))
+  (grain_codegen
+   (>= 0))))
 
 (package
-  (name graindoc)
-  (synopsis "Grain documentation generator")
-  (depends
-    (reason (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+ (name grainc)
+ (synopsis "The core Grain language compiler CLI")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (js_of_ocaml-compiler
+   (>= 3.6.0))
+  (dune-build-info
+   (>= 2.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (binaryen
+   (= 0.9.1))
+  (cmdliner
+   (>= 1.0.2))
+  (grain
+   (>= 0))))
 
 (package
-  (name grainformat)
-  (synopsis "Grain formatter")
-  (depends
-    (reason (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+ (name graindoc)
+ (synopsis "Grain documentation generator")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (dune-build-info
+   (>= 2.0))
+  (binaryen
+   (= 0.9.1))
+  (cmdliner
+   (>= 1.0.2))
+  (grain
+   (>= 0))))
 
 (package
-  (name grain_linking)
-  (synopsis "The Grain linker")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (binaryen (= 0.9.1))
-    (ocamlgraph (>= 2.0.0))
-    (grain_utils (>= 0))
-    (grain_codegen (>= 0))))
+ (name grainformat)
+ (synopsis "Grain formatter")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (dune-build-info
+   (>= 2.0))
+  (binaryen
+   (= 0.9.1))
+  (cmdliner
+   (>= 1.0.2))
+  (grain
+   (>= 0))))
 
 (package
-  (name grain_codegen)
-  (synopsis "Grain WebAssembly code generation")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (binaryen (= 0.9.1))
-    (grain_utils (>= 0))
-    (grain_middle_end (>= 0))))
+ (name grainlsp)
+ (synopsis "Grain LSP")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (dune-build-info
+   (>= 2.0))
+  (cmdliner
+   (>= 1.0.2))
+  (grain
+   (>= 0))))
 
 (package
-  (name grain_middle_end)
-  (synopsis "Grain itermediate representations")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))
-    (grain_typed (>= 0))))
+ (name grain_linking)
+ (synopsis "The Grain linker")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (binaryen
+   (= 0.9.1))
+  (ocamlgraph
+   (>= 2.0.0))
+  (grain_utils
+   (>= 0))
+  (grain_codegen
+   (>= 0))))
 
 (package
-  (name grain_parsing)
-  (synopsis "The Grain parser")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (menhir (= 20211125))
-    (cmdliner (>= 1.0.2))
-    (utf8 (>= 0.0.0))
-    (ppx_deriving_yojson (>= 3.5.2))
-    (yojson (>= 1.7.0))
-    (grain_utils (>= 0))))
+ (name grain_codegen)
+ (synopsis "Grain WebAssembly code generation")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (cmdliner
+   (>= 1.0.2))
+  (binaryen
+   (= 0.9.1))
+  (grain_utils
+   (>= 0))
+  (grain_middle_end
+   (>= 0))))
 
 (package
-  (name grain_typed)
-  (synopsis "The Grain typechecker")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (ocamlgraph (>= 2.0.0))
-    (cmdliner (>= 1.0.2))
-    (ppx_deriving_yojson (>= 3.5.2))
-    (yojson (>= 1.7.0))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))))
+ (name grain_middle_end)
+ (synopsis "Grain itermediate representations")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (cmdliner
+   (>= 1.0.2))
+  (grain_utils
+   (>= 0))
+  (grain_parsing
+   (>= 0))
+  (grain_typed
+   (>= 0))))
 
 (package
-  (name grain_utils)
-  (synopsis "Various Grain utilities")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (fp (>= 0.0.0))
-    (fs (>= 0.0.0))
-    (cmdliner (>= 1.0.2))))
+ (name grain_parsing)
+ (synopsis "The Grain parser")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (menhir
+   (= 20211125))
+  (cmdliner
+   (>= 1.0.2))
+  (utf8
+   (>= 0.0.0))
+  (ppx_deriving_yojson
+   (>= 3.5.2))
+  (yojson
+   (>= 1.7.0))
+  (grain_utils
+   (>= 0))))
+
+(package
+ (name grain_typed)
+ (synopsis "The Grain typechecker")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (ocamlgraph
+   (>= 2.0.0))
+  (cmdliner
+   (>= 1.0.2))
+  (ppx_deriving_yojson
+   (>= 3.5.2))
+  (yojson
+   (>= 1.7.0))
+  (grain_utils
+   (>= 0))
+  (grain_parsing
+   (>= 0))))
+
+(package
+ (name grain_utils)
+ (synopsis "Various Grain utilities")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (ppx_sexp_conv
+   (>= 0.14.0))
+  (sexplib
+   (>= 0.14.0))
+  (fp
+   (>= 0.0.0))
+  (fs
+   (>= 0.0.0))
+  (cmdliner
+   (>= 1.0.2))))
 
 (package
  (name grain_diagnostics)
  (synopsis "Diagnostics support")
  (depends
-  (reason (>= 3.6.0))
-  (ppx_deriving_yojson (>= 3.5.2))
-  (yojson (>= 1.7.0))
-  (grain_utils (>= 0))
-  (grain_parsing (>= 0))))
+  (reason
+   (>= 3.6.0))
+  (ppx_deriving_yojson
+   (>= 3.5.2))
+  (yojson
+   (>= 1.7.0))
+  (grain_utils
+   (>= 0))
+  (grain_parsing
+   (>= 0))))
 
 (package
-  (name grain-tests)
-  (synopsis "Tests")
-  (depends
-    (reason (>= 3.6.0))
-    (rely (>= 3.2.1))))
+ (name grain-tests)
+ (synopsis "Tests")
+ (depends
+  (reason
+   (>= 3.6.0))
+  (rely
+   (>= 3.2.1))))

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -14,13 +14,15 @@
       "GRAINDOC_JS_PATH": "#{self.target_dir / 'default' / 'graindoc' / 'graindoc_js.bc.js'}",
       "GRAINFORMAT_BIN_PATH": "#{self.target_dir / 'default' / 'grainformat' / 'grainformat.exe'}",
       "GRAINFORMAT_JS_PATH": "#{self.target_dir / 'default' / 'grainformat' / 'grainformat_js.bc.js'}",
+      "GRAINLSP_BIN_PATH": "#{self.target_dir / 'default' / 'grainlsp' / 'grainlsp.exe'}",
+      "GRAINLSP_JS_PATH": "#{self.target_dir / 'default' / 'grainlsp' / 'grainlsp_js.bc.js'}",
       "CLI_BIN_DIR": "#{self.root / '..' / 'cli' / 'bin'}",
       "TEST_EXEC_PATH": "#{self.target_dir / 'default' / 'test' / 'test.exe'}"
     }
   },
   "scripts": {
-    "copy:exe": "cp #{$GRAINC_BIN_PATH} #{$GRAINDOC_BIN_PATH} #{$GRAINFORMAT_BIN_PATH} #{$CLI_BIN_DIR}",
-    "copy:js": "cp #{$GRAINC_JS_PATH} #{$GRAINDOC_JS_PATH} #{$GRAINFORMAT_JS_PATH} #{$CLI_BIN_DIR}",
+    "copy:exe": "cp #{$GRAINC_BIN_PATH} #{$GRAINDOC_BIN_PATH} #{$GRAINFORMAT_BIN_PATH} #{$GRAINLSP_BIN_PATH} #{$CLI_BIN_DIR}",
+    "copy:js": "cp #{$GRAINC_JS_PATH} #{$GRAINDOC_JS_PATH} #{$GRAINFORMAT_JS_PATH} #{$GRAINLSP_JS_PATH}  #{$CLI_BIN_DIR}",
     "clean": "rm -rf #{self.root}/_esy",
     "test": "#{$TEST_EXEC_PATH}",
     "format": "dune build @fmt --auto-promote",

--- a/compiler/grainlsp/config/dune
+++ b/compiler/grainlsp/config/dune
@@ -1,0 +1,8 @@
+(executable
+ (name flags)
+ (libraries dune.configurator))
+
+(rule
+ (targets flags.sexp)
+ (action
+  (run ./flags.exe)))

--- a/compiler/grainlsp/config/flags.re
+++ b/compiler/grainlsp/config/flags.re
@@ -1,0 +1,20 @@
+module C = Configurator.V1;
+
+let () = {
+  C.main(~name="grainc_flags", c => {
+    let default = [];
+
+    let flags =
+      switch (C.ocaml_config_var(c, "system")) {
+      | Some("mingw64") =>
+        // MinGW needs the -static flag passed directly to the linker,
+        // to avoid needing MinGW locations in the path
+        // Ref https://github.com/grain-lang/binaryen.ml#static-linking
+        ["-ccopt", "--", "-ccopt", "-static"]
+      | Some(_) => default
+      | None => default
+      };
+
+    C.Flags.write_sexp("flags.sexp", flags);
+  });
+};

--- a/compiler/grainlsp/definitions.re
+++ b/compiler/grainlsp/definitions.re
@@ -1,4 +1,5 @@
 open Grain_typed;
+open Grain_diagnostics;
 
 let goto_definition = (log, id, json, compiled_code, cached_code) => {
   switch (Utils.getTextDocumenUriAndPosition(json)) {
@@ -24,7 +25,7 @@ let goto_definition = (log, id, json, compiled_code, cached_code) => {
             | lookup =>
               let loc = lookup.val_loc;
               let (filename, _, _, _) =
-                Utils.get_raw_pos_info(loc.loc_start);
+                Locations.get_raw_pos_info(loc.loc_start);
               let range = Utils.loc_to_range(loc);
 
               // if the file is the one we are looking up in, we get just the filename rather than the

--- a/compiler/grainlsp/definitions.re
+++ b/compiler/grainlsp/definitions.re
@@ -1,0 +1,49 @@
+open Grain_typed;
+
+let goto_definition = (log, id, json, compiled_code, cached_code) => {
+  switch (Utils.getTextDocumenUriAndPosition(json)) {
+  | (Some(uri), Some(line), Some(char)) =>
+    let ln = line + 1;
+    let compiled_code_opt = Hashtbl.find_opt(cached_code, uri);
+    switch (compiled_code_opt) {
+    | None => log("No compiled code available")
+    | Some(compiled_code) =>
+      let node = Utils.findBestMatch(compiled_code, ln, char);
+      switch (node) {
+      | Some(stmt) =>
+        let node = Utils.getNodeFromStmt(log, stmt, ln, char);
+        switch ((node: Utils.node_t)) {
+        | Error(err) => log(err)
+        | NotInRange => log("Not in range")
+        | Expression(e) =>
+          let desc = e.exp_desc;
+          switch (desc) {
+          | TExpIdent(path, _, _) =>
+            switch (Env.find_value(path, compiled_code.env)) {
+            | exception exn => log("No definition found")
+            | lookup =>
+              let loc = lookup.val_loc;
+              let (filename, _, _, _) =
+                Utils.get_raw_pos_info(loc.loc_start);
+              let range = Utils.loc_to_range(loc);
+
+              // if the file is the one we are looking up in, we get just the filename rather than the
+              // full path, so we use the uri instead
+              if (String.contains(filename, '/')
+                  || String.contains(filename, '\\')) {
+                Rpc.send_go_to_definition(log, stdout, id, filename, range);
+              } else {
+                Rpc.send_go_to_definition(log, stdout, id, uri, range);
+              };
+            }
+          | _ => log("Not defined")
+          };
+        | Pattern(p) => log("Pattern definition")
+        };
+
+      | _ => log("No matching node found.")
+      };
+    };
+  | _ => log("Error, missing paramaters from client")
+  };
+};

--- a/compiler/grainlsp/dune
+++ b/compiler/grainlsp/dune
@@ -2,13 +2,8 @@
  (name lspserver)
  (public_name grain.lspserver)
  (modules log utils rpc lspserver)
- (libraries
-  grain
-  grain_diagnostics
-  grain_parsing
-  grain_utils
-  ppx_deriving_yojson.runtime
-  yojson)
+ (libraries grain grain_diagnostics grain_parsing grain_utils
+   ppx_deriving_yojson.runtime yojson)
  (preprocess
   (pps ppx_deriving_yojson)))
 
@@ -20,10 +15,5 @@
  (flags
   (:standard
    (:include ./config/flags.sexp)))
- (libraries
-  cmdliner
-  grain
-  grain_utils
-  grain_parsing
-  grain.lspserver
-  dune-build-info))
+ (libraries cmdliner grain grain_utils grain_parsing grain.lspserver
+   dune-build-info))

--- a/compiler/grainlsp/dune
+++ b/compiler/grainlsp/dune
@@ -1,0 +1,29 @@
+(library
+ (name lspserver)
+ (public_name grain.lspserver)
+ (modules log utils rpc lspserver)
+ (libraries
+  grain
+  grain_diagnostics
+  grain_parsing
+  grain_utils
+  ppx_deriving_yojson.runtime
+  yojson)
+ (preprocess
+  (pps ppx_deriving_yojson)))
+
+(executable
+ (name grainlsp)
+ (public_name grainlsp)
+ (package grainlsp)
+ (modules grainlsp)
+ (flags
+  (:standard
+   (:include ./config/flags.sexp)))
+ (libraries
+  cmdliner
+  grain
+  grain_utils
+  grain_parsing
+  grain.lspserver
+  dune-build-info))

--- a/compiler/grainlsp/dune
+++ b/compiler/grainlsp/dune
@@ -1,7 +1,7 @@
 (library
  (name lspserver)
  (public_name grain.lspserver)
- (modules log utils rpc lenses processcode lspserver)
+ (modules log utils rpc lenses processcode hover definitions lspserver)
  (libraries grain grain_diagnostics grain_parsing grain_utils
    ppx_deriving_yojson.runtime yojson)
  (preprocess

--- a/compiler/grainlsp/dune
+++ b/compiler/grainlsp/dune
@@ -1,7 +1,7 @@
 (library
  (name lspserver)
  (public_name grain.lspserver)
- (modules log utils rpc lspserver)
+ (modules log utils rpc lenses processcode lspserver)
  (libraries grain grain_diagnostics grain_parsing grain_utils
    ppx_deriving_yojson.runtime yojson)
  (preprocess

--- a/compiler/grainlsp/grainlsp.re
+++ b/compiler/grainlsp/grainlsp.re
@@ -1,0 +1,1 @@
+let _ = Lspserver.run();

--- a/compiler/grainlsp/hover.re
+++ b/compiler/grainlsp/hover.re
@@ -1,0 +1,156 @@
+open Grain_typed;
+
+let get_hover_from_statement =
+    (log, stmt: Typedtree.toplevel_stmt, line, char) =>
+  switch (stmt.ttop_desc) {
+  | TTopImport(import_declaration) => ("import declaration", None)
+  | TTopForeign(export_flag, value_description) => ("foreign", None)
+  | TTopData(data_declarations) =>
+    switch (data_declarations) {
+    | [] => ("", None)
+    | _ =>
+      let matches =
+        List.filter(
+          (dd: Typedtree.data_declaration) =>
+            Utils.is_point_inside_location(log, dd.data_loc, line, char),
+          data_declarations,
+        );
+      switch (matches) {
+      | [] => ("Internal error parsing", Some(stmt.ttop_loc))
+      | [node] =>
+        let name = node.data_name;
+        switch (node.data_kind) {
+        | TDataAbstract => ("Abstract declaration", Some(node.data_loc))
+        | TDataVariant(constrs) =>
+          let matches =
+            List.filter(
+              (cd: Typedtree.constructor_declaration) =>
+                if (Utils.is_point_inside_location(log, cd.cd_loc, line, char)) {
+                  true;
+                } else {
+                  false;
+                },
+              constrs,
+            );
+
+          switch (matches) {
+          | [decl] => (decl.cd_name.txt, Some(decl.cd_loc))
+          | _ => ("enum " ++ name.txt, Some(node.data_loc))
+          };
+
+        | TDataRecord(_) =>
+          switch (node.data_params) {
+          | [] => ("record " ++ node.data_name.txt, Some(node.data_loc))
+          | _ =>
+            let matches =
+              List.filter(
+                (dp: Typedtree.core_type) =>
+                  if (Utils.is_point_inside_location(
+                        log,
+                        dp.ctyp_loc,
+                        line,
+                        char,
+                      )) {
+                    true;
+                  } else {
+                    false;
+                  },
+                node.data_params,
+              );
+            switch (matches) {
+            | [decl] => (
+                Utils.lens_sig(decl.ctyp_type),
+                Some(decl.ctyp_loc),
+              )
+            | _ => ("record " ++ node.data_name.txt, Some(node.data_loc))
+            };
+          }
+        };
+      | _ => ("Internal error: Too many matches", None)
+      };
+    }
+
+  | TTopLet(export_flag, rec_flag, mut_flag, value_bindings) =>
+    switch (value_bindings) {
+    | [] => ("", None)
+    | _ =>
+      let matches =
+        List.map(
+          (vb: Typedtree.value_binding) =>
+            Utils.get_node_from_expression(log, vb.vb_expr, line, char),
+          value_bindings,
+        );
+      let filtered =
+        List.filter(
+          m =>
+            switch ((m: Utils.node_t)) {
+            | Error(_) => false
+            | NotInRange => false
+            | _ => true
+            },
+          matches,
+        );
+      switch (filtered) {
+      | [] =>
+        let vb = List.hd(value_bindings);
+        let expr = vb.vb_expr;
+        // return the type for the whole statement
+        (Utils.lens_sig(expr.exp_type), Some(vb.vb_loc));
+
+      | [node] =>
+        switch (node) {
+        | Error(err) => (err, None)
+        | NotInRange => ("Not in range", None)
+        | Expression(e) => (Utils.lens_sig(e.exp_type), Some(e.exp_loc))
+        | Pattern(p) => (Utils.lens_sig(p.pat_type), Some(p.pat_loc))
+        }
+      | _ => ("Internal error", None)
+      };
+    }
+
+  | TTopExpr(expression) =>
+    let node = Utils.get_node_from_expression(log, expression, line, char);
+    switch (node) {
+    | Error(err) => (err, None)
+    | NotInRange => (
+        Utils.lens_sig(expression.exp_type),
+        Some(expression.exp_loc),
+      )
+    | Expression(e) => (Utils.lens_sig(e.exp_type), Some(e.exp_loc))
+    | Pattern(p) => (Utils.lens_sig(p.pat_type), Some(p.pat_loc))
+    };
+
+  | TTopException(export_flag, type_exception) => ("exception", None)
+  | TTopExport(export_declarations) => ("export", None)
+  };
+
+let get_hover = (log, id, json, compiled_code) => {
+  switch (Utils.getTextDocumenUriAndPosition(json)) {
+  | (Some(uri), Some(line), Some(char)) =>
+    if (Hashtbl.mem(compiled_code, uri)) {
+      let ln = line + 1;
+
+      let compiled_code_opt = Hashtbl.find_opt(compiled_code, uri);
+      switch (compiled_code_opt) {
+      | None => ()
+      | Some(compiled_code) =>
+        let node = Utils.findBestMatch(compiled_code, ln, char);
+        switch (node) {
+        | Some(stmt) =>
+          let (signature, loc) =
+            get_hover_from_statement(log, stmt, ln, char);
+          let range =
+            switch (loc) {
+            | None => Utils.loc_to_range(stmt.ttop_loc)
+            | Some(l) => Utils.loc_to_range(l)
+            };
+          Rpc.send_hover(log, stdout, id, signature, range);
+        | None => ()
+        };
+      };
+    } else {
+      ();
+    }
+  | _ => ()
+  };
+};

--- a/compiler/grainlsp/lenses.re
+++ b/compiler/grainlsp/lenses.re
@@ -1,4 +1,5 @@
 open Grain_typed;
+open Grain_diagnostics;
 
 let get_signature_from_statement =
     (stmt: Grain_typed__Typedtree.toplevel_stmt) =>
@@ -51,7 +52,7 @@ let get_lenses = (typed_program: Typedtree.typed_program) => {
   List.fold_left(
     (acc, stmt: Grain_typed__Typedtree.toplevel_stmt) => {
       let (file, startline, startchar, sbol) =
-        Utils.get_raw_pos_info(stmt.ttop_loc.loc_start);
+        Locations.get_raw_pos_info(stmt.ttop_loc.loc_start);
 
       let signature = get_signature_from_statement(stmt);
       switch (signature) {

--- a/compiler/grainlsp/lenses.re
+++ b/compiler/grainlsp/lenses.re
@@ -1,0 +1,59 @@
+open Grain_typed;
+
+let get_signature_from_statement =
+    (stmt: Grain_typed__Typedtree.toplevel_stmt) =>
+  switch (stmt.ttop_desc) {
+  | TTopImport(import_declaration) => "import declaration"
+  | TTopForeign(export_flag, value_description) => "foreign"
+  | TTopData(data_declarations) => "data declaration"
+  | TTopLet(export_flag, rec_flag, mut_flag, value_bindings) =>
+    if (List.length(value_bindings) > 0) {
+      let vbs: Typedtree.value_binding = List.hd(value_bindings);
+      Utils.lens_sig(vbs.vb_expr.exp_type);
+    } else {
+      "";
+    }
+
+  | TTopExpr(expression) =>
+    let expr_type = expression.exp_type;
+    Utils.lens_sig(expr_type);
+  | TTopException(export_flag, type_exception) => "exception"
+  | TTopExport(export_declarations) => "export"
+  };
+let get_lenses = (typed_program: Typedtree.typed_program) => {
+  List.fold_left(
+    (acc, stmt: Grain_typed__Typedtree.toplevel_stmt) => {
+      let (file, startline, startchar, sbol) =
+        Utils.get_raw_pos_info(stmt.ttop_loc.loc_start);
+
+      let signature = get_signature_from_statement(stmt);
+      let lens: Rpc.lens_t = {line: startline, signature};
+
+      [lens, ...acc];
+    },
+    [],
+    typed_program.statements,
+  );
+};
+
+let process_get_lenses = (log, id, json, compiled_code) => {
+  log("process_get_lenses requested");
+  let params = Yojson.Safe.Util.member("params", json);
+  let text_document = Yojson.Safe.Util.member("textDocument", params);
+
+  let uri =
+    Yojson.Safe.Util.member("uri", text_document)
+    |> Yojson.Safe.Util.to_string_option;
+
+  switch (uri) {
+  | None => Rpc.send_lenses(log, stdout, id, [])
+  | Some(u) =>
+    if (Hashtbl.mem(compiled_code, u)) {
+      let compiled_code = Hashtbl.find(compiled_code, u);
+      let lenses = get_lenses(compiled_code);
+      Rpc.send_lenses(log, stdout, id, lenses);
+    } else {
+      Rpc.send_lenses(log, stdout, id, []);
+    }
+  };
+};

--- a/compiler/grainlsp/log.re
+++ b/compiler/grainlsp/log.re
@@ -1,0 +1,28 @@
+let out = ref(None);
+
+let initial_dest = Filename.concat(Filename.get_temp_dir_name(), "lsp.log");
+out := Some(open_out(initial_dest));
+
+let set_location = location => {
+  switch (out^) {
+  | None => ()
+  | Some(out) => close_out(out)
+  };
+  output_string(stderr, "Setting log location: " ++ location ++ "\n");
+  flush(stderr);
+  out := Some(open_out(location));
+};
+
+let spam_error = ref(false);
+
+let log = msg =>
+  switch (out^) {
+  | None => ()
+  | Some(out) =>
+    output_string(out, msg ++ "\n");
+    if (spam_error^) {
+      output_string(stderr, msg ++ "\n");
+      flush(stderr);
+    };
+    flush(out);
+  };

--- a/compiler/grainlsp/lspserver.re
+++ b/compiler/grainlsp/lspserver.re
@@ -1,54 +1,48 @@
 let rootPath = ".";
 
+let documents = Hashtbl.create(128);
+let compiled_code = Hashtbl.create(128);
+let cached_code = Hashtbl.create(128); // we keep the last successful compile to help with completion and definitions
+
 /* Will wait up to 100ms */
-let canRead = desc => {
+let can_read = desc => {
   let (r, _, _) = Unix.select([desc], [], [], 0.1);
   r != [];
 };
 
-let run = () => {
-  Log.set_location(rootPath ++ "/lsp_debug.log");
-  Log.log("Hello - from " ++ Sys.executable_name);
-  let log = Log.log;
+let break = ref(false);
+let is_shutting_down = ref(false);
+let stdin_descr = Unix.descr_of_in_channel(stdin);
 
-  let stdin_descr = Unix.descr_of_in_channel(stdin);
-
-  log("Starting main loop");
-  let rec loop = (~isShuttingDown, ~documents, ~compiledCode) =>
-    // let state = tick(state);
-    if (canRead(stdin_descr)) {
+let loop = log =>
+  while (! break^) {
+    if (can_read(stdin_descr)) {
       switch (Rpc.read_message(log, stdin)) {
       | Message(id, action, json) =>
         log("received message " ++ action);
         switch (action) {
-        //     | "textDocument/hover" =>
-        //       Messages.get_hover(log, id, json, compiledCode)
+        | "textDocument/hover" =>
+          Hover.get_hover(log, id, json, compiled_code)
         | "textDocument/codeLens" =>
-          Lenses.process_get_lenses(log, id, json, compiledCode);
-          loop(~isShuttingDown, ~documents, ~compiledCode);
-        //     | "textDocument/codeAction" =>
-        //       Codeaction.process_request(log, id, json, compiledCode, documents)
-        //     | "textDocument/definition" =>
-        //       Messages.goto_definition(log, id, json, compiledCode)
-        //     | "textDocument/completion" =>
-        //       Completion.process_completion(
-        //         log,
-        //         id,
-        //         json,
-        //         compiledCode,
-        //         documents,
-        //       )
-        //     | "textDocument/signatureHelp" =>
-        //       Messages.signature_help(log, id, json, compiledCode, documents)
+          Lenses.process_get_lenses(log, id, json, compiled_code)
+        | "textDocument/definition" =>
+          Definitions.goto_definition(
+            log,
+            id,
+            json,
+            compiled_code,
+            cached_code,
+          )
         | "shutdown" =>
-          Rpc.sendNullMessage(log, stdout, id);
-          loop(~isShuttingDown=true, ~documents, ~compiledCode);
-        | _ => loop(~isShuttingDown, ~documents, ~compiledCode)
+          Rpc.send_null_message(log, stdout, id);
+          is_shutting_down := true;
+        | _ => ()
         };
 
       | Notification("exit", _) =>
-        if (isShuttingDown) {
+        if (is_shutting_down^) {
           log("Got exit! Terminating loop");
+          break := true;
         } else {
           log("Got exit without shutdown. Erroring out");
           exit(1);
@@ -62,31 +56,31 @@ let run = () => {
             log,
             json,
             documents,
-            compiledCode,
+            compiled_code,
+            cached_code,
           )
         | _ => ()
         };
-        loop(~isShuttingDown, ~documents, ~compiledCode);
       | Error(_) =>
         log("!!!Received Error");
-        loop(~isShuttingDown=true, ~documents, ~compiledCode);
+        is_shutting_down := true;
       };
-    } else {
-      loop(~isShuttingDown, ~documents, ~compiledCode);
     };
+  };
 
-  let initialize = (~documents, ~compiledCode) =>
+let run = () => {
+  Log.set_location(rootPath ++ "/lsp_debug.log");
+  Log.log("Hello - from " ++ Sys.executable_name);
+  let log = Log.log;
+
+  let initialize = () =>
     switch (Rpc.read_message(log, stdin)) {
     | Message(id, "initialize", _) =>
       log("initialize");
       Rpc.send_capabilities(log, stdout, id);
-      loop(~isShuttingDown=false, ~documents, ~compiledCode);
-
+      loop(log);
     | _ => failwith("Client must send 'initialize' as first event")
     };
 
-  let documents = Hashtbl.create(128);
-  let compiledCode = Hashtbl.create(128);
-
-  initialize(~documents, ~compiledCode);
+  initialize();
 };

--- a/compiler/grainlsp/lspserver.re
+++ b/compiler/grainlsp/lspserver.re
@@ -1,0 +1,86 @@
+let rootPath = ".";
+
+/* Will wait up to 100ms */
+let canRead = desc => {
+  let (r, _, _) = Unix.select([desc], [], [], 0.1);
+  r != [];
+};
+
+let run = () => {
+  Log.set_location(rootPath ++ "/lsp_debug.log");
+  Log.log("Hello - from " ++ Sys.executable_name);
+  let log = Log.log;
+
+  let stdin_descr = Unix.descr_of_in_channel(stdin);
+
+  log("Starting main loop");
+  let rec loop = (~isShuttingDown, ~documents, ~compiledCode) =>
+    // let state = tick(state);
+    if (canRead(stdin_descr)) {
+      //   switch (Rpc.read_message(log, stdin)) {
+      //   | Message(id, action, json) =>
+      //     log("received message " ++ action);
+      //     switch (action) {
+      //     | "textDocument/hover" =>
+      //       Messages.get_hover(log, id, json, compiledCode)
+      //     | "textDocument/codeLens" =>
+      //       Messages.process_get_lenses(log, id, json, compiledCode)
+      //     | "textDocument/codeAction" =>
+      //       Codeaction.process_request(log, id, json, compiledCode, documents)
+      //     | "textDocument/definition" =>
+      //       Messages.goto_definition(log, id, json, compiledCode)
+      //     | "textDocument/completion" =>
+      //       Completion.process_completion(
+      //         log,
+      //         id,
+      //         json,
+      //         compiledCode,
+      //         documents,
+      //       )
+      //     | "textDocument/signatureHelp" =>
+      //       Messages.signature_help(log, id, json, compiledCode, documents)
+      //     | _ => ()
+      //     };
+      //     loop(~isShuttingDown, ~documents, ~compiledCode);
+      //   | Notification(method, json) =>
+      //     // log("received notification " ++ method);
+      //     switch (method) {
+      //     | "textDocument/didOpen"
+      //     | "textDocument/didChange" =>
+      //       Notifications.textDocument_didOpenOrChange(
+      //         log,
+      //         json,
+      //         documents,
+      //         compiledCode,
+      //       )
+      //     | _ => ()
+      //     };
+      //     loop(~isShuttingDown, ~documents, ~compiledCode);
+      //   | Error(_) =>
+      //     log("!!!Received Error");
+      //     loop(~isShuttingDown=true, ~documents, ~compiledCode);
+      //   };
+      loop(
+        ~isShuttingDown,
+        ~documents,
+        ~compiledCode,
+      );
+    } else {
+      loop(~isShuttingDown, ~documents, ~compiledCode);
+    };
+
+  let initialize = (~documents, ~compiledCode) =>
+    switch (Rpc.read_message(log, stdin)) {
+    | Message(id, "initialize", _) =>
+      log("initialize");
+      ///////     Rpc.send_capabilities(log, stdout, id);
+      loop(~isShuttingDown=false, ~documents, ~compiledCode);
+
+    | _ => failwith("Client must send 'initialize' as first event")
+    };
+
+  let documents = Hashtbl.create(128);
+  let compiledCode = Hashtbl.create(128);
+
+  initialize(~documents, ~compiledCode);
+};

--- a/compiler/grainlsp/lspserver.re
+++ b/compiler/grainlsp/lspserver.re
@@ -17,54 +17,50 @@ let run = () => {
   let rec loop = (~isShuttingDown, ~documents, ~compiledCode) =>
     // let state = tick(state);
     if (canRead(stdin_descr)) {
-      //   switch (Rpc.read_message(log, stdin)) {
-      //   | Message(id, action, json) =>
-      //     log("received message " ++ action);
-      //     switch (action) {
-      //     | "textDocument/hover" =>
-      //       Messages.get_hover(log, id, json, compiledCode)
-      //     | "textDocument/codeLens" =>
-      //       Messages.process_get_lenses(log, id, json, compiledCode)
-      //     | "textDocument/codeAction" =>
-      //       Codeaction.process_request(log, id, json, compiledCode, documents)
-      //     | "textDocument/definition" =>
-      //       Messages.goto_definition(log, id, json, compiledCode)
-      //     | "textDocument/completion" =>
-      //       Completion.process_completion(
-      //         log,
-      //         id,
-      //         json,
-      //         compiledCode,
-      //         documents,
-      //       )
-      //     | "textDocument/signatureHelp" =>
-      //       Messages.signature_help(log, id, json, compiledCode, documents)
-      //     | _ => ()
-      //     };
-      //     loop(~isShuttingDown, ~documents, ~compiledCode);
-      //   | Notification(method, json) =>
-      //     // log("received notification " ++ method);
-      //     switch (method) {
-      //     | "textDocument/didOpen"
-      //     | "textDocument/didChange" =>
-      //       Notifications.textDocument_didOpenOrChange(
-      //         log,
-      //         json,
-      //         documents,
-      //         compiledCode,
-      //       )
-      //     | _ => ()
-      //     };
-      //     loop(~isShuttingDown, ~documents, ~compiledCode);
-      //   | Error(_) =>
-      //     log("!!!Received Error");
-      //     loop(~isShuttingDown=true, ~documents, ~compiledCode);
-      //   };
-      loop(
-        ~isShuttingDown,
-        ~documents,
-        ~compiledCode,
-      );
+      switch (Rpc.read_message(log, stdin)) {
+      | Message(id, action, json) =>
+        log("received message " ++ action);
+        switch (action) {
+        //     | "textDocument/hover" =>
+        //       Messages.get_hover(log, id, json, compiledCode)
+        | "textDocument/codeLens" =>
+          Lenses.process_get_lenses(log, id, json, compiledCode)
+        //     | "textDocument/codeAction" =>
+        //       Codeaction.process_request(log, id, json, compiledCode, documents)
+        //     | "textDocument/definition" =>
+        //       Messages.goto_definition(log, id, json, compiledCode)
+        //     | "textDocument/completion" =>
+        //       Completion.process_completion(
+        //         log,
+        //         id,
+        //         json,
+        //         compiledCode,
+        //         documents,
+        //       )
+        //     | "textDocument/signatureHelp" =>
+        //       Messages.signature_help(log, id, json, compiledCode, documents)
+        | _ => ()
+        };
+        loop(~isShuttingDown, ~documents, ~compiledCode);
+
+      | Notification(method, json) =>
+        log("received notification " ++ method);
+        switch (method) {
+        | "textDocument/didOpen"
+        | "textDocument/didChange" =>
+          Processcode.textDocument_didOpenOrChange(
+            log,
+            json,
+            documents,
+            compiledCode,
+          )
+        | _ => ()
+        };
+        loop(~isShuttingDown, ~documents, ~compiledCode);
+      | Error(_) =>
+        log("!!!Received Error");
+        loop(~isShuttingDown=true, ~documents, ~compiledCode);
+      };
     } else {
       loop(~isShuttingDown, ~documents, ~compiledCode);
     };
@@ -73,7 +69,7 @@ let run = () => {
     switch (Rpc.read_message(log, stdin)) {
     | Message(id, "initialize", _) =>
       log("initialize");
-      ///////     Rpc.send_capabilities(log, stdout, id);
+      Rpc.send_capabilities(log, stdout, id);
       loop(~isShuttingDown=false, ~documents, ~compiledCode);
 
     | _ => failwith("Client must send 'initialize' as first event")

--- a/compiler/grainlsp/processcode.re
+++ b/compiler/grainlsp/processcode.re
@@ -9,7 +9,7 @@ let compile_source = (log, uri, source) => {
 
   let filename = Filename.basename(uri);
 
-  // Grain_utils.Config.stdlib_dir := Some("/Users/marcus/Projects/grain/stdlib");
+  Grain_utils.Config.stdlib_dir := Some("/Users/marcus/Projects/grain/stdlib");
   switch (
     Compile.compile_string(
       ~hook=stop_after_typed_well_formed,

--- a/compiler/grainlsp/processcode.re
+++ b/compiler/grainlsp/processcode.re
@@ -43,7 +43,6 @@ let compile_source = (log, uri, source) => {
       );
     (Some(typed_program), None, Some(warnings));
   | _ =>
-    log("Some other state from compilation");
     let lsp_error: Grain_diagnostics.Output.lsp_error = {
       file: uri,
       line: 0,
@@ -91,7 +90,8 @@ let getTextDocumentFromParams = json => {
   };
 };
 
-let textDocument_didOpenOrChange = (log, json, documents, compiledCode) => {
+let textDocument_didOpenOrChange =
+    (log, json, documents, compiledCode, cachedCode) => {
   switch (getTextDocumentFromParams(json)) {
   | Some((uri, text)) =>
     if (!Hashtbl.mem(documents, uri)) {
@@ -106,6 +106,11 @@ let textDocument_didOpenOrChange = (log, json, documents, compiledCode) => {
         Hashtbl.add(compiledCode, uri, typed_program);
       } else {
         Hashtbl.replace(compiledCode, uri, typed_program);
+      };
+      if (!Hashtbl.mem(cachedCode, uri)) {
+        Hashtbl.add(cachedCode, uri, typed_program);
+      } else {
+        Hashtbl.replace(cachedCode, uri, typed_program);
       };
       switch (warnings) {
       | None => Rpc.clear_diagnostics(log, stdout, uri)

--- a/compiler/grainlsp/processcode.re
+++ b/compiler/grainlsp/processcode.re
@@ -1,0 +1,123 @@
+open Grain;
+open Compile;
+open Grain_parsing;
+open Grain_utils;
+open Grain_typed;
+
+let compile_source = (log, uri, source) => {
+  log("Compiling the source for " ++ uri);
+
+  let filename = Filename.basename(uri);
+
+  // Grain_utils.Config.stdlib_dir := Some("/Users/marcus/Projects/grain/stdlib");
+  switch (
+    Compile.compile_string(
+      ~hook=stop_after_typed_well_formed,
+      ~name=filename,
+      source,
+    )
+  ) {
+  | exception exn =>
+    let error = Grain_diagnostics.Output.exn_to_lsp_error(exn);
+    let errors =
+      switch (error) {
+      | None =>
+        let lsp_err: Grain_diagnostics.Output.lsp_error = {
+          file: uri,
+          line: 0,
+          startchar: 0,
+          endline: 0,
+          endchar: 0,
+          lsp_message: "Unable to parse",
+        };
+        (None, Some(lsp_err), None);
+      | Some(err) => (None, Some(err), None)
+      };
+    errors;
+
+  | {cstate_desc: TypedWellFormed(typed_program)} =>
+    let warnings: list(Grain_diagnostics.Output.lsp_warning) =
+      Grain_diagnostics.Output.convert_warnings(
+        Grain_utils.Warnings.get_warnings(),
+        uri,
+      );
+    (Some(typed_program), None, Some(warnings));
+  | _ =>
+    log("Some other state from compilation");
+    let lsp_error: Grain_diagnostics.Output.lsp_error = {
+      file: uri,
+      line: 0,
+      startchar: 0,
+      endline: 0,
+      endchar: 0,
+      lsp_message: "Compilation failed with an internal error",
+    };
+    (None, Some(lsp_error), None);
+  };
+};
+
+let getTextDocumentFromParams = json => {
+  let params = Yojson.Safe.Util.member("params", json);
+  let textDocument = Yojson.Safe.Util.member("textDocument", params);
+  let uri =
+    Yojson.Safe.Util.member("uri", textDocument)
+    |> Yojson.Safe.Util.to_string_option;
+
+  switch (uri) {
+  | None => None
+  | Some(u) =>
+    let text =
+      Yojson.Safe.Util.member("text", textDocument)
+      |> Yojson.Safe.Util.to_string_option;
+
+    switch (text) {
+    | Some(t) => Some((u, t))
+    | _ =>
+      let changes = Yojson.Safe.Util.member("contentChanges", params);
+
+      switch (changes) {
+      | `Null => None
+      | _ =>
+        let text =
+          Yojson.Safe.Util.member("text", Yojson.Safe.Util.index(0, changes))
+          |> Yojson.Safe.Util.to_string_option;
+
+        switch (text) {
+        | Some(t) => Some((u, t))
+        | _ => None
+        };
+      };
+    };
+  };
+};
+
+let textDocument_didOpenOrChange = (log, json, documents, compiledCode) => {
+  switch (getTextDocumentFromParams(json)) {
+  | Some((uri, text)) =>
+    if (!Hashtbl.mem(documents, uri)) {
+      Hashtbl.add(documents, uri, text);
+    } else {
+      Hashtbl.replace(documents, uri, text);
+    };
+    let compilerRes = compile_source(log, uri, text);
+    switch (compilerRes) {
+    | (Some(typed_program), None, warnings) =>
+      if (!Hashtbl.mem(compiledCode, uri)) {
+        Hashtbl.add(compiledCode, uri, typed_program);
+      } else {
+        Hashtbl.replace(compiledCode, uri, typed_program);
+      };
+      switch (warnings) {
+      | None => Rpc.clear_diagnostics(log, stdout, uri)
+      | Some(wrns) => Rpc.send_diagnostics(log, stdout, uri, None, warnings)
+      };
+
+    | (_, Some(err), _) =>
+      Hashtbl.remove(compiledCode, uri);
+      log("failed to compile");
+      Rpc.send_diagnostics(log, stdout, uri, Some(err), None);
+    | (None, None, _) => Rpc.clear_diagnostics(log, stdout, uri)
+    };
+  | _ => ()
+  };
+};

--- a/compiler/grainlsp/rpc.re
+++ b/compiler/grainlsp/rpc.re
@@ -147,6 +147,21 @@ let send = (output, content) => {
   flush(output);
 };
 
+let sendNullMessage = (log, output, id) => {
+  let res =
+    `Assoc([
+      ("jsonrpc", `String("2.0")),
+      ("id", `Int(id)),
+      ("result", `Null),
+    ]);
+
+  let strJson = Yojson.Safe.pretty_to_string(res);
+
+  log(strJson);
+
+  send(output, strJson);
+};
+
 let send_capabilities = (log, output, id: int) => {
   //   let sigHelpers: signatureHelpers = {
   //     triggerCharacters: ["("],

--- a/compiler/grainlsp/rpc.re
+++ b/compiler/grainlsp/rpc.re
@@ -1,7 +1,109 @@
+let jsonrpc = "2.0";
+
 type protocolMsg =
   | Message(int, string, Yojson.Safe.t)
   | Error(string)
   | Notification(string, Yojson.Safe.t);
+
+[@deriving yojson]
+type completionValues = {
+  resolveProvider: bool,
+  triggerCharacters: list(string),
+};
+
+[@deriving yojson]
+type signatureHelpers = {
+  triggerCharacters: list(string),
+  retriggerCharacters: list(string),
+};
+
+[@deriving yojson]
+type codeValues = {resolveProvider: bool};
+
+[@deriving yojson]
+type lspCapabilities = {
+  documentFormattingProvider: bool,
+  textDocumentSync: int,
+  hoverProvider: bool,
+  // completionProvider: completionValues,
+  // signatureHelpProvider: signatureHelpers,
+  definitionProvider: bool,
+  typeDefinitionProvider: bool,
+  referencesProvider: bool,
+  documentSymbolProvider: bool,
+  codeActionProvider: bool,
+  codeLensProvider: codeValues,
+  documentHighlightProvider: bool,
+  documentRangeFormattingProvider: bool,
+  renameProvider: bool,
+};
+
+[@deriving yojson]
+type position = {
+  line: int,
+  character: int,
+};
+
+[@deriving yojson]
+type lens_t = {
+  line: int,
+  signature: string,
+};
+
+[@deriving yojson]
+type range = {
+  start: position,
+  [@key "end"]
+  range_end: position,
+};
+
+[@deriving yojson]
+type capabilities_result = {capabilities: lspCapabilities};
+[@deriving yojson]
+type capabilities_response = {
+  jsonrpc: string,
+  id: int,
+  result: capabilities_result,
+};
+
+[@deriving yojson]
+type command_t = {
+  title: string,
+  command: string,
+};
+
+[@deriving yojson]
+type lsp_lens_t = {
+  range,
+  command: command_t,
+};
+
+[@deriving yojson]
+type lens_response = {
+  jsonrpc: string,
+  id: int,
+  result: list(lsp_lens_t),
+};
+
+[@deriving yojson]
+type diagnostic_t = {
+  range,
+  severity: int,
+  message: string,
+};
+
+[@deriving yojson]
+type document_diagnostics = {
+  uri: string,
+  diagnostics: list(diagnostic_t),
+};
+
+[@deriving yojson]
+type diagnostics_message = {
+  jsonrpc: string,
+  method: string,
+  params: document_diagnostics,
+};
 
 let read_message = (log, input): protocolMsg => {
   let clength = input_line(input);
@@ -20,11 +122,6 @@ let read_message = (log, input): protocolMsg => {
 
     let json = Yojson.Safe.from_string(raw);
 
-    switch (json) {
-    | `Assoc(items) => ()
-    | _ => ()
-    };
-
     let action =
       Yojson.Safe.Util.member("method", json) |> Yojson.Safe.Util.to_string;
 
@@ -38,4 +135,195 @@ let read_message = (log, input): protocolMsg => {
   } else {
     failwith("Invalid header");
   };
+};
+
+let send = (output, content) => {
+  let length = String.length(content);
+  let sep = Sys.os_type == "Unix" ? "\r\n\r\n" : "\n\n";
+
+  let len = string_of_int(length);
+
+  output_string(output, "Content-Length: " ++ len ++ sep ++ content);
+  flush(output);
+};
+
+let send_capabilities = (log, output, id: int) => {
+  //   let sigHelpers: signatureHelpers = {
+  //     triggerCharacters: ["("],
+  //     retriggerCharacters: [","],
+  //   };
+
+  //   let completionVals: completionValues = {
+  //     resolveProvider: true,
+  //     triggerCharacters: ["."],
+  //   };
+
+  let codeVals: codeValues = {resolveProvider: true};
+
+  let capabilities: lspCapabilities = {
+    documentFormattingProvider: false,
+    textDocumentSync: 1,
+    hoverProvider: true,
+    //  completionProvider: completionVals,
+    //  signatureHelpProvider: sigHelpers,
+    definitionProvider: false, // to restore
+    typeDefinitionProvider: false,
+    referencesProvider: false,
+    documentSymbolProvider: false,
+    codeActionProvider: false,
+    codeLensProvider: codeVals,
+    documentHighlightProvider: false,
+    documentRangeFormattingProvider: false,
+    renameProvider: false,
+  };
+
+  let response: capabilities_response = {
+    jsonrpc,
+    id,
+    result: {
+      capabilities: capabilities,
+    },
+  };
+
+  let res = capabilities_response_to_yojson(response);
+
+  let strJson = Yojson.Safe.to_string(res);
+
+  log(strJson);
+
+  send(output, strJson);
+};
+
+let send_lenses = (log, output, id: int, lenses: list(lens_t)) => {
+  let convertedLenses =
+    List.map(
+      (l: lens_t) => {
+        let rstart: position = {line: l.line - 1, character: 1};
+        let rend: position = {line: l.line - 1, character: 1};
+
+        let range = {
+          {start: rstart, range_end: rend};
+        };
+
+        let command = {title: l.signature, command: "command string"};
+        let lsp_lens: lsp_lens_t = {range, command};
+        lsp_lens;
+      },
+      lenses,
+    );
+
+  let response: lens_response = {jsonrpc, id, result: convertedLenses};
+
+  let res = lens_response_to_yojson(response);
+
+  let strJson = Yojson.Safe.pretty_to_string(res);
+
+  send(output, strJson);
+};
+
+let send_diagnostics =
+    (
+      log,
+      output,
+      uri,
+      error: option(Grain_diagnostics.Output.lsp_error),
+      warnings: option(list(Grain_diagnostics.Output.lsp_warning)),
+    ) => {
+  let errorDiags =
+    switch (error) {
+    | None => []
+    | Some(err) =>
+      let rstart: position = {line: err.line - 1, character: err.startchar};
+      let rend: position = {line: err.endline - 1, character: err.endchar};
+      // let range = range_to_yojson({start: rstart, range_end: rend});
+
+      let range = {start: rstart, range_end: rend};
+
+      [
+        // `Assoc([
+        //   ("range", range),
+        //   ("severity", `Int(1)),
+        //   ("message", `String(err.lsp_message)),
+        // ]),
+        {range, severity: 1, message: err.lsp_message},
+      ];
+    };
+
+  let with_warnings =
+    switch (warnings) {
+    | None => errorDiags
+    | Some(warns) =>
+      let warningDiags =
+        List.map(
+          (w: Grain_diagnostics.Output.lsp_warning) => {
+            let rstart: position = {line: w.line - 1, character: w.startchar};
+            let rend: position = {line: w.endline - 1, character: w.endchar};
+            // let range = range_to_yojson({start: rstart, range_end: rend});
+
+            let range = {start: rstart, range_end: rend};
+
+            // `Assoc([
+            //   ("range", range),
+            //   ("severity", `Int(2)),
+            //   ("message", `String(w.lsp_message)),
+            // ]);
+
+            {range, severity: 2, message: w.lsp_message};
+          },
+          warns,
+        );
+      List.append(errorDiags, warningDiags);
+    };
+
+  //let diagnostics = `List(with_warnings);
+
+  //   let notification =
+  //     `Assoc([
+  //       ("jsonrpc", `String("2.0")),
+  //       ("method", `String("textDocument/publishDiagnostics")),
+  //       (
+  //         "params",
+  //         `Assoc([("uri", `String(uri)), ("diagnostics", diagnostics)]),
+  //       ),
+  //     ]);
+
+  let message: diagnostics_message = {
+    jsonrpc,
+    method: "textDocument/publishDiagnostics",
+    params: {
+      uri,
+      diagnostics: with_warnings,
+    },
+  };
+
+  let jsonMessage =
+    Yojson.Safe.to_string(diagnostics_message_to_yojson(message));
+
+  log(jsonMessage);
+
+  send(output, jsonMessage);
+};
+
+let clear_diagnostics = (log, output, uri) => {
+  let message: diagnostics_message = {
+    jsonrpc,
+    method: "textDocument/publishDiagnostics",
+    params: {
+      uri,
+      diagnostics: [],
+    },
+  };
+  // `Assoc([
+  //   ("jsonrpc", `String("2.0")),
+  //   ("method", `String("textDocument/publishDiagnostics")),
+  //   (
+  //     "params",
+  //     `Assoc([("uri", `String(uri)), ("diagnostics", `List([]))]),
+  //   ),
+  // ]);
+
+  let jsonMessage =
+    Yojson.Safe.to_string(diagnostics_message_to_yojson(message));
+
+  send(output, jsonMessage);
 };

--- a/compiler/grainlsp/rpc.re
+++ b/compiler/grainlsp/rpc.re
@@ -1,0 +1,41 @@
+type protocolMsg =
+  | Message(int, string, Yojson.Safe.t)
+  | Error(string)
+  | Notification(string, Yojson.Safe.t);
+
+let read_message = (log, input): protocolMsg => {
+  let clength = input_line(input);
+  let cl = "Content-Length: ";
+  let cll = String.length(cl);
+  if (String.sub(clength, 0, cll) == cl) {
+    /* if on windows, dont need the extra -1 */
+    let offset = Sys.os_type == "Win32" ? 0 : (-1); /* -1 for trailing \r */
+
+    let num =
+      String.sub(clength, cll, String.length(clength) - cll + offset);
+    let num = (num |> int_of_string) + (Sys.os_type == "Win32" ? 1 : 2);
+    let buffer = Buffer.create(num);
+    Buffer.add_channel(buffer, input, num);
+    let raw = Buffer.contents(buffer);
+
+    let json = Yojson.Safe.from_string(raw);
+
+    switch (json) {
+    | `Assoc(items) => ()
+    | _ => ()
+    };
+
+    let action =
+      Yojson.Safe.Util.member("method", json) |> Yojson.Safe.Util.to_string;
+
+    let idOpt =
+      Yojson.Safe.Util.member("id", json) |> Yojson.Safe.Util.to_int_option;
+
+    switch (idOpt) {
+    | None => Notification(action, json)
+    | Some(id) => Message(id, action, json)
+    };
+  } else {
+    failwith("Invalid header");
+  };
+};

--- a/compiler/grainlsp/utils.re
+++ b/compiler/grainlsp/utils.re
@@ -11,15 +11,9 @@ type node_t =
   | NotInRange
   | Error(string);
 
-let get_raw_pos_info = (pos: Lexing.position) => (
-  pos.pos_fname,
-  pos.pos_lnum,
-  pos.pos_cnum - pos.pos_bol,
-  pos.pos_bol,
-);
-
 let loc_to_range = (pos: Location.t): Rpc.range_t => {
-  let (_, startline, startchar, _) = get_raw_pos_info(pos.loc_start);
+  let (_, startline, startchar, _) =
+    Locations.get_raw_pos_info(pos.loc_start);
   let (_, endline, endchar) =
     Grain_parsing.Location.get_pos_info(pos.loc_end);
 
@@ -33,9 +27,8 @@ let loc_to_range = (pos: Location.t): Rpc.range_t => {
 };
 
 let is_point_inside_stmt = (loc1: Grain_parsing.Location.t, line: int) => {
-  let (_, raw1l, raw1c, _) = get_raw_pos_info(loc1.loc_start);
-  let (_, raw1le, raw1ce, _) = get_raw_pos_info(loc1.loc_end);
-
+  let (_, raw1l, raw1c, _) = Locations.get_raw_pos_info(loc1.loc_start);
+  let (_, raw1le, raw1ce, _) = Locations.get_raw_pos_info(loc1.loc_end);
   if (line == raw1l || line == raw1le) {
     true;
   } else if (line > raw1l && line < raw1le) {
@@ -46,8 +39,8 @@ let is_point_inside_stmt = (loc1: Grain_parsing.Location.t, line: int) => {
 };
 let is_point_inside_location =
     (log, loc1: Grain_parsing.Location.t, line: int, char: int) => {
-  let (_, raw1l, raw1c, _) = get_raw_pos_info(loc1.loc_start);
-  let (_, raw1le, raw1ce, _) = get_raw_pos_info(loc1.loc_end);
+  let (_, raw1l, raw1c, _) = Locations.get_raw_pos_info(loc1.loc_start);
+  let (_, raw1le, raw1ce, _) = Locations.get_raw_pos_info(loc1.loc_end);
 
   let res =
     if (line == raw1l) {
@@ -221,7 +214,7 @@ let rec get_node_from_expression =
           switch (exps) {
           | [] => Error("No function application matches")
           | [expr] => Expression(expr)
-          | _ => Error("Multiple functionn applications match")
+          | _ => Error("Multiple function applications match")
           };
         };
       }

--- a/compiler/grainlsp/utils.re
+++ b/compiler/grainlsp/utils.re
@@ -1,0 +1,90 @@
+open Grain;
+open Compile;
+open Grain_parsing;
+open Grain_utils;
+open Grain_typed;
+open Grain_diagnostics;
+
+type node_t =
+  | Expression(Typedtree.expression)
+  | Pattern(Typedtree.pattern)
+  | NotInRange
+  | Error(string);
+
+let get_raw_pos_info = (pos: Lexing.position) => (
+  pos.pos_fname,
+  pos.pos_lnum,
+  pos.pos_cnum - pos.pos_bol,
+  pos.pos_bol,
+);
+
+// let loc_to_range = (pos: Location.t): Rpc.range_t => {
+//   let (_, startline, startchar, _) = get_raw_pos_info(pos.loc_start);
+//   let (_, endline, endchar) =
+//     Grain_parsing.Location.get_pos_info(pos.loc_end);
+
+//   let range: Rpc.range_t = {
+//     start_line: startline,
+//     start_char: startchar,
+//     end_line: endline,
+//     end_char: endchar,
+//   };
+//   range;
+// };
+
+let is_point_inside_stmt = (loc1: Grain_parsing.Location.t, line: int) => {
+  let (_, raw1l, raw1c, _) = get_raw_pos_info(loc1.loc_start);
+
+  let (_, raw1le, raw1ce, _) = get_raw_pos_info(loc1.loc_end);
+
+  if (line == raw1l || line == raw1le) {
+    true;
+  } else if (line > raw1l && line < raw1le) {
+    true;
+  } else {
+    false;
+  };
+};
+let is_point_inside_location =
+    (log, loc1: Grain_parsing.Location.t, line: int, char: int) => {
+  let (_, raw1l, raw1c, _) = get_raw_pos_info(loc1.loc_start);
+  let (_, raw1le, raw1ce, _) = get_raw_pos_info(loc1.loc_end);
+
+  let res =
+    if (line == raw1l) {
+      if (char >= raw1c) {
+        if (line == raw1le) {
+          if (char <= raw1ce) {
+            true;
+          } else {
+            false;
+          };
+        } else {
+          true;
+        };
+      } else {
+        false;
+      };
+    } else if (line == raw1le) {
+      if (char <= raw1ce) {
+        true;
+      } else {
+        false;
+      };
+    } else if (line > raw1l && line < raw1le) {
+      true;
+    } else {
+      false;
+    };
+
+  res;
+};
+
+let lens_sig = (t: Types.type_expr) => {
+  let buf = Buffer.create(64);
+  let ppf = Format.formatter_of_buffer(buf);
+  Printtyp.type_expr(ppf, t);
+  Format.pp_print_flush(ppf, ());
+  let sigStr = Buffer.contents(buf);
+  sigStr;
+};

--- a/compiler/grainlsp/utils.re
+++ b/compiler/grainlsp/utils.re
@@ -18,23 +18,22 @@ let get_raw_pos_info = (pos: Lexing.position) => (
   pos.pos_bol,
 );
 
-// let loc_to_range = (pos: Location.t): Rpc.range_t => {
-//   let (_, startline, startchar, _) = get_raw_pos_info(pos.loc_start);
-//   let (_, endline, endchar) =
-//     Grain_parsing.Location.get_pos_info(pos.loc_end);
+let loc_to_range = (pos: Location.t): Rpc.range_t => {
+  let (_, startline, startchar, _) = get_raw_pos_info(pos.loc_start);
+  let (_, endline, endchar) =
+    Grain_parsing.Location.get_pos_info(pos.loc_end);
 
-//   let range: Rpc.range_t = {
-//     start_line: startline,
-//     start_char: startchar,
-//     end_line: endline,
-//     end_char: endchar,
-//   };
-//   range;
-// };
+  let range: Rpc.range_t = {
+    start_line: startline,
+    start_char: startchar,
+    end_line: endline,
+    end_char: endchar,
+  };
+  range;
+};
 
 let is_point_inside_stmt = (loc1: Grain_parsing.Location.t, line: int) => {
   let (_, raw1l, raw1c, _) = get_raw_pos_info(loc1.loc_start);
-
   let (_, raw1le, raw1ce, _) = get_raw_pos_info(loc1.loc_end);
 
   if (line == raw1l || line == raw1le) {
@@ -80,6 +79,43 @@ let is_point_inside_location =
   res;
 };
 
+let findBestMatch = (typed_program: Typedtree.typed_program, line, char) => {
+  // see if it falls within a top level statement (which it must!)
+
+  let rec loop = (statements: list(Grain_typed.Typedtree.toplevel_stmt)) =>
+    switch (statements) {
+    | [] => None
+    | [stmt, ...tail] =>
+      let loc = stmt.ttop_loc;
+      if (is_point_inside_stmt(loc, line)) {
+        Some(stmt);
+      } else {
+        loop(List.tl(statements));
+      };
+    };
+  loop(typed_program.statements);
+};
+
+let getTextDocumenUriAndPosition = json => {
+  let params = Yojson.Safe.Util.member("params", json);
+  let textDocument = Yojson.Safe.Util.member("textDocument", params);
+  let position = Yojson.Safe.Util.member("position", params);
+
+  let uri =
+    Yojson.Safe.Util.member("uri", textDocument)
+    |> Yojson.Safe.Util.to_string_option;
+
+  let line =
+    Yojson.Safe.Util.member("line", position)
+    |> Yojson.Safe.Util.to_int_option;
+
+  let char =
+    Yojson.Safe.Util.member("character", position)
+    |> Yojson.Safe.Util.to_int_option;
+
+  (uri, line, char);
+};
+
 let lens_sig = (t: Types.type_expr) => {
   let buf = Buffer.create(64);
   let ppf = Format.formatter_of_buffer(buf);
@@ -87,4 +123,230 @@ let lens_sig = (t: Types.type_expr) => {
   Format.pp_print_flush(ppf, ());
   let sigStr = Buffer.contents(buf);
   sigStr;
+};
+
+let print_expr = (~t: Types.type_expr) => {
+  let buf = Buffer.create(64);
+  let ppf = Format.formatter_of_buffer(buf);
+  Printtyp.type_expr(ppf, t);
+  Format.pp_print_flush(ppf, ());
+  let sigStr = Buffer.contents(buf);
+  sigStr;
+};
+
+let rec get_node_from_pattern = (log, pattern: Typedtree.pattern, line, char) => {
+  switch (pattern.pat_desc) {
+  | TPatTuple(args) =>
+    let pats =
+      List.filter(
+        (p: Typedtree.pattern) =>
+          is_point_inside_location(log, p.pat_loc, line, char),
+        args,
+      );
+    switch (pats) {
+    | [p] => Pattern(p)
+    | _ => Error("")
+    };
+
+  | TPatConstant(c) => Pattern(pattern)
+  | TPatVar(v, _) => Pattern(pattern)
+  | _ => Error("Pattern")
+  };
+};
+
+let rec get_node_from_expression =
+        (log, expr: Typedtree.expression, line, char) => {
+  let node =
+    switch (expr.exp_desc) {
+    | TExpLet(rec_flag, mut_flag, vbs) =>
+      switch (vbs) {
+      | [] => Error("")
+      | _ =>
+        let matches =
+          List.map(
+            (vb: Typedtree.value_binding) =>
+              get_node_from_expression(log, vb.vb_expr, line, char),
+            vbs,
+          );
+        let filtered =
+          List.filter(
+            m =>
+              switch (m) {
+              | Error(_) => false
+              | _ => true
+              },
+            matches,
+          );
+        switch (filtered) {
+        | [] =>
+          // return the type for the whole statement
+          let vb = List.hd(vbs);
+          let expr = vb.vb_expr;
+          Expression(expr);
+        | [hd] => hd
+        | _ => Error("Too many let matches")
+        };
+      }
+    | TExpBlock(expressions) =>
+      switch (expressions) {
+      | [] => Error("")
+      | _ =>
+        let exps =
+          List.filter(
+            (e: Typedtree.expression) =>
+              is_point_inside_location(log, e.exp_loc, line, char),
+            expressions,
+          );
+        switch (exps) {
+        | [] => NotInRange
+        | [expr] => get_node_from_expression(log, expr, line, char)
+        | _ => Error("Multiple blocks match")
+        };
+      }
+
+    | TExpApp(func, expressions) =>
+      if (is_point_inside_location(log, func.exp_loc, line, char)) {
+        Expression(func);
+      } else {
+        switch (expressions) {
+        | [] => Error("")
+        | _ =>
+          let exps =
+            List.filter(
+              (e: Typedtree.expression) =>
+                is_point_inside_location(log, e.exp_loc, line, char),
+              expressions,
+            );
+
+          switch (exps) {
+          | [] => Error("No function application matches")
+          | [expr] => Expression(expr)
+          | _ => Error("Multiple functionn applications match")
+          };
+        };
+      }
+    | TExpLambda([{mb_pat: pattern, mb_body: body}], _) =>
+      let node = get_node_from_pattern(log, pattern, line, char);
+      switch (node) {
+      | Error(_) => get_node_from_expression(log, body, line, char)
+      | _ => node
+      };
+    | TExpIf(cond, trueexp, falseexp) =>
+      let condNode = get_node_from_expression(log, cond, line, char);
+      let trueMatch =
+        switch (condNode) {
+        | NotInRange
+        | Error(_) => get_node_from_expression(log, trueexp, line, char)
+        | _ => condNode
+        };
+
+      switch (trueMatch) {
+      | NotInRange
+      | Error(_) => get_node_from_expression(log, falseexp, line, char)
+      | _ => trueMatch
+      };
+
+    | TExpArray(expressions)
+    | TExpTuple(expressions) =>
+      let exps =
+        List.filter(
+          (e: Typedtree.expression) =>
+            is_point_inside_location(log, e.exp_loc, line, char),
+          expressions,
+        );
+
+      switch (exps) {
+      | [] => Error("No match")
+      | [expr] => Expression(expr)
+      | _ => Error("Multiple matches")
+      };
+
+    | TExpLambda([], _) => failwith("Impossible: transl_imm: Empty lambda")
+    | TExpLambda(_, _) => failwith("NYI: transl_imm: Multi-branch lambda")
+    | TExpContinue => Error("TExpContinue")
+    | TExpBreak => Error("TExpBreak")
+    | TExpNull => Error("TExpNull")
+    | TExpIdent(_) => Error("TExpIdent")
+    | TExpConstant(const) =>
+      if (is_point_inside_location(log, expr.exp_loc, line, char)) {
+        Expression(expr);
+      } else {
+        NotInRange;
+      }
+    | TExpArrayGet(_) => Error("TExpArrayGet")
+    | TExpArraySet(_) => Error("TExpArraySet")
+    | TExpRecord(_) => Error("TExpRecord")
+    | TExpRecordGet(_) => Error("TExpRecordGet")
+    | TExpRecordSet(_) => Error("TExpRecordSet")
+    | TExpMatch(_) => Error("TExpMatch")
+    | TExpPrim1(_) => Error("TExpPrim1")
+    | TExpPrim2(_) => Error("TExpPrim2")
+    | TExpPrimN(_) => Error("TExpPrimN")
+    | TExpBoxAssign(_) => Error("TExpBoxAssign")
+    | TExpAssign(_) => Error("TExpAssign")
+    | TExpWhile(_) => Error("TExpWhile")
+    | TExpFor(_) => Error("TExpFor")
+    | TExpConstruct(_) => Error("TExpConstruct")
+    };
+
+  switch (node) {
+  | NotInRange
+  | Error(_) =>
+    if (is_point_inside_location(log, expr.exp_loc, line, char)) {
+      Expression(expr);
+    } else {
+      NotInRange;
+    }
+  | _ => node
+  };
+};
+
+let getNodeFromStmt =
+    (log, stmt: Grain_typed__Typedtree.toplevel_stmt, line, char) =>
+  switch (stmt.ttop_desc) {
+  | TTopImport(import_declaration) => Error("import declaration")
+  | TTopForeign(export_flag, value_description) => Error("foreign")
+  | TTopData(data_declarations) => Error("data declaration")
+  | TTopLet(export_flag, rec_flag, mut_flag, value_bindings) =>
+    switch (value_bindings) {
+    | [] => Error("")
+    | _ =>
+      let matches =
+        List.map(
+          (vb: Typedtree.value_binding) =>
+            get_node_from_expression(log, vb.vb_expr, line, char),
+          value_bindings,
+        );
+      let filtered =
+        List.filter(
+          m =>
+            switch (m) {
+            | Error(_) => false
+            | _ => true
+            },
+          matches,
+        );
+      switch (filtered) {
+      | [] =>
+        // return the type for the whole statement
+        let vb = List.hd(value_bindings);
+        let expr = vb.vb_expr;
+        Expression(expr);
+      | [node] => node
+      | _ => Error("Too many ttoplet matches")
+      };
+    }
+
+  | TTopExpr(expression) =>
+    get_node_from_expression(log, expression, line, char)
+  | TTopException(export_flag, type_exception) => Error("exception")
+  | TTopExport(export_declarations) => Error("export")
+  };
+
+let rec print_path = (ident: Path.t) => {
+  switch (ident) {
+  | PIdent(name) => name.name
+  | PExternal(externalIdent, second, _) =>
+    print_path(externalIdent) ++ "." ++ second
+  };
 };

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -69,12 +69,12 @@ let add_modtype = (id, ty, s) => {
 
 let for_saving = s => {...s, for_saving: true};
 
-let loc = (s, x) =>
-  if (s.for_saving) {
-    Location.dummy_loc;
-  } else {
-    x;
-  };
+let loc = (s, x) => x;
+// if (s.for_saving) {
+//   Location.dummy_loc;
+// } else {
+//   x;
+// };
 
 let remove_loc =
   Ast_mapper.{


### PR DESCRIPTION
The Grain LSP can now be run as a long-running server process listening for requests on stdin.

This brings big performance improvements as the current compile state is in memory ready for lookups for hovers, go to definitions, peek definition, etc.    It also hugely reduces the overhead in the information sent from the server to the client as only the information needed is returned instead of all data as before.

The LS protocol is now cleanly implemented for lenses, previously I was relying on the VSCode extension to decode which worked OK but broke other editors.

A restart LSP command has also been added.
