### PR TITLE
feat(stdlib): Add `Json` module

### DIFF
--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -531,28 +531,32 @@ module ToString {
   // Emitting
 
   // Simple values of each type
-  assert toStringCompact(JSONNull) == Ok("null")
-  assert toStringCompact(JSONBoolean(true)) == Ok("true")
-  assert toStringCompact(JSONBoolean(false)) == Ok("false")
-  assert toStringCompact(JSONString("")) == Ok("\"\"")
-  assert toStringCompact(JSONNumber(0)) == Ok("0")
-  assert toStringCompact(JSONArray([])) == Ok("[]")
-  assert toStringCompact(JSONObject([])) == Ok("{}")
+  assert toString(JSONNull, format=Compact) == Ok("null")
+  assert toString(JSONBoolean(true), format=Compact) == Ok("true")
+  assert toString(JSONBoolean(false), format=Compact) == Ok("false")
+  assert toString(JSONString(""), format=Compact) == Ok("\"\"")
+  assert toString(JSONNumber(0), format=Compact) == Ok("0")
+  assert toString(JSONArray([]), format=Compact) == Ok("[]")
+  assert toString(JSONObject([]), format=Compact) == Ok("{}")
 
   // Various strings. Escapes, emojis etc.
-  assert toStringCompact(JSONString("ASCII Hello world!")) ==
+  assert toString(JSONString("ASCII Hello world!"), format=Compact) ==
     Ok("\"ASCII Hello world!\"")
 
-  assert toStringCompact(JSONString("Unicode こんにちは世界!")) ==
+  assert toString(
+    JSONString("Unicode こんにちは世界!"),
+    format=Compact
+  ) ==
     Ok("\"Unicode こんにちは世界!\"")
-  assert toStringCompact(JSONString("A \"quoted\" string")) ==
+  assert toString(JSONString("A \"quoted\" string"), format=Compact) ==
     Ok("\"A \\\"quoted\\\" string\"")
-  assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
-  assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
-  assert toStringCompact(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
+  assert toString(JSONString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
+  assert toString(JSONString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
+  assert toString(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Compact) ==
     Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
-  assert toStringCompact(
-    JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+  assert toString(
+    JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
+    format=Compact
   ) ==
     Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
 
@@ -561,47 +565,47 @@ module ToString {
   // and internal details of JSON formatting. We definetely want them to fail
   // when the latter changes. The former shouldn't be an issue assuming here
   // constants with decimal point or exponentials are float64.
-  assert toStringCompact(JSONNumber(-10)) == Ok("-10")
-  assert toStringCompact(JSONNumber(-2)) == Ok("-2")
-  assert toStringCompact(JSONNumber(-1)) == Ok("-1")
-  assert toStringCompact(JSONNumber(1)) == Ok("1")
-  assert toStringCompact(JSONNumber(2)) == Ok("2")
-  assert toStringCompact(JSONNumber(10)) == Ok("10")
-  assert toStringCompact(JSONNumber(100)) == Ok("100")
-  assert toStringCompact(JSONNumber(1000)) == Ok("1000")
-  assert toStringCompact(JSONNumber(0.0)) == Ok("0.0")
-  assert toStringCompact(JSONNumber(0.1)) == Ok("0.1")
-  assert toStringCompact(JSONNumber(0.123)) == Ok("0.123")
-  assert toStringCompact(JSONNumber(0.9)) == Ok("0.9")
-  assert toStringCompact(JSONNumber(1.123)) == Ok("1.123")
-  assert toStringCompact(JSONNumber(0e0)) == Ok("0.0")
-  assert toStringCompact(JSONNumber(1e0)) == Ok("1.0")
-  assert toStringCompact(JSONNumber(1e1)) == Ok("10.0")
-  assert toStringCompact(JSONNumber(1E1)) == Ok("10.0")
-  assert toStringCompact(JSONNumber(1e2)) == Ok("100.0")
-  assert toStringCompact(JSONNumber(1e3)) == Ok("1000.0")
-  assert toStringCompact(JSONNumber(-1e2)) == Ok("-100.0")
-  assert toStringCompact(JSONNumber(1e-1)) == Ok("0.1")
-  assert toStringCompact(JSONNumber(1.23e-4)) == Ok("0.000123")
+  assert toString(JSONNumber(-10), format=Compact) == Ok("-10")
+  assert toString(JSONNumber(-2), format=Compact) == Ok("-2")
+  assert toString(JSONNumber(-1), format=Compact) == Ok("-1")
+  assert toString(JSONNumber(1), format=Compact) == Ok("1")
+  assert toString(JSONNumber(2), format=Compact) == Ok("2")
+  assert toString(JSONNumber(10), format=Compact) == Ok("10")
+  assert toString(JSONNumber(100), format=Compact) == Ok("100")
+  assert toString(JSONNumber(1000), format=Compact) == Ok("1000")
+  assert toString(JSONNumber(0.0), format=Compact) == Ok("0.0")
+  assert toString(JSONNumber(0.1), format=Compact) == Ok("0.1")
+  assert toString(JSONNumber(0.123), format=Compact) == Ok("0.123")
+  assert toString(JSONNumber(0.9), format=Compact) == Ok("0.9")
+  assert toString(JSONNumber(1.123), format=Compact) == Ok("1.123")
+  assert toString(JSONNumber(0e0), format=Compact) == Ok("0.0")
+  assert toString(JSONNumber(1e0), format=Compact) == Ok("1.0")
+  assert toString(JSONNumber(1e1), format=Compact) == Ok("10.0")
+  assert toString(JSONNumber(1E1), format=Compact) == Ok("10.0")
+  assert toString(JSONNumber(1e2), format=Compact) == Ok("100.0")
+  assert toString(JSONNumber(1e3), format=Compact) == Ok("1000.0")
+  assert toString(JSONNumber(-1e2), format=Compact) == Ok("-100.0")
+  assert toString(JSONNumber(1e-1), format=Compact) == Ok("0.1")
+  assert toString(JSONNumber(1.23e-4), format=Compact) == Ok("0.000123")
 
   // Big numbers
-  assert toStringCompact(JSONNumber(1152921504606846976)) ==
+  assert toString(JSONNumber(1152921504606846976), format=Compact) ==
     Ok("1152921504606846976")
-  assert toStringCompact(JSONNumber(1152921504606847000.0)) ==
+  assert toString(JSONNumber(1152921504606847000.0), format=Compact) ==
     Ok("1152921504606847000.0")
 
   // Invalid numbers
-  assert match (toStringCompact(JSONNumber(NaN))) {
+  assert match (toString(JSONNumber(NaN), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toStringCompact(JSONNumber(Infinity))) {
+  assert match (toString(JSONNumber(Infinity), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toStringCompact(JSONNumber(-Infinity))) {
+  assert match (toString(JSONNumber(-Infinity), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
@@ -678,16 +682,18 @@ module ToString {
   assert List.map(json =>
     toString(
       json,
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: CompactArrayEntries,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
+      format=Custom(
+        {
+          indentation: IndentWithSpaces(2),
+          arrayFormat: CompactArrayEntries,
+          objectFormat: CompactObjectEntries,
+          lineEnding: LineFeed,
+          finishWithNewLine: false,
+          escapeAllControlPoints: false,
+          escapeHTMLUnsafeSequences: false,
+          escapeNonASCII: false,
+        }
+      )
     ), comprehensiveNestingCombinations) ==
     [
       Ok("[]"),
@@ -709,16 +715,18 @@ module ToString {
   assert List.map(json =>
     toString(
       json,
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: OneObjectEntryPerLine,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
+      format=Custom(
+        {
+          indentation: IndentWithSpaces(2),
+          arrayFormat: OneArrayEntryPerLine,
+          objectFormat: OneObjectEntryPerLine,
+          lineEnding: LineFeed,
+          finishWithNewLine: false,
+          escapeAllControlPoints: false,
+          escapeHTMLUnsafeSequences: false,
+          escapeNonASCII: false,
+        }
+      )
     ), comprehensiveNestingCombinations) ==
     [
       Ok("[]"),
@@ -740,9 +748,12 @@ module ToString {
     ]
 
   // Round trips
-  assert Result.map(parse, toStringCompact(comprehensiveJSONObject)) ==
+  assert Result.map(parse, toString(comprehensiveJSONObject)) ==
     Ok(Ok(comprehensiveJSONObject))
 
-  assert Result.map(parse, toStringPretty(comprehensiveJSONObject)) ==
+  assert Result.map(parse, toString(comprehensiveJSONObject, format=Compact)) ==
+    Ok(Ok(comprehensiveJSONObject))
+
+  assert Result.map(parse, toString(comprehensiveJSONObject, format=Pretty)) ==
     Ok(Ok(comprehensiveJSONObject))
 }

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -175,113 +175,113 @@ module Validation {
 }
 module Parse {
   // Constants
-  assert parse("true") == Ok(JSONBoolean(true))
-  assert parse("false") == Ok(JSONBoolean(false))
-  assert parse("null") == Ok(JSONNull)
+  assert parse("true") == Ok(JsonBoolean(true))
+  assert parse("false") == Ok(JsonBoolean(false))
+  assert parse("null") == Ok(JsonNull)
   // Numbers
-  assert parse("0") == Ok(JSONNumber(0))
+  assert parse("0") == Ok(JsonNumber(0))
   assert match (parse("-0")) {
-    Ok(JSONNumber(n)) => 1.0 / n == -Infinity,
+    Ok(JsonNumber(n)) => 1.0 / n == -Infinity,
     _ => false,
   }
   assert match (parse("-0.0")) {
-    Ok(JSONNumber(n)) => 1.0 / n == -Infinity,
+    Ok(JsonNumber(n)) => 1.0 / n == -Infinity,
     _ => false,
   }
-  assert parse("3.141592653589793") == Ok(JSONNumber(3.141592653589793))
-  assert parse("0.05") == Ok(JSONNumber(0.05))
+  assert parse("3.141592653589793") == Ok(JsonNumber(3.141592653589793))
+  assert parse("0.05") == Ok(JsonNumber(0.05))
   // These tests are not testing accuracy, grain uses f64 which these exhaust its just checking that we can handle parsing correctly and equivalently to grain
   assert parse(
     "2.22507385850720113605740979670913197593481954635164564e-308"
   ) ==
-    Ok(JSONNumber(2.22507385850720113605740979670913197593481954635164564e-308))
+    Ok(JsonNumber(2.22507385850720113605740979670913197593481954635164564e-308))
   assert parse(
     "1e999999999999999999999999999999999999999999999999999999999999"
   ) ==
     Ok(
-      JSONNumber(1e999999999999999999999999999999999999999999999999999999999999)
+      JsonNumber(1e999999999999999999999999999999999999999999999999999999999999)
     )
-  assert parse("42") == Ok(JSONNumber(42))
-  assert parse("-42") == Ok(JSONNumber(-42))
-  assert parse("5e2") == Ok(JSONNumber(5e2))
-  assert parse("5E2") == Ok(JSONNumber(5e2))
-  assert parse("5e+2") == Ok(JSONNumber(5e+2))
-  assert parse("5E+2") == Ok(JSONNumber(5e+2))
-  assert parse("5e-2") == Ok(JSONNumber(5e-2))
-  assert parse("5E-2") == Ok(JSONNumber(5e-2))
-  assert parse("18446744073709551616") == Ok(JSONNumber(18446744073709551616))
-  assert parse("18446744073709551616") == Ok(JSONNumber(18446744073709551616))
-  assert parse("1152921504606846976") == Ok(JSONNumber(1152921504606846976))
-  assert parse("-10") == Ok(JSONNumber(-10))
-  assert parse("-2") == Ok(JSONNumber(-2))
-  assert parse("-1") == Ok(JSONNumber(-1))
-  assert parse("1") == Ok(JSONNumber(1))
-  assert parse("2") == Ok(JSONNumber(2))
-  assert parse("10") == Ok(JSONNumber(10))
-  assert parse("100") == Ok(JSONNumber(100))
-  assert parse("1000") == Ok(JSONNumber(1000))
-  assert parse("0.0") == Ok(JSONNumber(0.0))
-  assert parse("0.1") == Ok(JSONNumber(0.1))
-  assert parse("0.123") == Ok(JSONNumber(0.123))
-  assert parse("0.9") == Ok(JSONNumber(0.9))
-  assert parse("1.123") == Ok(JSONNumber(1.123))
-  assert parse("0e0") == Ok(JSONNumber(0.0))
-  assert parse("1e0") == Ok(JSONNumber(1.0))
-  assert parse("1e1") == Ok(JSONNumber(10.0))
-  assert parse("1E1") == Ok(JSONNumber(10.0))
-  assert parse("1e2") == Ok(JSONNumber(100.0))
-  assert parse("1e3") == Ok(JSONNumber(1000.0))
-  assert parse("-1e2") == Ok(JSONNumber(-100.0))
-  assert parse("1e-1") == Ok(JSONNumber(0.1))
-  assert parse("1.23e-4") == Ok(JSONNumber(0.000123))
-  assert parse("1E200") == Ok(JSONNumber(1E200))
-  assert parse("1E-200") == Ok(JSONNumber(1E-200))
+  assert parse("42") == Ok(JsonNumber(42))
+  assert parse("-42") == Ok(JsonNumber(-42))
+  assert parse("5e2") == Ok(JsonNumber(5e2))
+  assert parse("5E2") == Ok(JsonNumber(5e2))
+  assert parse("5e+2") == Ok(JsonNumber(5e+2))
+  assert parse("5E+2") == Ok(JsonNumber(5e+2))
+  assert parse("5e-2") == Ok(JsonNumber(5e-2))
+  assert parse("5E-2") == Ok(JsonNumber(5e-2))
+  assert parse("18446744073709551616") == Ok(JsonNumber(18446744073709551616))
+  assert parse("18446744073709551616") == Ok(JsonNumber(18446744073709551616))
+  assert parse("1152921504606846976") == Ok(JsonNumber(1152921504606846976))
+  assert parse("-10") == Ok(JsonNumber(-10))
+  assert parse("-2") == Ok(JsonNumber(-2))
+  assert parse("-1") == Ok(JsonNumber(-1))
+  assert parse("1") == Ok(JsonNumber(1))
+  assert parse("2") == Ok(JsonNumber(2))
+  assert parse("10") == Ok(JsonNumber(10))
+  assert parse("100") == Ok(JsonNumber(100))
+  assert parse("1000") == Ok(JsonNumber(1000))
+  assert parse("0.0") == Ok(JsonNumber(0.0))
+  assert parse("0.1") == Ok(JsonNumber(0.1))
+  assert parse("0.123") == Ok(JsonNumber(0.123))
+  assert parse("0.9") == Ok(JsonNumber(0.9))
+  assert parse("1.123") == Ok(JsonNumber(1.123))
+  assert parse("0e0") == Ok(JsonNumber(0.0))
+  assert parse("1e0") == Ok(JsonNumber(1.0))
+  assert parse("1e1") == Ok(JsonNumber(10.0))
+  assert parse("1E1") == Ok(JsonNumber(10.0))
+  assert parse("1e2") == Ok(JsonNumber(100.0))
+  assert parse("1e3") == Ok(JsonNumber(1000.0))
+  assert parse("-1e2") == Ok(JsonNumber(-100.0))
+  assert parse("1e-1") == Ok(JsonNumber(0.1))
+  assert parse("1.23e-4") == Ok(JsonNumber(0.000123))
+  assert parse("1E200") == Ok(JsonNumber(1E200))
+  assert parse("1E-200") == Ok(JsonNumber(1E-200))
   assert parse("85070591730234615884290395931651604481") ==
-    Ok(JSONNumber(85070591730234615884290395931651604481))
+    Ok(JsonNumber(85070591730234615884290395931651604481))
   assert parse("1.797693134862315708145274237317043567981e+308") ==
-    Ok(JSONNumber(1.797693134862315708145274237317043567981e+308))
-  assert parse("1.121333") == Ok(JSONNumber(1.121333))
-  assert parse("1.001") == Ok(JSONNumber(1.001))
+    Ok(JsonNumber(1.797693134862315708145274237317043567981e+308))
+  assert parse("1.121333") == Ok(JsonNumber(1.121333))
+  assert parse("1.001") == Ok(JsonNumber(1.001))
   // Strings
-  assert parse("\"\"") == Ok(JSONString(""))
+  assert parse("\"\"") == Ok(JsonString(""))
   assert parse("\"\\r\\n\\t\\b\\f\\\\\\/\\\"\"") ==
-    Ok(JSONString("\r\n\t\u{8}\u{c}\\/\""))
-  assert parse("\"\\u2764\\ufe0f\"") == Ok(JSONString("❤️"))
-  assert parse("\"\\uD834\\uDD1E\"") == Ok(JSONString("𝄞"))
-  assert parse("\"ASCII Hello world!\"") == Ok(JSONString("ASCII Hello world!"))
+    Ok(JsonString("\r\n\t\u{8}\u{c}\\/\""))
+  assert parse("\"\\u2764\\ufe0f\"") == Ok(JsonString("❤️"))
+  assert parse("\"\\uD834\\uDD1E\"") == Ok(JsonString("𝄞"))
+  assert parse("\"ASCII Hello world!\"") == Ok(JsonString("ASCII Hello world!"))
   assert parse("\"Unicode こんにちは世界!\"") ==
-    Ok(JSONString("Unicode こんにちは世界!"))
+    Ok(JsonString("Unicode こんにちは世界!"))
   assert parse("\"A \\\"quoted\\\" string\"") ==
-    Ok(JSONString("A \"quoted\" string"))
-  assert parse("\"\\uD801\\uDC37\"") == Ok(JSONString("𐐷"))
-  assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
-  assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
+    Ok(JsonString("A \"quoted\" string"))
+  assert parse("\"\\uD801\\uDC37\"") == Ok(JsonString("𐐷"))
+  assert parse("\"🤘🏻\"") == Ok(JsonString("🤘🏻"))
+  assert parse("\"🤘🏻\"") == Ok(JsonString("🤘🏻"))
   assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") ==
-    Ok(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+    Ok(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
   assert parse(
     "\"\\u6000 \\ud800\\udc82 \\ud83e\\udd18\\ud83c\\udffb \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\""
   ) ==
-    Ok(JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+    Ok(JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
   // Array
-  assert parse("[]") == Ok(JSONArray([]))
-  assert parse("[[]]") == Ok(JSONArray([JSONArray([])]))
-  assert parse("[  ]") == Ok(JSONArray([]))
-  assert parse("[1]") == Ok(JSONArray([JSONNumber(1)]))
+  assert parse("[]") == Ok(JsonArray([]))
+  assert parse("[[]]") == Ok(JsonArray([JsonArray([])]))
+  assert parse("[  ]") == Ok(JsonArray([]))
+  assert parse("[1]") == Ok(JsonArray([JsonNumber(1)]))
   assert parse("[10, \"foo\", true, null]") ==
     Ok(
-      JSONArray(
-        [JSONNumber(10), JSONString("foo"), JSONBoolean(true), JSONNull]
+      JsonArray(
+        [JsonNumber(10), JsonString("foo"), JsonBoolean(true), JsonNull]
       )
     )
   // Object
-  assert parse("{}") == Ok(JSONObject([]))
+  assert parse("{}") == Ok(JsonObject([]))
   assert parse("
   {
     \"foo\": \"bar\",
     \"num\": 10
   }
   ") ==
-    Ok(JSONObject([("foo", JSONString("bar")), ("num", JSONNumber(10))]))
+    Ok(JsonObject([("foo", JsonString("bar")), ("num", JsonNumber(10))]))
   // Note: Grain-json does not worry about duplicate keys
   assert parse(
     "
@@ -293,19 +293,19 @@ module Parse {
   "
   ) ==
     Ok(
-      JSONObject(
+      JsonObject(
         [
-          ("foo", JSONString("bar")),
-          ("num", JSONNumber(10)),
-          ("foo", JSONNumber(1)),
+          ("foo", JsonString("bar")),
+          ("num", JsonNumber(10)),
+          ("foo", JsonNumber(1)),
         ]
       )
     )
   // Nesting
   assert parse("{\"foo\": [1, 2, 3]}") ==
     Ok(
-      JSONObject(
-        [("foo", JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))]
+      JsonObject(
+        [("foo", JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]))]
       )
     )
   assert parse(
@@ -321,25 +321,25 @@ module Parse {
     }"
   ) ==
     Ok(
-      JSONObject(
+      JsonObject(
         [
           (
             "l10n",
-            JSONArray(
+            JsonArray(
               [
-                JSONObject(
+                JsonObject(
                   [
                     (
                       "product",
-                      JSONObject(
+                      JsonObject(
                         [
                           (
                             "inStock",
-                            JSONObject(
+                            JsonObject(
                               [
                                 (
                                   "DE",
-                                  JSONString(
+                                  JsonString(
                                     "Lieferung innerhalb von 1-3 Werktagen"
                                   ),
                                 ),
@@ -357,69 +357,69 @@ module Parse {
         ]
       )
     )
-  assert parse("{ \"pi\": 3.14 }") == Ok(JSONObject([("pi", JSONNumber(3.14))]))
+  assert parse("{ \"pi\": 3.14 }") == Ok(JsonObject([("pi", JsonNumber(3.14))]))
   assert parse("[100, 200, false, null, \"foo\"]") ==
     Ok(
-      JSONArray(
+      JsonArray(
         [
-          JSONNumber(100),
-          JSONNumber(200),
-          JSONBoolean(false),
-          JSONNull,
-          JSONString("foo"),
+          JsonNumber(100),
+          JsonNumber(200),
+          JsonBoolean(false),
+          JsonNull,
+          JsonString("foo"),
         ]
       )
     )
   assert parse("{ \"Hello\" : \"World!\" }") ==
-    Ok(JSONObject([("Hello", JSONString("World!"))]))
+    Ok(JsonObject([("Hello", JsonString("World!"))]))
 
   assert parse("{\"a\":\"A\",\"b\":\"B\"}") ==
-    Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+    Ok(JsonObject([("a", JsonString("A")), ("b", JsonString("B"))]))
 
   assert parse(
     "{ \"a\" : { \"0\": false, \"1\":true }, \"b\" : [\"A\",\"B\",\"C\"] }"
   ) ==
     Ok(
-      JSONObject(
+      JsonObject(
         [
           (
             "a",
-            JSONObject([("0", JSONBoolean(false)), ("1", JSONBoolean(true))]),
+            JsonObject([("0", JsonBoolean(false)), ("1", JsonBoolean(true))]),
           ),
-          ("b", JSONArray([JSONString("A"), JSONString("B"), JSONString("C")])),
+          ("b", JsonArray([JsonString("A"), JsonString("B"), JsonString("C")])),
         ]
       )
     )
 
   assert parse("[1,\"2\",true,false,null]") ==
     Ok(
-      JSONArray(
+      JsonArray(
         [
-          JSONNumber(1),
-          JSONString("2"),
-          JSONBoolean(true),
-          JSONBoolean(false),
-          JSONNull,
+          JsonNumber(1),
+          JsonString("2"),
+          JsonBoolean(true),
+          JsonBoolean(false),
+          JsonNull,
         ]
       )
     )
 
   assert parse("[[[[[[[[[[]]]]]]]]]]") ==
     Ok(
-      JSONArray(
+      JsonArray(
         [
-          JSONArray(
+          JsonArray(
             [
-              JSONArray(
+              JsonArray(
                 [
-                  JSONArray(
+                  JsonArray(
                     [
-                      JSONArray(
+                      JsonArray(
                         [
-                          JSONArray(
+                          JsonArray(
                             [
-                              JSONArray(
-                                [JSONArray([JSONArray([JSONArray([])])])]
+                              JsonArray(
+                                [JsonArray([JsonArray([JsonArray([])])])]
                               ),
                             ]
                           ),
@@ -439,47 +439,47 @@ module Parse {
     "{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}"
   ) ==
     Ok(
-      JSONObject(
+      JsonObject(
         [
           (
             "1",
-            JSONObject(
+            JsonObject(
               [
                 (
                   "2",
-                  JSONObject(
+                  JsonObject(
                     [
                       (
                         "3",
-                        JSONObject(
+                        JsonObject(
                           [
                             (
                               "4",
-                              JSONObject(
+                              JsonObject(
                                 [
                                   (
                                     "5",
-                                    JSONObject(
+                                    JsonObject(
                                       [
                                         (
                                           "6",
-                                          JSONObject(
+                                          JsonObject(
                                             [
                                               (
                                                 "7",
-                                                JSONObject(
+                                                JsonObject(
                                                   [
                                                     (
                                                       "8",
-                                                      JSONObject(
+                                                      JsonObject(
                                                         [
                                                           (
                                                             "9",
-                                                            JSONObject(
+                                                            JsonObject(
                                                               [
                                                                 (
                                                                   "10",
-                                                                  JSONObject(
+                                                                  JsonObject(
                                                                     []
                                                                   ),
                                                                 ),
@@ -515,47 +515,47 @@ module Parse {
     )
 
   assert parse("[1,2,3]") ==
-    Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+    Ok(JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]))
   assert parse("[\"a\",\"b\",\"c\"]") ==
-    Ok(JSONArray([JSONString("a"), JSONString("b"), JSONString("c")]))
+    Ok(JsonArray([JsonString("a"), JsonString("b"), JsonString("c")]))
   // White spaces
-  assert parse("\tnull \r\n") == Ok(JSONNull)
-  assert parse("  {\r}") == Ok(JSONObject([]))
+  assert parse("\tnull \r\n") == Ok(JsonNull)
+  assert parse("  {\r}") == Ok(JsonObject([]))
   assert parse("[1,\n2\n,3\n]\n") ==
-    Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+    Ok(JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]))
   assert parse("{ \"a\" :  \"A\" ,  \"b\" : \"B\" }") ==
-    Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+    Ok(JsonObject([("a", JsonString("A")), ("b", JsonString("B"))]))
 }
 
 module ToString {
   // Emitting
 
   // Simple values of each type
-  assert toString(JSONNull, format=Compact) == Ok("null")
-  assert toString(JSONBoolean(true), format=Compact) == Ok("true")
-  assert toString(JSONBoolean(false), format=Compact) == Ok("false")
-  assert toString(JSONString(""), format=Compact) == Ok("\"\"")
-  assert toString(JSONNumber(0), format=Compact) == Ok("0")
-  assert toString(JSONArray([]), format=Compact) == Ok("[]")
-  assert toString(JSONObject([]), format=Compact) == Ok("{}")
+  assert toString(JsonNull, format=Compact) == Ok("null")
+  assert toString(JsonBoolean(true), format=Compact) == Ok("true")
+  assert toString(JsonBoolean(false), format=Compact) == Ok("false")
+  assert toString(JsonString(""), format=Compact) == Ok("\"\"")
+  assert toString(JsonNumber(0), format=Compact) == Ok("0")
+  assert toString(JsonArray([]), format=Compact) == Ok("[]")
+  assert toString(JsonObject([]), format=Compact) == Ok("{}")
 
   // Various strings. Escapes, emojis etc.
-  assert toString(JSONString("ASCII Hello world!"), format=Compact) ==
+  assert toString(JsonString("ASCII Hello world!"), format=Compact) ==
     Ok("\"ASCII Hello world!\"")
 
   assert toString(
-    JSONString("Unicode こんにちは世界!"),
+    JsonString("Unicode こんにちは世界!"),
     format=Compact
   ) ==
     Ok("\"Unicode こんにちは世界!\"")
-  assert toString(JSONString("A \"quoted\" string"), format=Compact) ==
+  assert toString(JsonString("A \"quoted\" string"), format=Compact) ==
     Ok("\"A \\\"quoted\\\" string\"")
-  assert toString(JSONString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
-  assert toString(JSONString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
-  assert toString(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Compact) ==
+  assert toString(JsonString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Compact) ==
     Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
   assert toString(
-    JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
+    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
     format=Compact
   ) ==
     Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
@@ -565,47 +565,47 @@ module ToString {
   // and internal details of JSON formatting. We definetely want them to fail
   // when the latter changes. The former shouldn't be an issue assuming here
   // constants with decimal point or exponentials are float64.
-  assert toString(JSONNumber(-10), format=Compact) == Ok("-10")
-  assert toString(JSONNumber(-2), format=Compact) == Ok("-2")
-  assert toString(JSONNumber(-1), format=Compact) == Ok("-1")
-  assert toString(JSONNumber(1), format=Compact) == Ok("1")
-  assert toString(JSONNumber(2), format=Compact) == Ok("2")
-  assert toString(JSONNumber(10), format=Compact) == Ok("10")
-  assert toString(JSONNumber(100), format=Compact) == Ok("100")
-  assert toString(JSONNumber(1000), format=Compact) == Ok("1000")
-  assert toString(JSONNumber(0.0), format=Compact) == Ok("0.0")
-  assert toString(JSONNumber(0.1), format=Compact) == Ok("0.1")
-  assert toString(JSONNumber(0.123), format=Compact) == Ok("0.123")
-  assert toString(JSONNumber(0.9), format=Compact) == Ok("0.9")
-  assert toString(JSONNumber(1.123), format=Compact) == Ok("1.123")
-  assert toString(JSONNumber(0e0), format=Compact) == Ok("0.0")
-  assert toString(JSONNumber(1e0), format=Compact) == Ok("1.0")
-  assert toString(JSONNumber(1e1), format=Compact) == Ok("10.0")
-  assert toString(JSONNumber(1E1), format=Compact) == Ok("10.0")
-  assert toString(JSONNumber(1e2), format=Compact) == Ok("100.0")
-  assert toString(JSONNumber(1e3), format=Compact) == Ok("1000.0")
-  assert toString(JSONNumber(-1e2), format=Compact) == Ok("-100.0")
-  assert toString(JSONNumber(1e-1), format=Compact) == Ok("0.1")
-  assert toString(JSONNumber(1.23e-4), format=Compact) == Ok("0.000123")
+  assert toString(JsonNumber(-10), format=Compact) == Ok("-10")
+  assert toString(JsonNumber(-2), format=Compact) == Ok("-2")
+  assert toString(JsonNumber(-1), format=Compact) == Ok("-1")
+  assert toString(JsonNumber(1), format=Compact) == Ok("1")
+  assert toString(JsonNumber(2), format=Compact) == Ok("2")
+  assert toString(JsonNumber(10), format=Compact) == Ok("10")
+  assert toString(JsonNumber(100), format=Compact) == Ok("100")
+  assert toString(JsonNumber(1000), format=Compact) == Ok("1000")
+  assert toString(JsonNumber(0.0), format=Compact) == Ok("0.0")
+  assert toString(JsonNumber(0.1), format=Compact) == Ok("0.1")
+  assert toString(JsonNumber(0.123), format=Compact) == Ok("0.123")
+  assert toString(JsonNumber(0.9), format=Compact) == Ok("0.9")
+  assert toString(JsonNumber(1.123), format=Compact) == Ok("1.123")
+  assert toString(JsonNumber(0e0), format=Compact) == Ok("0.0")
+  assert toString(JsonNumber(1e0), format=Compact) == Ok("1.0")
+  assert toString(JsonNumber(1e1), format=Compact) == Ok("10.0")
+  assert toString(JsonNumber(1E1), format=Compact) == Ok("10.0")
+  assert toString(JsonNumber(1e2), format=Compact) == Ok("100.0")
+  assert toString(JsonNumber(1e3), format=Compact) == Ok("1000.0")
+  assert toString(JsonNumber(-1e2), format=Compact) == Ok("-100.0")
+  assert toString(JsonNumber(1e-1), format=Compact) == Ok("0.1")
+  assert toString(JsonNumber(1.23e-4), format=Compact) == Ok("0.000123")
 
   // Big numbers
-  assert toString(JSONNumber(1152921504606846976), format=Compact) ==
+  assert toString(JsonNumber(1152921504606846976), format=Compact) ==
     Ok("1152921504606846976")
-  assert toString(JSONNumber(1152921504606847000.0), format=Compact) ==
+  assert toString(JsonNumber(1152921504606847000.0), format=Compact) ==
     Ok("1152921504606847000.0")
 
   // Invalid numbers
-  assert match (toString(JSONNumber(NaN), format=Compact)) {
+  assert match (toString(JsonNumber(NaN), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toString(JSONNumber(Infinity), format=Compact)) {
+  assert match (toString(JsonNumber(Infinity), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toString(JSONNumber(-Infinity), format=Compact)) {
+  assert match (toString(JsonNumber(-Infinity), format=Compact)) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
@@ -613,56 +613,56 @@ module ToString {
   // Pretty printing
 
   let simplePrimitives = [
-    JSONNull,
-    JSONBoolean(true),
-    JSONBoolean(false),
-    JSONNumber(2),
-    JSONString("abc"),
+    JsonNull,
+    JsonBoolean(true),
+    JsonBoolean(false),
+    JsonNumber(2),
+    JsonString("abc"),
   ]
 
   let comprehensiveNestingCombinations = [
-    JSONArray([]),
-    JSONArray([JSONNumber(1)]),
-    JSONArray([JSONNumber(1), JSONNumber(2)]),
-    JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
-    JSONArray(
+    JsonArray([]),
+    JsonArray([JsonNumber(1)]),
+    JsonArray([JsonNumber(1), JsonNumber(2)]),
+    JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
+    JsonArray(
       [
-        JSONArray([]),
-        JSONArray([JSONNumber(1)]),
-        JSONArray([JSONNumber(1), JSONNumber(2)]),
-        JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+        JsonArray([]),
+        JsonArray([JsonNumber(1)]),
+        JsonArray([JsonNumber(1), JsonNumber(2)]),
+        JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
       ]
     ),
-    JSONArray([JSONArray([JSONArray([])])]),
-    JSONObject([]),
-    JSONObject([("a", JSONString("A"))]),
-    JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]),
-    JSONObject(
-      [("a", JSONString("A")), ("b", JSONString("B")), ("c", JSONString("C"))]
+    JsonArray([JsonArray([JsonArray([])])]),
+    JsonObject([]),
+    JsonObject([("a", JsonString("A"))]),
+    JsonObject([("a", JsonString("A")), ("b", JsonString("B"))]),
+    JsonObject(
+      [("a", JsonString("A")), ("b", JsonString("B")), ("c", JsonString("C"))]
     ),
-    JSONObject(
-      [("a", JSONObject([("b", JSONObject([("c", JSONObject([]))]))]))]
+    JsonObject(
+      [("a", JsonObject([("b", JsonObject([("c", JsonObject([]))]))]))]
     ),
-    JSONObject(
+    JsonObject(
       [
         (
           "arrays",
-          JSONArray(
+          JsonArray(
             [
-              JSONArray([]),
-              JSONArray([JSONNumber(1)]),
-              JSONArray([JSONNumber(1), JSONNumber(2)]),
-              JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+              JsonArray([]),
+              JsonArray([JsonNumber(1)]),
+              JsonArray([JsonNumber(1), JsonNumber(2)]),
+              JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
             ]
           ),
         ),
         (
           "objects",
-          JSONObject(
+          JsonObject(
             [
-              ("a", JSONString("A")),
-              ("b", JSONString("B")),
-              ("c", JSONString("C")),
+              ("a", JsonString("A")),
+              ("b", JsonString("B")),
+              ("c", JsonString("C")),
             ]
           ),
         ),
@@ -670,10 +670,10 @@ module ToString {
     ),
   ]
 
-  let comprehensiveJSONObject = JSONObject(
+  let comprehensiveJsonObject = JsonObject(
     [
-      ("primitives", JSONArray(simplePrimitives)),
-      ("nesting", JSONArray(comprehensiveNestingCombinations)),
+      ("primitives", JsonArray(simplePrimitives)),
+      ("nesting", JsonArray(comprehensiveNestingCombinations)),
     ]
   )
 
@@ -748,12 +748,12 @@ module ToString {
     ]
 
   // Round trips
-  assert Result.map(parse, toString(comprehensiveJSONObject)) ==
-    Ok(Ok(comprehensiveJSONObject))
+  assert Result.map(parse, toString(comprehensiveJsonObject)) ==
+    Ok(Ok(comprehensiveJsonObject))
 
-  assert Result.map(parse, toString(comprehensiveJSONObject, format=Compact)) ==
-    Ok(Ok(comprehensiveJSONObject))
+  assert Result.map(parse, toString(comprehensiveJsonObject, format=Compact)) ==
+    Ok(Ok(comprehensiveJsonObject))
 
-  assert Result.map(parse, toString(comprehensiveJSONObject, format=Pretty)) ==
-    Ok(Ok(comprehensiveJSONObject))
+  assert Result.map(parse, toString(comprehensiveJsonObject, format=Pretty)) ==
+    Ok(Ok(comprehensiveJsonObject))
 }

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -1,0 +1,557 @@
+import * from "json"
+import Result from "result"
+import List from "list"
+
+// Parsing
+
+// Simple values of each type
+assert parse("null") == Ok(JSONNull)
+assert parse("true") == Ok(JSONBoolean(true))
+assert parse("false") == Ok(JSONBoolean(false))
+assert parse("\"\"") == Ok(JSONString(""))
+assert parse("0") == Ok(JSONNumber(0))
+assert parse("[]") == Ok(JSONArray([]))
+assert parse("{}") == Ok(JSONObject([]))
+
+// Various strings. Escapes, emojis etc.
+assert parse("\"ASCII Hello world!\"") == Ok(JSONString("ASCII Hello world!"))
+
+assert parse("\"Unicode こんにちは世界!\"") ==
+Ok(JSONString("Unicode こんにちは世界!"))
+assert parse("\"A \\\"quoted\\\" string\"") ==
+Ok(JSONString("A \"quoted\" string"))
+assert parse("\"\\uD801\\uDC37\"") == Ok(JSONString("𐐷"))
+assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
+assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
+assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") ==
+Ok(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+assert parse(
+  "\"\\u6000 \\ud800\\udc82 \\ud83e\\udd18\\ud83c\\udffb \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\""
+) ==
+Ok(JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+
+// Different number types and values
+assert parse("-10") == Ok(JSONNumber(-10))
+assert parse("-2") == Ok(JSONNumber(-2))
+assert parse("-1") == Ok(JSONNumber(-1))
+assert parse("1") == Ok(JSONNumber(1))
+assert parse("2") == Ok(JSONNumber(2))
+assert parse("10") == Ok(JSONNumber(10))
+assert parse("100") == Ok(JSONNumber(100))
+assert parse("1000") == Ok(JSONNumber(1000))
+assert parse("0.0") == Ok(JSONNumber(0.0))
+assert parse("0.1") == Ok(JSONNumber(0.1))
+assert parse("0.123") == Ok(JSONNumber(0.123))
+assert parse("0.9") == Ok(JSONNumber(0.9))
+assert parse("1.123") == Ok(JSONNumber(1.123))
+assert parse("0e0") == Ok(JSONNumber(0.0))
+assert parse("1e0") == Ok(JSONNumber(1.0))
+assert parse("1e1") == Ok(JSONNumber(10.0))
+assert parse("1E1") == Ok(JSONNumber(10.0))
+assert parse("1e2") == Ok(JSONNumber(100.0))
+assert parse("1e3") == Ok(JSONNumber(1000.0))
+assert parse("-1e2") == Ok(JSONNumber(-100.0))
+assert parse("1e-1") == Ok(JSONNumber(0.1))
+assert parse("1.23e-4") == Ok(JSONNumber(0.000123))
+
+// FIXME
+// "-0" currently parses to 0, but should it?
+// assert parse("-0") == Ok(JSONNumber(?))
+// Note that in Grain these are true:
+// assert 0 == 0
+// assert 0.0 == -0.0
+// assert 0 == -0.0
+// And printing constant "-0" results in "0"
+
+// Big numbers
+assert parse("1152921504606846976") == Ok(JSONNumber(1152921504606846976))
+
+// TODO Bigger numbers.
+// Numbers with large exponents not yet handled in parsing. Waiting for arbitrary precision number support in Grain.
+//assert parse("1E200") == Ok(JSONNumber(1E200))
+//assert parse("1E-200") == Ok(JSONNumber(1E-200))
+
+// Complex objects and arrays.
+
+assert parse("{ \"Hello\" : \"World!\" }") ==
+Ok(JSONObject([("Hello", JSONString("World!"))]))
+
+assert parse("{\"a\":\"A\",\"b\":\"B\"}") ==
+Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+
+assert parse(
+  "{ \"a\" : { \"0\": false, \"1\":true }, \"b\" : [\"A\",\"B\",\"C\"] }"
+) ==
+Ok(
+  JSONObject(
+    [
+      ("a", JSONObject([("0", JSONBoolean(false)), ("1", JSONBoolean(true))])),
+      ("b", JSONArray([JSONString("A"), JSONString("B"), JSONString("C")])),
+    ]
+  )
+)
+
+assert parse("[1,\"2\",true,false,null]") ==
+Ok(
+  JSONArray(
+    [
+      JSONNumber(1),
+      JSONString("2"),
+      JSONBoolean(true),
+      JSONBoolean(false),
+      JSONNull,
+    ]
+  )
+)
+
+assert parse("[[[[[[[[[[]]]]]]]]]]") ==
+Ok(
+  JSONArray(
+    [
+      JSONArray(
+        [
+          JSONArray(
+            [
+              JSONArray(
+                [
+                  JSONArray(
+                    [
+                      JSONArray(
+                        [JSONArray([JSONArray([JSONArray([JSONArray([])])])])]
+                      ),
+                    ]
+                  ),
+                ]
+              ),
+            ]
+          ),
+        ]
+      ),
+    ]
+  )
+)
+
+assert parse(
+  "{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}"
+) ==
+Ok(
+  JSONObject(
+    [
+      (
+        "1",
+        JSONObject(
+          [
+            (
+              "2",
+              JSONObject(
+                [
+                  (
+                    "3",
+                    JSONObject(
+                      [
+                        (
+                          "4",
+                          JSONObject(
+                            [
+                              (
+                                "5",
+                                JSONObject(
+                                  [
+                                    (
+                                      "6",
+                                      JSONObject(
+                                        [
+                                          (
+                                            "7",
+                                            JSONObject(
+                                              [
+                                                (
+                                                  "8",
+                                                  JSONObject(
+                                                    [
+                                                      (
+                                                        "9",
+                                                        JSONObject(
+                                                          [
+                                                            (
+                                                              "10",
+                                                              JSONObject([]),
+                                                            ),
+                                                          ]
+                                                        ),
+                                                      ),
+                                                    ]
+                                                  ),
+                                                ),
+                                              ]
+                                            ),
+                                          ),
+                                        ]
+                                      ),
+                                    ),
+                                  ]
+                                ),
+                              ),
+                            ]
+                          ),
+                        ),
+                      ]
+                    ),
+                  ),
+                ]
+              ),
+            ),
+          ]
+        ),
+      ),
+    ]
+  )
+)
+
+assert parse("[1,2,3]") ==
+Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+assert parse("[\"a\",\"b\",\"c\"]") ==
+Ok(JSONArray([JSONString("a"), JSONString("b"), JSONString("c")]))
+
+// White spaces
+assert parse("\tnull \r\n") == Ok(JSONNull)
+assert parse("  {\r}") == Ok(JSONObject([]))
+assert parse("[1,\n2\n,3\n]\n") ==
+Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+assert parse("{ \"a\" :  \"A\" ,  \"b\" : \"B\" }") ==
+Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+
+// Invalid inputs
+
+// JSON numbers should start with a non zero digit or minus sign.
+assert match (parse("01")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse(".1")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{}error")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("[]error")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("]")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("}")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("\"k\":\"v\"")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+assert match (parse("[")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{\"k")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{\"k\"")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{\"k\":")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{\"k\":\"v")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+assert match (parse("{\"k\":\"v\"")) {
+  Err(UnexpectedEndOfInput(_)) => true,
+  _ => false,
+}
+
+// UTF-16 surrogate pairs should be the high half followed by the low half.
+
+// Two high surrogates.
+assert match (parse("\"\\uD801\\uD801\"")) {
+  Err(InvalidUTF16SurrogatePair(_)) => true,
+  _ => false,
+}
+
+// Inverted low and high surrogate order.
+assert match (parse("\"\\uDC37\\uD801\"")) {
+  Err(InvalidUTF16SurrogatePair(_)) => true,
+  _ => false,
+}
+
+// Single low surrogate
+assert match (parse("\"\\uDC37\"")) {
+  Err(InvalidUTF16SurrogatePair(_)) => true,
+  _ => false,
+}
+
+// Single high surrogate
+assert match (parse("\"\\uD801\"")) {
+  Err(UnexpectedToken(_)) => true,
+  _ => false,
+}
+
+// High surrogate + non surrogate code point
+assert match (parse("\"\\uD801\\u0524\"")) {
+  Err(InvalidUTF16SurrogatePair(_)) => true,
+  _ => false,
+}
+
+// Low surrogate + non surrogate code point
+assert match (parse("\"\\uDC37\\u0524\"")) {
+  Err(InvalidUTF16SurrogatePair(_)) => true,
+  _ => false,
+}
+
+// Emitting
+
+// Simple values of each type
+assert toStringCompact(JSONNull) == Ok("null")
+assert toStringCompact(JSONBoolean(true)) == Ok("true")
+assert toStringCompact(JSONBoolean(false)) == Ok("false")
+assert toStringCompact(JSONString("")) == Ok("\"\"")
+assert toStringCompact(JSONNumber(0)) == Ok("0")
+assert toStringCompact(JSONArray([])) == Ok("[]")
+assert toStringCompact(JSONObject([])) == Ok("{}")
+
+// Various strings. Escapes, emojis etc.
+assert toStringCompact(JSONString("ASCII Hello world!")) ==
+Ok("\"ASCII Hello world!\"")
+
+assert toStringCompact(JSONString("Unicode こんにちは世界!")) ==
+Ok("\"Unicode こんにちは世界!\"")
+assert toStringCompact(JSONString("A \"quoted\" string")) ==
+Ok("\"A \\\"quoted\\\" string\"")
+assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
+assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
+assert toStringCompact(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
+Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+assert toStringCompact(
+  JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+) ==
+Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+
+// Note that number tests are sensitive both to compiler's interpretation of
+// the constants as different number tags (simple numbers, float32, float64)
+// and internal details of JSON formatting. We definetely want them to fail
+// when the latter changes. The former shouldn't be an issue assuming here
+// constants with decimal point or exponentials are float64.
+assert toStringCompact(JSONNumber(-10)) == Ok("-10")
+assert toStringCompact(JSONNumber(-2)) == Ok("-2")
+assert toStringCompact(JSONNumber(-1)) == Ok("-1")
+assert toStringCompact(JSONNumber(1)) == Ok("1")
+assert toStringCompact(JSONNumber(2)) == Ok("2")
+assert toStringCompact(JSONNumber(10)) == Ok("10")
+assert toStringCompact(JSONNumber(100)) == Ok("100")
+assert toStringCompact(JSONNumber(1000)) == Ok("1000")
+assert toStringCompact(JSONNumber(0.0)) == Ok("0.0")
+assert toStringCompact(JSONNumber(0.1)) == Ok("0.1")
+assert toStringCompact(JSONNumber(0.123)) == Ok("0.123")
+assert toStringCompact(JSONNumber(0.9)) == Ok("0.9")
+assert toStringCompact(JSONNumber(1.123)) == Ok("1.123")
+assert toStringCompact(JSONNumber(0e0)) == Ok("0.0")
+assert toStringCompact(JSONNumber(1e0)) == Ok("1.0")
+assert toStringCompact(JSONNumber(1e1)) == Ok("10.0")
+assert toStringCompact(JSONNumber(1E1)) == Ok("10.0")
+assert toStringCompact(JSONNumber(1e2)) == Ok("100.0")
+assert toStringCompact(JSONNumber(1e3)) == Ok("1000.0")
+assert toStringCompact(JSONNumber(-1e2)) == Ok("-100.0")
+assert toStringCompact(JSONNumber(1e-1)) == Ok("0.1")
+assert toStringCompact(JSONNumber(1.23e-4)) == Ok("0.000123")
+
+// FIXME semantics for negative zero still not defined
+
+// Big numbers
+assert toStringCompact(JSONNumber(1152921504606846976)) ==
+Ok("1152921504606846976")
+assert toStringCompact(JSONNumber(1152921504606847000.0)) ==
+Ok("1152921504606847000.0")
+
+// Invalid numbers
+
+// There's currently a github issue for NaN and infinity syntax: https://github.com/grain-lang/grain/issues/693
+let nan = 0.0 / 0.0
+let infinity = 1.0 / 0.0
+let negativeinfinity = -1.0 / 0.0
+
+assert match (toStringCompact(JSONNumber(nan))) {
+  Err(InvalidNumber(_)) => true,
+  _ => false,
+}
+
+assert match (toStringCompact(JSONNumber(infinity))) {
+  Err(InvalidNumber(_)) => true,
+  _ => false,
+}
+
+assert match (toStringCompact(JSONNumber(negativeinfinity))) {
+  Err(InvalidNumber(_)) => true,
+  _ => false,
+}
+
+// Pretty printing
+
+let simplePrimitives = [
+  JSONNull,
+  JSONBoolean(true),
+  JSONBoolean(false),
+  JSONNumber(2),
+  JSONString("abc"),
+]
+
+let comprehensiveNestingCombinations = [
+  JSONArray([]),
+  JSONArray([JSONNumber(1)]),
+  JSONArray([JSONNumber(1), JSONNumber(2)]),
+  JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+  JSONArray(
+    [
+      JSONArray([]),
+      JSONArray([JSONNumber(1)]),
+      JSONArray([JSONNumber(1), JSONNumber(2)]),
+      JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+    ]
+  ),
+  JSONArray([JSONArray([JSONArray([])])]),
+  JSONObject([]),
+  JSONObject([("a", JSONString("A"))]),
+  JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]),
+  JSONObject(
+    [("a", JSONString("A")), ("b", JSONString("B")), ("c", JSONString("C"))]
+  ),
+  JSONObject([("a", JSONObject([("b", JSONObject([("c", JSONObject([]))]))]))]),
+  JSONObject(
+    [
+      (
+        "arrays",
+        JSONArray(
+          [
+            JSONArray([]),
+            JSONArray([JSONNumber(1)]),
+            JSONArray([JSONNumber(1), JSONNumber(2)]),
+            JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+          ]
+        ),
+      ),
+      (
+        "objects",
+        JSONObject(
+          [
+            ("a", JSONString("A")),
+            ("b", JSONString("B")),
+            ("c", JSONString("C")),
+          ]
+        ),
+      ),
+    ]
+  ),
+]
+
+let comprehensiveJSONObject = JSONObject(
+  [
+    ("primitives", JSONArray(simplePrimitives)),
+    ("nesting", JSONArray(comprehensiveNestingCombinations)),
+  ]
+)
+
+// Indentation and line breaks
+
+assert List.map(json =>
+  toString(
+    json,
+    {
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
+  ), comprehensiveNestingCombinations) ==
+[
+  Ok("[]"),
+  Ok("[1]"),
+  Ok("[1,2]"),
+  Ok("[1,2,3]"),
+  Ok("[[],[1],[1,2],[1,2,3]]"),
+  Ok("[[[]]]"),
+  Ok("{}"),
+  Ok("{\"a\":\"A\"}"),
+  Ok("{\"a\":\"A\",\"b\":\"B\"}"),
+  Ok("{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}"),
+  Ok("{\"a\":{\"b\":{\"c\":{}}}}"),
+  Ok(
+    "{\"arrays\":[[],[1],[1,2],[1,2,3]],\"objects\":{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}}"
+  ),
+]
+
+assert List.map(json =>
+  toString(
+    json,
+    {
+      indentation: IndentWithSpaces(2),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
+  ), comprehensiveNestingCombinations) ==
+[
+  Ok("[]"),
+  Ok("[\n  1\n]"),
+  Ok("[\n  1,\n  2\n]"),
+  Ok("[\n  1,\n  2,\n  3\n]"),
+  Ok(
+    "[\n  [],\n  [\n    1\n  ],\n  [\n    1,\n    2\n  ],\n  [\n    1,\n    2,\n    3\n  ]\n]"
+  ),
+  Ok("[\n  [\n    []\n  ]\n]"),
+  Ok("{}"),
+  Ok("{\n  \"a\": \"A\"\n}"),
+  Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\"\n}"),
+  Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\",\n  \"c\": \"C\"\n}"),
+  Ok("{\n  \"a\": {\n    \"b\": {\n      \"c\": {}\n    }\n  }\n}"),
+  Ok(
+    "{\n  \"arrays\": [\n    [],\n    [\n      1\n    ],\n    [\n      1,\n      2\n    ],\n    [\n      1,\n      2,\n      3\n    ]\n  ],\n  \"objects\": {\n    \"a\": \"A\",\n    \"b\": \"B\",\n    \"c\": \"C\"\n  }\n}"
+  ),
+]
+
+// Round trips
+assert Result.map(parse, toStringCompact(comprehensiveJSONObject)) ==
+Ok(Ok(comprehensiveJSONObject))
+
+assert Result.map(parse, toStringPretty(comprehensiveJSONObject)) ==
+Ok(Ok(comprehensiveJSONObject))

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -978,6 +978,63 @@ module ToString {
     }
   ) ==
     Ok("{\n  \"one\": 1,\n  \"two\": 2,\n  \"three\": 3\n}")
+  // Formatting - escaping
+  assert toString(
+    JsonString("\nr🌾"),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: true,
+    }
+  ) ==
+    Ok("\"\\nr\\ud83c\\udf3e\"")
+  assert toString(
+    JsonString("\nr🌾"),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: true,
+    }
+  ) ==
+    Ok("\"\\nr\\ud83c\\udf3e\\u0080\"")
+  assert toString(
+    JsonString("r🌾"),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: true,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: true,
+    }
+  ) ==
+    Ok("\"r\\ud83c\\udf3e\\u0080\"")
+  assert toString(
+    JsonString("</"),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: true,
+      escapeNonASCII: false,
+    }
+  ) ==
+    Ok("\"<\\/\"")
 
   // Indentation and line breaks
 

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -539,6 +539,24 @@ module ToString {
   assert toString(JsonArray([]), format=Compact) == Ok("[]")
   assert toString(JsonObject([]), format=Compact) == Ok("{}")
 
+  assert toString(JsonNull) == toString(JsonNull, format=Compact)
+  assert toString(JsonBoolean(true)) ==
+    toString(JsonBoolean(true), format=Compact)
+  assert toString(JsonBoolean(false)) ==
+    toString(JsonBoolean(false), format=Compact)
+  assert toString(JsonString("")) == toString(JsonString(""), format=Compact)
+  assert toString(JsonNumber(0)) == toString(JsonNumber(0), format=Compact)
+  assert toString(JsonArray([])) == toString(JsonArray([]), format=Compact)
+  assert toString(JsonObject([])) == toString(JsonObject([]), format=Compact)
+
+  assert toString(JsonNull, format=Pretty) == Ok("null\n")
+  assert toString(JsonBoolean(true), format=Pretty) == Ok("true\n")
+  assert toString(JsonBoolean(false), format=Pretty) == Ok("false\n")
+  assert toString(JsonString(""), format=Pretty) == Ok("\"\"\n")
+  assert toString(JsonNumber(0), format=Pretty) == Ok("0\n")
+  assert toString(JsonArray([]), format=Pretty) == Ok("[]\n")
+  assert toString(JsonObject([]), format=Pretty) == Ok("{}\n")
+
   // Various strings. Escapes, emojis etc.
   assert toString(JsonString("ASCII Hello world!"), format=Compact) ==
     Ok("\"ASCII Hello world!\"")
@@ -676,6 +694,262 @@ module ToString {
       ("nesting", JsonArray(comprehensiveNestingCombinations)),
     ]
   )
+
+  // Formatting - Indentation
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n  1\n]")
+  assert toString(
+    JsonArray([JsonArray([JsonNumber(1)])]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n  [\n    1\n  ]\n]")
+  assert toString(
+    JsonArray([JsonArray([JsonNumber(1)])]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n[\n1\n]\n]")
+
+  // Formatting - line endings
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n1\n]")
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: NoLineEnding,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[1]")
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: CarriageReturnLineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\r\n1\r\n]")
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: CarriageReturn,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\r1\r]")
+
+  // Formatting - finish with new line
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n1\n]")
+  assert toString(
+    JsonArray([JsonNumber(1)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(0),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: true,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n1\n]\n")
+
+  // Formatting - array format
+  assert toString(
+    JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: CompactArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[1,2,3]")
+  assert toString(
+    JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: SpacedArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[1, 2, 3]")
+  assert toString(
+    JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("[\n  1,\n  2,\n  3\n]")
+
+  // Formatting - object format
+  assert toString(
+    JsonObject(
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+    ),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: CompactArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("{\"one\":1,\"two\":2,\"three\":3}")
+  assert toString(
+    JsonObject(
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+    ),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: CompactArrayEntries,
+        objectFormat: SpacedObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("{\"one\": 1, \"two\": 2, \"three\": 3}")
+  assert toString(
+    JsonObject(
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+    ),
+    format=Custom(
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: CompactArrayEntries,
+        objectFormat: OneObjectEntryPerLine,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    )
+  ) ==
+    Ok("{\n  \"one\": 1,\n  \"two\": 2,\n  \"three\": 3\n}")
 
   // Indentation and line breaks
 

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -30,12 +30,12 @@ http://www.json.org/JSON_checker/
 */
 module JsonTest
 
-include "json"
-include "result"
-include "buffer"
-include "char"
-include "list"
-from Json use *
+from "json" include Json
+from "result" include Result
+from "buffer" include Buffer
+from "char" include Char
+from "list" include List
+use Json.*
 module Validation {
   // Valid
   assert Result.isOk(
@@ -191,15 +191,11 @@ module Parse {
   assert parse("3.141592653589793") == Ok(JsonNumber(3.141592653589793))
   assert parse("0.05") == Ok(JsonNumber(0.05))
   // These tests are not testing accuracy, grain uses f64 which these exhaust its just checking that we can handle parsing correctly and equivalently to grain
-  assert parse(
-    "2.22507385850720113605740979670913197593481954635164564e-308"
-  ) ==
+  assert parse("2.22507385850720113605740979670913197593481954635164564e-308") ==
     Ok(JsonNumber(2.22507385850720113605740979670913197593481954635164564e-308))
-  assert parse(
-    "1e999999999999999999999999999999999999999999999999999999999999"
-  ) ==
+  assert parse("1e999999999999999999999999999999999999999999999999999999999999") ==
     Ok(
-      JsonNumber(1e999999999999999999999999999999999999999999999999999999999999)
+      JsonNumber(1e999999999999999999999999999999999999999999999999999999999999),
     )
   assert parse("42") == Ok(JsonNumber(42))
   assert parse("-42") == Ok(JsonNumber(-42))
@@ -256,8 +252,7 @@ module Parse {
   assert parse("\"\\uD801\\uDC37\"") == Ok(JsonString("𐐷"))
   assert parse("\"🤘🏻\"") == Ok(JsonString("🤘🏻"))
   assert parse("\"🤘🏻\"") == Ok(JsonString("🤘🏻"))
-  assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") ==
-    Ok(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+  assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") == Ok(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
   assert parse(
     "\"\\u6000 \\ud800\\udc82 \\ud83e\\udd18\\ud83c\\udffb \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\""
   ) ==
@@ -270,8 +265,8 @@ module Parse {
   assert parse("[10, \"foo\", true, null]") ==
     Ok(
       JsonArray(
-        [JsonNumber(10), JsonString("foo"), JsonBoolean(true), JsonNull]
-      )
+        [JsonNumber(10), JsonString("foo"), JsonBoolean(true), JsonNull],
+      ),
     )
   // Object
   assert parse("{}") == Ok(JsonObject([]))
@@ -298,15 +293,15 @@ module Parse {
           ("foo", JsonString("bar")),
           ("num", JsonNumber(10)),
           ("foo", JsonNumber(1)),
-        ]
-      )
+        ],
+      ),
     )
   // Nesting
   assert parse("{\"foo\": [1, 2, 3]}") ==
     Ok(
       JsonObject(
-        [("foo", JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]))]
-      )
+        [("foo", JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]))],
+      ),
     )
   assert parse(
     "
@@ -340,22 +335,22 @@ module Parse {
                                 (
                                   "DE",
                                   JsonString(
-                                    "Lieferung innerhalb von 1-3 Werktagen"
+                                    "Lieferung innerhalb von 1-3 Werktagen",
                                   ),
                                 ),
-                              ]
+                              ],
                             ),
                           ),
-                        ]
+                        ],
                       ),
                     ),
-                  ]
+                  ],
                 ),
-              ]
+              ],
             ),
           ),
-        ]
-      )
+        ],
+      ),
     )
   assert parse("{ \"pi\": 3.14 }") == Ok(JsonObject([("pi", JsonNumber(3.14))]))
   assert parse("[100, 200, false, null, \"foo\"]") ==
@@ -367,8 +362,8 @@ module Parse {
           JsonBoolean(false),
           JsonNull,
           JsonString("foo"),
-        ]
-      )
+        ],
+      ),
     )
   assert parse("{ \"Hello\" : \"World!\" }") ==
     Ok(JsonObject([("Hello", JsonString("World!"))]))
@@ -387,8 +382,8 @@ module Parse {
             JsonObject([("0", JsonBoolean(false)), ("1", JsonBoolean(true))]),
           ),
           ("b", JsonArray([JsonString("A"), JsonString("B"), JsonString("C")])),
-        ]
-      )
+        ],
+      ),
     )
 
   assert parse("[1,\"2\",true,false,null]") ==
@@ -400,8 +395,8 @@ module Parse {
           JsonBoolean(true),
           JsonBoolean(false),
           JsonNull,
-        ]
-      )
+        ],
+      ),
     )
 
   assert parse("[[[[[[[[[[]]]]]]]]]]") ==
@@ -419,20 +414,20 @@ module Parse {
                           JsonArray(
                             [
                               JsonArray(
-                                [JsonArray([JsonArray([JsonArray([])])])]
+                                [JsonArray([JsonArray([JsonArray([])])])],
                               ),
-                            ]
+                            ],
                           ),
-                        ]
+                        ],
                       ),
-                    ]
+                    ],
                   ),
-                ]
+                ],
               ),
-            ]
+            ],
           ),
-        ]
-      )
+        ],
+      ),
     )
 
   assert parse(
@@ -479,39 +474,37 @@ module Parse {
                                                               [
                                                                 (
                                                                   "10",
-                                                                  JsonObject(
-                                                                    []
-                                                                  ),
+                                                                  JsonObject([]),
                                                                 ),
-                                                              ]
+                                                              ],
                                                             ),
                                                           ),
-                                                        ]
+                                                        ],
                                                       ),
                                                     ),
-                                                  ]
+                                                  ],
                                                 ),
                                               ),
-                                            ]
+                                            ],
                                           ),
                                         ),
-                                      ]
+                                      ],
                                     ),
                                   ),
-                                ]
+                                ],
                               ),
                             ),
-                          ]
+                          ],
                         ),
                       ),
-                    ]
+                    ],
                   ),
                 ),
-              ]
+              ],
             ),
           ),
-        ]
-      )
+        ],
+      ),
     )
 
   assert parse("[1,2,3]") ==
@@ -567,12 +560,8 @@ module ToString {
     Ok("\"A \\\"quoted\\\" string\"")
   assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
   assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
-  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
-    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
-  assert toString(
-    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
-  ) ==
-    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) == Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")) == Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
   assert toString(JsonString("ASCII Hello world!")) ==
     Ok("\"ASCII Hello world!\"")
 
@@ -582,30 +571,19 @@ module ToString {
     Ok("\"A \\\"quoted\\\" string\"")
   assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
   assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
-  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
-    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
-  assert toString(
-    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
-  ) ==
-    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) == Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")) == Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
   assert toString(JsonString("ASCII Hello world!"), format=Pretty) ==
     Ok("\"ASCII Hello world!\"\n")
 
-  assert toString(
-    JsonString("Unicode こんにちは世界!"),
-    format=Pretty
-  ) ==
+  assert toString(JsonString("Unicode こんにちは世界!"), format=Pretty) ==
     Ok("\"Unicode こんにちは世界!\"\n")
   assert toString(JsonString("A \"quoted\" string"), format=Pretty) ==
     Ok("\"A \\\"quoted\\\" string\"\n")
   assert toString(JsonString("🤘🏻"), format=Pretty) == Ok("\"🤘🏻\"\n")
   assert toString(JsonString("🤘🏻"), format=Pretty) == Ok("\"🤘🏻\"\n")
-  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Pretty) ==
-    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
-  assert toString(
-    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
-    format=Pretty
-  ) ==
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Pretty) == Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
+  assert toString(JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Pretty) ==
     Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
   assert toString(JsonString("ASCII Hello world!"), format=PrettyAndSafe) ==
     Ok("\"ASCII Hello world!\"\n")
@@ -618,12 +596,9 @@ module ToString {
     Ok("\"A \\\"quoted\\\" string\"\n")
   assert toString(JsonString("🤘🏻"), format=PrettyAndSafe) ==
     Ok("\"\\ud83e\\udd18\\ud83c\\udffb\"\n")
-  assert toString(
-    JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
-    format=PrettyAndSafe
-  ) ==
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=PrettyAndSafe) ==
     Ok(
-      "\"\\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\"\n"
+      "\"\\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\"\n",
     )
 
   // Note that number tests are sensitive both to compiler's interpretation of
@@ -701,17 +676,17 @@ module ToString {
         JsonArray([JsonNumber(1)]),
         JsonArray([JsonNumber(1), JsonNumber(2)]),
         JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
-      ]
+      ],
     ),
     JsonArray([JsonArray([JsonArray([])])]),
     JsonObject([]),
     JsonObject([("a", JsonString("A"))]),
     JsonObject([("a", JsonString("A")), ("b", JsonString("B"))]),
     JsonObject(
-      [("a", JsonString("A")), ("b", JsonString("B")), ("c", JsonString("C"))]
+      [("a", JsonString("A")), ("b", JsonString("B")), ("c", JsonString("C"))],
     ),
     JsonObject(
-      [("a", JsonObject([("b", JsonObject([("c", JsonObject([]))]))]))]
+      [("a", JsonObject([("b", JsonObject([("c", JsonObject([]))]))]))],
     ),
     JsonObject(
       [
@@ -723,7 +698,7 @@ module ToString {
               JsonArray([JsonNumber(1)]),
               JsonArray([JsonNumber(1), JsonNumber(2)]),
               JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
-            ]
+            ],
           ),
         ),
         (
@@ -733,10 +708,10 @@ module ToString {
               ("a", JsonString("A")),
               ("b", JsonString("B")),
               ("c", JsonString("C")),
-            ]
+            ],
           ),
         ),
-      ]
+      ],
     ),
   ]
 
@@ -744,7 +719,7 @@ module ToString {
     [
       ("primitives", JsonArray(simplePrimitives)),
       ("nesting", JsonArray(comprehensiveNestingCombinations)),
-    ]
+    ],
   )
 
   // Formatting - Indentation
@@ -758,7 +733,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n  1\n]")
@@ -772,7 +747,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n  [\n    1\n  ]\n]")
@@ -786,7 +761,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n[\n1\n]\n]")
@@ -802,7 +777,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n1\n]")
@@ -816,7 +791,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[1]")
@@ -830,7 +805,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\r\n1\r\n]")
@@ -844,7 +819,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\r1\r]")
@@ -860,7 +835,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n1\n]")
@@ -874,7 +849,7 @@ module ToString {
       finishWithNewLine: true,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n1\n]\n")
@@ -890,7 +865,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[1,2,3]")
@@ -904,7 +879,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[1, 2, 3]")
@@ -918,7 +893,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("[\n  1,\n  2,\n  3\n]")
@@ -926,7 +901,7 @@ module ToString {
   // Formatting - object format
   assert toString(
     JsonObject(
-      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))],
     ),
     format=Custom{
       indentation: IndentWithSpaces(2),
@@ -936,13 +911,13 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("{\"one\":1,\"two\":2,\"three\":3}")
   assert toString(
     JsonObject(
-      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))],
     ),
     format=Custom{
       indentation: IndentWithSpaces(2),
@@ -952,13 +927,13 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("{\"one\": 1, \"two\": 2, \"three\": 3}")
   assert toString(
     JsonObject(
-      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))],
     ),
     format=Custom{
       indentation: IndentWithSpaces(2),
@@ -968,7 +943,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("{\n  \"one\": 1,\n  \"two\": 2,\n  \"three\": 3\n}")
@@ -983,7 +958,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: true,
+      escapeNonASCII: true
     }
   ) ==
     Ok("\"\\nr\\ud83c\\udf3e\"")
@@ -997,7 +972,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: true,
+      escapeNonASCII: true
     }
   ) ==
     Ok("\"\\nr\\ud83c\\udf3e\\u0080\"")
@@ -1011,7 +986,7 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: true,
       escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: true,
+      escapeNonASCII: true
     }
   ) ==
     Ok("\"r\\ud83c\\udf3e\\u0080\"")
@@ -1025,27 +1000,30 @@ module ToString {
       finishWithNewLine: false,
       escapeAllControlPoints: false,
       escapeHTMLUnsafeSequences: true,
-      escapeNonASCII: false,
+      escapeNonASCII: false
     }
   ) ==
     Ok("\"<\\/\"")
 
   // Indentation and line breaks
 
-  assert List.map(json =>
-    toString(
-      json,
-      format=Custom{
-        indentation: IndentWithSpaces(2),
-        arrayFormat: CompactArrayEntries,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    ), comprehensiveNestingCombinations) ==
+  assert List.map(
+    json =>
+      toString(
+        json,
+        format=Custom{
+          indentation: IndentWithSpaces(2),
+          arrayFormat: CompactArrayEntries,
+          objectFormat: CompactObjectEntries,
+          lineEnding: LineFeed,
+          finishWithNewLine: false,
+          escapeAllControlPoints: false,
+          escapeHTMLUnsafeSequences: false,
+          escapeNonASCII: false
+        }
+      ),
+    comprehensiveNestingCombinations
+  ) ==
     [
       Ok("[]"),
       Ok("[1]"),
@@ -1059,31 +1037,34 @@ module ToString {
       Ok("{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}"),
       Ok("{\"a\":{\"b\":{\"c\":{}}}}"),
       Ok(
-        "{\"arrays\":[[],[1],[1,2],[1,2,3]],\"objects\":{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}}"
+        "{\"arrays\":[[],[1],[1,2],[1,2,3]],\"objects\":{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}}",
       ),
     ]
 
-  assert List.map(json =>
-    toString(
-      json,
-      format=Custom{
-        indentation: IndentWithSpaces(2),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: OneObjectEntryPerLine,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    ), comprehensiveNestingCombinations) ==
+  assert List.map(
+    json =>
+      toString(
+        json,
+        format=Custom{
+          indentation: IndentWithSpaces(2),
+          arrayFormat: OneArrayEntryPerLine,
+          objectFormat: OneObjectEntryPerLine,
+          lineEnding: LineFeed,
+          finishWithNewLine: false,
+          escapeAllControlPoints: false,
+          escapeHTMLUnsafeSequences: false,
+          escapeNonASCII: false
+        }
+      ),
+    comprehensiveNestingCombinations
+  ) ==
     [
       Ok("[]"),
       Ok("[\n  1\n]"),
       Ok("[\n  1,\n  2\n]"),
       Ok("[\n  1,\n  2,\n  3\n]"),
       Ok(
-        "[\n  [],\n  [\n    1\n  ],\n  [\n    1,\n    2\n  ],\n  [\n    1,\n    2,\n    3\n  ]\n]"
+        "[\n  [],\n  [\n    1\n  ],\n  [\n    1,\n    2\n  ],\n  [\n    1,\n    2,\n    3\n  ]\n]",
       ),
       Ok("[\n  [\n    []\n  ]\n]"),
       Ok("{}"),
@@ -1092,7 +1073,7 @@ module ToString {
       Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\",\n  \"c\": \"C\"\n}"),
       Ok("{\n  \"a\": {\n    \"b\": {\n      \"c\": {}\n    }\n  }\n}"),
       Ok(
-        "{\n  \"arrays\": [\n    [],\n    [\n      1\n    ],\n    [\n      1,\n      2\n    ],\n    [\n      1,\n      2,\n      3\n    ]\n  ],\n  \"objects\": {\n    \"a\": \"A\",\n    \"b\": \"B\",\n    \"c\": \"C\"\n  }\n}"
+        "{\n  \"arrays\": [\n    [],\n    [\n      1\n    ],\n    [\n      1,\n      2\n    ],\n    [\n      1,\n      2,\n      3\n    ]\n  ],\n  \"objects\": {\n    \"a\": \"A\",\n    \"b\": \"B\",\n    \"c\": \"C\"\n  }\n}",
       ),
     ]
 

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -1,113 +1,411 @@
-import * from "json"
-import Result from "result"
-import List from "list"
+/*
+Copyright (c) 2016 Maciej Hirsz <maciej.hirsz@gmail.com>
 
-// Parsing
+The MIT License (MIT)
 
-// Simple values of each type
-assert parse("null") == Ok(JSONNull)
-assert parse("true") == Ok(JSONBoolean(true))
-assert parse("false") == Ok(JSONBoolean(false))
-assert parse("\"\"") == Ok(JSONString(""))
-assert parse("0") == Ok(JSONNumber(0))
-assert parse("[]") == Ok(JSONArray([]))
-assert parse("{}") == Ok(JSONObject([]))
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-// Various strings. Escapes, emojis etc.
-assert parse("\"ASCII Hello world!\"") == Ok(JSONString("ASCII Hello world!"))
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-assert parse("\"Unicode こんにちは世界!\"") ==
-Ok(JSONString("Unicode こんにちは世界!"))
-assert parse("\"A \\\"quoted\\\" string\"") ==
-Ok(JSONString("A \"quoted\" string"))
-assert parse("\"\\uD801\\uDC37\"") == Ok(JSONString("𐐷"))
-assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
-assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
-assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") ==
-Ok(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
-assert parse(
-  "\"\\u6000 \\ud800\\udc82 \\ud83e\\udd18\\ud83c\\udffb \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\""
-) ==
-Ok(JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-// Different number types and values
-assert parse("-10") == Ok(JSONNumber(-10))
-assert parse("-2") == Ok(JSONNumber(-2))
-assert parse("-1") == Ok(JSONNumber(-1))
-assert parse("1") == Ok(JSONNumber(1))
-assert parse("2") == Ok(JSONNumber(2))
-assert parse("10") == Ok(JSONNumber(10))
-assert parse("100") == Ok(JSONNumber(100))
-assert parse("1000") == Ok(JSONNumber(1000))
-assert parse("0.0") == Ok(JSONNumber(0.0))
-assert parse("0.1") == Ok(JSONNumber(0.1))
-assert parse("0.123") == Ok(JSONNumber(0.123))
-assert parse("0.9") == Ok(JSONNumber(0.9))
-assert parse("1.123") == Ok(JSONNumber(1.123))
-assert parse("0e0") == Ok(JSONNumber(0.0))
-assert parse("1e0") == Ok(JSONNumber(1.0))
-assert parse("1e1") == Ok(JSONNumber(10.0))
-assert parse("1E1") == Ok(JSONNumber(10.0))
-assert parse("1e2") == Ok(JSONNumber(100.0))
-assert parse("1e3") == Ok(JSONNumber(1000.0))
-assert parse("-1e2") == Ok(JSONNumber(-100.0))
-assert parse("1e-1") == Ok(JSONNumber(0.1))
-assert parse("1.23e-4") == Ok(JSONNumber(0.000123))
+A Number of the tests in this file are taken from
+https://github.com/maciejhirsz/json-rust/blob/master/tests/number.rs
 
-// FIXME
-// "-0" currently parses to 0, but should it?
-// assert parse("-0") == Ok(JSONNumber(?))
-// Note that in Grain these are true:
-// assert 0 == 0
-// assert 0.0 == -0.0
-// assert 0 == -0.0
-// And printing constant "-0" results in "0"
+A few tests are taken from
+http://www.json.org/JSON_checker/
 
-// Big numbers
-assert parse("1152921504606846976") == Ok(JSONNumber(1152921504606846976))
+*/
+module JsonTest
 
-// TODO Bigger numbers.
-// Numbers with large exponents not yet handled in parsing. Waiting for arbitrary precision number support in Grain.
-//assert parse("1E200") == Ok(JSONNumber(1E200))
-//assert parse("1E-200") == Ok(JSONNumber(1E-200))
-
-// Complex objects and arrays.
-
-assert parse("{ \"Hello\" : \"World!\" }") ==
-Ok(JSONObject([("Hello", JSONString("World!"))]))
-
-assert parse("{\"a\":\"A\",\"b\":\"B\"}") ==
-Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
-
-assert parse(
-  "{ \"a\" : { \"0\": false, \"1\":true }, \"b\" : [\"A\",\"B\",\"C\"] }"
-) ==
-Ok(
-  JSONObject(
-    [
-      ("a", JSONObject([("0", JSONBoolean(false)), ("1", JSONBoolean(true))])),
-      ("b", JSONArray([JSONString("A"), JSONString("B"), JSONString("C")])),
-    ]
+include "json"
+include "result"
+include "buffer"
+include "char"
+include "list"
+from Json use *
+module Validation {
+  // Valid
+  assert Result.isOk(
+    parse(
+      "[\r\n    \"JSON Test Pattern pass1\",\r\n    {\"object with 1 member\":[\"array with 1 element\"]},\r\n    {},\r\n    [],\r\n    -42,\r\n    true,\r\n    false,\r\n    null,\r\n    {\r\n        \"integer\": 1234567890,\r\n        \"real\": -9876.543210,\r\n        \"e\": 0.123456789e-12,\r\n        \"E\": 1.234567890E+34,\r\n        \"\":  23456789012E66,\r\n        \"zero\": 0,\r\n        \"one\": 1,\r\n        \"space\": \" \",\r\n        \"quote\": \"\\\"\",\r\n        \"backslash\": \"\\\\\",\r\n        \"controls\": \"\\b\\f\\n\\r\\t\",\r\n        \"slash\": \"\/ & \\\/\",\r\n        \"alpha\": \"abcdefghijklmnopqrstuvwyz\",\r\n        \"ALPHA\": \"ABCDEFGHIJKLMNOPQRSTUVWYZ\",\r\n        \"digit\": \"0123456789\",\r\n        \"0123456789\": \"digit\",\r\n        \"special\": \"`1~!@#$%^&*()_+-={':[,]}|;.<\/>?\",\r\n        \"hex\": \"\\u0123\\u4567\\u89AB\\uCDEF\\uabcd\\uef4A\",\r\n        \"true\": true,\r\n        \"false\": false,\r\n        \"null\": null,\r\n        \"array\":[  ],\r\n        \"object\":{  },\r\n        \"address\": \"50 St. James Street\",\r\n        \"url\": \"http:\/\/www.JSON.org\/\",\r\n        \"comment\": \"\/\/ \/* <!-- --\",\r\n        \"# -- --> *\/\": \" \",\r\n        \" s p a c e d \" :[1,2 , 3\r\n\r\n,\r\n\r\n4 , 5        ,          6           ,7        ],\"compact\":[1,2,3,4,5,6,7],\r\n        \"jsontext\": \"{\\\"object with 1 member\\\":[\\\"array with 1 element\\\"]}\",\r\n        \"quotes\": \"&#34; \\u0022 %22 0x22 034 &#x22;\",\r\n        \"\\\/\\\\\\\"\\uCAFE\\uBABE\\uAB98\\uFCDE\\ubcda\\uef4A\\b\\f\\n\\r\\t`1~!@#$%^&*()_+-=[]{}|;:',.\/<>?\"\r\n: \"A key can be any string\"\r\n    },\r\n    0.5 ,98.6\r\n,\r\n99.44\r\n,\r\n\r\n1066,\r\n1e1,\r\n0.1e1,\r\n1e-1,\r\n1e00,2e+00,2e-00\r\n,\"rosebud\"]"
+    )
   )
-)
-
-assert parse("[1,\"2\",true,false,null]") ==
-Ok(
-  JSONArray(
-    [
-      JSONNumber(1),
-      JSONString("2"),
-      JSONBoolean(true),
-      JSONBoolean(false),
-      JSONNull,
-    ]
+  assert Result.isOk(
+    parse(
+      "{\r\n        \"Image\": {\r\n            \"Width\":  800,\r\n            \"Height\": 600,\r\n            \"Title\":  \"View from 15th Floor\",\r\n            \"Thumbnail\": {\r\n                \"Url\":    \"http:\/\/www.example.com\/image\/481989943\",\r\n                \"Height\": 125,\r\n                \"Width\":  100\r\n            },\r\n            \"Animated\" : false,\r\n            \"IDs\": [116, 943, 234, 38793]\r\n          }\r\n      }"
+    )
   )
-)
+  assert Result.isOk(
+    parse(
+      "{
+    \"JSON Test Pattern pass3\": {
+        \"The outermost value\": \"must be an object or array.\",
+        \"In this test\": \"It is an object.\"
+    }
+  }"
+    )
+  )
+  let depth = 256
+  let text = Buffer.make(2052)
+  for (let mut i = 0; i < depth; i += 1) {
+    Buffer.addString("[{\"a\":", text)
+  }
+  Buffer.addString("null", text)
+  for (let mut i = 0; i < depth; i += 1) {
+    Buffer.addString("}]", text)
+  }
+  assert Result.isOk(parse(Buffer.toString(text)))
+  let text = Buffer.make(101)
+  Buffer.addString("8", text)
+  for (let mut i = 0; i < 100; i += 1) {
+    Buffer.addString("0", text)
+  }
+  assert Result.isOk(parse(Buffer.toString(text)))
+  // Invalid
+  for (let mut i = 0x0000; i <= 0x0001F; i += 1) {
+    assert Result.isErr(parse("\"" ++ Char.toString(Char.fromCode(i)) ++ "\""))
+  }
+  assert Result.isErr(parse("[\"Unclosed array\""))
+  assert Result.isErr(parse("{unquoted_key: \"keys must be quoted\"}"))
+  assert Result.isErr(parse("[\"extra comma\",]"))
+  assert Result.isErr(parse("[\"double extra comma\",,]"))
+  assert Result.isErr(parse("[   , \"<-- missing value\"]"))
+  assert Result.isErr(parse("[\"Comma after the close\"],"))
+  assert Result.isErr(parse("[\"Extra close\"]]"))
+  assert Result.isErr(parse("{\"Extra comma\": true,}"))
+  assert Result.isErr(
+    parse("{\"Extra value after close\": true} \"misplaced quoted value\"")
+  )
+  assert Result.isErr(parse("{\"Illegal expression\": 1 + 2}"))
+  assert Result.isErr(parse("{\"Illegal invocation\": alert()}"))
+  assert Result.isErr(parse("{\"Numbers cannot have leading zeroes\": 013}"))
+  assert Result.isErr(parse("{\"Numbers cannot be hex\": 0x14}"))
+  assert Result.isErr(parse("[\"Illegal backslash escape: \\x15\"]"))
+  assert Result.isErr(parse("[\\naked]"))
+  assert Result.isErr(parse("[\"Illegal backslash escape: \\017\"]"))
+  assert Result.isErr(parse("{\"Missing colon\" null}"))
+  assert Result.isErr(parse("{\"Double colon\":: null}"))
+  assert Result.isErr(parse("{\"Comma instead of colon\", null}"))
+  assert Result.isErr(parse("[\"Colon instead of comma\": false]"))
+  assert Result.isErr(parse("[\"Bad value\", truth]"))
+  assert Result.isErr(parse("['single quote']"))
+  assert Result.isErr(parse("[\"	tab	character	in	string	\"]"))
+  assert Result.isErr(parse("[\"tab\\   character\\   in\\  string\\  \"]"))
+  assert Result.isErr(parse("[\"line\nbreak\"]"))
+  assert Result.isErr(parse("[\"line\\\nbreak\"]"))
+  assert Result.isErr(parse("[0e]"))
+  assert Result.isErr(parse("[0e+]"))
+  assert Result.isErr(parse("[0e+-1]"))
+  assert Result.isErr(parse("{\"Comma instead if closing brace\": true,"))
+  assert Result.isErr(parse("[\"mismatch\"}"))
+  assert Result.isErr(parse("1."))
+  assert Result.isErr(parse(".05"))
+  assert Result.isErr(parse("-01"))
+  assert Result.isErr(parse("01"))
+  assert Result.isErr(parse("0e"))
+  assert Result.isErr(parse("0e-"))
+  assert Result.isErr(parse("0e+"))
+  assert Result.isErr(parse("[,]"))
+  assert Result.isErr(parse("[1,]"))
+  assert Result.isErr(parse("[,1]"))
+  assert Result.isErr(parse("[,1,]"))
+  assert Result.isErr(parse("\"\\uD834 \\uDD1E\""))
+  assert Result.isErr(parse("{}error"))
+  assert Result.isErr(parse("[]error"))
+  assert Result.isErr(parse("]error"))
+  assert Result.isErr(parse("]"))
+  assert Result.isErr(parse("}"))
+  assert Result.isErr(parse("{"))
+  assert Result.isErr(parse("\"k\":\"v\""))
+  assert Result.isErr(parse("["))
+  assert Result.isErr(parse("{\"k"))
+  assert Result.isErr(parse("{\"k\":"))
+  assert Result.isErr(parse("{\"k\":\"v"))
+  assert Result.isErr(parse("{\"k\":\"v\""))
+  // UTF-16 surrogate pairs should be the high half followed by the low half.
 
-assert parse("[[[[[[[[[[]]]]]]]]]]") ==
-Ok(
-  JSONArray(
-    [
+  // Two high surrogates.
+  assert match (parse("\"\\uD801\\uD801\"")) {
+    Err(InvalidUTF16SurrogatePair(_)) => true,
+    _ => false,
+  }
+
+  // Inverted low and high surrogate order.
+  assert match (parse("\"\\uDC37\\uD801\"")) {
+    Err(InvalidUTF16SurrogatePair(_)) => true,
+    _ => false,
+  }
+
+  // Single low surrogate
+  assert match (parse("\"\\uDC37\"")) {
+    Err(InvalidUTF16SurrogatePair(_)) => true,
+    _ => false,
+  }
+
+  // Single high surrogate
+  assert match (parse("\"\\uD801\"")) {
+    Err(UnexpectedToken(_)) => true,
+    _ => false,
+  }
+
+  // High surrogate + non surrogate code point
+  assert match (parse("\"\\uD801\\u0524\"")) {
+    Err(InvalidUTF16SurrogatePair(_)) => true,
+    _ => false,
+  }
+
+  // Low surrogate + non surrogate code point
+  assert match (parse("\"\\uDC37\\u0524\"")) {
+    Err(InvalidUTF16SurrogatePair(_)) => true,
+    _ => false,
+  }
+}
+module Parse {
+  // Constants
+  assert parse("true") == Ok(JSONBoolean(true))
+  assert parse("false") == Ok(JSONBoolean(false))
+  assert parse("null") == Ok(JSONNull)
+  // Numbers
+  assert parse("0") == Ok(JSONNumber(0))
+  assert match (parse("-0")) {
+    Ok(JSONNumber(n)) => 1.0 / n == -Infinity,
+    _ => false,
+  }
+  assert match (parse("-0.0")) {
+    Ok(JSONNumber(n)) => 1.0 / n == -Infinity,
+    _ => false,
+  }
+  assert parse("3.141592653589793") == Ok(JSONNumber(3.141592653589793))
+  assert parse("0.05") == Ok(JSONNumber(0.05))
+  // These tests are not testing accuracy, grain uses f64 which these exhaust its just checking that we can handle parsing correctly and equivalently to grain
+  assert parse(
+    "2.22507385850720113605740979670913197593481954635164564e-308"
+  ) ==
+    Ok(JSONNumber(2.22507385850720113605740979670913197593481954635164564e-308))
+  assert parse(
+    "1e999999999999999999999999999999999999999999999999999999999999"
+  ) ==
+    Ok(
+      JSONNumber(1e999999999999999999999999999999999999999999999999999999999999)
+    )
+  assert parse("42") == Ok(JSONNumber(42))
+  assert parse("-42") == Ok(JSONNumber(-42))
+  assert parse("5e2") == Ok(JSONNumber(5e2))
+  assert parse("5E2") == Ok(JSONNumber(5e2))
+  assert parse("5e+2") == Ok(JSONNumber(5e+2))
+  assert parse("5E+2") == Ok(JSONNumber(5e+2))
+  assert parse("5e-2") == Ok(JSONNumber(5e-2))
+  assert parse("5E-2") == Ok(JSONNumber(5e-2))
+  assert parse("18446744073709551616") == Ok(JSONNumber(18446744073709551616))
+  assert parse("18446744073709551616") == Ok(JSONNumber(18446744073709551616))
+  assert parse("1152921504606846976") == Ok(JSONNumber(1152921504606846976))
+  assert parse("-10") == Ok(JSONNumber(-10))
+  assert parse("-2") == Ok(JSONNumber(-2))
+  assert parse("-1") == Ok(JSONNumber(-1))
+  assert parse("1") == Ok(JSONNumber(1))
+  assert parse("2") == Ok(JSONNumber(2))
+  assert parse("10") == Ok(JSONNumber(10))
+  assert parse("100") == Ok(JSONNumber(100))
+  assert parse("1000") == Ok(JSONNumber(1000))
+  assert parse("0.0") == Ok(JSONNumber(0.0))
+  assert parse("0.1") == Ok(JSONNumber(0.1))
+  assert parse("0.123") == Ok(JSONNumber(0.123))
+  assert parse("0.9") == Ok(JSONNumber(0.9))
+  assert parse("1.123") == Ok(JSONNumber(1.123))
+  assert parse("0e0") == Ok(JSONNumber(0.0))
+  assert parse("1e0") == Ok(JSONNumber(1.0))
+  assert parse("1e1") == Ok(JSONNumber(10.0))
+  assert parse("1E1") == Ok(JSONNumber(10.0))
+  assert parse("1e2") == Ok(JSONNumber(100.0))
+  assert parse("1e3") == Ok(JSONNumber(1000.0))
+  assert parse("-1e2") == Ok(JSONNumber(-100.0))
+  assert parse("1e-1") == Ok(JSONNumber(0.1))
+  assert parse("1.23e-4") == Ok(JSONNumber(0.000123))
+  assert parse("1E200") == Ok(JSONNumber(1E200))
+  assert parse("1E-200") == Ok(JSONNumber(1E-200))
+  assert parse("85070591730234615884290395931651604481") ==
+    Ok(JSONNumber(85070591730234615884290395931651604481))
+  assert parse("1.797693134862315708145274237317043567981e+308") ==
+    Ok(JSONNumber(1.797693134862315708145274237317043567981e+308))
+  assert parse("1.121333") == Ok(JSONNumber(1.121333))
+  assert parse("1.001") == Ok(JSONNumber(1.001))
+  // Strings
+  assert parse("\"\"") == Ok(JSONString(""))
+  assert parse("\"\\r\\n\\t\\b\\f\\\\\\/\\\"\"") ==
+    Ok(JSONString("\r\n\t\u{8}\u{c}\\/\""))
+  assert parse("\"\\u2764\\ufe0f\"") == Ok(JSONString("❤️"))
+  assert parse("\"\\uD834\\uDD1E\"") == Ok(JSONString("𝄞"))
+  assert parse("\"ASCII Hello world!\"") == Ok(JSONString("ASCII Hello world!"))
+  assert parse("\"Unicode こんにちは世界!\"") ==
+    Ok(JSONString("Unicode こんにちは世界!"))
+  assert parse("\"A \\\"quoted\\\" string\"") ==
+    Ok(JSONString("A \"quoted\" string"))
+  assert parse("\"\\uD801\\uDC37\"") == Ok(JSONString("𐐷"))
+  assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
+  assert parse("\"🤘🏻\"") == Ok(JSONString("🤘🏻"))
+  assert parse("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"") ==
+    Ok(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+  assert parse(
+    "\"\\u6000 \\ud800\\udc82 \\ud83e\\udd18\\ud83c\\udffb \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\""
+  ) ==
+    Ok(JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"))
+  // Array
+  assert parse("[]") == Ok(JSONArray([]))
+  assert parse("[[]]") == Ok(JSONArray([JSONArray([])]))
+  assert parse("[  ]") == Ok(JSONArray([]))
+  assert parse("[1]") == Ok(JSONArray([JSONNumber(1)]))
+  assert parse("[10, \"foo\", true, null]") ==
+    Ok(
+      JSONArray(
+        [JSONNumber(10), JSONString("foo"), JSONBoolean(true), JSONNull]
+      )
+    )
+  // Object
+  assert parse("{}") == Ok(JSONObject([]))
+  assert parse("
+  {
+    \"foo\": \"bar\",
+    \"num\": 10
+  }
+  ") ==
+    Ok(JSONObject([("foo", JSONString("bar")), ("num", JSONNumber(10))]))
+  // Note: Grain-json does not worry about duplicate keys
+  assert parse(
+    "
+  {
+    \"foo\": \"bar\",
+    \"num\": 10,
+    \"foo\": 1
+  }
+  "
+  ) ==
+    Ok(
+      JSONObject(
+        [
+          ("foo", JSONString("bar")),
+          ("num", JSONNumber(10)),
+          ("foo", JSONNumber(1)),
+        ]
+      )
+    )
+  // Nesting
+  assert parse("{\"foo\": [1, 2, 3]}") ==
+    Ok(
+      JSONObject(
+        [("foo", JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))]
+      )
+    )
+  assert parse(
+    "
+   {
+        \"l10n\": [ {
+            \"product\": {
+                \"inStock\": {
+                    \"DE\": \"Lieferung innerhalb von 1-3 Werktagen\"
+                }
+            }
+        } ]
+    }"
+  ) ==
+    Ok(
+      JSONObject(
+        [
+          (
+            "l10n",
+            JSONArray(
+              [
+                JSONObject(
+                  [
+                    (
+                      "product",
+                      JSONObject(
+                        [
+                          (
+                            "inStock",
+                            JSONObject(
+                              [
+                                (
+                                  "DE",
+                                  JSONString(
+                                    "Lieferung innerhalb von 1-3 Werktagen"
+                                  ),
+                                ),
+                              ]
+                            ),
+                          ),
+                        ]
+                      ),
+                    ),
+                  ]
+                ),
+              ]
+            ),
+          ),
+        ]
+      )
+    )
+  assert parse("{ \"pi\": 3.14 }") == Ok(JSONObject([("pi", JSONNumber(3.14))]))
+  assert parse("[100, 200, false, null, \"foo\"]") ==
+    Ok(
+      JSONArray(
+        [
+          JSONNumber(100),
+          JSONNumber(200),
+          JSONBoolean(false),
+          JSONNull,
+          JSONString("foo"),
+        ]
+      )
+    )
+  assert parse("{ \"Hello\" : \"World!\" }") ==
+    Ok(JSONObject([("Hello", JSONString("World!"))]))
+
+  assert parse("{\"a\":\"A\",\"b\":\"B\"}") ==
+    Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+
+  assert parse(
+    "{ \"a\" : { \"0\": false, \"1\":true }, \"b\" : [\"A\",\"B\",\"C\"] }"
+  ) ==
+    Ok(
+      JSONObject(
+        [
+          (
+            "a",
+            JSONObject([("0", JSONBoolean(false)), ("1", JSONBoolean(true))]),
+          ),
+          ("b", JSONArray([JSONString("A"), JSONString("B"), JSONString("C")])),
+        ]
+      )
+    )
+
+  assert parse("[1,\"2\",true,false,null]") ==
+    Ok(
+      JSONArray(
+        [
+          JSONNumber(1),
+          JSONString("2"),
+          JSONBoolean(true),
+          JSONBoolean(false),
+          JSONNull,
+        ]
+      )
+    )
+
+  assert parse("[[[[[[[[[[]]]]]]]]]]") ==
+    Ok(
       JSONArray(
         [
           JSONArray(
@@ -117,7 +415,15 @@ Ok(
                   JSONArray(
                     [
                       JSONArray(
-                        [JSONArray([JSONArray([JSONArray([JSONArray([])])])])]
+                        [
+                          JSONArray(
+                            [
+                              JSONArray(
+                                [JSONArray([JSONArray([JSONArray([])])])]
+                              ),
+                            ]
+                          ),
+                        ]
                       ),
                     ]
                   ),
@@ -126,432 +432,317 @@ Ok(
             ]
           ),
         ]
-      ),
-    ]
-  )
-)
+      )
+    )
 
-assert parse(
-  "{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}"
-) ==
-Ok(
-  JSONObject(
-    [
-      (
-        "1",
-        JSONObject(
-          [
-            (
-              "2",
-              JSONObject(
-                [
-                  (
-                    "3",
-                    JSONObject(
-                      [
-                        (
-                          "4",
-                          JSONObject(
-                            [
-                              (
-                                "5",
-                                JSONObject(
-                                  [
-                                    (
-                                      "6",
-                                      JSONObject(
-                                        [
-                                          (
-                                            "7",
-                                            JSONObject(
-                                              [
-                                                (
-                                                  "8",
-                                                  JSONObject(
-                                                    [
-                                                      (
-                                                        "9",
-                                                        JSONObject(
-                                                          [
-                                                            (
-                                                              "10",
-                                                              JSONObject([]),
+  assert parse(
+    "{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}"
+  ) ==
+    Ok(
+      JSONObject(
+        [
+          (
+            "1",
+            JSONObject(
+              [
+                (
+                  "2",
+                  JSONObject(
+                    [
+                      (
+                        "3",
+                        JSONObject(
+                          [
+                            (
+                              "4",
+                              JSONObject(
+                                [
+                                  (
+                                    "5",
+                                    JSONObject(
+                                      [
+                                        (
+                                          "6",
+                                          JSONObject(
+                                            [
+                                              (
+                                                "7",
+                                                JSONObject(
+                                                  [
+                                                    (
+                                                      "8",
+                                                      JSONObject(
+                                                        [
+                                                          (
+                                                            "9",
+                                                            JSONObject(
+                                                              [
+                                                                (
+                                                                  "10",
+                                                                  JSONObject(
+                                                                    []
+                                                                  ),
+                                                                ),
+                                                              ]
                                                             ),
-                                                          ]
-                                                        ),
+                                                          ),
+                                                        ]
                                                       ),
-                                                    ]
-                                                  ),
+                                                    ),
+                                                  ]
                                                 ),
-                                              ]
-                                            ),
+                                              ),
+                                            ]
                                           ),
-                                        ]
-                                      ),
+                                        ),
+                                      ]
                                     ),
-                                  ]
-                                ),
+                                  ),
+                                ]
                               ),
-                            ]
-                          ),
+                            ),
+                          ]
                         ),
-                      ]
-                    ),
+                      ),
+                    ]
                   ),
-                ]
-              ),
+                ),
+              ]
             ),
-          ]
+          ),
+        ]
+      )
+    )
+
+  assert parse("[1,2,3]") ==
+    Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+  assert parse("[\"a\",\"b\",\"c\"]") ==
+    Ok(JSONArray([JSONString("a"), JSONString("b"), JSONString("c")]))
+  // White spaces
+  assert parse("\tnull \r\n") == Ok(JSONNull)
+  assert parse("  {\r}") == Ok(JSONObject([]))
+  assert parse("[1,\n2\n,3\n]\n") ==
+    Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
+  assert parse("{ \"a\" :  \"A\" ,  \"b\" : \"B\" }") ==
+    Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
+}
+
+module ToString {
+  // Emitting
+
+  // Simple values of each type
+  assert toStringCompact(JSONNull) == Ok("null")
+  assert toStringCompact(JSONBoolean(true)) == Ok("true")
+  assert toStringCompact(JSONBoolean(false)) == Ok("false")
+  assert toStringCompact(JSONString("")) == Ok("\"\"")
+  assert toStringCompact(JSONNumber(0)) == Ok("0")
+  assert toStringCompact(JSONArray([])) == Ok("[]")
+  assert toStringCompact(JSONObject([])) == Ok("{}")
+
+  // Various strings. Escapes, emojis etc.
+  assert toStringCompact(JSONString("ASCII Hello world!")) ==
+    Ok("\"ASCII Hello world!\"")
+
+  assert toStringCompact(JSONString("Unicode こんにちは世界!")) ==
+    Ok("\"Unicode こんにちは世界!\"")
+  assert toStringCompact(JSONString("A \"quoted\" string")) ==
+    Ok("\"A \\\"quoted\\\" string\"")
+  assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toStringCompact(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
+    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toStringCompact(
+    JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+  ) ==
+    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+
+  // Note that number tests are sensitive both to compiler's interpretation of
+  // the constants as different number tags (simple numbers, float32, float64)
+  // and internal details of JSON formatting. We definetely want them to fail
+  // when the latter changes. The former shouldn't be an issue assuming here
+  // constants with decimal point or exponentials are float64.
+  assert toStringCompact(JSONNumber(-10)) == Ok("-10")
+  assert toStringCompact(JSONNumber(-2)) == Ok("-2")
+  assert toStringCompact(JSONNumber(-1)) == Ok("-1")
+  assert toStringCompact(JSONNumber(1)) == Ok("1")
+  assert toStringCompact(JSONNumber(2)) == Ok("2")
+  assert toStringCompact(JSONNumber(10)) == Ok("10")
+  assert toStringCompact(JSONNumber(100)) == Ok("100")
+  assert toStringCompact(JSONNumber(1000)) == Ok("1000")
+  assert toStringCompact(JSONNumber(0.0)) == Ok("0.0")
+  assert toStringCompact(JSONNumber(0.1)) == Ok("0.1")
+  assert toStringCompact(JSONNumber(0.123)) == Ok("0.123")
+  assert toStringCompact(JSONNumber(0.9)) == Ok("0.9")
+  assert toStringCompact(JSONNumber(1.123)) == Ok("1.123")
+  assert toStringCompact(JSONNumber(0e0)) == Ok("0.0")
+  assert toStringCompact(JSONNumber(1e0)) == Ok("1.0")
+  assert toStringCompact(JSONNumber(1e1)) == Ok("10.0")
+  assert toStringCompact(JSONNumber(1E1)) == Ok("10.0")
+  assert toStringCompact(JSONNumber(1e2)) == Ok("100.0")
+  assert toStringCompact(JSONNumber(1e3)) == Ok("1000.0")
+  assert toStringCompact(JSONNumber(-1e2)) == Ok("-100.0")
+  assert toStringCompact(JSONNumber(1e-1)) == Ok("0.1")
+  assert toStringCompact(JSONNumber(1.23e-4)) == Ok("0.000123")
+
+  // Big numbers
+  assert toStringCompact(JSONNumber(1152921504606846976)) ==
+    Ok("1152921504606846976")
+  assert toStringCompact(JSONNumber(1152921504606847000.0)) ==
+    Ok("1152921504606847000.0")
+
+  // Invalid numbers
+  assert match (toStringCompact(JSONNumber(NaN))) {
+    Err(InvalidNumber(_)) => true,
+    _ => false,
+  }
+
+  assert match (toStringCompact(JSONNumber(Infinity))) {
+    Err(InvalidNumber(_)) => true,
+    _ => false,
+  }
+
+  assert match (toStringCompact(JSONNumber(-Infinity))) {
+    Err(InvalidNumber(_)) => true,
+    _ => false,
+  }
+
+  // Pretty printing
+
+  let simplePrimitives = [
+    JSONNull,
+    JSONBoolean(true),
+    JSONBoolean(false),
+    JSONNumber(2),
+    JSONString("abc"),
+  ]
+
+  let comprehensiveNestingCombinations = [
+    JSONArray([]),
+    JSONArray([JSONNumber(1)]),
+    JSONArray([JSONNumber(1), JSONNumber(2)]),
+    JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+    JSONArray(
+      [
+        JSONArray([]),
+        JSONArray([JSONNumber(1)]),
+        JSONArray([JSONNumber(1), JSONNumber(2)]),
+        JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+      ]
+    ),
+    JSONArray([JSONArray([JSONArray([])])]),
+    JSONObject([]),
+    JSONObject([("a", JSONString("A"))]),
+    JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]),
+    JSONObject(
+      [("a", JSONString("A")), ("b", JSONString("B")), ("c", JSONString("C"))]
+    ),
+    JSONObject(
+      [("a", JSONObject([("b", JSONObject([("c", JSONObject([]))]))]))]
+    ),
+    JSONObject(
+      [
+        (
+          "arrays",
+          JSONArray(
+            [
+              JSONArray([]),
+              JSONArray([JSONNumber(1)]),
+              JSONArray([JSONNumber(1), JSONNumber(2)]),
+              JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
+            ]
+          ),
         ),
-      ),
+        (
+          "objects",
+          JSONObject(
+            [
+              ("a", JSONString("A")),
+              ("b", JSONString("B")),
+              ("c", JSONString("C")),
+            ]
+          ),
+        ),
+      ]
+    ),
+  ]
+
+  let comprehensiveJSONObject = JSONObject(
+    [
+      ("primitives", JSONArray(simplePrimitives)),
+      ("nesting", JSONArray(comprehensiveNestingCombinations)),
     ]
   )
-)
 
-assert parse("[1,2,3]") ==
-Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
-assert parse("[\"a\",\"b\",\"c\"]") ==
-Ok(JSONArray([JSONString("a"), JSONString("b"), JSONString("c")]))
+  // Indentation and line breaks
 
-// White spaces
-assert parse("\tnull \r\n") == Ok(JSONNull)
-assert parse("  {\r}") == Ok(JSONObject([]))
-assert parse("[1,\n2\n,3\n]\n") ==
-Ok(JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]))
-assert parse("{ \"a\" :  \"A\" ,  \"b\" : \"B\" }") ==
-Ok(JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]))
-
-// Invalid inputs
-
-// JSON numbers should start with a non zero digit or minus sign.
-assert match (parse("01")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse(".1")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{}error")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("[]error")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("]")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("}")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("\"k\":\"v\"")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-assert match (parse("[")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{\"k")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{\"k\"")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{\"k\":")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{\"k\":\"v")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-assert match (parse("{\"k\":\"v\"")) {
-  Err(UnexpectedEndOfInput(_)) => true,
-  _ => false,
-}
-
-// UTF-16 surrogate pairs should be the high half followed by the low half.
-
-// Two high surrogates.
-assert match (parse("\"\\uD801\\uD801\"")) {
-  Err(InvalidUTF16SurrogatePair(_)) => true,
-  _ => false,
-}
-
-// Inverted low and high surrogate order.
-assert match (parse("\"\\uDC37\\uD801\"")) {
-  Err(InvalidUTF16SurrogatePair(_)) => true,
-  _ => false,
-}
-
-// Single low surrogate
-assert match (parse("\"\\uDC37\"")) {
-  Err(InvalidUTF16SurrogatePair(_)) => true,
-  _ => false,
-}
-
-// Single high surrogate
-assert match (parse("\"\\uD801\"")) {
-  Err(UnexpectedToken(_)) => true,
-  _ => false,
-}
-
-// High surrogate + non surrogate code point
-assert match (parse("\"\\uD801\\u0524\"")) {
-  Err(InvalidUTF16SurrogatePair(_)) => true,
-  _ => false,
-}
-
-// Low surrogate + non surrogate code point
-assert match (parse("\"\\uDC37\\u0524\"")) {
-  Err(InvalidUTF16SurrogatePair(_)) => true,
-  _ => false,
-}
-
-// Emitting
-
-// Simple values of each type
-assert toStringCompact(JSONNull) == Ok("null")
-assert toStringCompact(JSONBoolean(true)) == Ok("true")
-assert toStringCompact(JSONBoolean(false)) == Ok("false")
-assert toStringCompact(JSONString("")) == Ok("\"\"")
-assert toStringCompact(JSONNumber(0)) == Ok("0")
-assert toStringCompact(JSONArray([])) == Ok("[]")
-assert toStringCompact(JSONObject([])) == Ok("{}")
-
-// Various strings. Escapes, emojis etc.
-assert toStringCompact(JSONString("ASCII Hello world!")) ==
-Ok("\"ASCII Hello world!\"")
-
-assert toStringCompact(JSONString("Unicode こんにちは世界!")) ==
-Ok("\"Unicode こんにちは世界!\"")
-assert toStringCompact(JSONString("A \"quoted\" string")) ==
-Ok("\"A \\\"quoted\\\" string\"")
-assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
-assert toStringCompact(JSONString("🤘🏻")) == Ok("\"🤘🏻\"")
-assert toStringCompact(JSONString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
-Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
-assert toStringCompact(
-  JSONString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
-) ==
-Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
-
-// Note that number tests are sensitive both to compiler's interpretation of
-// the constants as different number tags (simple numbers, float32, float64)
-// and internal details of JSON formatting. We definetely want them to fail
-// when the latter changes. The former shouldn't be an issue assuming here
-// constants with decimal point or exponentials are float64.
-assert toStringCompact(JSONNumber(-10)) == Ok("-10")
-assert toStringCompact(JSONNumber(-2)) == Ok("-2")
-assert toStringCompact(JSONNumber(-1)) == Ok("-1")
-assert toStringCompact(JSONNumber(1)) == Ok("1")
-assert toStringCompact(JSONNumber(2)) == Ok("2")
-assert toStringCompact(JSONNumber(10)) == Ok("10")
-assert toStringCompact(JSONNumber(100)) == Ok("100")
-assert toStringCompact(JSONNumber(1000)) == Ok("1000")
-assert toStringCompact(JSONNumber(0.0)) == Ok("0.0")
-assert toStringCompact(JSONNumber(0.1)) == Ok("0.1")
-assert toStringCompact(JSONNumber(0.123)) == Ok("0.123")
-assert toStringCompact(JSONNumber(0.9)) == Ok("0.9")
-assert toStringCompact(JSONNumber(1.123)) == Ok("1.123")
-assert toStringCompact(JSONNumber(0e0)) == Ok("0.0")
-assert toStringCompact(JSONNumber(1e0)) == Ok("1.0")
-assert toStringCompact(JSONNumber(1e1)) == Ok("10.0")
-assert toStringCompact(JSONNumber(1E1)) == Ok("10.0")
-assert toStringCompact(JSONNumber(1e2)) == Ok("100.0")
-assert toStringCompact(JSONNumber(1e3)) == Ok("1000.0")
-assert toStringCompact(JSONNumber(-1e2)) == Ok("-100.0")
-assert toStringCompact(JSONNumber(1e-1)) == Ok("0.1")
-assert toStringCompact(JSONNumber(1.23e-4)) == Ok("0.000123")
-
-// FIXME semantics for negative zero still not defined
-
-// Big numbers
-assert toStringCompact(JSONNumber(1152921504606846976)) ==
-Ok("1152921504606846976")
-assert toStringCompact(JSONNumber(1152921504606847000.0)) ==
-Ok("1152921504606847000.0")
-
-// Invalid numbers
-
-// There's currently a github issue for NaN and infinity syntax: https://github.com/grain-lang/grain/issues/693
-let nan = 0.0 / 0.0
-let infinity = 1.0 / 0.0
-let negativeinfinity = -1.0 / 0.0
-
-assert match (toStringCompact(JSONNumber(nan))) {
-  Err(InvalidNumber(_)) => true,
-  _ => false,
-}
-
-assert match (toStringCompact(JSONNumber(infinity))) {
-  Err(InvalidNumber(_)) => true,
-  _ => false,
-}
-
-assert match (toStringCompact(JSONNumber(negativeinfinity))) {
-  Err(InvalidNumber(_)) => true,
-  _ => false,
-}
-
-// Pretty printing
-
-let simplePrimitives = [
-  JSONNull,
-  JSONBoolean(true),
-  JSONBoolean(false),
-  JSONNumber(2),
-  JSONString("abc"),
-]
-
-let comprehensiveNestingCombinations = [
-  JSONArray([]),
-  JSONArray([JSONNumber(1)]),
-  JSONArray([JSONNumber(1), JSONNumber(2)]),
-  JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
-  JSONArray(
+  assert List.map(json =>
+    toString(
+      json,
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: CompactArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    ), comprehensiveNestingCombinations) ==
     [
-      JSONArray([]),
-      JSONArray([JSONNumber(1)]),
-      JSONArray([JSONNumber(1), JSONNumber(2)]),
-      JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
-    ]
-  ),
-  JSONArray([JSONArray([JSONArray([])])]),
-  JSONObject([]),
-  JSONObject([("a", JSONString("A"))]),
-  JSONObject([("a", JSONString("A")), ("b", JSONString("B"))]),
-  JSONObject(
-    [("a", JSONString("A")), ("b", JSONString("B")), ("c", JSONString("C"))]
-  ),
-  JSONObject([("a", JSONObject([("b", JSONObject([("c", JSONObject([]))]))]))]),
-  JSONObject(
-    [
-      (
-        "arrays",
-        JSONArray(
-          [
-            JSONArray([]),
-            JSONArray([JSONNumber(1)]),
-            JSONArray([JSONNumber(1), JSONNumber(2)]),
-            JSONArray([JSONNumber(1), JSONNumber(2), JSONNumber(3)]),
-          ]
-        ),
-      ),
-      (
-        "objects",
-        JSONObject(
-          [
-            ("a", JSONString("A")),
-            ("b", JSONString("B")),
-            ("c", JSONString("C")),
-          ]
-        ),
+      Ok("[]"),
+      Ok("[1]"),
+      Ok("[1,2]"),
+      Ok("[1,2,3]"),
+      Ok("[[],[1],[1,2],[1,2,3]]"),
+      Ok("[[[]]]"),
+      Ok("{}"),
+      Ok("{\"a\":\"A\"}"),
+      Ok("{\"a\":\"A\",\"b\":\"B\"}"),
+      Ok("{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}"),
+      Ok("{\"a\":{\"b\":{\"c\":{}}}}"),
+      Ok(
+        "{\"arrays\":[[],[1],[1,2],[1,2,3]],\"objects\":{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}}"
       ),
     ]
-  ),
-]
 
-let comprehensiveJSONObject = JSONObject(
-  [
-    ("primitives", JSONArray(simplePrimitives)),
-    ("nesting", JSONArray(comprehensiveNestingCombinations)),
-  ]
-)
+  assert List.map(json =>
+    toString(
+      json,
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: OneObjectEntryPerLine,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
+    ), comprehensiveNestingCombinations) ==
+    [
+      Ok("[]"),
+      Ok("[\n  1\n]"),
+      Ok("[\n  1,\n  2\n]"),
+      Ok("[\n  1,\n  2,\n  3\n]"),
+      Ok(
+        "[\n  [],\n  [\n    1\n  ],\n  [\n    1,\n    2\n  ],\n  [\n    1,\n    2,\n    3\n  ]\n]"
+      ),
+      Ok("[\n  [\n    []\n  ]\n]"),
+      Ok("{}"),
+      Ok("{\n  \"a\": \"A\"\n}"),
+      Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\"\n}"),
+      Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\",\n  \"c\": \"C\"\n}"),
+      Ok("{\n  \"a\": {\n    \"b\": {\n      \"c\": {}\n    }\n  }\n}"),
+      Ok(
+        "{\n  \"arrays\": [\n    [],\n    [\n      1\n    ],\n    [\n      1,\n      2\n    ],\n    [\n      1,\n      2,\n      3\n    ]\n  ],\n  \"objects\": {\n    \"a\": \"A\",\n    \"b\": \"B\",\n    \"c\": \"C\"\n  }\n}"
+      ),
+    ]
 
-// Indentation and line breaks
+  // Round trips
+  assert Result.map(parse, toStringCompact(comprehensiveJSONObject)) ==
+    Ok(Ok(comprehensiveJSONObject))
 
-assert List.map(json =>
-  toString(
-    json,
-    {
-      indentation: IndentWithSpaces(2),
-      arrayFormat: CompactArrayEntries,
-      objectFormat: CompactObjectEntries,
-      lineEnding: LineFeed,
-      finishWithNewLine: false,
-      escapeAllControlPoints: false,
-      escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
-    }
-  ), comprehensiveNestingCombinations) ==
-[
-  Ok("[]"),
-  Ok("[1]"),
-  Ok("[1,2]"),
-  Ok("[1,2,3]"),
-  Ok("[[],[1],[1,2],[1,2,3]]"),
-  Ok("[[[]]]"),
-  Ok("{}"),
-  Ok("{\"a\":\"A\"}"),
-  Ok("{\"a\":\"A\",\"b\":\"B\"}"),
-  Ok("{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}"),
-  Ok("{\"a\":{\"b\":{\"c\":{}}}}"),
-  Ok(
-    "{\"arrays\":[[],[1],[1,2],[1,2,3]],\"objects\":{\"a\":\"A\",\"b\":\"B\",\"c\":\"C\"}}"
-  ),
-]
-
-assert List.map(json =>
-  toString(
-    json,
-    {
-      indentation: IndentWithSpaces(2),
-      arrayFormat: OneArrayEntryPerLine,
-      objectFormat: OneObjectEntryPerLine,
-      lineEnding: LineFeed,
-      finishWithNewLine: false,
-      escapeAllControlPoints: false,
-      escapeHTMLUnsafeSequences: false,
-      escapeNonASCII: false,
-    }
-  ), comprehensiveNestingCombinations) ==
-[
-  Ok("[]"),
-  Ok("[\n  1\n]"),
-  Ok("[\n  1,\n  2\n]"),
-  Ok("[\n  1,\n  2,\n  3\n]"),
-  Ok(
-    "[\n  [],\n  [\n    1\n  ],\n  [\n    1,\n    2\n  ],\n  [\n    1,\n    2,\n    3\n  ]\n]"
-  ),
-  Ok("[\n  [\n    []\n  ]\n]"),
-  Ok("{}"),
-  Ok("{\n  \"a\": \"A\"\n}"),
-  Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\"\n}"),
-  Ok("{\n  \"a\": \"A\",\n  \"b\": \"B\",\n  \"c\": \"C\"\n}"),
-  Ok("{\n  \"a\": {\n    \"b\": {\n      \"c\": {}\n    }\n  }\n}"),
-  Ok(
-    "{\n  \"arrays\": [\n    [],\n    [\n      1\n    ],\n    [\n      1,\n      2\n    ],\n    [\n      1,\n      2,\n      3\n    ]\n  ],\n  \"objects\": {\n    \"a\": \"A\",\n    \"b\": \"B\",\n    \"c\": \"C\"\n  }\n}"
-  ),
-]
-
-// Round trips
-assert Result.map(parse, toStringCompact(comprehensiveJSONObject)) ==
-Ok(Ok(comprehensiveJSONObject))
-
-assert Result.map(parse, toStringPretty(comprehensiveJSONObject)) ==
-Ok(Ok(comprehensiveJSONObject))
+  assert Result.map(parse, toStringPretty(comprehensiveJSONObject)) ==
+    Ok(Ok(comprehensiveJSONObject))
+}

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -558,72 +558,130 @@ module ToString {
   assert toString(JsonObject([]), format=Pretty) == Ok("{}\n")
 
   // Various strings. Escapes, emojis etc.
-  assert toString(JsonString("ASCII Hello world!"), format=Compact) ==
+  assert toString(JsonString("ASCII Hello world!")) ==
     Ok("\"ASCII Hello world!\"")
+
+  assert toString(JsonString("Unicode こんにちは世界!")) ==
+    Ok("\"Unicode こんにちは世界!\"")
+  assert toString(JsonString("A \"quoted\" string")) ==
+    Ok("\"A \\\"quoted\\\" string\"")
+  assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
+    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(
+    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+  ) ==
+    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("ASCII Hello world!")) ==
+    Ok("\"ASCII Hello world!\"")
+
+  assert toString(JsonString("Unicode こんにちは世界!")) ==
+    Ok("\"Unicode こんにちは世界!\"")
+  assert toString(JsonString("A \"quoted\" string")) ==
+    Ok("\"A \\\"quoted\\\" string\"")
+  assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🤘🏻")) == Ok("\"🤘🏻\"")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿")) ==
+    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(
+    JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+  ) ==
+    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+  assert toString(JsonString("ASCII Hello world!"), format=Pretty) ==
+    Ok("\"ASCII Hello world!\"\n")
 
   assert toString(
     JsonString("Unicode こんにちは世界!"),
-    format=Compact
+    format=Pretty
   ) ==
-    Ok("\"Unicode こんにちは世界!\"")
-  assert toString(JsonString("A \"quoted\" string"), format=Compact) ==
-    Ok("\"A \\\"quoted\\\" string\"")
-  assert toString(JsonString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
-  assert toString(JsonString("🤘🏻"), format=Compact) == Ok("\"🤘🏻\"")
-  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Compact) ==
-    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+    Ok("\"Unicode こんにちは世界!\"\n")
+  assert toString(JsonString("A \"quoted\" string"), format=Pretty) ==
+    Ok("\"A \\\"quoted\\\" string\"\n")
+  assert toString(JsonString("🤘🏻"), format=Pretty) == Ok("\"🤘🏻\"\n")
+  assert toString(JsonString("🤘🏻"), format=Pretty) == Ok("\"🤘🏻\"\n")
+  assert toString(JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"), format=Pretty) ==
+    Ok("\"🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
   assert toString(
     JsonString("怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
-    format=Compact
+    format=Pretty
   ) ==
-    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"")
+    Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
+  assert toString(
+    JsonString("ASCII Hello world!"),
+    format=PrettyAndSafeFormat
+  ) ==
+    Ok("\"ASCII Hello world!\"\n")
+  assert toString(
+    JsonString("Unicode こんにちは世界!"),
+    format=PrettyAndSafeFormat
+  ) ==
+    Ok("\"Unicode \\u3053\\u3093\\u306b\\u3061\\u306f\\u4e16\\u754c!\"\n")
+  assert toString(
+    JsonString("A \"quoted\" string"),
+    format=PrettyAndSafeFormat
+  ) ==
+    Ok("\"A \\\"quoted\\\" string\"\n")
+  assert toString(JsonString("🤘🏻"), format=PrettyAndSafeFormat) ==
+    Ok("\"\\ud83e\\udd18\\ud83c\\udffb\"\n")
+  assert toString(
+    JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
+    format=PrettyAndSafeFormat
+  ) ==
+    Ok(
+      "\"\\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\"\n"
+    )
 
   // Note that number tests are sensitive both to compiler's interpretation of
   // the constants as different number tags (simple numbers, float32, float64)
   // and internal details of JSON formatting. We definetely want them to fail
   // when the latter changes. The former shouldn't be an issue assuming here
   // constants with decimal point or exponentials are float64.
-  assert toString(JsonNumber(-10), format=Compact) == Ok("-10")
-  assert toString(JsonNumber(-2), format=Compact) == Ok("-2")
-  assert toString(JsonNumber(-1), format=Compact) == Ok("-1")
-  assert toString(JsonNumber(1), format=Compact) == Ok("1")
-  assert toString(JsonNumber(2), format=Compact) == Ok("2")
-  assert toString(JsonNumber(10), format=Compact) == Ok("10")
-  assert toString(JsonNumber(100), format=Compact) == Ok("100")
-  assert toString(JsonNumber(1000), format=Compact) == Ok("1000")
-  assert toString(JsonNumber(0.0), format=Compact) == Ok("0.0")
-  assert toString(JsonNumber(0.1), format=Compact) == Ok("0.1")
-  assert toString(JsonNumber(0.123), format=Compact) == Ok("0.123")
-  assert toString(JsonNumber(0.9), format=Compact) == Ok("0.9")
-  assert toString(JsonNumber(1.123), format=Compact) == Ok("1.123")
-  assert toString(JsonNumber(0e0), format=Compact) == Ok("0.0")
-  assert toString(JsonNumber(1e0), format=Compact) == Ok("1.0")
-  assert toString(JsonNumber(1e1), format=Compact) == Ok("10.0")
-  assert toString(JsonNumber(1E1), format=Compact) == Ok("10.0")
-  assert toString(JsonNumber(1e2), format=Compact) == Ok("100.0")
-  assert toString(JsonNumber(1e3), format=Compact) == Ok("1000.0")
-  assert toString(JsonNumber(-1e2), format=Compact) == Ok("-100.0")
-  assert toString(JsonNumber(1e-1), format=Compact) == Ok("0.1")
-  assert toString(JsonNumber(1.23e-4), format=Compact) == Ok("0.000123")
+  assert toString(JsonNumber(-10)) == Ok("-10")
+  assert toString(JsonNumber(-2)) == Ok("-2")
+  assert toString(JsonNumber(-1)) == Ok("-1")
+  assert toString(JsonNumber(1)) == Ok("1")
+  assert toString(JsonNumber(2)) == Ok("2")
+  assert toString(JsonNumber(10)) == Ok("10")
+  assert toString(JsonNumber(100)) == Ok("100")
+  assert toString(JsonNumber(1000)) == Ok("1000")
+  assert toString(JsonNumber(0.0)) == Ok("0.0")
+  assert toString(JsonNumber(0.1)) == Ok("0.1")
+  assert toString(JsonNumber(0.123)) == Ok("0.123")
+  assert toString(JsonNumber(0.9)) == Ok("0.9")
+  assert toString(JsonNumber(1.123)) == Ok("1.123")
+  assert toString(JsonNumber(0e0)) == Ok("0.0")
+  assert toString(JsonNumber(1e0)) == Ok("1.0")
+  assert toString(JsonNumber(1e1)) == Ok("10.0")
+  assert toString(JsonNumber(1E1)) == Ok("10.0")
+  assert toString(JsonNumber(1e2)) == Ok("100.0")
+  assert toString(JsonNumber(1e3)) == Ok("1000.0")
+  assert toString(JsonNumber(-1e2)) == Ok("-100.0")
+  assert toString(JsonNumber(1e-1)) == Ok("0.1")
+  assert toString(JsonNumber(1.23e-4)) == Ok("0.000123")
+
+  // Rationals
+  assert toString(JsonNumber(1/3)) == Ok("0.3333333333333333")
+  assert toString(JsonNumber(2/3)) == Ok("0.6666666666666666")
+  assert toString(JsonNumber(3/3)) == Ok("1")
 
   // Big numbers
-  assert toString(JsonNumber(1152921504606846976), format=Compact) ==
-    Ok("1152921504606846976")
-  assert toString(JsonNumber(1152921504606847000.0), format=Compact) ==
+  assert toString(JsonNumber(1152921504606846976)) == Ok("1152921504606846976")
+  assert toString(JsonNumber(1152921504606847000.0)) ==
     Ok("1152921504606847000.0")
 
   // Invalid numbers
-  assert match (toString(JsonNumber(NaN), format=Compact)) {
+  assert match (toString(JsonNumber(NaN))) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toString(JsonNumber(Infinity), format=Compact)) {
+  assert match (toString(JsonNumber(Infinity))) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
 
-  assert match (toString(JsonNumber(-Infinity), format=Compact)) {
+  assert match (toString(JsonNumber(-Infinity))) {
     Err(InvalidNumber(_)) => true,
     _ => false,
   }
@@ -995,5 +1053,17 @@ module ToString {
     Ok(Ok(comprehensiveJsonObject))
 
   assert Result.map(parse, toString(comprehensiveJsonObject, format=Pretty)) ==
+    Ok(Ok(comprehensiveJsonObject))
+
+  assert Result.map(
+    parse,
+    toString(comprehensiveJsonObject, format=CompactAndSafeFormat)
+  ) ==
+    Ok(Ok(comprehensiveJsonObject))
+
+  assert Result.map(
+    parse,
+    toString(comprehensiveJsonObject, format=PrettyAndSafeFormat)
+  ) ==
     Ok(Ok(comprehensiveJsonObject))
 }

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -607,26 +607,20 @@ module ToString {
     format=Pretty
   ) ==
     Ok("\"怀 𐂂 🤘🏻 🏴󠁧󠁢󠁷󠁬󠁳󠁿\"\n")
-  assert toString(
-    JsonString("ASCII Hello world!"),
-    format=PrettyAndSafeFormat
-  ) ==
+  assert toString(JsonString("ASCII Hello world!"), format=PrettyAndSafe) ==
     Ok("\"ASCII Hello world!\"\n")
   assert toString(
     JsonString("Unicode こんにちは世界!"),
-    format=PrettyAndSafeFormat
+    format=PrettyAndSafe
   ) ==
     Ok("\"Unicode \\u3053\\u3093\\u306b\\u3061\\u306f\\u4e16\\u754c!\"\n")
-  assert toString(
-    JsonString("A \"quoted\" string"),
-    format=PrettyAndSafeFormat
-  ) ==
+  assert toString(JsonString("A \"quoted\" string"), format=PrettyAndSafe) ==
     Ok("\"A \\\"quoted\\\" string\"\n")
-  assert toString(JsonString("🤘🏻"), format=PrettyAndSafeFormat) ==
+  assert toString(JsonString("🤘🏻"), format=PrettyAndSafe) ==
     Ok("\"\\ud83e\\udd18\\ud83c\\udffb\"\n")
   assert toString(
     JsonString("🏴󠁧󠁢󠁷󠁬󠁳󠁿"),
-    format=PrettyAndSafeFormat
+    format=PrettyAndSafe
   ) ==
     Ok(
       "\"\\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc77\\udb40\\udc6c\\udb40\\udc73\\udb40\\udc7f\"\n"
@@ -634,7 +628,7 @@ module ToString {
 
   // Note that number tests are sensitive both to compiler's interpretation of
   // the constants as different number tags (simple numbers, float32, float64)
-  // and internal details of JSON formatting. We definetely want them to fail
+  // and internal details of JSON formatting. We definitely want them to fail
   // when the latter changes. The former shouldn't be an issue assuming here
   // constants with decimal point or exponentials are float64.
   assert toString(JsonNumber(-10)) == Ok("-10")
@@ -1114,13 +1108,13 @@ module ToString {
 
   assert Result.map(
     parse,
-    toString(comprehensiveJsonObject, format=CompactAndSafeFormat)
+    toString(comprehensiveJsonObject, format=CompactAndSafe)
   ) ==
     Ok(Ok(comprehensiveJsonObject))
 
   assert Result.map(
     parse,
-    toString(comprehensiveJsonObject, format=PrettyAndSafeFormat)
+    toString(comprehensiveJsonObject, format=PrettyAndSafe)
   ) ==
     Ok(Ok(comprehensiveJsonObject))
 }

--- a/compiler/test/stdlib/json.test.gr
+++ b/compiler/test/stdlib/json.test.gr
@@ -698,200 +698,176 @@ module ToString {
   // Formatting - Indentation
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n  1\n]")
   assert toString(
     JsonArray([JsonArray([JsonNumber(1)])]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n  [\n    1\n  ]\n]")
   assert toString(
     JsonArray([JsonArray([JsonNumber(1)])]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n[\n1\n]\n]")
 
   // Formatting - line endings
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n1\n]")
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: NoLineEnding,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: NoLineEnding,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[1]")
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: CarriageReturnLineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: CarriageReturnLineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\r\n1\r\n]")
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: CarriageReturn,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: CarriageReturn,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\r1\r]")
 
   // Formatting - finish with new line
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n1\n]")
   assert toString(
     JsonArray([JsonNumber(1)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(0),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: true,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(0),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: true,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n1\n]\n")
 
   // Formatting - array format
   assert toString(
     JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: CompactArrayEntries,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[1,2,3]")
   assert toString(
     JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: SpacedArrayEntries,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: SpacedArrayEntries,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[1, 2, 3]")
   assert toString(
     JsonArray([JsonNumber(1), JsonNumber(2), JsonNumber(3)]),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: OneArrayEntryPerLine,
-        objectFormat: CompactObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: OneArrayEntryPerLine,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
   ) ==
     Ok("[\n  1,\n  2,\n  3\n]")
 
@@ -900,8 +876,57 @@ module ToString {
     JsonObject(
       [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
     ),
-    format=Custom(
-      {
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: CompactObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
+  ) ==
+    Ok("{\"one\":1,\"two\":2,\"three\":3}")
+  assert toString(
+    JsonObject(
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+    ),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: SpacedObjectEntries,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
+  ) ==
+    Ok("{\"one\": 1, \"two\": 2, \"three\": 3}")
+  assert toString(
+    JsonObject(
+      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
+    ),
+    format=Custom{
+      indentation: IndentWithSpaces(2),
+      arrayFormat: CompactArrayEntries,
+      objectFormat: OneObjectEntryPerLine,
+      lineEnding: LineFeed,
+      finishWithNewLine: false,
+      escapeAllControlPoints: false,
+      escapeHTMLUnsafeSequences: false,
+      escapeNonASCII: false,
+    }
+  ) ==
+    Ok("{\n  \"one\": 1,\n  \"two\": 2,\n  \"three\": 3\n}")
+
+  // Indentation and line breaks
+
+  assert List.map(json =>
+    toString(
+      json,
+      format=Custom{
         indentation: IndentWithSpaces(2),
         arrayFormat: CompactArrayEntries,
         objectFormat: CompactObjectEntries,
@@ -911,63 +936,6 @@ module ToString {
         escapeHTMLUnsafeSequences: false,
         escapeNonASCII: false,
       }
-    )
-  ) ==
-    Ok("{\"one\":1,\"two\":2,\"three\":3}")
-  assert toString(
-    JsonObject(
-      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
-    ),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: CompactArrayEntries,
-        objectFormat: SpacedObjectEntries,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
-  ) ==
-    Ok("{\"one\": 1, \"two\": 2, \"three\": 3}")
-  assert toString(
-    JsonObject(
-      [("one", JsonNumber(1)), ("two", JsonNumber(2)), ("three", JsonNumber(3))]
-    ),
-    format=Custom(
-      {
-        indentation: IndentWithSpaces(2),
-        arrayFormat: CompactArrayEntries,
-        objectFormat: OneObjectEntryPerLine,
-        lineEnding: LineFeed,
-        finishWithNewLine: false,
-        escapeAllControlPoints: false,
-        escapeHTMLUnsafeSequences: false,
-        escapeNonASCII: false,
-      }
-    )
-  ) ==
-    Ok("{\n  \"one\": 1,\n  \"two\": 2,\n  \"three\": 3\n}")
-
-  // Indentation and line breaks
-
-  assert List.map(json =>
-    toString(
-      json,
-      format=Custom(
-        {
-          indentation: IndentWithSpaces(2),
-          arrayFormat: CompactArrayEntries,
-          objectFormat: CompactObjectEntries,
-          lineEnding: LineFeed,
-          finishWithNewLine: false,
-          escapeAllControlPoints: false,
-          escapeHTMLUnsafeSequences: false,
-          escapeNonASCII: false,
-        }
-      )
     ), comprehensiveNestingCombinations) ==
     [
       Ok("[]"),
@@ -989,18 +957,16 @@ module ToString {
   assert List.map(json =>
     toString(
       json,
-      format=Custom(
-        {
-          indentation: IndentWithSpaces(2),
-          arrayFormat: OneArrayEntryPerLine,
-          objectFormat: OneObjectEntryPerLine,
-          lineEnding: LineFeed,
-          finishWithNewLine: false,
-          escapeAllControlPoints: false,
-          escapeHTMLUnsafeSequences: false,
-          escapeNonASCII: false,
-        }
-      )
+      format=Custom{
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: OneObjectEntryPerLine,
+        lineEnding: LineFeed,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      }
     ), comprehensiveNestingCombinations) ==
     [
       Ok("[]"),

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -84,6 +84,7 @@ describe("stdlib", ({test, testSkip}) => {
   assertStdlib("int16.test");
   assertStdlib("int32.test");
   assertStdlib("int64.test");
+  assertStdlib("json.test");
   assertStdlib("uint8.test");
   assertStdlib("uint16.test");
   assertStdlib("uint32.test");

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -90,158 +90,177 @@ provide enum JsonToStringError {
 /**
  * Controls how indentation is performed in custom formatting.
  *
- * Following examples have whitespaces and line breaks replaced with visible
+ * The following examples have whitespaces and line breaks replaced with visible
  * characters for illustrative purposes.
- *
- * `NoIndentation`
- * ```
- * {↵
- * "currency":·"€",↵
- * "price":·99.9↵
- * }
- * ```
- *
- * `IndentWithTab`
- * ```
- * {↵
- * →"currency":·"€",↵
- * →"price":·99.9↵
- * }
- * ```
- *
- * `IndentWithSpaces(2)`
- * ```
- * {↵
- * ··"currency":·"€",↵
- * ··"price":·99.9↵
- * }
- * ```
- *
- * `IndentWithSpaces(4)`
- * ```
- * {↵
- * ····"currency":·"€",↵
- * ····"price":·99.9↵
- * }
- * ```
  */
 provide enum IndentationFormat {
+  /**
+   * No indentation is emitted.
+   *
+   * ```json
+   * {↵
+   * "currency":·"€",↵
+   * "price":·99.9↵
+   * }
+   * ```
+   */
   NoIndentation,
+  /**
+   * Tabs are emitted.
+   *
+   * ```json
+   * {↵
+   * →"currency":·"€",↵
+   * →"price":·99.9↵
+   * }
+   * ```
+   */
   IndentWithTab,
+  /**
+   * The desired number of spaces are emitted.
+   *
+   * `IndentWithSpaces(2)`
+   * ```json
+   * {↵
+   * ··"currency":·"€",↵
+   * ··"price":·99.9↵
+   * }
+   * ```
+   *
+   * `IndentWithSpaces(4)`
+   * ```json
+   * {↵
+   * ····"currency":·"€",↵
+   * ····"price":·99.9↵
+   * }
+   * ```
+   */
   IndentWithSpaces(Number),
 }
 
 /**
  * Controls how arrays are printed in custom formatting.
  *
- * Following examples have whitespaces and line breaks replaced with visible
+ * The following examples have whitespaces and line breaks replaced with visible
  * characters for illustrative purposes.
- *
- * `CompactArrayEntries`
- * ```
- * []
- * ```
- *
- * ```
- * [1]
- * ```
- *
- * ```
- * [1,2,3]
- * ```
- *
- * `SpacedArrayEntries`
- * ```
- * [ ]
- * ```
- *
- * ```
- * [1]
- * ```
- *
- * ```
- * [1,2,3]
- * ```
- *
- * `OneArrayEntryPerLine`
- * ```
- * []
- * ```
- *
- * ```
- * [↵
- * ··1↵
- * ]
- * ```
- *
- * ```
- * [↵
- * ··1,↵
- * ··2,↵
- * ··3↵
- * ]
- * ```
  */
 provide enum ArrayFormat {
+  /**
+   * Arrays are emitted in a compact manner.
+   *
+   * ```json
+   * []
+   * ```
+   *
+   * ```json
+   * [1]
+   * ```
+   *
+   * ```json
+   * [1,2,3]
+   * ```
+   */
   CompactArrayEntries,
+  /**
+   * Arrays are emitted with spaces between elements.
+   *
+   * ```json
+   * [ ]
+   * ```
+   *
+   * ```json
+   * [1]
+   * ```
+   *
+   * ```json
+   * [1, 2, 3]
+   * ```
+   */
   SpacedArrayEntries,
+  /**
+   * Arrays are emitted with newlines and indentation between each element.
+   *
+   * ```json
+   * []
+   * ```
+   *
+   * ```json
+   * [↵
+   * ··1↵
+   * ]
+   * ```
+   *
+   * ```json
+   * [↵
+   * ··1,↵
+   * ··2,↵
+   * ··3↵
+   * ]
+   * ```
+   */
   OneArrayEntryPerLine,
 }
 
 /**
  * Controls how objects are printed in custom formatting.
  *
- * Following examples have whitespaces and line breaks replaced with visible
+ * The following examples have whitespaces and line breaks replaced with visible
  * characters for illustrative purposes.
- *
- * `CompactObjectEntries`
- * ```
- * {}
- * ```
- *
- * ```
- * {"a":1}
- * ```
- *
- * ```
- * {"a":1,"b":2,"c":3}
- * ```
- *
- * `SpacedObjectEntries`
- * ```
- * { }
- * ```
- *
- * ```
- * {"a": 1}
- * ```
- *
- * ```
- * {"a": 1, "b": 2, "c": 3}
- * ```
- *
- * `OneObjectEntryPerLine`
- * ```
- * {}
- * ```
- *
- * ```
- * {↵
- * ··"a":·1↵
- * }
- * ```
- *
- * ```
- * {↵
- * ··"a":·1,↵
- * ··"b":·2,↵
- * ··"c":·3↵
- * }
- * ```
  */
 provide enum ObjectFormat {
+  /**
+   * Objects are emitted in a compact manner.
+   *
+   * ```json
+   * {}
+   * ```
+   *
+   * ```json
+   * {"a":1}
+   * ```
+   *
+   * ```json
+   * {"a":1,"b":2,"c":3}
+   * ```
+   */
   CompactObjectEntries,
+  /**
+   * Objects are emitted with spaces between entries.
+   *
+   * ```json
+   * { }
+   * ```
+   *
+   * ```json
+   * {"a": 1}
+   * ```
+   *
+   * ```json
+   * {"a": 1, "b": 2, "c": 3}
+   * ```
+   */
   SpacedObjectEntries,
+  /**
+   * Objects are emitted with each entry on a new line.
+   *
+   * ```
+   * {}
+   * ```
+   *
+   * ```
+   * {↵
+   * ··"a":·1↵
+   * }
+   * ```
+   *
+   * ```
+   * {↵
+   * ··"a":·1,↵
+   * ··"b":·2,↵
+   * ··"c":·3↵
+   * }
+   * ```
+   */
   OneObjectEntryPerLine,
 }
 
@@ -249,9 +268,21 @@ provide enum ObjectFormat {
  * Controls line ending type in custom formatting.
  */
 provide enum LineEnding {
+  /**
+   * No line endings will be emitted.
+   */
   NoLineEnding,
+  /**
+   * A `\n` will be emitted at the end of each line.
+   */
   LineFeed,
+  /**
+   * A `\r\n` will be emitted at the end of each line
+   */
   CarriageReturnLineFeed,
+  /**
+   * A `\r` will be emitted at the end of each line
+   */
   CarriageReturn,
 }
 
@@ -281,7 +312,7 @@ provide enum FormattingChoices {
    * is not safe to be transported in ASCII encoding.
    *
    * Roughly Equivalent to:
-   * ```
+   * ```grain
    * Custom{
    *  indentation: IndentWithSpaces(2),
    *  arrayFormat: OneArrayEntryPerLine,
@@ -296,7 +327,7 @@ provide enum FormattingChoices {
    *
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
-   * ```
+   * ```json
    * {↵
    * ··"currency":·"€",↵
    * ··"price":·99.9,↵
@@ -314,7 +345,7 @@ provide enum FormattingChoices {
    * transported in ASCII encoding.
    *
    * Roughly Equivalent to:
-   * ```
+   * ```grain
    * Custom{
    *  indentation: NoIndentation,
    *  arrayFormat: CompactArrayEntries,
@@ -329,7 +360,7 @@ provide enum FormattingChoices {
    *
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
-   * ```
+   * ```json
    * {"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
    * ```
    */
@@ -342,7 +373,7 @@ provide enum FormattingChoices {
    * plain ASCII.
    *
    * Roughly Equivalent to:
-   * ```
+   * ```grain
    * Custom{
    *  indentation: IndentWithSpaces(2),
    *  arrayFormat: OneArrayEntryPerLine,
@@ -357,7 +388,7 @@ provide enum FormattingChoices {
    *
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
-   * ```
+   * ```json
    * {↵
    * ··"currency":·"\u20ac",↵
    * ··"price":·99.9,↵
@@ -374,7 +405,7 @@ provide enum FormattingChoices {
    * plain ASCII.
    *
    * Roughly Equivalent to:
-   * ```
+   * ```grain
    * Custom{
    *  indentation: NoIndentation,
    *  arrayFormat: CompactArrayEntries,
@@ -389,7 +420,7 @@ provide enum FormattingChoices {
    *
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
-   * ```
+   * ```json
    * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
    * ```
    */

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -43,9 +43,6 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
 /**
  * Data structure representing the result of parsing and the input of printing JSON.
  *
- * This data structure is semantically equivalent to the JSON format allowing
- * mostly lossless round trips of printing and parsing.
- *
  * @example
  * assert Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
  *   ("currency", JsonString("€")),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -56,7 +56,7 @@ provide enum rec Json {
   JsonNumber(Number),
   JsonString(String),
   JsonArray(List<Json>),
-  // Note that JSONObject here is deliberately defined as a simple list of key value pair tuples as opposed
+  // Note that JsonObject here is deliberately defined as a simple list of key value pair tuples as opposed
   // to for example a Map in order to accommodate the fact that the ECMA-404 standard doesn't prohibit
   // duplicate names in Objects. Such JSON should be representable by the JSON data structure for lossless
   // processing. This also simplifies implementation by not requiring a purpose built data structure and
@@ -335,7 +335,7 @@ provide enum FormattingChoices {
    * Pretty and conservative formatting to maximize compatibility and
    * embeddability of the resulting JSON.
    *
-   * Should be safe to copy and paste directly into HTML and to transported in
+   * Should be safe to copy and paste directly into HTML and to be transported in
    * plain ASCII.
    *
    * Roughly Equivalent to:
@@ -977,9 +977,18 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
           Buffer.addChar('\t', buffer)
         }
       }),
+    // Implement fast path, for common indentation level to avoid closure
     IndentWithSpaces(spacesPerIndentation) when spacesPerIndentation == 2 =>
       Some(indentationLevel => {
         let spaceCount = indentationLevel * 2
+        for (let mut count = 0; count < spaceCount; count += 1) {
+          Buffer.addChar(' ', buffer)
+        }
+      }),
+    // Implement fast path, for common indentation level to avoid closure
+    IndentWithSpaces(spacesPerIndentation) when spacesPerIndentation == 4 =>
+      Some(indentationLevel => {
+        let spaceCount = indentationLevel * 4
         for (let mut count = 0; count < spaceCount; count += 1) {
           Buffer.addChar(' ', buffer)
         }
@@ -1596,48 +1605,40 @@ and parseString = (parserState: JsonParserState) => {
             match (parserState.currentCodePoint) {
               0x22 => { // '"'
                 Buffer.addChar('"', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x5C => { // '\'
                 Buffer.addChar('\\', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x2F => { // '/'
                 Buffer.addChar('/', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x62 => { // letter 'b' as in Backspace
                 // emit backspace control code
                 Buffer.addChar('\u{08}', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x66 => { // letter 'f' as in Form Feed
                 // emit Form Feed control code
                 Buffer.addChar('\u{0C}', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x6E => { // letter 'n' as in New line
                 // emit Line Feed control code
                 Buffer.addChar('\u{0A}', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x72 => { // letter 'r' as in carriage Return
                 // emit Carriage Return control code
                 Buffer.addChar('\u{0D}', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x74 => { // letter 't' as in Tab
                 // emit Tab control code
                 Buffer.addChar('\u{09}', buffer)
-                next(parserState)
-                void
+                ignore(next(parserState))
               },
               0x75 => { // 'u' (start of hexadecimal UTF-16 escape sequence)
                 next(parserState)
@@ -1689,8 +1690,7 @@ and parseString = (parserState: JsonParserState) => {
                     let shift = digitIndex * 4
                     codeUnit = codeUnit | digit << shift
 
-                    next(parserState)
-                    void
+                    ignore(next(parserState))
                   }
 
                   if (highSurrogate == -1) {
@@ -1833,7 +1833,6 @@ and parseNumberValue = (parserState: JsonParserState) => {
           break
         }
       }
-      void
     },
     unexpectedCodePoint => {
       // The integer part of the number has to have at least one digit.
@@ -1892,8 +1891,6 @@ and parseNumberValue = (parserState: JsonParserState) => {
           "exponent part is missing in number"
         )
       )
-
-    void
   }
   // Note that unlike all other JSON value types there's no explicit ending
   // character like ('"' for strings, ']' for arrays,'}' for objects etc). We
@@ -1956,7 +1953,6 @@ and parseArray = (parserState: JsonParserState) => {
                 first = false
                 trailingComma = false
                 elems = [elem, ...elems]
-                void
               },
               Err(e) => return Err(e),
             }
@@ -2005,8 +2001,7 @@ and parseObject = (parserState: JsonParserState) => {
               let detail = "expected a key-value pair or the end of the object, found ','"
               return Err(buildUnexpectedTokenError(parserState, detail))
             } else {
-              next(parserState)
-              void
+              ignore(next(parserState))
             }
           },
           0x7D => { // '}'
@@ -2034,7 +2029,6 @@ and parseObject = (parserState: JsonParserState) => {
                       Ok(value) => {
                         entries = [(key, value), ...entries]
                         first = false
-                        void
                       },
                       Err(e) => return Err(e),
                     }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -76,13 +76,13 @@ provide enum rec Json {
  */
 provide enum JsonToStringError {
   /**
-   * The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`
+   * The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`.
    */
   InvalidNumber(String),
 }
 
 /**
- * Controls how indentation is outputted in custom formatting.
+ * Controls how indentation is output in custom formatting.
  */
 provide enum IndentationFormat {
   /**
@@ -90,8 +90,8 @@ provide enum IndentationFormat {
    *
    * ```json
    * {
-   * "currency":·"€",
-   * "price":·99.9
+   * "currency": "€",
+   * "price": 99.9
    * }
    * ```
    */
@@ -101,8 +101,8 @@ provide enum IndentationFormat {
    *
    * ```json
    * {
-   *   "currency":·"€",
-   *   "price":·99.9
+   *   "currency": "€",
+   *   "price": 99.9
    * }
    * ```
    */
@@ -113,16 +113,16 @@ provide enum IndentationFormat {
    * `IndentWithSpaces(2)`
    * ```json
    * {
-   * ··"currency":·"€",
-   * ··"price":·99.9
+   *   "currency": "€",
+   *   "price": 99.9
    * }
    * ```
    *
    * `IndentWithSpaces(4)`
    * ```json
    * {
-   * ····"currency":·"€",
-   * ····"price":·99.9
+   *     "currency": "€",
+   *     "price": 99.9
    * }
    * ```
    */
@@ -130,7 +130,7 @@ provide enum IndentationFormat {
 }
 
 /**
- * Controls how arrays are outputted in custom formatting.
+ * Controls how arrays are output in custom formatting.
  */
 provide enum ArrayFormat {
   /**
@@ -174,15 +174,15 @@ provide enum ArrayFormat {
    *
    * ```json
    * [
-   * ··1
+   *   1
    * ]
    * ```
    *
    * ```json
    * [
-   * ··1,
-   * ··2,
-   * ··3
+   *   1,
+   *   2,
+   *   3
    * ]
    * ```
    */
@@ -190,7 +190,7 @@ provide enum ArrayFormat {
 }
 
 /**
- * Controls how objects are outputted in custom formatting.
+ * Controls how objects are output in custom formatting.
  */
 provide enum ObjectFormat {
   /**
@@ -234,15 +234,15 @@ provide enum ObjectFormat {
    *
    * ```
    * {
-   * ··"a":·1
+   *   "a": 1
    * }
    * ```
    *
    * ```
    * {
-   * ··"a":·1,
-   * ··"b":·2,
-   * ··"c":·3
+   *   "a": 1,
+   *   "b": 2,
+   *   "c": 3
    * }
    * ```
    */
@@ -250,7 +250,7 @@ provide enum ObjectFormat {
 }
 
 /**
- * Controls how line endings are outputted in custom formatting.
+ * Controls how line endings are output in custom formatting.
  */
 provide enum LineEnding {
   /**
@@ -262,11 +262,11 @@ provide enum LineEnding {
    */
   LineFeed,
   /**
-   * A `\r\n` will be emitted at the end of each line
+   * A `\r\n` will be emitted at the end of each line.
    */
   CarriageReturnLineFeed,
   /**
-   * A `\r` will be emitted at the end of each line
+   * A `\r` will be emitted at the end of each line.
    */
   CarriageReturn,
 }
@@ -312,9 +312,9 @@ provide enum FormattingChoices {
    *
    * ```json
    * {
-   * ··"currency":·"€",
-   * ··"price":·99.9,
-   * ··"currencyDescription":·"EURO\u007f",
+   *   "currency": "€",
+   *   "price": 99.9,
+   *   "currencyDescription": "EURO\u007f",
    * }
    * ```
    */
@@ -369,9 +369,9 @@ provide enum FormattingChoices {
    *
    * ```json
    * {
-   * ··"currency":·"\u20ac",
-   * ··"price":·99.9,
-   * ··"currencyDescription":·"EURO\u007f",
+   *   "currency": "\u20ac",
+   *   "price": 99.9,
+   *   "currencyDescription": "EURO\u007f",
    * }
    * ```
    */

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -421,8 +421,8 @@ record JsonWriterImplHelper {
   format: FormattingSettings,
   buffer: Buffer.Buffer,
   emitEscapedQuotedStringPretty: String => Void,
-  printNewLine: () => Void,
-  printIndentation: Number => Void,
+  printNewLine: Option<() => Void>,
+  printIndentation: Option<Number => Void>,
 }
 
 // The idea for this type is to allow reusing a bit of work done in preparing for printing JSON.
@@ -693,21 +693,33 @@ let rec printElementPretty =
           Buffer.addChar('[', buffer)
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
-            implHelper.printNewLine()
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
           }
 
           let elemLevel = indentationLevel + 1
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
-            implHelper.printIndentation(elemLevel)
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(elemLevel),
+              None => void,
+            }
           }
 
           let err = printElementPretty(e, implHelper, elemLevel)
           if (Option.isSome(err)) return err
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
-            implHelper.printNewLine()
-            implHelper.printIndentation(indentationLevel)
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(indentationLevel),
+              None => void,
+            }
           }
 
           Buffer.addChar(']', buffer)
@@ -720,7 +732,10 @@ let rec printElementPretty =
           Buffer.addChar('[', buffer)
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
-            implHelper.printNewLine()
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
           }
 
           let mut currentHead = initialHead
@@ -736,12 +751,18 @@ let rec printElementPretty =
               }
 
               if (format.arrayFormat == OneArrayEntryPerLine) {
-                implHelper.printNewLine()
+                match (implHelper.printNewLine) {
+                  Some(printNewLine) => printNewLine(),
+                  None => void,
+                }
               }
             }
 
             if (format.arrayFormat == OneArrayEntryPerLine) {
-              implHelper.printIndentation(elemLevel)
+              match (implHelper.printIndentation) {
+                Some(printIndentation) => printIndentation(elemLevel),
+                None => void,
+              }
             }
 
             let err = printElementPretty(currentHead, implHelper, elemLevel)
@@ -757,8 +778,14 @@ let rec printElementPretty =
           }
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
-            implHelper.printNewLine()
-            implHelper.printIndentation(indentationLevel)
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(indentationLevel),
+              None => void,
+            }
           }
 
           Buffer.addChar(']', buffer)
@@ -785,8 +812,14 @@ let rec printElementPretty =
           let elemLevel = indentationLevel + 1
 
           if (format.objectFormat == OneObjectEntryPerLine) {
-            implHelper.printNewLine()
-            implHelper.printIndentation(elemLevel)
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(elemLevel),
+              None => void,
+            }
           }
 
           implHelper.emitEscapedQuotedStringPretty(key)
@@ -803,8 +836,14 @@ let rec printElementPretty =
           if (Option.isSome(err)) return err
 
           if (format.objectFormat == OneObjectEntryPerLine) {
-            implHelper.printNewLine()
-            implHelper.printIndentation(indentationLevel)
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(indentationLevel),
+              None => void,
+            }
           }
 
           Buffer.addChar('}', buffer)
@@ -817,7 +856,10 @@ let rec printElementPretty =
           Buffer.addChar('{', buffer)
 
           if (format.objectFormat == OneObjectEntryPerLine) {
-            implHelper.printNewLine()
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
           }
 
           let mut currentHead = initialHead
@@ -833,12 +875,18 @@ let rec printElementPretty =
               }
 
               if (format.objectFormat == OneObjectEntryPerLine) {
-                implHelper.printNewLine()
+                match (implHelper.printNewLine) {
+                  Some(printNewLine) => printNewLine(),
+                  None => void,
+                }
               }
             }
 
             if (format.objectFormat == OneObjectEntryPerLine) {
-              implHelper.printIndentation(elemLevel)
+              match (implHelper.printIndentation) {
+                Some(printIndentation) => printIndentation(elemLevel),
+                None => void,
+              }
             }
 
             let (key, value) = currentHead
@@ -866,8 +914,14 @@ let rec printElementPretty =
           }
 
           if (format.objectFormat == OneObjectEntryPerLine) {
-            implHelper.printNewLine()
-            implHelper.printIndentation(indentationLevel)
+            match (implHelper.printNewLine) {
+              Some(printNewLine) => printNewLine(),
+              None => void,
+            }
+            match (implHelper.printIndentation) {
+              Some(printIndentation) => printIndentation(indentationLevel),
+              None => void,
+            }
           }
 
           Buffer.addChar('}', buffer)
@@ -900,41 +954,41 @@ let combineSurrogatePairToCodePoint =
 
 let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   let printNewLine = match (format.lineEnding) {
-    NoLineEnding => () => void,
+    NoLineEnding => None,
     LineFeed =>
-      () => {
+      Some(() => {
         Buffer.addChar('\n', buffer)
-      },
+      }),
     CarriageReturnLineFeed =>
-      () => {
+      Some(() => {
         Buffer.addChar('\r', buffer)
         Buffer.addChar('\n', buffer)
-      },
+      }),
     CarriageReturn =>
-      () => {
+      Some(() => {
         Buffer.addChar('\r', buffer)
-      },
+      }),
   }
 
   let printIndentation = match (format.indentation) {
     IndentWithTab =>
-      indentationLevel => {
+      Some(indentationLevel => {
         let mut count = 0
         while (count < indentationLevel) {
           Buffer.addChar('\t', buffer)
           count += 1
         }
-      },
+      }),
     IndentWithSpaces(spacesPerIndentation) =>
-      indentationLevel => {
+      Some(indentationLevel => {
         let mut count = 0
         let spaceCount = indentationLevel * spacesPerIndentation
         while (count < spaceCount) {
           Buffer.addChar(' ', buffer)
           count += 1
         }
-      },
-    NoIndentation => indentationLevel => void,
+      }),
+    NoIndentation => None,
   }
 
   // A possible optimization to make this faster would be to
@@ -1079,7 +1133,12 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
     emit: json => {
       let error = printElementPretty(json, implHelper, 0)
       if (Option.isSome(error)) return error
-      if (format.finishWithNewLine) printNewLine()
+      if (format.finishWithNewLine) {
+        match (printNewLine) {
+          Some(printNewLine) => printNewLine(),
+          None => void,
+        }
+      }
       return None
     },
   }: JsonWriter

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1433,6 +1433,8 @@ let rec readCodePoint = (bytePosition: Number, string: String) => {
 
   let byteSize = WasmI32.load(strPtr, 4n)
 
+  Memory.incRef(WasmI32.fromGrain(coerceNumberToWasmI32))
+  Memory.incRef(WasmI32.fromGrain(bytePosition))
   let bytePositionW32 = coerceNumberToWasmI32(bytePosition)
 
   let ptr = WasmI32.add(WasmI32.add(strPtr, 8n), bytePositionW32)

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -631,25 +631,12 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             None
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
-            from WasmF64 use { (/) }
-            // As a compromise, convert the rational into a float
-            // and then print that. This means there can be
-            // precision loss even for values that could be printed
-            // exactly in decimal notation, but doing otherwise
-            // could both compromise performance and confuse
-            // developers as most JSON libraries in other languages
-            // likely only deal with integers and floats.
-            // Note that the ECMA-404 standard only specifies how
-            // numbers should be formatted as text (in decimal
-            // notation), so we could go the extra mile and at
-            // least for some numbers try printing the exact
-            // number. For example those that have a power of 10
-            // in the denominator.
-            let asWasmF64 = WasmF64.convertI32S(
-              Numbers.boxedRationalNumerator(ptr)
-            ) /
-              WasmF64.convertI32S(Numbers.boxedRationalDenominator(ptr))
-
+            // JSON does not support rationals as a compromise
+            // we coerce them to an f64 and print that
+            // this means there is a slight loss in precision
+            let asFloat64 = Numbers.coerceNumberToFloat64(value)
+            let ptr = WasmI32.fromGrain(asFloat64)
+            let asWasmF64 = WasmF64.load(ptr, _Float64_BOXED_VALUE_OFFSET)
             printNumberWasmF64(asWasmF64, buffer)
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1332,7 +1332,7 @@ export enum JSONParseError {
 /**
  * Internal data structure used during parsing.
  */
-record JSONParserImplHelper {
+record JSONParserState {
   string: String,
   bufferParse: Buffer.Buffer,
   mut currentCodePoint: Number,
@@ -1457,43 +1457,43 @@ let codePointUTF8ByteCount = (usv: Number) => {
   }
 }
 
-let isAtEndOfInput = (parserImplHelper: JSONParserImplHelper) => {
-  parserImplHelper.currentCodePoint == _END_OF_INPUT
+let isAtEndOfInput = (parserState: JSONParserState) => {
+  parserState.currentCodePoint == _END_OF_INPUT
 }
 
-let next = (parserImplHelper: JSONParserImplHelper) => {
-  let mut c = parserImplHelper.currentCodePoint
+let next = (parserState: JSONParserState) => {
+  let mut c = parserState.currentCodePoint
   if (c != _END_OF_INPUT) {
-    parserImplHelper.bytePos = parserImplHelper.bytePos +
+    parserState.bytePos = parserState.bytePos +
     codePointUTF8ByteCount(c)
 
-    c = readCodePoint(parserImplHelper.bytePos, parserImplHelper.string)
+    c = readCodePoint(parserState.bytePos, parserState.string)
 
-    parserImplHelper.currentCodePoint = c
-    parserImplHelper.pos = parserImplHelper.pos + 1
+    parserState.currentCodePoint = c
+    parserState.pos = parserState.pos + 1
   }
   c
 }
 
-let skipWhiteSpace = (parserImplHelper: JSONParserImplHelper) => {
+let skipWhiteSpace = (parserState: JSONParserState) => {
   // isAtEndOfInput is not strictly necessary here
   // could remove as an optimization
   while (
-    isInterTokenWhiteSpace(parserImplHelper.currentCodePoint) &&
-    !isAtEndOfInput(parserImplHelper)
+    isInterTokenWhiteSpace(parserState.currentCodePoint) &&
+    !isAtEndOfInput(parserState)
   ) {
-    next(parserImplHelper)
+    next(parserState)
     void
   }
 }
 
 let buildUnexpectedTokenError =
   (
-    parserImplHelper: JSONParserImplHelper,
+    parserState: JSONParserState,
     detail: String,
   ) => {
-  let codePoint = parserImplHelper.currentCodePoint
-  let pos = parserImplHelper.pos
+  let codePoint = parserState.currentCodePoint
+  let pos = parserState.pos
   if (codePoint == _END_OF_INPUT) {
     UnexpectedEndOfInput(
       "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail
@@ -1539,58 +1539,58 @@ let formatCodePointOrEOF = (codePoint: Number) => {
 let expectCodePointAndAdvance =
   (
     expectedCodePoint: Number,
-    parserImplHelper: JSONParserImplHelper,
+    parserState: JSONParserState,
   ) => {
-  let c = parserImplHelper.currentCodePoint
+  let c = parserState.currentCodePoint
   if (c == expectedCodePoint) {
-    next(parserImplHelper)
+    next(parserState)
     None
   } else {
     let detail = "expected " ++
       formatCodePointOrEOF(expectedCodePoint) ++
       ", found " ++
       formatCodePointOrEOF(c)
-    Some(buildUnexpectedTokenError(parserImplHelper, detail))
+    Some(buildUnexpectedTokenError(parserState, detail))
   }
 }
 
-let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
-  skipWhiteSpace(parserImplHelper)
+let rec parseValue = (parserState: JSONParserState) => {
+  skipWhiteSpace(parserState)
 
-  let result = match (parserImplHelper.currentCodePoint) {
-    0x7B => parseObject(parserImplHelper), // '{'
-    0x5B => parseArray(parserImplHelper), // '['
-    0x22 => parseStringValue(parserImplHelper), // '"'
-    0x74 => parseTrueValue(parserImplHelper), // 't'
-    0x66 => parseFalseValue(parserImplHelper), // 'f'
-    0x6E => parseNullValue(parserImplHelper), // 'n'
+  let result = match (parserState.currentCodePoint) {
+    0x7B => parseObject(parserState), // '{'
+    0x5B => parseArray(parserState), // '['
+    0x22 => parseStringValue(parserState), // '"'
+    0x74 => parseTrueValue(parserState), // 't'
+    0x66 => parseFalseValue(parserState), // 'f'
+    0x6E => parseNullValue(parserState), // 'n'
     // TODO Check if having a match case for each digit would be faster or not.
     c when c >= 0x30 && c <= 0x39 || c == 0x2D =>
-      parseNumberValue(parserImplHelper), // '0'..'9' or '-'
+      parseNumberValue(parserState), // '0'..'9' or '-'
     c => {
       let detail = "expected start of a JSON value, found " ++
         formatCodePointOrEOF(c)
-      Err(buildUnexpectedTokenError(parserImplHelper, detail))
+      Err(buildUnexpectedTokenError(parserState, detail))
     },
   }
 
-  skipWhiteSpace(parserImplHelper)
+  skipWhiteSpace(parserState)
 
   result
-}, parseNullValue = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x6E, parserImplHelper)) {
+}, parseNullValue = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x6E, parserState)) {
     // 'n'
     Some(e) => Err(e),
     None => {
-      match (expectCodePointAndAdvance(0x75, parserImplHelper)) {
+      match (expectCodePointAndAdvance(0x75, parserState)) {
         // 'u'
         Some(e) => Err(e),
         None => {
-          match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+          match (expectCodePointAndAdvance(0x6C, parserState)) {
             // 'l'
             Some(e) => Err(e),
             None => {
-              match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+              match (expectCodePointAndAdvance(0x6C, parserState)) {
                 // 'l'
                 Some(e) => Err(e),
                 None => Ok(JSONNull),
@@ -1601,20 +1601,20 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       }
     },
   }
-}, parseTrueValue = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x74, parserImplHelper)) {
+}, parseTrueValue = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x74, parserState)) {
     // 't'
     Some(e) => Err(e),
     None => {
-      match (expectCodePointAndAdvance(0x72, parserImplHelper)) {
+      match (expectCodePointAndAdvance(0x72, parserState)) {
         // 'r'
         Some(e) => Err(e),
         None => {
-          match (expectCodePointAndAdvance(0x75, parserImplHelper)) {
+          match (expectCodePointAndAdvance(0x75, parserState)) {
             // 'u'
             Some(e) => Err(e),
             None => {
-              match (expectCodePointAndAdvance(0x65, parserImplHelper)) {
+              match (expectCodePointAndAdvance(0x65, parserState)) {
                 // 'e'
                 Some(e) => Err(e),
                 None => Ok(JSONBoolean(true)),
@@ -1625,24 +1625,24 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       }
     },
   }
-}, parseFalseValue = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x66, parserImplHelper)) {
+}, parseFalseValue = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x66, parserState)) {
     // 'f'
     Some(e) => Err(e),
     None => {
-      match (expectCodePointAndAdvance(0x61, parserImplHelper)) {
+      match (expectCodePointAndAdvance(0x61, parserState)) {
         // 'a'
         Some(e) => Err(e),
         None => {
-          match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+          match (expectCodePointAndAdvance(0x6C, parserState)) {
             // 'l'
             Some(e) => Err(e),
             None => {
-              match (expectCodePointAndAdvance(0x73, parserImplHelper)) {
+              match (expectCodePointAndAdvance(0x73, parserState)) {
                 // 's'
                 Some(e) => Err(e),
                 None => {
-                  match (expectCodePointAndAdvance(0x65, parserImplHelper)) {
+                  match (expectCodePointAndAdvance(0x65, parserState)) {
                     // 'e'
                     Some(e) => Err(e),
                     None => Ok(JSONBoolean(false)),
@@ -1655,20 +1655,20 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       }
     },
   }
-}, parseString = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x22, parserImplHelper)) {
+}, parseString = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x22, parserState)) {
     // '"'
     Some(e) => Err(e),
     None => {
       let mut err = None
       let mut done = false
-      let buffer = parserImplHelper.bufferParse
+      let buffer = parserState.bufferParse
       Buffer.clear(buffer)
 
       while (!done) {
-        match (parserImplHelper.currentCodePoint) {
+        match (parserState.currentCodePoint) {
           0x22 => { // '"'
-            next(parserImplHelper)
+            next(parserState)
             done = true
             break
           },
@@ -1678,58 +1678,58 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
           },
           0x5C => { // '\'
             // Keep the starting position for better error reporting.
-            let escapeStartPos = parserImplHelper.pos
+            let escapeStartPos = parserState.pos
 
-            next(parserImplHelper)
+            next(parserState)
 
-            match (parserImplHelper.currentCodePoint) {
+            match (parserState.currentCodePoint) {
               0x22 => { // '"'
                 Buffer.addChar('"', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x5C => { // '\'
                 Buffer.addChar('\\', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x2F => { // '/'
                 Buffer.addChar('/', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x62 => { // letter 'b' as in Backspace
                 // emit backspace control code
                 Buffer.addChar('\u{08}', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x66 => { // letter 'f' as in Form Feed
                 // emit Form Feed control code
                 Buffer.addChar('\u{0C}', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x6E => { // letter 'n' as in New line
                 // emit Line Feed control code
                 Buffer.addChar('\u{0A}', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x72 => { // letter 'r' as in carriage Return
                 // emit Carriage Return control code
                 Buffer.addChar('\u{0D}', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x74 => { // letter 't' as in Tab
                 // emit Tab control code
                 Buffer.addChar('\u{09}', buffer)
-                next(parserImplHelper)
+                next(parserState)
                 void
               },
               0x75 => { // 'u' (start of hexadecimal UTF-16 escape sequence)
-                next(parserImplHelper)
+                next(parserState)
 
                 // The escape sequence can either be a standalone code point or
                 // a UTF-16 surrogate pair made of two code units that have to
@@ -1752,7 +1752,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
                     digitIndex >= 0;
                     digitIndex -= 1
                   ) {
-                    let hexDigitCodePoint = parserImplHelper.currentCodePoint
+                    let hexDigitCodePoint = parserState.currentCodePoint
 
                     let mut digit = hexDigitCodePoint
 
@@ -1773,7 +1773,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
                       let detail = "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
                         runtimeToString(digitsSoFar)
                       err = Some(
-                        buildUnexpectedTokenError(parserImplHelper, detail)
+                        buildUnexpectedTokenError(parserState, detail)
                       )
                       break
                     }
@@ -1781,7 +1781,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
                     let shift = digitIndex * 4
                     codeUnit = codeUnit | digit << shift
 
-                    next(parserImplHelper)
+                    next(parserState)
                     void
                   }
 
@@ -1792,10 +1792,10 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
                     // Plane (U+0000..U+FFFF).
                     if (isHighSurrogate(codeUnit)) {
                       // Next characters should be "\u"
-                      err = expectCodePointAndAdvance(0x5C, parserImplHelper)
+                      err = expectCodePointAndAdvance(0x5C, parserState)
                       // '\'
                       if (Option.isSome(err)) break
-                      err = expectCodePointAndAdvance(0x75, parserImplHelper)
+                      err = expectCodePointAndAdvance(0x75, parserState)
                       // 'u'
                       if (Option.isSome(err)) break
 
@@ -1848,14 +1848,14 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
                 // Only the ones above.
                 let detail = "expected a valid escape sequence or the end of string, found " ++
                   formatCodePointOrEOF(unexpectedCodePoint)
-                err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+                err = Some(buildUnexpectedTokenError(parserState, detail))
                 break
               },
             }
           },
           c => {
             // Finally the happy case of a simple unescaped code point.
-            next(parserImplHelper)
+            next(parserState)
             addCharFromCodePoint(c, buffer)
           },
         }
@@ -1869,7 +1869,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
           } else {
             Err(
               buildUnexpectedTokenError(
-                parserImplHelper,
+                parserState,
                 "unexpected end of string value"
               )
             )
@@ -1879,18 +1879,18 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       }
     },
   }
-}, parseStringValue = (parserImplHelper: JSONParserImplHelper) => {
-  match (parseString(parserImplHelper)) {
+}, parseStringValue = (parserState: JSONParserState) => {
+  match (parseString(parserState)) {
     Ok(s) => Ok(JSONString(s)),
     Err(e) => Err(e),
   }
-}, parseNumberValue = (parserImplHelper: JSONParserImplHelper) => {
+}, parseNumberValue = (parserState: JSONParserState) => {
   // First char can optionally be a minus sign.
-  let mut c = parserImplHelper.currentCodePoint
+  let mut c = parserState.currentCodePoint
   let isNegative = c == 0x2D
   // '-'
   if (isNegative) {
-    c = next(parserImplHelper)
+    c = next(parserState)
   }
 
   let mut err = None
@@ -1923,7 +1923,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       // this function finishes with the parser positioned on a digit
       // and not on a token expected after a number like ',', ']', '}' or
       // EOF.
-      c = next(parserImplHelper)
+      c = next(parserState)
     },
     x when x >= 0x31 && x <= 0x39 => { // '1'..'9'
       for (;;) {
@@ -1931,7 +1931,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
 
         significand = significand * 10 + digit
 
-        c = next(parserImplHelper)
+        c = next(parserState)
 
         if (c < 0x30 || c > 0x39) {
           break
@@ -1945,13 +1945,13 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       // JSON doesn't allow numbers starting with decimal separator like ".1".
       let detail = "expected a decimal digit, found " ++
         formatCodePointOrEOF(unexpectedCodePoint)
-      err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+      err = Some(buildUnexpectedTokenError(parserState, detail))
     },
   }
 
   // Optional fractional part of the number.
   if (Option.isNone(err) && c == 0x2E) { // '.'
-    c = next(parserImplHelper)
+    c = next(parserState)
 
     // let mut decimalPos = 10
     // let mut denominator = 1
@@ -1962,7 +1962,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
 
       // denominator = denominator * 10
 
-      c = next(parserImplHelper)
+      c = next(parserState)
 
       exponent -= 1
     }
@@ -1971,16 +1971,16 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
 
   // Optional exponential part of the number.
   if (Option.isNone(err) && (c == 0x65 || c == 0x45)) { // 'e' or 'E'
-    c = next(parserImplHelper)
+    c = next(parserState)
 
     // can start with optional plus or minus sign
     isExponentNegative = match (c) {
       0x2D => { // '-'
-        c = next(parserImplHelper)
+        c = next(parserState)
         true
       },
       0x2B => { // '+'
-        c = next(parserImplHelper)
+        c = next(parserState)
         false
       },
       _ => {
@@ -1996,7 +1996,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
 
       explicitExponent = explicitExponent * 10 + digit
 
-      c = next(parserImplHelper)
+      c = next(parserState)
     }
 
     if (isExponentNegative) {
@@ -2042,8 +2042,8 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       Ok(JSONNumber(result))
     },
   }
-}, parseArray = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x5B, parserImplHelper)) {
+}, parseArray = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x5B, parserState)) {
     // '['
     Some(e) => Err(e),
     None => {
@@ -2054,14 +2054,14 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       let mut done = false
 
       while (!done) {
-        let c = parserImplHelper.currentCodePoint
+        let c = parserState.currentCodePoint
         match (c) {
           0x2C => { // ','
-            next(parserImplHelper)
-            skipWhiteSpace(parserImplHelper)
+            next(parserState)
+            skipWhiteSpace(parserState)
           },
           0x5D => { // ']'
-            next(parserImplHelper)
+            next(parserState)
             done = true
             break
           },
@@ -2071,7 +2071,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
           },
           _ => {
             // note that parseValue skips initial and final whitespace
-            match (parseValue(parserImplHelper)) {
+            match (parseValue(parserState)) {
               Ok(elem) => {
                 elems = [elem, ...elems]
                 void
@@ -2093,7 +2093,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
           } else {
             Err(
               buildUnexpectedTokenError(
-                parserImplHelper,
+                parserState,
                 "unexpected end of array"
               )
             )
@@ -2102,8 +2102,8 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
       }
     },
   }
-}, parseObject = (parserImplHelper: JSONParserImplHelper) => {
-  match (expectCodePointAndAdvance(0x7B, parserImplHelper)) {
+}, parseObject = (parserState: JSONParserState) => {
+  match (expectCodePointAndAdvance(0x7B, parserState)) {
     // '{'
     Some(e) => Err(e),
     None => {
@@ -2116,42 +2116,42 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
 
       // one iteration of this loop should correspond to a key-value pair
       while (!done) {
-        skipWhiteSpace(parserImplHelper)
+        skipWhiteSpace(parserState)
 
-        let c = parserImplHelper.currentCodePoint
+        let c = parserState.currentCodePoint
         match (c) {
           -1 => {
             let detail = "expected a key-value pair or the end of the object"
-            err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+            err = Some(buildUnexpectedTokenError(parserState, detail))
             break
           },
           0x2C => { // ','
             if (first) {
               let detail = "expected a key-value pair or the end of the object, found ','"
-              err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+              err = Some(buildUnexpectedTokenError(parserState, detail))
               break
             } else {
-              next(parserImplHelper)
+              next(parserState)
               void
             }
           },
           0x7D => { // '}'
-            next(parserImplHelper)
+            next(parserState)
             done = true
             break
           },
           _ => {
             // A new entry in current object.
             // Just call parseString directly. In case the current character id not '"', it will return an error we can pass along.
-            match (parseString(parserImplHelper)) {
+            match (parseString(parserState)) {
               Ok(key) => {
-                skipWhiteSpace(parserImplHelper)
+                skipWhiteSpace(parserState)
 
-                match (expectCodePointAndAdvance(0x3A, parserImplHelper)) {
+                match (expectCodePointAndAdvance(0x3A, parserState)) {
                   // ':'
                   None => {
                     // note that parseValue skips initial and final whitespace
-                    match (parseValue(parserImplHelper)) {
+                    match (parseValue(parserState)) {
                       Ok(value) => {
                         entries = [(key, value), ...entries]
                         first = false
@@ -2189,7 +2189,7 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
             // but in case it does, may just as well do the right thing.
             Err(
               buildUnexpectedTokenError(
-                parserImplHelper,
+                parserState,
                 "unexpected end of object"
               )
             )
@@ -2214,26 +2214,26 @@ let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
  * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
  */
 export let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
-  let parserImplHelper = {
+  let parserState = {
     string: str,
     bufferParse: Buffer.make(16),
     currentCodePoint: readCodePoint(0, str),
     pos: 0,
     bytePos: 0,
-  }: JSONParserImplHelper
+  }: JSONParserState
 
-  let root = parseValue(parserImplHelper)
+  let root = parseValue(parserState)
 
-  skipWhiteSpace(parserImplHelper)
+  skipWhiteSpace(parserState)
 
-  if (isAtEndOfInput(parserImplHelper)) {
+  if (isAtEndOfInput(parserState)) {
     root
   } else {
     match (root) {
       Ok(_) => {
         let detail = "expected end of input, found " ++
-          formatCodePointOrEOF(parserImplHelper.currentCodePoint)
-        Err(buildUnexpectedTokenError(parserImplHelper, detail))
+          formatCodePointOrEOF(parserState.currentCodePoint)
+        Err(buildUnexpectedTokenError(parserState, detail))
       },
       e => e,
     }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -8,7 +8,7 @@ include "runtime/bigint" as BI
 include "runtime/dataStructures"
 include "runtime/numbers"
 include "runtime/numberUtils"
-include "runtime/string" as RunTimeString
+include "runtime/string" as RuntimeString
 include "runtime/unsafe/memory"
 include "runtime/unsafe/memory"
 include "runtime/unsafe/tags"
@@ -23,69 +23,63 @@ include "list"
 include "number"
 include "option"
 include "uint8"
-from RunTimeString use { toString as runtimeToString, getCodePoint }
+from RuntimeString use { toString as runtimeToString, getCodePoint }
 from Numbers use { coerceNumberToWasmI32 }
 from DataStructures use { tagSimpleNumber, newFloat64, untagSimpleNumber }
 
 // Primitive offsets
-// TODO(703): Get these offsets from the runtime
+// TODO(#703): Get these offsets from the runtime
 @unsafe
 let _INT64_BOXED_VALUE_OFFSET = 8n
 @unsafe
 let _Float64_BOXED_VALUE_OFFSET = 8n
 
 /**
- * Data structure representing the result of parsing and the input of printing
- * JSON.
+ * Data structure representing the result of parsing and the input of printing JSON.
  *
- * For example this object
- * ```grain
- * JsonObject([
+ * @example
+ * Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
  *   ("currency", JsonString("€")),
  *   ("price", JsonNumber(99.99)),
  * ])
- * ```
- * is equivalent to the following JSON:
- * ```json
- * {"currency":"€","price":99.99}
- * ```
+ *
+ * @example
+ * Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
+ *   ("currency", JsonString("€")),
+ *   ("price", JsonNumber(99.99)),
+ * ])
  *
  * This data structure is semantically equivalent to the JSON format allowing
  * mostly lossless round trips of printing and parsing. Exceptions to this are
  * whitespace, multiple ways JSON allows escaping characters in strings, and
  * some edge cases related to Grain's `Number` type.
- *
- * For example parsing the following JSON text will also result in the same
- * `JSON` object as above.
- * ```json
- * {
- *   "currency": "\u20ac",
- *   "price": 99.99
- * }
- * ```
  */
-provide enum Json {
+provide enum rec Json {
   JsonNull,
   JsonBoolean(Bool),
   JsonNumber(Number),
   JsonString(String),
   JsonArray(List<Json>),
   // Note that JSONObject here is deliberately defined as a simple list of key value pair tuples as opposed
-  // to for example a Map in order to accomodate the fact that the ECMA-404 standard doesn't prohibit
+  // to for example a Map in order to accommodate the fact that the ECMA-404 standard doesn't prohibit
   // duplicate names in Objects. Such JSON should be representable by the JSON data structure for lossless
   // processing. This also simplifies implementation by not requiring a purpose built data structure and
-  // has the benefit of List's immutability. It's a concious decision that sacrifices ease of use of the
+  // has the benefit of List's immutability. It's a conscious decision that sacrifices ease of use of the
   // API for lossless handing of these edge cases with intention of later building more ergonomic APIs on a
   // higher level of abstraction.
   JsonObject(List<(String, Json)>),
 }
 
+// TODO(#992): Remove part about occurrence here because it is covered by the variant doc.
 /**
- * Represents errors for cases when a `JSON` object cannot be represente in the
+ * Represents errors for cases where a `JSON` object cannot be represented in the
  * JSON format along with a human readable text message. This can happen when
  * it contains number values `NaN`, `Infinity` or `-Infinity`.
  */
 provide enum JsonToStringError {
+  /**
+   * The JSON object contains a number value of `NaN`, `Infinity` or `-Infinity`.
+   */
   InvalidNumber(String),
 }
 
@@ -137,11 +131,24 @@ provide enum IndentationFormat {
  * Controls how arrays are printed in custom formatting.
  *
  * Following examples have whitespaces and line breaks replaced with visible
- * charactes for illustrative purposes.
+ * characters for illustrative purposes.
  *
  * `CompactArrayEntries`
  * ```
  * []
+ * ```
+ *
+ * ```
+ * [1]
+ * ```
+ *
+ * ```
+ * [1,2,3]
+ * ```
+ *
+ * `SpacedArrayEntries`
+ * ```
+ * [ ]
  * ```
  *
  * ```
@@ -173,6 +180,7 @@ provide enum IndentationFormat {
  */
 provide enum ArrayFormat {
   CompactArrayEntries,
+  SpacedArrayEntries,
   OneArrayEntryPerLine,
 }
 
@@ -180,7 +188,7 @@ provide enum ArrayFormat {
  * Controls how objects are printed in custom formatting.
  *
  * Following examples have whitespaces and line breaks replaced with visible
- * charactes for illustrative purposes.
+ * characters for illustrative purposes.
  *
  * `CompactObjectEntries`
  * ```
@@ -193,6 +201,19 @@ provide enum ArrayFormat {
  *
  * ```
  * {"a":1,"b":2,"c":3}
+ * ```
+ *
+ * `SpacedObjectEntries`
+ * ```
+ * { }
+ * ```
+ *
+ * ```
+ * {"a": 1}
+ * ```
+ *
+ * ```
+ * {"a": 1, "b": 2, "c": 3}
  * ```
  *
  * `OneObjectEntryPerLine`
@@ -216,6 +237,7 @@ provide enum ArrayFormat {
  */
 provide enum ObjectFormat {
   CompactObjectEntries,
+  SpacedObjectEntries,
   OneObjectEntryPerLine,
 }
 
@@ -368,16 +390,16 @@ provide let defaultPrettyAndSafeFormat = {
 
 record JsonWriterCompactImplHelper {
   buffer: Buffer.Buffer,
-  emitEscapedQuotedString: String -> Void,
+  emitEscapedQuotedString: String => Void,
 }
 
 record JsonWriterPrettyImplHelper {
   format: FormattingSettings,
   //TODO(#775): Note that the "Pretty" suffix here is a workaround for a Grain compiler bug.
   bufferPretty: Buffer.Buffer,
-  emitEscapedQuotedStringPretty: String -> Void,
-  printNewLine: () -> Void,
-  printIndentation: Number -> Void,
+  emitEscapedQuotedStringPretty: String => Void,
+  printNewLine: () => Void,
+  printIndentation: Number => Void,
 }
 
 // The idea for this type is to allow reusing a bit of work done in preparing for printing JSON.
@@ -385,7 +407,7 @@ record JsonWriterPrettyImplHelper {
 // It may make sense in the future to expose it and let the user reuse a writer for multiple
 // JSON emit operations without reallocating new closures and buffers each time.
 record JsonWriter {
-  emit: Json -> Option<JsonToStringError>,
+  emit: Json => Option<JsonToStringError>,
 }
 
 let addCharFromCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
@@ -394,7 +416,7 @@ let addCharFromCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
 
 let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
   // Emit the "\u" followed by hexadecimal representation of the codepoint
-  // with fixed length of 4 hexadecimal digits correspondeing to the two byte
+  // with fixed length of 4 hexadecimal digits corresponding to the two byte
   // codepoint. No checks are performed here if the codepoint is in the
   // "Basic Multilingual Plane" (0000-FFFF) as this funcion is only called
   // internally.
@@ -403,27 +425,27 @@ let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
   // optimization this loop could be unrolled possibly even converted to be
   // branchless and SIMD optimized, but it could be a bit of an overkill as
   // this codepath is only for escape sequences, which probably aren't all
-  // that common occurence.
+  // that common occurrence.
 
   Buffer.addChar('\\', buffer)
   Buffer.addChar('u', buffer)
   // Loop over the four digit from most to least significant.
   for (let mut digitIndex = 3; digitIndex >= 0; digitIndex -= 1) {
     // Use bit masking and shifting to extract from the codepoint a number
-    // with just the bits corresponding to this hexadecinak digit.
+    // with just the bits corresponding to this hexadecimal digit.
     let shift = digitIndex * 4
     let mask = 0b1111 << shift
     let digit = (codePoint & mask) >>> shift
 
     // Digit now is a number in the range 0..15 and we need to translate it
-    // into a unicode codepoint representing the hexacedimal digit
+    // into a unicode codepoint representing the hexadecimal digit
     // (0..9/a..f). We can use the fact that digits and latin letters in
     // ASCII and by extension in Unicode are adjacent and ordered.
     let hexDigitCodePoint = if (digit <= 9) {
-      // 48 is codeppoint for char '0'
+      // 48 is codepoint for char '0'
       digit + 48
     } else {
-      // 97 is codeppoint for char 'a'
+      // 97 is codepoint for char 'a'
       // But we also need to subtract 10 from it because we need
       // the 10..15 number range translated to 0..5 in order to
       // serve as an index in the ASCI range 'a'..'f'.
@@ -439,7 +461,6 @@ let emitEscapedUnicodeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
   // If the code point is "in the Basic Multilingual Plane", that is in range
   // 0..65535. Greater values need to be split into two UTF-16 chunks.
   if (codePoint <= 0xFFFF) {
-    // emitUTF16EscapeSequence(codePoint, writer)
     emitUTF16EscapeSequence(codePoint, buffer)
   } else {
     // The following three lines are copied from String module of Grain's
@@ -582,11 +603,11 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
             from WasmF64 use { (/) }
-            // As a compromnise, convert the rational into a float
+            // As a compromise, convert the rational into a float
             // and then print that. This means there can be
             // precision loss even for values that could be printed
             // exactly in decimal notation, but doing otherwise
-            // could both compromise perfomance and confuse
+            // could both compromise performance and confuse
             // developers as most JSON libraries in other languages
             // likely only deal with integers and floats.
             // Note that the ECMA-404 standard only specifies how
@@ -783,13 +804,7 @@ let makeCompactJsonWriter = (buffer: Buffer.Buffer) => {
     emitEscapedQuotedString,
   }: JsonWriterCompactImplHelper
 
-  {
-    emit: json => {
-      let error = printElementCompact(json, implHelper)
-
-      error
-    },
-  }: JsonWriter
+  { emit: json => printElementCompact(json, implHelper), }: JsonWriter
 }
 
 // Note that this could relatively easily be integrated with
@@ -820,6 +835,9 @@ let rec printElementPretty =
       match (elems) {
         [] => {
           Buffer.addChar('[', buffer)
+          if (implHelper.format.arrayFormat == SpacedArrayEntries) {
+            Buffer.addChar(' ', buffer)
+          }
           Buffer.addChar(']', buffer)
           return None
         },
@@ -867,6 +885,9 @@ let rec printElementPretty =
           for (let mut index = 0; ; index += 1) {
             if (index > 0) {
               Buffer.addChar(',', buffer)
+              if (format.arrayFormat == SpacedArrayEntries) {
+                Buffer.addChar(' ', buffer)
+              }
 
               if (format.arrayFormat == OneArrayEntryPerLine) {
                 implHelper.printNewLine()
@@ -904,6 +925,9 @@ let rec printElementPretty =
       match (entries) {
         [] => {
           Buffer.addChar('{', buffer)
+          if (implHelper.format.objectFormat == SpacedObjectEntries) {
+            Buffer.addChar(' ', buffer)
+          }
           Buffer.addChar('}', buffer)
           return None
         },
@@ -921,12 +945,10 @@ let rec printElementPretty =
 
           implHelper.emitEscapedQuotedStringPretty(key)
 
+          Buffer.addChar(':', buffer)
           match (format.objectFormat) {
-            CompactObjectEntries => {
-              Buffer.addChar(':', buffer)
-            },
-            OneObjectEntryPerLine => {
-              Buffer.addChar(':', buffer)
+            CompactObjectEntries => void,
+            SpacedObjectEntries | OneObjectEntryPerLine => {
               Buffer.addChar(' ', buffer)
             },
           }
@@ -960,6 +982,9 @@ let rec printElementPretty =
           for (let mut index = 0; ; index += 1) {
             if (index > 0) {
               Buffer.addChar(',', buffer)
+              if (format.objectFormat == SpacedObjectEntries) {
+                Buffer.addChar(' ', buffer)
+              }
 
               if (format.objectFormat == OneObjectEntryPerLine) {
                 implHelper.printNewLine()
@@ -974,12 +999,10 @@ let rec printElementPretty =
 
             implHelper.emitEscapedQuotedStringPretty(key)
 
+            Buffer.addChar(':', buffer)
             match (format.objectFormat) {
-              CompactObjectEntries => {
-                Buffer.addChar(':', buffer)
-              },
-              OneObjectEntryPerLine => {
-                Buffer.addChar(':', buffer)
+              CompactObjectEntries => void,
+              SpacedObjectEntries | OneObjectEntryPerLine => {
                 Buffer.addChar(' ', buffer)
               },
             }
@@ -1073,7 +1096,7 @@ let makePrettyPrintJsonWriter =
   }
 
   // A possible optimization to make this faster would be to
-  // prepare a different closure for each combination fo escaping options.
+  // prepare a different closure for each combination of escaping options.
   // This way unnecessary branching is avoided.
   // The most important thing is that the non pretty printed format is optimized for
   // as this is where the performance is most likely to matter.
@@ -1205,9 +1228,7 @@ let makePrettyPrintJsonWriter =
   let implHelper = {
     format,
     bufferPretty: buffer,
-    emitEscapedQuotedStringPretty: s => {
-      emitEscapedQuotedString(s)
-    },
+    emitEscapedQuotedStringPretty: emitEscapedQuotedString,
     printNewLine,
     printIndentation,
   }: JsonWriterPrettyImplHelper
@@ -1231,47 +1252,38 @@ let makePrettyPrintJsonWriter =
  *
  * @example
  * print(
- *   Result.unwrap(
- *     toString(
- *       format=Custom(defaultCompactAndSafeFormat),
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *     )
+ *   toString(
+ *     format=Custom(defaultCompactAndSafeFormat),
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *   )
  * )
- * // Output: {"currency":"\u20ac","price":99.9}"
+ * // Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
  * @example
  * print(
- *   Result.unwrap(
- *     toString(
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
- *     )
+ *   toString(
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
  *   )
  * )
- * // Output: {"currency":"€","price":99.9}
+ * // Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
  * @example
  * print(
- *   Result.unwrap(
- *     toString(
- *       format=Compact
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *      )
+ *   toString(
+ *     format=Compact
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *   )
  * )
- * // Output: {"currency":"€","price":99.9}
+ * // Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
  * @example
  * print(
- *   Result.unwrap(
- *     toString(
- *       format=Pretty,
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *     )
+ *   toString(
+ *     format=Pretty,
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *   )
  * )
- * // Output:
- * // {
- * // "currency": "€",
- * // "price": 99.9
- * //}
+ * // Output: Ok("{
+ * // \"currency\": \"€\",
+ * // \"price\": 99.9
+ * //}")
  *
  * @since v0.6.0
  */
@@ -1817,7 +1829,7 @@ and parseStringValue = (parserState: JsonParserState) => {
   }
 }
 and parseNumberValue = (parserState: JsonParserState) => {
-  // TODO: Use a streaming-optimized way to parse numbers
+  // TODO(#1878): Use a streaming-optimized way to parse numbers
   let buffer = parserState.bufferParse
   Buffer.clear(buffer)
   // First char can optionally be a minus sign.
@@ -1924,7 +1936,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
     true => {
       let str = Buffer.toString(buffer)
       match (Number.parseFloat(str)) {
-        Err(err) => fail "Impossible",
+        Err(err) => fail "Impossible: Json parse float on invalid float",
         Ok(n) => n,
       }
     },
@@ -2112,22 +2124,22 @@ and parseObject = (parserState: JsonParserState) => {
 }
 
 /**
- * Parses JSON input from a string into a `JSON` object.
+ * Parses JSON string into a `Json` data structure.
  *
  * @param str: The JSON text string
  * @returns A `Result` object with either the parsed `JSON` object or an error.
  *
- *
- * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
- *
- * Example output:
- * ```
- * Ok(JsonObject([("currency", JsonString("$")), ("price", JsonNumber(119))]))
- * ```
+ * @example
+ * assert parse("{\"currency\":\"$\",\"price\":119}") == Ok(
+ *  JsonObject([
+ *    ("currency", JsonString("$")),
+ *    ("price", JsonNumber(119))
+ *  ])
+ * )
  *
  * @since v0.6.0
  */
-provide let parse: String -> Result<Json, JsonParseError> = (str: String) => {
+provide let parse: String => Result<Json, JsonParseError> = (str: String) => {
   let parserState = {
     string: str,
     bufferParse: Buffer.make(16),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -55,13 +55,14 @@ export enum JSON {
   JSONBoolean(Bool),
   JSONNumber(Number),
   JSONString(String),
-  // Here I've chosen to use a List and not an array as a conscious trade of performance for immutability.
-  // I'd love to use a more advanced persistent collection instead, but there currently aren't any in Grain.
   JSONArray(List<JSON>),
   // Note that JSONObject here is deliberately defined as a simple list of key value pair tuples as opposed
   // to for example a Map in order to accomodate the fact that the ECMA-404 standard doesn't prohibit
   // duplicate names in Objects. Such JSON should be representable by the JSON data structure for lossless
-  // processing. This also vastly simplifies implementation and has the benefit of List's immutability.
+  // processing. This also simplifies implementation by not requiring a purpose built data structure and
+  // has the benefit of List's immutability. It's a concious decision that sacrifices ease of use of the
+  // API for lossless handing of these edge cases with intention of later building more ergonomic APIs on a
+  // higher level of abstraction.
   JSONObject(List<(String, JSON)>),
 }
 

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -783,9 +783,7 @@ let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
 
   let implHelper = {
     buffer,
-    emitEscapedQuotedString: s => {
-      emitEscapedQuotedString(s)
-    },
+    emitEscapedQuotedString,
   }: JSONWriterCompactImplHelper
 
   {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -979,6 +979,15 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
           count += 1
         }
       }),
+    IndentWithSpaces(spacesPerIndentation) when spacesPerIndentation == 2 =>
+      Some(indentationLevel => {
+        let mut count = 0
+        let spaceCount = indentationLevel * 2
+        while (count < spaceCount) {
+          Buffer.addChar(' ', buffer)
+          count += 1
+        }
+      }),
     IndentWithSpaces(spacesPerIndentation) =>
       Some(indentationLevel => {
         let mut count = 0

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -483,75 +483,34 @@ let printBool = (b: Bool, buffer: Buffer.Buffer) => {
 
 exception UnknownNumberTag
 
-// The following few functions are only meant to be called from a @disableGC
-// context of the printNumber function so there's no need to do all the
-// reference adjustment for the parameters and the functions themselves.
-
-@disableGC
+@unsafe
 let printNumberWasmI32 = (value: WasmI32, buffer: Buffer.Buffer) => {
   let s = NumberUtils.itoa32(value, 10n)
-
-  Memory.incRef(WasmI32.fromGrain(Buffer.addString))
-  Memory.incRef(WasmI32.fromGrain(s))
-  Memory.incRef(WasmI32.fromGrain(buffer))
   Buffer.addString(s, buffer)
-
-  Memory.decRef(WasmI32.fromGrain(s))
-
-  let none = None
-  Memory.incRef(WasmI32.fromGrain(none))
-  none
 }
 
-@disableGC
+@unsafe
 let printNumberWasmI64 = (value: WasmI64, buffer: Buffer.Buffer) => {
   let s = NumberUtils.itoa64(value, 10n)
-
-  Memory.incRef(WasmI32.fromGrain(Buffer.addString))
-  Memory.incRef(WasmI32.fromGrain(s))
-  Memory.incRef(WasmI32.fromGrain(buffer))
   Buffer.addString(s, buffer)
-
-  Memory.decRef(WasmI32.fromGrain(s))
-
-  let none = None
-  Memory.incRef(WasmI32.fromGrain(none))
-  none
 }
 
-@disableGC
+@unsafe
 let isFinite = (value: WasmF64) => {
   WasmF64.eq(WasmF64.sub(value, value), 0.W)
 }
 
-@disableGC
+@unsafe
 let isNaN = (value: WasmF64) => {
   WasmF64.ne(value, value)
 }
 
-let makeNaNError = () => Some(InvalidNumber("NaN is not allowed in JSONNumber"))
-
-let makeInfError = () =>
-  Some(InvalidNumber("Infinity is not allowed in JSONNumber"))
-
-let makeNegInfError = () =>
-  Some(InvalidNumber("-Infinity is not allowed in JSONNumber"))
-
-@disableGC
+@unsafe
 let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
-  let result = if (isFinite(value)) {
+  if (isFinite(value)) {
     let s = NumberUtils.dtoa(value)
-
-    Memory.incRef(WasmI32.fromGrain(Buffer.addString))
-    Memory.incRef(WasmI32.fromGrain(s))
-    Memory.incRef(WasmI32.fromGrain(buffer))
     Buffer.addString(s, buffer)
-
-    Memory.decRef(WasmI32.fromGrain(s))
-
-    let none = None
-    Memory.incRef(WasmI32.fromGrain(none))
-    none
+    None
   } else {
     // JSON standard doesn't allow NaN or infinite values in numbers,
     // but WASM f64 (IEEE 754-2008), as well as Grain's number types do
@@ -561,23 +520,16 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     // coninue formatting without representing these values correctly
     // (like JavaScript's JSON.stringify).
     if (isNaN(value)) {
-      // Allocating the exception in a function without @disableGC makes
-      // it easier to avoid problems with reference counting.
-      Memory.incRef(WasmI32.fromGrain(makeNaNError))
-      makeNaNError()
+      Some(InvalidNumber("NaN is not allowed in JSONNumber"))
     } else if (WasmF64.lt(value, 0.0W)) {
-      Memory.incRef(WasmI32.fromGrain(makeNegInfError))
-      makeNegInfError()
+      Some(InvalidNumber("-Infinity is not allowed in JSONNumber"))
     } else {
-      Memory.incRef(WasmI32.fromGrain(makeInfError))
-      makeInfError()
+      Some(InvalidNumber("Infinity is not allowed in JSONNumber"))
     }
   }
-
-  result
 }
 
-@disableGC
+@unsafe
 let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
   let (&) = WasmI32.and
   let (==) = WasmI32.eq
@@ -586,10 +538,11 @@ let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
   let (>>) = WasmI32.shrS
 
   let ptr = WasmI32.fromGrain(value)
-  let result = if ((ptr & 1n) != 0n) {
+  if ((ptr & 1n) != 0n) {
     // FIXME expose runtime/numbers.untagSimple?
     let asWasmI32 = ptr >> 1n
     printNumberWasmI32(asWasmI32, buffer)
+    None
   } else if ((ptr & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
     let tag = WasmI32.load(ptr, 0n)
     match (tag) {
@@ -600,11 +553,13 @@ let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
             let asWasmI32 = WasmI32.load(ptr, 8n)
             // FIXME magic numbers
             printNumberWasmI32(asWasmI32, buffer)
+            None
           },
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
             let asWasmI64 = WasmI64.load(ptr, 8n)
             // FIXME magic numbers
             printNumberWasmI64(asWasmI64, buffer)
+            None
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
             // As a compromnise, convert the rational into a float
@@ -650,12 +605,6 @@ let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
   } else {
     throw UnknownNumberTag
   }
-
-  Memory.decRef(WasmI32.fromGrain(value))
-  Memory.decRef(WasmI32.fromGrain(buffer))
-  Memory.decRef(WasmI32.fromGrain(printNumber))
-
-  result
 }
 
 // Note that this function is not allocated with the JSONWriter because currently
@@ -1567,15 +1516,10 @@ let buildUnexpectedTokenError =
   }
 }
 
-@disableGC
+@unsafe
 let rec toHex = (n: Number) => {
   let x = coerceNumberToWasmI32(n)
-  let result = NumberUtils.itoa32(x, 16n)
-
-  Memory.decRef(WasmI32.fromGrain(n))
-  Memory.decRef(WasmI32.fromGrain(toHex))
-
-  result
+  NumberUtils.itoa32(x, 16n)
 }
 
 let toHexWithZeroPadding = (n: Number, padTo: Number) => {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1223,7 +1223,7 @@ let makePrettyPrintJsonWriter =
 
       String.forEachCodePoint(codePoint => {
         if (codePoint == 47) {
-          if (format.escapeHTMLUnsafeSequences && prevCodePoint == 60) {
+          if (prevCodePoint == 60) {
             Buffer.addChar('\\', buffer)
             Buffer.addChar('/', buffer)
           } else {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -417,7 +417,7 @@ provide enum FormattingChoices {
   },
 }
 
-record JsonWriterImplHelper {
+record JsonWriterConfig {
   format: FormattingSettings,
   buffer: Buffer.Buffer,
   emitEscapedQuotedStringPretty: String => Void,
@@ -659,7 +659,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
 let rec printElementPretty =
   (
     json: Json,
-    implHelper: JsonWriterImplHelper,
+    implHelper: JsonWriterConfig,
     indentationLevel: Number,
   ) => {
   let buffer = implHelper.buffer
@@ -1136,7 +1136,7 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
     emitEscapedQuotedStringPretty: emitEscapedQuotedString,
     printNewLine,
     printIndentation,
-  }: JsonWriterImplHelper
+  }: JsonWriterConfig
 
   {
     emit: json => {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -76,11 +76,9 @@ provide enum rec Json {
   JsonObject(List<(String, Json)>),
 }
 
-// TODO(#992): Remove part about occurrence here because it is covered by the variant doc.
 /**
  * Represents errors for cases where a `JSON` object cannot be represented in the
- * JSON format along with a human readable text message. This can happen when
- * it contains number values `NaN`, `Infinity` or `-Infinity`.
+ * JSON format along with a human readable text message.
  */
 provide enum JsonToStringError {
   /**
@@ -305,8 +303,6 @@ provide enum FormattingChoices {
    * ··"currencyDescription":·"EURO\u007f",↵
    * }
    * ```
-   *
-   * @since v0.6.0
    */
   Pretty,
   /**
@@ -334,10 +330,8 @@ provide enum FormattingChoices {
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
    * ```
-   * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+   * {"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
    * ```
-   *
-   * @since v0.6.0
    */
   Compact,
   /**
@@ -368,11 +362,8 @@ provide enum FormattingChoices {
    * ··"currency":·"\u20ac",↵
    * ··"price":·99.9,↵
    * ··"currencyDescription":·"EURO\u007f",↵
-   * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
    * }
    * ```
-   *
-   * @since v0.6.0
    */
   PrettyAndSafe,
   /**
@@ -399,16 +390,12 @@ provide enum FormattingChoices {
    * The following example have whitespaces, line breaks and control points
    * replaced with visible characters.
    * ```
-   * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+   * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
    * ```
-   *
-   * @since v0.6.0
    */
   CompactAndSafe,
   /**
    * Allows for fined grained control of the formatting output.
-   *
-   * @since v0.6.0
    */
   Custom{
     indentation: IndentationFormat,

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1,7 +1,7 @@
 /**
  * JSON (JavaScript Object Notation) parsing, printing, and access utilities.
  *
- * @example include "json"
+ * @example from "json" include Json
  * @example Json.parse("{\"currency\":\"€\",\"price\":99.99}")
  * @example
  * print(
@@ -40,7 +40,7 @@ let _INT64_BOXED_VALUE_OFFSET = 8n
 let _Float64_BOXED_VALUE_OFFSET = 8n
 
 /**
- * Data structure representing the result of parsing and the input of printing JSON.
+ * Data structure representing JSON in Grain.
  *
  * @example
  * assert Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
@@ -71,30 +71,27 @@ provide enum rec Json {
 }
 
 /**
- * Represents errors for cases where a `JSON` object cannot be represented in the
- * JSON format along with a human readable text message.
+ * Represents errors for cases where a `Json` data structure cannot be represented as a
+ * JSON string.
  */
 provide enum JsonToStringError {
   /**
-   * The JSON object contains a number value of `NaN`, `Infinity` or `-Infinity`.
+   * The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`
    */
   InvalidNumber(String),
 }
 
 /**
- * Controls how indentation is performed in custom formatting.
- *
- * The following examples have whitespaces and line breaks replaced with visible
- * characters for illustrative purposes.
+ * Controls how indentation is outputted in custom formatting.
  */
 provide enum IndentationFormat {
   /**
    * No indentation is emitted.
    *
    * ```json
-   * {↵
-   * "currency":·"€",↵
-   * "price":·99.9↵
+   * {
+   * "currency":·"€",
+   * "price":·99.9
    * }
    * ```
    */
@@ -103,9 +100,9 @@ provide enum IndentationFormat {
    * Tabs are emitted.
    *
    * ```json
-   * {↵
-   * →"currency":·"€",↵
-   * →"price":·99.9↵
+   * {
+   *   "currency":·"€",
+   *   "price":·99.9
    * }
    * ```
    */
@@ -115,17 +112,17 @@ provide enum IndentationFormat {
    *
    * `IndentWithSpaces(2)`
    * ```json
-   * {↵
-   * ··"currency":·"€",↵
-   * ··"price":·99.9↵
+   * {
+   * ··"currency":·"€",
+   * ··"price":·99.9
    * }
    * ```
    *
    * `IndentWithSpaces(4)`
    * ```json
-   * {↵
-   * ····"currency":·"€",↵
-   * ····"price":·99.9↵
+   * {
+   * ····"currency":·"€",
+   * ····"price":·99.9
    * }
    * ```
    */
@@ -133,10 +130,7 @@ provide enum IndentationFormat {
 }
 
 /**
- * Controls how arrays are printed in custom formatting.
- *
- * The following examples have whitespaces and line breaks replaced with visible
- * characters for illustrative purposes.
+ * Controls how arrays are outputted in custom formatting.
  */
 provide enum ArrayFormat {
   /**
@@ -179,16 +173,16 @@ provide enum ArrayFormat {
    * ```
    *
    * ```json
-   * [↵
-   * ··1↵
+   * [
+   * ··1
    * ]
    * ```
    *
    * ```json
-   * [↵
-   * ··1,↵
-   * ··2,↵
-   * ··3↵
+   * [
+   * ··1,
+   * ··2,
+   * ··3
    * ]
    * ```
    */
@@ -196,10 +190,7 @@ provide enum ArrayFormat {
 }
 
 /**
- * Controls how objects are printed in custom formatting.
- *
- * The following examples have whitespaces and line breaks replaced with visible
- * characters for illustrative purposes.
+ * Controls how objects are outputted in custom formatting.
  */
 provide enum ObjectFormat {
   /**
@@ -242,16 +233,16 @@ provide enum ObjectFormat {
    * ```
    *
    * ```
-   * {↵
-   * ··"a":·1↵
+   * {
+   * ··"a":·1
    * }
    * ```
    *
    * ```
-   * {↵
-   * ··"a":·1,↵
-   * ··"b":·2,↵
-   * ··"c":·3↵
+   * {
+   * ··"a":·1,
+   * ··"b":·2,
+   * ··"c":·3
    * }
    * ```
    */
@@ -259,7 +250,7 @@ provide enum ObjectFormat {
 }
 
 /**
- * Controls line ending type in custom formatting.
+ * Controls how line endings are outputted in custom formatting.
  */
 provide enum LineEnding {
   /**
@@ -281,7 +272,7 @@ provide enum LineEnding {
 }
 
 /*
- * Allows fine-grained control of formatting in JSON printing.
+ * Allows fine-grained control of formatting in JSON output.
  */
 record FormattingSettings {
   indentation: IndentationFormat,
@@ -295,13 +286,13 @@ record FormattingSettings {
 }
 
 /**
- * Allows control of formatting in JSON printing.
+ * Allows control of formatting in JSON output.
  */
 provide enum FormattingChoices {
   /**
    * Recommended human readable formatting.
    *
-   * Escapes all control points for the sake of clarity, but prints unicode
+   * Escapes all control points for the sake of clarity, but outputs unicode
    * codepoints directly so the result needs to be treated as proper unicode and
    * is not safe to be transported in ASCII encoding.
    *
@@ -319,13 +310,11 @@ provide enum FormattingChoices {
    * }
    * ```
    *
-   * The following example have whitespaces, line breaks and control points
-   * replaced with visible characters.
    * ```json
-   * {↵
-   * ··"currency":·"€",↵
-   * ··"price":·99.9,↵
-   * ··"currencyDescription":·"EURO\u007f",↵
+   * {
+   * ··"currency":·"€",
+   * ··"price":·99.9,
+   * ··"currencyDescription":·"EURO\u007f",
    * }
    * ```
    */
@@ -352,8 +341,6 @@ provide enum FormattingChoices {
    * }
    * ```
    *
-   * The following example have whitespaces, line breaks and control points
-   * replaced with visible characters.
    * ```json
    * {"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
    * ```
@@ -380,13 +367,11 @@ provide enum FormattingChoices {
    * }
    * ```
    *
-   * The following example have whitespaces, line breaks and control points
-   * replaced with visible characters.
    * ```json
-   * {↵
-   * ··"currency":·"\u20ac",↵
-   * ··"price":·99.9,↵
-   * ··"currencyDescription":·"EURO\u007f",↵
+   * {
+   * ··"currency":·"\u20ac",
+   * ··"price":·99.9,
+   * ··"currencyDescription":·"EURO\u007f",
    * }
    * ```
    */
@@ -412,8 +397,6 @@ provide enum FormattingChoices {
    * }
    * ```
    *
-   * The following example have whitespaces, line breaks and control points
-   * replaced with visible characters.
    * ```json
    * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
    * ```
@@ -1170,11 +1153,11 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
 }
 
 /**
- * Prints the JSON object into a string with specific formatting settings.
+ * Converts the `Json` data structure into a JSON string with specific formatting settings.
  *
  * @param format: Formatting options
- * @param json: The JSON object to print
- * @returns `Ok(str)` containing the printed JSON or `Err(err)` if the inputted object cannot be represented in the JSON format.,
+ * @param json: The `Json` data structure to convert
+ * @returns `Ok(str)` containing the JSON string or `Err(err)` if the provided `Json` data structure cannot be converted to a string
  *
  * @example
  * assert toString(
@@ -1288,7 +1271,7 @@ provide let toString = (format=Compact, json: Json) => {
 }
 
 /**
- * Represents errors for JSON parsing along with a human readable text message.
+ * Represents errors for JSON parsing along with a human readable message.
  */
 provide enum JsonParseError {
   UnexpectedEndOfInput(String),
@@ -1296,7 +1279,7 @@ provide enum JsonParseError {
   InvalidUTF16SurrogatePair(String),
 }
 
-/**
+/*
  * Internal data structure used during parsing.
  */
 record JsonParserState {
@@ -2060,8 +2043,8 @@ and parseObject = (parserState: JsonParserState) => {
 /**
  * Parses JSON string into a `Json` data structure.
  *
- * @param str: The JSON text string
- * @returns `Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise.
+ * @param str: The JSON string to parse
+ * @returns `Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise
  *
  * @example
  * assert parse("{\"currency\":\"$\",\"price\":119}") == Ok(

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1152,8 +1152,8 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
 /**
  * Prints the JSON object into a string with specific formatting settings.
  *
- * @param json: The JSON object to print
  * @param format: formatting option
+ * @param json: The JSON object to print
  * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
  *
  * @example
@@ -2078,7 +2078,10 @@ and parseObject = (parserState: JsonParserState) => {
  *
  * @since v0.6.0
  */
-provide let parse: String => Result<Json, JsonParseError> = (str: String) => {
+provide let parse: (str: String) => Result<Json, JsonParseError> =
+  (
+    str: String,
+  ) => {
   let parserState = {
     string: str,
     bufferParse: Buffer.make(16),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1,0 +1,2308 @@
+/**
+ * @module Json: JSON (JavaScript Object Notation) parsing and printing.
+ */
+
+import String from "string"
+import Char from "char"
+import List from "list"
+import Option from "option"
+import Number from "number"
+import WasmI32 from "runtime/unsafe/wasmi32"
+import WasmI64 from "runtime/unsafe/wasmi64"
+import WasmF32 from "runtime/unsafe/wasmf32"
+import WasmF64 from "runtime/unsafe/wasmf64"
+import NumberUtils from "runtime/numberUtils"
+import Tags from "runtime/unsafe/tags"
+import Numbers from "runtime/numbers"
+import Memory from "runtime/unsafe/memory"
+import Buffer from "buffer"
+import { toString as runtimeToString } from "runtime/string"
+import { coerceNumberToWasmI32 } from "runtime/numbers"
+import { tagSimpleNumber } from "runtime/dataStructures"
+
+/**
+ * Data structure representing the result of parsing and the input of printing
+ * JSON.
+ * 
+ * For example this object
+ * ```grain
+ * JSONObject([
+ *   ("currency", JSONString("€")),
+ *   ("price", JSONNumber(99.99)),
+ * ])
+ * ```
+ * is equivalent to the following JSON:
+ * ```json
+ * {"currency":"€","price":99.99}
+ * ```
+ * 
+ * This data structure is semantically equivalent to the JSON format allowing
+ * mostly lossless round trips of printing and parsing. Exceptions to this are
+ * white spaces, multiple ways JSON allows escaping characters in strings and
+ * some edge-cases related to Grain's `Number` type.
+ * 
+ * For example parsing the following JSON text will also result in the same
+ * `JSON` object as above.
+ * ```json
+ * {
+ *   "currency": "\u20ac",
+ *   "price": 99.99
+ * }
+ * ```
+ */
+export enum JSON {
+  JSONNull,
+  JSONBoolean(Bool),
+  JSONNumber(Number),
+  JSONString(String),
+  // Here I've chosen to use a List and not an array as a conscious trade of performance for immutability.
+  // I'd love to use a more advanced persistent collection instead, but there currently aren't any in Grain.
+  JSONArray(List<JSON>),
+  // Note that JSONObject here is deliberately defined as a simple list of key value pair tuples as opposed
+  // to for example a Map in order to accomodate the fact that the ECMA-404 standard doesn't prohibit
+  // duplicate names in Objects. Such JSON should be representable by the JSON data structure for lossless
+  // processing. This also vastly simplifies implementation and has the benefit of List's immutability.
+  JSONObject(List<(String, JSON)>),
+}
+
+/**
+ * Represents errors for cases when a `JSON` object cannot be represente in the
+ * JSON format along with a human readable text message. This can happen when
+ * it contains number values `NaN`, `Infinity` or `-Infinity`.
+ */
+export enum JSONToStringError {
+  InvalidNumber(String),
+}
+
+/**
+ * Controls how indentation is performed in custom formatting.
+ * 
+ * Following examples have whitespaces and line breaks replaced with visible
+ * charactes for illustrative purposes.
+ * 
+ * `NoIndentation`
+ * ```
+ * {↵
+ * "currency":·"€",↵
+ * "price":·99.9↵
+ * }
+ * ```
+ * 
+ * `IndentWithTab`
+ * ```
+ * {↵
+ * →"currency":·"€",↵
+ * →"price":·99.9↵
+ * }
+ * ```
+ * 
+ * `IndentWithSpaces(2)`
+ * ```
+ * {↵
+ * ··"currency":·"€",↵
+ * ··"price":·99.9↵
+ * }
+ * ```
+ * 
+ * `IndentWithSpaces(4)`
+ * ```
+ * {↵
+ * ····"currency":·"€",↵
+ * ····"price":·99.9↵
+ * }
+ * ```
+ */
+export enum IndentationFormat {
+  NoIndentation,
+  IndentWithTab,
+  IndentWithSpaces(Number),
+}
+
+/**
+ * Controls how arrays are printed in custom formatting.
+ * 
+ * Following examples have whitespaces and line breaks replaced with visible
+ * charactes for illustrative purposes.
+ * 
+ * `CompactArrayEntries`
+ * ```
+ * []
+ * ```
+ * 
+ * ```
+ * [1]
+ * ```
+ * 
+ * ```
+ * [1,2,3]
+ * ```
+ * 
+ * `OneArrayEntryPerLine`
+ * ```
+ * []
+ * ```
+ * 
+ * ```
+ * [↵
+ * ··1↵
+ * ]
+ * ```
+ * 
+ * ```
+ * [↵
+ * ··1,↵
+ * ··2,↵
+ * ··3↵
+ * ]
+ * ```
+ */
+export enum ArrayFormat {
+  CompactArrayEntries,
+  OneArrayEntryPerLine,
+}
+
+/**
+ * Controls how objects are printed in custom formatting.
+ * 
+ * Following examples have whitespaces and line breaks replaced with visible
+ * charactes for illustrative purposes.
+ * 
+ * `CompactObjectEntries`
+ * ```
+ * {}
+ * ```
+ * 
+ * ```
+ * {"a":1}
+ * ```
+ * 
+ * ```
+ * {"a":1,"b":2,"c":3}
+ * ```
+ * 
+ * `OneObjectEntryPerLine`
+ * ```
+ * {}
+ * ```
+ * 
+ * ```
+ * {↵
+ * ··"a":·1↵
+ * }
+ * ```
+ * 
+ * ```
+ * {↵
+ * ··"a":·1,↵
+ * ··"b":·2,↵
+ * ··"c":·3↵
+ * }
+ * ```
+ */
+export enum ObjectFormat {
+  CompactObjectEntries,
+  OneObjectEntryPerLine,
+}
+
+/**
+ * Controls line ending type in custom formatting.
+ */
+export enum LineEnding {
+  NoLineEnding,
+  LineFeed,
+  CarriageReturnLineFeed,
+  CarriageReturn,
+}
+
+/**
+ * Allows fine grained control of formatting in JSON printing.
+ */
+export record FormattingSettings {
+  indentation: IndentationFormat,
+  arrayFormat: ArrayFormat,
+  objectFormat: ObjectFormat,
+  lineEnding: LineEnding,
+  finishWithNewLine: Bool,
+  escapeAllControlPoints: Bool,
+  escapeHTMLUnsafeSequences: Bool,
+  escapeNonASCII: Bool,
+}
+
+/**
+ * Compact formatting that minimizes the size of resulting JSON at cost of not
+ * being easily human readable.
+ * 
+ * Only performs minimal string escaping as required by the ECMA-404 standard,
+ * so the result needs to be treated as proper unicode and is not safe to be
+ * transported in ASCII encoding.
+ * 
+ * The following example have whitespaces, line breaks and control points
+ * replaced with visible characters.
+ * ```
+ * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+ * ```
+ */
+export let defaultCompactFormat = () =>
+  {
+    indentation: NoIndentation,
+    arrayFormat: CompactArrayEntries,
+    objectFormat: CompactObjectEntries,
+    lineEnding: NoLineEnding,
+    finishWithNewLine: false,
+    escapeAllControlPoints: false,
+    escapeHTMLUnsafeSequences: false,
+    escapeNonASCII: false,
+  }: FormattingSettings
+
+/**
+ * Recommended human readable formatting.
+ * 
+ * Escapes all control points for the sake of clarity, but prints unicode
+ * codepoints directly so the result needs to be treated as proper unicode and
+ * is not safe to be transported in ASCII encoding.
+ * 
+ * The following example have whitespaces, line breaks and control points
+ * replaced with visible characters.
+ * ```
+ * {↵
+ * ··"currency":·"€",↵
+ * ··"price":·99.9,↵
+ * ··"currencyDescription":·"EURO\u007f",↵
+ * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
+ * }
+ * ```
+ */
+export let defaultPrettyFormat = () =>
+  {
+    indentation: IndentWithSpaces(2),
+    arrayFormat: OneArrayEntryPerLine,
+    objectFormat: OneObjectEntryPerLine,
+    lineEnding: LineFeed,
+    finishWithNewLine: true,
+    escapeAllControlPoints: true,
+    escapeHTMLUnsafeSequences: false,
+    escapeNonASCII: false,
+  }: FormattingSettings
+
+/**
+ * Compact and conservative formatting to maximize compatibility and
+ * embeddability of the resulting JSON.
+ * 
+ * Should be safe to copy and paste directly into HTML and to transported in
+ * plain ASCII.
+ * 
+ * The following example have whitespaces, line breaks and control points
+ * replaced with visible characters.
+ * ```
+ * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+ * ```
+ */
+export let defaultCompactAndSafeFormat = () =>
+  {
+    indentation: NoIndentation,
+    arrayFormat: CompactArrayEntries,
+    objectFormat: CompactObjectEntries,
+    lineEnding: NoLineEnding,
+    finishWithNewLine: false,
+    escapeAllControlPoints: true,
+    escapeHTMLUnsafeSequences: true,
+    escapeNonASCII: true,
+  }: FormattingSettings
+
+/**
+ * Pretty and conservative formatting to maximize compatibility and
+ * embeddability of the resulting JSON.
+ * 
+ * Should be safe to copy and paste directly into HTML and to transported in
+ * plain ASCII.
+ * 
+ * The following example have whitespaces, line breaks and control points
+ * replaced with visible characters.
+ * ```
+ * {↵
+ * ··"currency":·"\u20ac",↵
+ * ··"price":·99.9,↵
+ * ··"currencyDescription":·"EURO\u007f",↵
+ * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
+ * }
+ * ```
+ */
+export let defaultPrettyAndSafeFormat = () =>
+  {
+    indentation: IndentWithSpaces(2),
+    arrayFormat: OneArrayEntryPerLine,
+    objectFormat: OneObjectEntryPerLine,
+    lineEnding: LineFeed,
+    finishWithNewLine: true,
+    escapeAllControlPoints: true,
+    escapeHTMLUnsafeSequences: true,
+    escapeNonASCII: true,
+  }: FormattingSettings
+
+record JSONWriterCompactImplHelper {
+  buffer: Buffer.Buffer,
+  emitEscapedQuotedString: String -> Void,
+}
+
+record JSONWriterPrettyImplHelper {
+  format: FormattingSettings,
+  // Note that the "Pretty" suffix here is a workaround for a Grain compiler bug.
+  // It generates warnings just because two record types have some field names in common.
+  // Unless there's something I don't understand about its type system.
+  bufferPretty: Buffer.Buffer,
+  emitEscapedQuotedStringPretty: String -> Void,
+  printNewLine: () -> Void,
+  printIndentation: Number -> Void,
+}
+
+// The idea for this type is to allow reusing a bit of work done in preparing for printing JSON.
+// For now this is not exposed and remains an internal implementation detail.
+// It may make sense in the future to expose it and let the user reuse a writer for multiple
+// JSON emit operations without reallocating new closures and buffers each time.
+record JSONWriter {
+  emit: JSON -> Option<JSONToStringError>,
+}
+
+let addCharFromCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
+  Buffer.addChar(Char.fromCode(codePoint), buffer)
+}
+
+let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
+  // Emit the "\u" followed by hexadecimal representation of the codepoint
+  // with fixed length of 4 hexadecimal digits correspondeing to the two byte
+  // codepoint. No checks are performed here if the codepoint is in the
+  // "Basic Multilingual Plane" (0000-FFFF) as this funcion is only called
+  // internally.
+  // An alternative was to this implementation was to use NumberUtils.itoa32,
+  // but I wanted to avoid unnecessary heap allocations. As a possible future
+  // optimization this loop could be unrolled possibly even converted to be
+  // branchless and SIMD optimized, but it could be a bit of an overkill as
+  // this codepath is only for escape sequences, which probably aren't all
+  // that common occurence.
+
+  Buffer.addChar('\\', buffer)
+  Buffer.addChar('u', buffer)
+  // Loop over the four digit from most to least significant.
+  for (let mut digitIndex = 3; digitIndex >= 0; digitIndex -= 1) {
+    // Use bit masking and shifting to extract from the codepoint a number
+    // with just the bits corresponding to this hexadecinak digit.
+    let shift = digitIndex * 4
+    let mask = 0b1111 << shift
+    let digit = (codePoint & mask) >>> shift
+
+    // Digit now is a number in the range 0..15 and we need to translate it
+    // into a unicode codepoint representing the hexacedimal digit
+    // (0..9/a..f). We can use the fact that digits and latin letters in
+    // ASCII and by extension in Unicode are adjacent and ordered.
+    let hexDigitCodePoint = if (digit <= 9) {
+      // 48 is codeppoint for char '0'
+      digit + 48
+    } else {
+      // 97 is codeppoint for char 'a'
+      // But we also need to subtract 10 from it because we need
+      // the 10..15 number range translated to 0..5 in order to
+      // serve as an index in the ASCI range 'a'..'f'.
+      digit + 87
+    }
+
+    addCharFromCodePoint(hexDigitCodePoint, buffer)
+  }
+}
+
+let emitEscapedUnicodeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
+  // See the String section in the ECMA-404 doc.
+  // If the code point is "in the Basic Multilingual Plane", that is in range
+  // 0..65535. Greater values need to be split into two UTF-16 chunks.
+  if (codePoint <= 0xFFFF) {
+    // emitUTF16EscapeSequence(codePoint, writer)
+    emitUTF16EscapeSequence(codePoint, buffer)
+  } else {
+    // The following three lines are copied from String module of Grain's
+    // stdlib. It would be nice to share more code. On the other hand it
+    // may make sense to just have these few instructions directly here
+    // from the performance standpoint so we can print millions of emojis
+    // per second 😄.
+
+    // https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF
+    let uPrime = codePoint - 0x10000
+    let highSurrogate = ((uPrime & 0b11111111110000000000) >>> 10) + 0xD800
+    // High surrogate
+    let lowSurrogate = (uPrime & 0b00000000001111111111) + 0xDC00
+    // Low surrogate
+
+    emitUTF16EscapeSequence(highSurrogate, buffer)
+    emitUTF16EscapeSequence(lowSurrogate, buffer)
+  }
+}
+
+let emitEscapedCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
+  match (codePoint) {
+    0x0008 => { // backspace
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('b', buffer)
+    },
+    0x0009 => { // tab
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('t', buffer)
+    },
+    0x000A => { // line feed
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('n', buffer)
+    },
+    0x000C => { // form feed
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('f', buffer)
+    },
+    0x000D => { // carriage return
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('r', buffer)
+    },
+    0x0022 => { // quotation mark
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('"', buffer)
+    },
+    0x005C => { // backslash or "Reverse Solidus"
+      Buffer.addChar('\\', buffer)
+      Buffer.addChar('\\', buffer)
+    },
+    _ => {
+      emitEscapedUnicodeSequence(codePoint, buffer)
+    },
+  }
+}
+
+let printNull = (buffer: Buffer.Buffer) => Buffer.addString("null", buffer)
+
+let printBool = (b: Bool, buffer: Buffer.Buffer) => {
+  if (b) {
+    Buffer.addString("true", buffer)
+  } else {
+    Buffer.addString("false", buffer)
+  }
+}
+
+exception UnknownNumberTag
+
+// The following few functions are only meant to be called from a @disableGC
+// context of the printNumber function so there's no need to do all the
+// reference adjustment for the parameters and the functions themselves.
+
+@disableGC
+let printNumberWasmI32 = (value: WasmI32, buffer: Buffer.Buffer) => {
+  let s = NumberUtils.itoa32(value, 10n)
+
+  Memory.incRef(WasmI32.fromGrain(Buffer.addString))
+  Memory.incRef(WasmI32.fromGrain(s))
+  Memory.incRef(WasmI32.fromGrain(buffer))
+  Buffer.addString(s, buffer)
+
+  Memory.decRef(WasmI32.fromGrain(s))
+
+  let none = None
+  Memory.incRef(WasmI32.fromGrain(none))
+  none
+}
+
+@disableGC
+let printNumberWasmI64 = (value: WasmI64, buffer: Buffer.Buffer) => {
+  let s = NumberUtils.itoa64(value, 10n)
+
+  Memory.incRef(WasmI32.fromGrain(Buffer.addString))
+  Memory.incRef(WasmI32.fromGrain(s))
+  Memory.incRef(WasmI32.fromGrain(buffer))
+  Buffer.addString(s, buffer)
+
+  Memory.decRef(WasmI32.fromGrain(s))
+
+  let none = None
+  Memory.incRef(WasmI32.fromGrain(none))
+  none
+}
+
+@disableGC
+let isFinite = (value: WasmF64) => {
+  WasmF64.eq(WasmF64.sub(value, value), 0.W)
+}
+
+@disableGC
+let isNaN = (value: WasmF64) => {
+  WasmF64.ne(value, value)
+}
+
+let makeNaNError = () => Some(InvalidNumber("NaN is not allowed in JSONNumber"))
+
+let makeInfError = () =>
+  Some(InvalidNumber("Infinity is not allowed in JSONNumber"))
+
+let makeNegInfError = () =>
+  Some(InvalidNumber("-Infinity is not allowed in JSONNumber"))
+
+@disableGC
+let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
+  let result = if (isFinite(value)) {
+    let s = NumberUtils.dtoa(value)
+
+    Memory.incRef(WasmI32.fromGrain(Buffer.addString))
+    Memory.incRef(WasmI32.fromGrain(s))
+    Memory.incRef(WasmI32.fromGrain(buffer))
+    Buffer.addString(s, buffer)
+
+    Memory.decRef(WasmI32.fromGrain(s))
+
+    let none = None
+    Memory.incRef(WasmI32.fromGrain(none))
+    none
+  } else {
+    // JSON standard doesn't allow NaN or infinite values in numbers,
+    // but WASM f64 (IEEE 754-2008), as well as Grain's number types do
+    // (Float64 as well as Number). This is the only reason that the
+    // formatting needs to return a Result and not just a String
+    // directly. Other possible choices were to throw exceptions or to
+    // coninue formatting without representing these values correctly
+    // (like JavaScript's JSON.stringify).
+    if (isNaN(value)) {
+      // Allocating the exception in a function without @disableGC makes
+      // it easier to avoid problems with reference counting.
+      Memory.incRef(WasmI32.fromGrain(makeNaNError))
+      makeNaNError()
+    } else if (WasmF64.lt(value, 0.0W)) {
+      Memory.incRef(WasmI32.fromGrain(makeNegInfError))
+      makeNegInfError()
+    } else {
+      Memory.incRef(WasmI32.fromGrain(makeInfError))
+      makeInfError()
+    }
+  }
+
+  result
+}
+
+@disableGC
+let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
+  let (&) = WasmI32.and
+  let (==) = WasmI32.eq
+  let (!=) = WasmI32.ne
+  let (<<) = WasmI32.shl
+  let (>>) = WasmI32.shrS
+
+  let ptr = WasmI32.fromGrain(value)
+  let result = if ((ptr & 1n) != 0n) {
+    // FIXME expose runtime/numbers.untagSimple?
+    let asWasmI32 = ptr >> 1n
+    printNumberWasmI32(asWasmI32, buffer)
+  } else if ((ptr & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
+    let tag = WasmI32.load(ptr, 0n)
+    match (tag) {
+      t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
+        let numberTag = WasmI32.load(ptr, 4n)
+        match (numberTag) {
+          t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
+            let asWasmI32 = WasmI32.load(ptr, 8n)
+            // FIXME magic numbers
+            printNumberWasmI32(asWasmI32, buffer)
+          },
+          t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
+            let asWasmI64 = WasmI64.load(ptr, 8n)
+            // FIXME magic numbers
+            printNumberWasmI64(asWasmI64, buffer)
+          },
+          t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
+            // As a compromnise, convert the rational into a float
+            // and then print that. This means there can be
+            // precision loss even for values that could be printed
+            // exactly in decimal notation, but doing otherwise
+            // could both compromise perfomance and confuse
+            // developers as most JSON libraries in other languages
+            // likely only deal with integers and floats.
+            // Note that the ECMA-404 standard only specifies how
+            // numbers should be formatted as text (in decimal
+            // notation), so we could go the extra mile and at
+            // least for some numbers try printing the exact
+            // number. For example those that have a power of 10
+            // in the denominator.
+            let asWasmF64 = WasmF64.div(
+              WasmF64.convertI32S(Numbers.boxedRationalNumerator(ptr)),
+              WasmF64.convertI32S(Numbers.boxedRationalDenominator(ptr))
+            )
+
+            printNumberWasmF64(asWasmF64, buffer)
+          },
+          t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
+            let asWasmF32 = WasmF32.load(ptr, 8n)
+            // FIXME magic numbers
+            let asWasmF64 = WasmF64.promoteF32(asWasmF32)
+            printNumberWasmF64(asWasmF64, buffer)
+          },
+          t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
+            let asWasmF64 = WasmF64.load(ptr, 8n)
+            // FIXME magic numbers
+            printNumberWasmF64(asWasmF64, buffer)
+          },
+          _ => {
+            throw UnknownNumberTag
+          },
+        }
+      },
+      _ => {
+        throw UnknownNumberTag
+      },
+    }
+  } else {
+    throw UnknownNumberTag
+  }
+
+  Memory.decRef(WasmI32.fromGrain(value))
+  Memory.decRef(WasmI32.fromGrain(buffer))
+  Memory.decRef(WasmI32.fromGrain(printNumber))
+
+  result
+}
+
+// Note that this function is not allocated with the JSONWriter because currently
+// Grain leaks memory each time a recursive closure is allocated. Not reallocating
+// it may also be a better thing to do.
+let rec printElementCompact =
+  (
+    json: JSON,
+    implHelper: JSONWriterCompactImplHelper,
+  ) => {
+  let buffer = implHelper.buffer
+  match (json) {
+    JSONNull => {
+      printNull(buffer)
+      None
+    },
+    JSONBoolean(b) => {
+      printBool(b, buffer)
+      None
+    },
+    JSONNumber(n) => printNumber(n, buffer),
+    JSONString(s) => {
+      implHelper.emitEscapedQuotedString(s)
+      None
+    },
+    JSONArray(elems) => {
+      // Here I'm not using List.forEachi or similar in order to avoid
+      // allocations of closures. The code is verbose and a bit ugly as a
+      // consequence, but I think it's an OK price for performance gain.
+      // Another approach would be to allocate a function for the
+      // formattng arrays just once at the start of formatting and pass
+      // it in emitJSONElement.
+      match (elems) {
+        [] => {
+          Buffer.addChar('[', buffer)
+          Buffer.addChar(']', buffer)
+          None
+        },
+        [e] => {
+          Buffer.addChar('[', buffer)
+
+          let err = printElementCompact(e, implHelper)
+
+          if (Option.isNone(err)) {
+            Buffer.addChar(']', buffer)
+          }
+
+          err
+        },
+        [initialHead, ...initialRest] => {
+          Buffer.addChar('[', buffer)
+
+          let mut currentHead = initialHead
+          let mut currentRest = initialRest
+
+          let mut err = None
+
+          for (let mut index = 0; ; index += 1) {
+            if (index > 0) {
+              Buffer.addChar(',', buffer)
+            }
+
+            err = printElementCompact(currentHead, implHelper)
+            if (Option.isSome(err)) break
+
+            match (currentRest) {
+              [] => break,
+              [newHead, ...newRest] => {
+                currentHead = newHead
+                currentRest = newRest
+              },
+            }
+          }
+
+          if (Option.isNone(err)) {
+            Buffer.addChar(']', buffer)
+          }
+
+          err
+        },
+      }
+    },
+    JSONObject(entries) => {
+      match (entries) {
+        [] => {
+          Buffer.addChar('{', buffer)
+          Buffer.addChar('}', buffer)
+          None
+        },
+        [(key, value)] => {
+          Buffer.addChar('{', buffer)
+
+          implHelper.emitEscapedQuotedString(key)
+
+          Buffer.addChar(':', buffer)
+
+          let err = printElementCompact(value, implHelper)
+
+          if (Option.isNone(err)) {
+            Buffer.addChar('}', buffer)
+          }
+
+          err
+        },
+        [initialHead, ...initialRest] => {
+          Buffer.addChar('{', buffer)
+
+          let mut currentHead = initialHead
+          let mut currentRest = initialRest
+
+          let mut err = None
+
+          for (let mut index = 0; ; index += 1) {
+            if (index > 0) {
+              Buffer.addChar(',', buffer)
+            }
+
+            let (key, value) = currentHead
+
+            implHelper.emitEscapedQuotedString(key)
+
+            Buffer.addChar(':', buffer)
+
+            err = printElementCompact(value, implHelper)
+
+            if (Option.isSome(err)) {
+              break
+            }
+
+            match (currentRest) {
+              [] => break,
+              [newHead, ...newRest] => {
+                currentHead = newHead
+                currentRest = newRest
+              },
+            }
+          }
+
+          if (Option.isNone(err)) {
+            Buffer.addChar('}', buffer)
+          }
+
+          err
+        },
+      }
+    },
+  }
+}
+
+let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
+  // As an optimization prepare a closure function to execute for each code
+  // point of the input. It's important that this is not inlide in the
+  // emitEscapedQuotedString function directly to avoid allocating the closue
+  // for each input string.
+  let emitCodePoint = (codePoint: Number) => {
+    // For the compact formatting only escape backslash, double quotes and
+    // code points 0..31 (the so called "C0" control point group) as
+    // required by ECMA-404. For the non pretty printed case we don't want
+    // to escape more than what is stricty required to avoid increasing the
+    // output size.
+    if (codePoint > 31 && codePoint != 0x0022 && codePoint != 0x005C) {
+      addCharFromCodePoint(codePoint, buffer)
+    } else {
+      emitEscapedCodePoint(codePoint, buffer)
+    }
+  }
+
+  let emitEscapedQuotedString = (s: String) => {
+    Buffer.addChar('"', buffer)
+
+    String.forEachCodePoint(emitCodePoint, s)
+
+    Buffer.addChar('"', buffer)
+  }
+
+  let implHelper = {
+    buffer,
+    emitEscapedQuotedString: s => {
+      emitEscapedQuotedString(s)
+    },
+  }: JSONWriterCompactImplHelper
+
+  {
+    emit: json => {
+      let error = printElementCompact(json, implHelper)
+
+      error
+    },
+  }: JSONWriter
+}
+
+// Note that this could relatively easily be integrated with
+// printElementCompact to avoid code duplication, but it would mean
+// compromising peak performance and also increasing complexity in other ways.
+let rec printElementPretty =
+  (
+    json: JSON,
+    implHelper: JSONWriterPrettyImplHelper,
+    indentationLevel: Number,
+  ) => {
+  let buffer = implHelper.bufferPretty
+  match (json) {
+    JSONNull => {
+      printNull(buffer)
+      None
+    },
+    JSONBoolean(b) => {
+      printBool(b, buffer)
+      None
+    },
+    JSONNumber(n) => printNumber(n, buffer),
+    JSONString(s) => {
+      implHelper.emitEscapedQuotedStringPretty(s)
+      None
+    },
+    JSONArray(elems) => {
+      match (elems) {
+        [] => {
+          Buffer.addChar('[', buffer)
+          Buffer.addChar(']', buffer)
+          None
+        },
+        [e] => {
+          let format = implHelper.format
+
+          Buffer.addChar('[', buffer)
+
+          if (format.arrayFormat == OneArrayEntryPerLine) {
+            implHelper.printNewLine()
+          }
+
+          let elemLevel = indentationLevel + 1
+
+          if (format.arrayFormat == OneArrayEntryPerLine) {
+            implHelper.printIndentation(elemLevel)
+          }
+
+          let err = printElementPretty(e, implHelper, elemLevel)
+
+          if (Option.isNone(err)) {
+            if (format.arrayFormat == OneArrayEntryPerLine) {
+              implHelper.printNewLine()
+              implHelper.printIndentation(indentationLevel)
+            }
+
+            Buffer.addChar(']', buffer)
+          }
+
+          err
+        },
+        [initialHead, ...initialRest] => {
+          let format = implHelper.format
+
+          Buffer.addChar('[', buffer)
+
+          if (format.arrayFormat == OneArrayEntryPerLine) {
+            implHelper.printNewLine()
+          }
+
+          let mut currentHead = initialHead
+          let mut currentRest = initialRest
+
+          let mut err = None
+
+          let elemLevel = indentationLevel + 1
+
+          for (let mut index = 0; ; index += 1) {
+            if (index > 0) {
+              Buffer.addChar(',', buffer)
+
+              if (format.arrayFormat == OneArrayEntryPerLine) {
+                implHelper.printNewLine()
+              }
+            }
+
+            if (format.arrayFormat == OneArrayEntryPerLine) {
+              implHelper.printIndentation(elemLevel)
+            }
+
+            err = printElementPretty(currentHead, implHelper, elemLevel)
+            if (Option.isSome(err)) {
+              break
+            }
+
+            match (currentRest) {
+              [] => break,
+              [newHead, ...newRest] => {
+                currentHead = newHead
+                currentRest = newRest
+              },
+            }
+          }
+
+          if (Option.isNone(err)) {
+            if (format.arrayFormat == OneArrayEntryPerLine) {
+              implHelper.printNewLine()
+              implHelper.printIndentation(indentationLevel)
+            }
+
+            Buffer.addChar(']', buffer)
+          }
+
+          err
+        },
+      }
+    },
+    JSONObject(entries) => {
+      match (entries) {
+        [] => {
+          Buffer.addChar('{', buffer)
+          Buffer.addChar('}', buffer)
+          None
+        },
+        [(key, value)] => {
+          let format = implHelper.format
+
+          Buffer.addChar('{', buffer)
+
+          let elemLevel = indentationLevel + 1
+
+          if (format.objectFormat == OneObjectEntryPerLine) {
+            implHelper.printNewLine()
+            implHelper.printIndentation(elemLevel)
+          }
+
+          implHelper.emitEscapedQuotedStringPretty(key)
+
+          match (format.objectFormat) {
+            CompactObjectEntries => {
+              Buffer.addChar(':', buffer)
+            },
+            OneObjectEntryPerLine => {
+              Buffer.addChar(':', buffer)
+              Buffer.addChar(' ', buffer)
+            },
+          }
+
+          let err = printElementPretty(value, implHelper, elemLevel)
+
+          if (Option.isNone(err)) {
+            if (format.objectFormat == OneObjectEntryPerLine) {
+              implHelper.printNewLine()
+              implHelper.printIndentation(indentationLevel)
+            }
+
+            Buffer.addChar('}', buffer)
+          }
+
+          err
+        },
+        [initialHead, ...initialRest] => {
+          let format = implHelper.format
+
+          Buffer.addChar('{', buffer)
+
+          if (format.objectFormat == OneObjectEntryPerLine) {
+            implHelper.printNewLine()
+          }
+
+          let mut currentHead = initialHead
+          let mut currentRest = initialRest
+
+          let mut err = None
+
+          let elemLevel = indentationLevel + 1
+
+          for (let mut index = 0; ; index += 1) {
+            if (index > 0) {
+              Buffer.addChar(',', buffer)
+
+              if (format.objectFormat == OneObjectEntryPerLine) {
+                implHelper.printNewLine()
+              }
+            }
+
+            if (format.objectFormat == OneObjectEntryPerLine) {
+              implHelper.printIndentation(elemLevel)
+            }
+
+            let (key, value) = currentHead
+
+            implHelper.emitEscapedQuotedStringPretty(key)
+
+            match (format.objectFormat) {
+              CompactObjectEntries => {
+                Buffer.addChar(':', buffer)
+              },
+              OneObjectEntryPerLine => {
+                Buffer.addChar(':', buffer)
+                Buffer.addChar(' ', buffer)
+              },
+            }
+
+            err = printElementPretty(value, implHelper, elemLevel)
+
+            if (Option.isSome(err)) {
+              break
+            }
+
+            match (currentRest) {
+              [] => break,
+              [newHead, ...newRest] => {
+                currentHead = newHead
+                currentRest = newRest
+              },
+            }
+          }
+
+          if (Option.isNone(err)) {
+            if (format.objectFormat == OneObjectEntryPerLine) {
+              implHelper.printNewLine()
+              implHelper.printIndentation(indentationLevel)
+            }
+
+            Buffer.addChar('}', buffer)
+          }
+
+          err
+        },
+      }
+    },
+  }
+}
+
+let isCodePointInBasicMultilingualPlane = (code: Number) =>
+  code >= 0x0000 &&
+  code <= 0xFFFF
+
+let isHighSurrogate = (code: Number) => code >= 0xD800 && code <= 0xDBFF
+
+let isLowSurrogate = (code: Number) => code >= 0xDC00 && code <= 0xDFFF
+
+let combineSurrogatePairToCodePoint =
+  (
+    highSurrogate: Number,
+    lowSurrogate: Number,
+  ) => {
+  // If this was a method exposed by itself in a library then it should check the
+  // ranges of the input surrogates, but here it's necessary because checks are made
+  // as part of the parsing logic.
+  (highSurrogate - 0xD800 << 10) + (lowSurrogate - 0xDC00) + 0x10000
+}
+
+let makePrettyPrintJSONWriter =
+  (
+    format: FormattingSettings,
+    buffer: Buffer.Buffer,
+  ) => {
+  let printNewLine = match (format.lineEnding) {
+    NoLineEnding => () => void,
+    LineFeed =>
+      () => {
+        Buffer.addChar('\n', buffer)
+      },
+    CarriageReturnLineFeed =>
+      () => {
+        Buffer.addChar('\r', buffer)
+        Buffer.addChar('\n', buffer)
+      },
+    CarriageReturn =>
+      () => {
+        Buffer.addChar('\r', buffer)
+      },
+  }
+
+  let printIndentation = match (format.indentation) {
+    IndentWithTab =>
+      indentationLevel => {
+        let mut count = 0
+        while (count < indentationLevel) {
+          Buffer.addChar('\t', buffer)
+          count += 1
+        }
+      },
+    IndentWithSpaces(spacesPerIndentation) =>
+      indentationLevel => {
+        let mut count = 0
+        let spaceCount = indentationLevel * spacesPerIndentation
+        while (count < spaceCount) {
+          Buffer.addChar(' ', buffer)
+          count += 1
+        }
+      },
+    NoIndentation => indentationLevel => void,
+  }
+
+  // As an optimization prepare a different closure function for each
+  // combination of escaping options. This ways we can avoid unnecessary
+  // branching in the code executed for each character. What is most
+  // important here is to optimize for the non pretty printed format as this
+  // is where the performance is most likely to matter. In every case escape
+  // code points 0..31 as required by ECMA-404 (the so called "C0" control
+  // point group). For the non pretty printed case we don't want to escape
+  // more than what is stricty required to avoid increasing the output size.
+  // But for pretty printing or compatiblity it may be desirable to escape
+  // other control points or even everything other than printable ASCII
+  // characters. Thus I've decided to expose options for this, but otherwise
+  // just a sane default would suffice.
+  // Additionally many JSON libraries escape additional two character
+  // sequences for direct embedding into html for example. This is
+  // specifically to avoid emitting the sequence "</" like in "</script>".
+  // The lazy approach would be to just escape the slash (which can become
+  // "\\/", not necessarily "\u002F"). This more conservative approach only
+  // escapes it when needed, but requires to keep track of the previous code
+  // point in the iteration so it's more complicated and handled separately.
+  let emitCodePoint = if (
+    !format.escapeAllControlPoints && !format.escapeNonASCII
+  ) {
+    (codePoint: Number) => {
+      if (codePoint > 31 && codePoint != 0x0022 && codePoint != 0x005C) {
+        addCharFromCodePoint(codePoint, buffer)
+      } else {
+        emitEscapedCodePoint(codePoint, buffer)
+      }
+    }
+  } else if (!format.escapeAllControlPoints && format.escapeNonASCII) {
+    // If desired, escape all non ASCII code points. So the only non
+    // escaped code points are those in the range of ASCII chacarcters
+    // from 31 to 127.
+    (codePoint: Number) => {
+      if (
+        codePoint > 31 &&
+        codePoint != 0x0022 &&
+        codePoint != 0x005C &&
+        codePoint < 128
+      ) {
+        addCharFromCodePoint(codePoint, buffer)
+      } else {
+        emitEscapedCodePoint(codePoint, buffer)
+      }
+    }
+  } else if (format.escapeAllControlPoints && !format.escapeNonASCII) {
+    // If desired, in addition to the required 0..31 control points,
+    // also escape unicode control point group C1 (128-159).
+    // There could be more control points or otherwise escape worthy
+    // codepoints, but covering that would be overkill.
+    (codePoint: Number) => {
+      if (
+        codePoint > 31 &&
+        codePoint != 0x0022 &&
+        codePoint != 0x005C &&
+        codePoint < 127 ||
+        codePoint > 159
+      ) {
+        addCharFromCodePoint(codePoint, buffer)
+      } else {
+        emitEscapedCodePoint(codePoint, buffer)
+      }
+    }
+  } else {
+    // And this is just the combination of both flags, which means
+    // doing almost the same as for the case above for
+    // escapeNonASCII=true, but also escape the ASCII control codepoint
+    // 127 (Delete).
+    (codePoint: Number) => {
+      if (
+        codePoint > 31 &&
+        codePoint != 0x0022 &&
+        codePoint != 0x005C &&
+        codePoint < 127
+      ) {
+        // fast path for chars that never need any escaping
+        addCharFromCodePoint(codePoint, buffer)
+      } else {
+        emitEscapedCodePoint(codePoint, buffer)
+      }
+    }
+  }
+
+  let emitEscapedQuotedString = if (!format.escapeHTMLUnsafeSequences) {
+    (s: String) => {
+      Buffer.addChar('"', buffer)
+
+      // Note that it's important for performance that the closure passed to forEachCodePoint
+      // is not allocated inline here, but just once when creating the writer.
+
+      String.forEachCodePoint(emitCodePoint, s)
+
+      Buffer.addChar('"', buffer)
+    }
+  } else {
+    // Special handling for the escapeHTMLUnsafeSequences flag.
+    // Escaping a sequence requires keeping track of previous characters,
+    // which is difficult and suboptimal when using a function to iterate
+    // the input string. So we don't want to pay the price in other cases.
+    // This cannot be done just in the emitCodePoint function.
+    // It could be possible to implement more optimally, but would
+    // complicate things even more than this.
+    (s: String) => {
+      Buffer.addChar('"', buffer)
+
+      let mut prevCodePoint = 0
+
+      String.forEachCodePoint(codePoint => {
+        if (codePoint == 47) {
+          if (format.escapeHTMLUnsafeSequences && prevCodePoint == 60) {
+            Buffer.addChar('\\', buffer)
+            Buffer.addChar('/', buffer)
+          } else {
+            // otherwise just emit the slash as-is
+            addCharFromCodePoint(codePoint, buffer)
+          }
+        } else {
+          emitCodePoint(codePoint)
+        }
+
+        prevCodePoint = codePoint
+      }, s)
+
+      Buffer.addChar('"', buffer)
+    }
+  }
+
+  let implHelper = {
+    format,
+    bufferPretty: buffer,
+    emitEscapedQuotedStringPretty: s => {
+      emitEscapedQuotedString(s)
+    },
+    printNewLine,
+    printIndentation,
+  }: JSONWriterPrettyImplHelper
+
+  {
+    emit: json => {
+      let error = printElementPretty(json, implHelper, 0)
+
+      if (format.finishWithNewLine && Option.isNone(error)) {
+        printNewLine()
+      }
+
+      error
+    },
+  }: JSONWriter
+}
+
+/**
+ * Prints the JSON object into a string with specific formatting settings.
+ * 
+ * @param json: The JSON object to print
+ * @param format: Custom formatting setttings
+ * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
+ *
+ * @example print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
+ * 
+ * Example output:
+ * ```json
+ * {"currency":"\u20ac","price":99.9}
+ * ```
+ */
+export let toString = (json: JSON, format: FormattingSettings) => {
+  let buf = Buffer.make(16)
+
+  let writer = makePrettyPrintJSONWriter(format, buf)
+
+  let error = writer.emit(json)
+
+  match (error) {
+    None => Ok(Buffer.toString(buf)),
+    Some(e) => Err(e),
+  }
+}
+
+/**
+ * Prints the JSON object into a string with compact formatting optimized for
+ * small size. Recommended for all uses where the intended consumer is a
+ * machine program. For example in REST APIs.
+ * 
+ * Using this function can be preferred over `toString` with compact formatting
+ * settings since it can be slightly faster.
+ * 
+ * @param json: The JSON object to print
+ * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
+ *
+ * @example print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+ * 
+ * Example output:
+ * ```json
+ * {"currency":"€","price":99.9}
+ * ```
+ */
+export let toStringCompact = (json: JSON) => {
+  let buf = Buffer.make(16)
+
+  let writer = makeCompactJSONWriter(buf)
+
+  let error = writer.emit(json)
+
+  match (error) {
+    None => Ok(Buffer.toString(buf)),
+    Some(e) => Err(e),
+  }
+}
+
+/**
+ * Prints the JSON object into a string with default pretty formatting
+ * settings. Recommended for uses where the intended consumer is a person or
+ * the text should be easily inspectable. For example configuration files or
+ * document file formats.
+ * 
+ * @param json: The JSON object to print
+ * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
+ * 
+ * Example output:
+ * ```json
+ * {
+ *   "currency": "€",
+ *   "price": 99.9
+ * }
+ * ```
+ *
+ * @example print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+ */
+export let toStringPretty = (json: JSON) =>
+  toString(json, defaultPrettyFormat())
+
+/**
+ * Represents errors for JSON parsing along with a human readable text message.
+ */
+export enum JSONParseError {
+  UnexpectedEndOfInput(String),
+  UnexpectedToken(String),
+  InvalidUTF16SurrogatePair(String),
+}
+
+/**
+ * Internal data structure used during parsing.
+ */
+record JSONParserImplHelper {
+  string: String,
+  bufferParse: Buffer.Buffer,
+  mut currentCodePoint: Number,
+  mut pos: Number,
+  mut bytePos: Number,
+}
+
+let isInterTokenWhiteSpace = (codePoint: Number) => {
+  match (codePoint) {
+    0x0009 => true, // tab
+    0x000A => true, // line feed
+    0x000D => true, // carriage return
+    0x0020 => true, // space
+    _ => false,
+  }
+}
+
+let _END_OF_INPUT = -1
+
+exception MalformedUnicode
+
+// This function has been copied from the String module as a temporary
+// solution. This will likely be replaced by a more robust solution for
+// iterating over strings in the near future.
+@disableGC
+let getCodePoint = (ptr: WasmI32) => {
+  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
+  let (+) = WasmI32.add
+  let (==) = WasmI32.eq
+  let (>=) = WasmI32.geU
+  let (<=) = WasmI32.leU
+  let (<<) = WasmI32.shl
+  let (&) = WasmI32.and
+  let (|) = WasmI32.or
+
+  let mut codePoint = 0n
+  let mut bytesSeen = 0n
+  let mut bytesNeeded = 0n
+  let mut lowerBoundary = 0x80n
+  let mut upperBoundary = 0xBFn
+
+  let mut offset = 0n
+
+  let mut result = 0n
+
+  while (true) {
+    let byte = WasmI32.load8U(ptr + offset, 0n)
+    offset += 1n
+    if (bytesNeeded == 0n) {
+      if (byte >= 0x00n && byte <= 0x7Fn) {
+        result = byte
+        break
+      } else if (byte >= 0xC2n && byte <= 0xDFn) {
+        bytesNeeded = 1n
+        codePoint = byte & 0x1Fn
+      } else if (byte >= 0xE0n && byte <= 0xEFn) {
+        if (byte == 0xE0n) lowerBoundary = 0xA0n
+        if (byte == 0xEDn) upperBoundary = 0x9Fn
+        bytesNeeded = 2n
+        codePoint = byte & 0xFn
+      } else if (byte >= 0xF0n && byte <= 0xF4n) {
+        if (byte == 0xF0n) lowerBoundary = 0x90n
+        if (byte == 0xF4n) upperBoundary = 0x8Fn
+        bytesNeeded = 3n
+        codePoint = byte & 0x7n
+      } else {
+        throw MalformedUnicode
+      }
+      continue
+    }
+    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
+      throw MalformedUnicode
+    }
+    lowerBoundary = 0x80n
+    upperBoundary = 0xBFn
+    codePoint = codePoint << 6n | byte & 0x3Fn
+    bytesSeen += 1n
+    if (bytesSeen == bytesNeeded) {
+      result = codePoint
+      break
+    }
+  }
+  result: WasmI32
+}
+
+@disableGC
+let rec readCodePoint = (bytePosition: Number, string: String) => {
+  let (>>>) = WasmI32.shrU
+  let (+) = WasmI32.add
+  let (-) = WasmI32.sub
+  let (&) = WasmI32.and
+  let (<) = WasmI32.ltU
+  let (<=) = WasmI32.leU
+  let (==) = WasmI32.eq
+
+  let strPtr = WasmI32.fromGrain(string)
+
+  let byteSize = WasmI32.load(strPtr, 4n)
+
+  let bytePositionW32 = coerceNumberToWasmI32(bytePosition)
+
+  let ptr = WasmI32.add(WasmI32.add(strPtr, 8n), bytePositionW32)
+
+  let mut idx = 0n
+  let result = if (bytePositionW32 < byteSize) {
+    let codePoint = getCodePoint(ptr)
+    tagSimpleNumber(codePoint)
+  } else {
+    _END_OF_INPUT
+  }
+
+  Memory.decRef(WasmI32.fromGrain(bytePosition))
+  Memory.decRef(WasmI32.fromGrain(string))
+  Memory.decRef(WasmI32.fromGrain(readCodePoint))
+
+  result
+}
+
+let codePointUTF8ByteCount = (usv: Number) => {
+  if (!Char.isValid(usv)) {
+    throw InvalidArgument("Invalid unicode scalar value")
+  }
+
+  if (usv <= 127) {
+    1
+  } else if (usv <= 2047) {
+    2
+  } else if (usv <= 65535) {
+    3
+  } else {
+    4
+  }
+}
+
+let isAtEndOfInput = (parserImplHelper: JSONParserImplHelper) => {
+  parserImplHelper.currentCodePoint == _END_OF_INPUT
+}
+
+let next = (parserImplHelper: JSONParserImplHelper) => {
+  let mut c = parserImplHelper.currentCodePoint
+  if (c != _END_OF_INPUT) {
+    parserImplHelper.bytePos = parserImplHelper.bytePos +
+    codePointUTF8ByteCount(c)
+
+    c = readCodePoint(parserImplHelper.bytePos, parserImplHelper.string)
+
+    parserImplHelper.currentCodePoint = c
+    parserImplHelper.pos = parserImplHelper.pos + 1
+  }
+  c
+}
+
+let skipWhiteSpace = (parserImplHelper: JSONParserImplHelper) => {
+  // isAtEndOfInput is not strictly necessary here
+  // could remove as an optimization
+  while (
+    isInterTokenWhiteSpace(parserImplHelper.currentCodePoint) &&
+    !isAtEndOfInput(parserImplHelper)
+  ) {
+    next(parserImplHelper)
+    void
+  }
+}
+
+let buildUnexpectedTokenError =
+  (
+    parserImplHelper: JSONParserImplHelper,
+    detail: String,
+  ) => {
+  let codePoint = parserImplHelper.currentCodePoint
+  let pos = parserImplHelper.pos
+  if (codePoint == _END_OF_INPUT) {
+    UnexpectedEndOfInput(
+      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail
+    )
+  } else {
+    UnexpectedToken(
+      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail
+    )
+  }
+}
+
+@disableGC
+let rec toHex = (n: Number) => {
+  let x = coerceNumberToWasmI32(n)
+  let result = NumberUtils.itoa32(x, 16n)
+
+  Memory.decRef(WasmI32.fromGrain(n))
+  Memory.decRef(WasmI32.fromGrain(toHex))
+
+  result
+}
+
+let toHexWithZeroPadding = (n: Number, padTo: Number) => {
+  // Note that this function is only called in exceptional cases so no effort
+  // was made to optimize it.
+  let mut result = toHex(n)
+  while (String.length(result) < padTo) {
+    result = "0" ++ result
+  }
+  result
+}
+
+let formatCodePointOrEOF = (codePoint: Number) => {
+  if (codePoint >= 32 && codePoint <= 126) {
+    // If the codepoint is in the range of printable ASCII charactes, then
+    // display the character itself . Whether it's a good idea to display
+    // all of them, especially space is up for debate.
+    "'" ++ runtimeToString(Char.fromCode(codePoint)) ++ "'"
+  } else if (codePoint == -1) {
+    // Special case for value used by the parsing code to avoid heap allocations.
+    "end of input"
+  } else {
+    // Format any other code point as hexadecimal value.
+    "U+" ++ toHexWithZeroPadding(codePoint, 4)
+  }
+}
+
+let expectCodePointAndAdvance =
+  (
+    expectedCodePoint: Number,
+    parserImplHelper: JSONParserImplHelper,
+  ) => {
+  let c = parserImplHelper.currentCodePoint
+  if (c == expectedCodePoint) {
+    next(parserImplHelper)
+    None
+  } else {
+    let detail = "expected " ++
+      formatCodePointOrEOF(expectedCodePoint) ++
+      ", found " ++
+      formatCodePointOrEOF(c)
+    Some(buildUnexpectedTokenError(parserImplHelper, detail))
+  }
+}
+
+let rec parseValue = (parserImplHelper: JSONParserImplHelper) => {
+  skipWhiteSpace(parserImplHelper)
+
+  let result = match (parserImplHelper.currentCodePoint) {
+    0x7B => parseObject(parserImplHelper), // '{'
+    0x5B => parseArray(parserImplHelper), // '['
+    0x22 => parseStringValue(parserImplHelper), // '"'
+    0x74 => parseTrueValue(parserImplHelper), // 't'
+    0x66 => parseFalseValue(parserImplHelper), // 'f'
+    0x6E => parseNullValue(parserImplHelper), // 'n'
+    // TODO Check if having a match case for each digit would be faster or not.
+    c when c >= 0x30 && c <= 0x39 || c == 0x2D =>
+      parseNumberValue(parserImplHelper), // '0'..'9' or '-'
+    c => {
+      let detail = "expected start of a JSON value, found " ++
+        formatCodePointOrEOF(c)
+      Err(buildUnexpectedTokenError(parserImplHelper, detail))
+    },
+  }
+
+  skipWhiteSpace(parserImplHelper)
+
+  result
+}, parseNullValue = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x6E, parserImplHelper)) {
+    // 'n'
+    Some(e) => Err(e),
+    None => {
+      match (expectCodePointAndAdvance(0x75, parserImplHelper)) {
+        // 'u'
+        Some(e) => Err(e),
+        None => {
+          match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+            // 'l'
+            Some(e) => Err(e),
+            None => {
+              match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+                // 'l'
+                Some(e) => Err(e),
+                None => Ok(JSONNull),
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}, parseTrueValue = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x74, parserImplHelper)) {
+    // 't'
+    Some(e) => Err(e),
+    None => {
+      match (expectCodePointAndAdvance(0x72, parserImplHelper)) {
+        // 'r'
+        Some(e) => Err(e),
+        None => {
+          match (expectCodePointAndAdvance(0x75, parserImplHelper)) {
+            // 'u'
+            Some(e) => Err(e),
+            None => {
+              match (expectCodePointAndAdvance(0x65, parserImplHelper)) {
+                // 'e'
+                Some(e) => Err(e),
+                None => Ok(JSONBoolean(true)),
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}, parseFalseValue = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x66, parserImplHelper)) {
+    // 'f'
+    Some(e) => Err(e),
+    None => {
+      match (expectCodePointAndAdvance(0x61, parserImplHelper)) {
+        // 'a'
+        Some(e) => Err(e),
+        None => {
+          match (expectCodePointAndAdvance(0x6C, parserImplHelper)) {
+            // 'l'
+            Some(e) => Err(e),
+            None => {
+              match (expectCodePointAndAdvance(0x73, parserImplHelper)) {
+                // 's'
+                Some(e) => Err(e),
+                None => {
+                  match (expectCodePointAndAdvance(0x65, parserImplHelper)) {
+                    // 'e'
+                    Some(e) => Err(e),
+                    None => Ok(JSONBoolean(false)),
+                  }
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}, parseString = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x22, parserImplHelper)) {
+    // '"'
+    Some(e) => Err(e),
+    None => {
+      let mut err = None
+      let mut done = false
+      let buffer = parserImplHelper.bufferParse
+      Buffer.clear(buffer)
+
+      while (!done) {
+        match (parserImplHelper.currentCodePoint) {
+          0x22 => { // '"'
+            next(parserImplHelper)
+            done = true
+            break
+          },
+          -1 => {
+            // just end the loop without setting done to true
+            break
+          },
+          0x5C => { // '\'
+            // Keep the starting position for better error reporting.
+            let escapeStartPos = parserImplHelper.pos
+
+            next(parserImplHelper)
+
+            match (parserImplHelper.currentCodePoint) {
+              0x22 => { // '"'
+                Buffer.addChar('"', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x5C => { // '\'
+                Buffer.addChar('\\', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x2F => { // '/'
+                Buffer.addChar('/', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x62 => { // letter 'b' as in Backspace
+                // emit backspace control code
+                Buffer.addChar('\u{08}', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x66 => { // letter 'f' as in Form Feed
+                // emit Form Feed control code
+                Buffer.addChar('\u{0C}', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x6E => { // letter 'n' as in New line
+                // emit Line Feed control code
+                Buffer.addChar('\u{0A}', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x72 => { // letter 'r' as in carriage Return
+                // emit Carriage Return control code
+                Buffer.addChar('\u{0D}', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x74 => { // letter 't' as in Tab
+                // emit Tab control code
+                Buffer.addChar('\u{09}', buffer)
+                next(parserImplHelper)
+                void
+              },
+              0x75 => { // 'u' (start of hexadecimal UTF-16 escape sequence)
+                next(parserImplHelper)
+
+                // The escape sequence can either be a standalone code point or
+                // a UTF-16 surrogate pair made of two code units that have to
+                // be combined to form a code point. This is legacy of
+                // JavaScript's UTF-16 string representation, despite JSON
+                // mandating UTF-8 (kind of, as stated in rfc8259: "JSON text
+                // exchanged between systems that are not part of a closed
+                // ecosystem MUST be encoded using UTF-8").
+                // This would be easy to do using a function for shared logic,
+                // but in order to avoid heap allocation I've chosen to instead
+                // use a loop and local state.
+
+                let mut highSurrogate = -1
+
+                while (true) {
+                  let mut codeUnit = 0
+
+                  for (
+                    let mut digitIndex = 3;
+                    digitIndex >= 0;
+                    digitIndex -= 1
+                  ) {
+                    let hexDigitCodePoint = parserImplHelper.currentCodePoint
+
+                    let mut digit = hexDigitCodePoint
+
+                    if (
+                      hexDigitCodePoint >= 48 && hexDigitCodePoint <= 57
+                    ) { // 0..9
+                      digit -= 48
+                    } else if (
+                      hexDigitCodePoint >= 65 && hexDigitCodePoint <= 70
+                    ) { // A..F
+                      digit -= 55 // (65 - 10)
+                    } else if (
+                      hexDigitCodePoint >= 97 && hexDigitCodePoint <= 102
+                    ) { // a..f
+                      digit -= 87 // (97 - 10)
+                    } else {
+                      let digitsSoFar = 3 - digitIndex
+                      let detail = "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
+                        runtimeToString(digitsSoFar)
+                      err = Some(
+                        buildUnexpectedTokenError(parserImplHelper, detail)
+                      )
+                      break
+                    }
+
+                    let shift = digitIndex * 4
+                    codeUnit = codeUnit | digit << shift
+
+                    next(parserImplHelper)
+                    void
+                  }
+
+                  if (highSurrogate == -1) {
+                    // This is the first iteration of the loop.
+                    // The code unit should either be the high surrogate of the
+                    // pair or a full code point in the Basic Multilingual
+                    // Plane (U+0000..U+FFFF).
+                    if (isHighSurrogate(codeUnit)) {
+                      // Next characters should be "\u"
+                      err = expectCodePointAndAdvance(0x5C, parserImplHelper)
+                      // '\'
+                      if (Option.isSome(err)) break
+                      err = expectCodePointAndAdvance(0x75, parserImplHelper)
+                      // 'u'
+                      if (Option.isSome(err)) break
+
+                      // Keep the high surrogate and proceed to the second
+                      // iteration of the loop.
+                      highSurrogate = codeUnit
+                    } else if (
+                      isCodePointInBasicMultilingualPlane(codeUnit) &&
+                      !isLowSurrogate(codeUnit)
+                    ) {
+                      let codePoint = codeUnit
+                      addCharFromCodePoint(codePoint, buffer)
+                      break
+                    } else {
+                      let message = "Invalid character escape sequence at position " ++
+                        runtimeToString(escapeStartPos) ++
+                        ": expected a Unicode code point in Basic Multilingual Plane (U+0000..U+FFFF) or a high surrogate (0xD800..0xDBFF) of a UTF-16 surrogate pair, found " ++
+                        "0x" ++
+                        toHexWithZeroPadding(codeUnit, 4)
+                      err = Some(InvalidUTF16SurrogatePair(message))
+                      break
+                    }
+                  } else {
+                    // This is the second iteration of the loop.
+                    // The code unit should be the low surrogate of the pair.
+                    if (isLowSurrogate(codeUnit)) {
+                      let lowSurrogate = codeUnit
+                      let combinedCodePoint = combineSurrogatePairToCodePoint(
+                        highSurrogate,
+                        lowSurrogate
+                      )
+                      addCharFromCodePoint(combinedCodePoint, buffer)
+                      break
+                    } else {
+                      let message = "Invalid character escape sequence at position " ++
+                        runtimeToString(escapeStartPos) ++
+                        ": expected a low surrogate (0xDC00..0xDFFF) in the second code unit of the UTF-16 sequence, found " ++
+                        "0x" ++
+                        toHexWithZeroPadding(codeUnit, 4)
+                      err = Some(InvalidUTF16SurrogatePair(message))
+                      break
+                    }
+                  }
+                }
+
+                if (Option.isSome(err)) break
+              },
+              unexpectedCodePoint => {
+                // JSON doesn't allow arbitrary characters to be preceded by backslash escape.
+                // Only the ones above.
+                let detail = "expected a valid escape sequence or the end of string, found " ++
+                  formatCodePointOrEOF(unexpectedCodePoint)
+                err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+                break
+              },
+            }
+          },
+          c => {
+            // Finally the happy case of a simple unescaped code point.
+            next(parserImplHelper)
+            addCharFromCodePoint(c, buffer)
+          },
+        }
+      }
+
+      match (err) {
+        None => {
+          if (done) {
+            let s = Buffer.toString(buffer)
+            Ok(s)
+          } else {
+            Err(
+              buildUnexpectedTokenError(
+                parserImplHelper,
+                "unexpected end of string value"
+              )
+            )
+          }
+        },
+        Some(e) => Err(e),
+      }
+    },
+  }
+}, parseStringValue = (parserImplHelper: JSONParserImplHelper) => {
+  match (parseString(parserImplHelper)) {
+    Ok(s) => Ok(JSONString(s)),
+    Err(e) => Err(e),
+  }
+}, parseNumberValue = (parserImplHelper: JSONParserImplHelper) => {
+  // First char can optionally be a minus sign.
+  let mut c = parserImplHelper.currentCodePoint
+  let isNegative = c == 0x2D
+  // '-'
+  if (isNegative) {
+    c = next(parserImplHelper)
+  }
+
+  let mut err = None
+
+  let mut significand = 0
+  let mut exponent = 0
+  let mut isExponentNegative = false
+
+  // Note on performance: the hope here is to keep calculations in a way to
+  // do at least the intermediate operations with Simple Numbers (non heap
+  // allocated). If there's no fractional part then the resulting number
+  // itself is packed into the "pointer" / value and only an instance of
+  // JSONNumber is allocated on the heap. If the number has a fractional part
+  // or a negative exponent then the final number will be heap allocated.
+  // If the number doesn't fit 31 bits then intermetdiate calculations will
+  // allocate numbers on the heap. This could be alleviated by doing
+  // intermediate calculations with raw wasm numbers, but it would add some
+  // complexity.
+
+  // After that, the first/second char can only be a decimal digit ('0'..'9').
+  match (c) {
+    0x30 => { // '0'
+      // JSON doesn't allow numbers with additional leading zeros like
+      // "01". Which means that if a number starts with zero then the
+      // integer part is just zero and the next one can only be one of
+      // '.', 'e' or 'E'. In any case all that needs to be done here is
+      // to advance over the zero character and proceed to the optional
+      // fractional and exponential parts. If another digit follows then
+      // a parsing error will occur as expected, but implicitly because
+      // this function finishes with the parser positioned on a digit
+      // and not on a token expected after a number like ',', ']', '}' or
+      // EOF.
+      c = next(parserImplHelper)
+    },
+    x when x >= 0x31 && x <= 0x39 => { // '1'..'9'
+      for (;;) {
+        let digit = c - 0x30
+
+        significand = significand * 10 + digit
+
+        c = next(parserImplHelper)
+
+        if (c < 0x30 || c > 0x39) {
+          break
+        }
+      }
+
+      void
+    },
+    unexpectedCodePoint => {
+      // The integer part of the number has to have at least one digit.
+      // JSON doesn't allow numbers starting with decimal separator like ".1".
+      let detail = "expected a decimal digit, found " ++
+        formatCodePointOrEOF(unexpectedCodePoint)
+      err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+    },
+  }
+
+  // Optional fractional part of the number.
+  if (Option.isNone(err) && c == 0x2E) { // '.'
+    c = next(parserImplHelper)
+
+    // let mut decimalPos = 10
+    // let mut denominator = 1
+    for (; c >= 0x30 && c <= 0x39;) {
+      let digit = c - 0x30
+
+      significand = significand * 10 + digit
+
+      // denominator = denominator * 10
+
+      c = next(parserImplHelper)
+
+      exponent -= 1
+    }
+    // result /= denominator
+  }
+
+  // Optional exponential part of the number.
+  if (Option.isNone(err) && (c == 0x65 || c == 0x45)) { // 'e' or 'E'
+    c = next(parserImplHelper)
+
+    // can start with optional plus or minus sign
+    isExponentNegative = match (c) {
+      0x2D => { // '-'
+        c = next(parserImplHelper)
+        true
+      },
+      0x2B => { // '+'
+        c = next(parserImplHelper)
+        false
+      },
+      _ => {
+        false
+      },
+    }
+
+    // followed by one or more digits (0-9)
+
+    let mut explicitExponent = 0
+    for (; c >= 0x30 && c <= 0x39;) {
+      let digit = c - 0x30
+
+      explicitExponent = explicitExponent * 10 + digit
+
+      c = next(parserImplHelper)
+    }
+
+    if (isExponentNegative) {
+      exponent -= explicitExponent
+    } else {
+      exponent += explicitExponent
+    }
+
+    void
+  }
+
+  // Note that unlike all other JSON value types there's no explicit ending
+  // character like ('"' for strings, ']' for arrays,'}' for objects etc). We
+  // just leave the parser state at current position and the reading of next
+  // token will succeed or fail, but number parsing just ends here.
+
+  match (err) {
+    Some(e) => Err(e),
+    None => {
+      let mut result = significand
+
+      if (exponent != 0) {
+        // This is just a temporary naive implementation.
+
+        if (exponent > 0) {
+          let mut factor = 1
+          for (let mut i = 0; i < exponent; i += 1) {
+            factor *= 10
+          }
+          result *= factor
+        } else {
+          let mut factor = 1
+          for (let mut i = 0; i < 0 - exponent; i += 1) {
+            factor *= 10
+          }
+          result /= factor
+        }
+      }
+
+      if (isNegative) {
+        result = 0 - result
+      }
+      Ok(JSONNumber(result))
+    },
+  }
+}, parseArray = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x5B, parserImplHelper)) {
+    // '['
+    Some(e) => Err(e),
+    None => {
+      let mut err = None
+
+      let mut elems = []: List<JSON>
+
+      let mut done = false
+
+      while (!done) {
+        let c = parserImplHelper.currentCodePoint
+        match (c) {
+          0x2C => { // ','
+            next(parserImplHelper)
+            skipWhiteSpace(parserImplHelper)
+          },
+          0x5D => { // ']'
+            next(parserImplHelper)
+            done = true
+            break
+          },
+          -1 => {
+            // just end the loop without setting done to true
+            break
+          },
+          _ => {
+            // note that parseValue skips initial and final whitespace
+            match (parseValue(parserImplHelper)) {
+              Ok(elem) => {
+                elems = [elem, ...elems]
+                void
+              },
+              Err(e) => {
+                err = Some(e)
+                break
+              },
+            }
+          },
+        }
+      }
+
+      match (err) {
+        Some(e) => Err(e),
+        None => {
+          if (done) {
+            Ok(JSONArray(List.reverse(elems)))
+          } else {
+            Err(
+              buildUnexpectedTokenError(
+                parserImplHelper,
+                "unexpected end of array"
+              )
+            )
+          }
+        },
+      }
+    },
+  }
+}, parseObject = (parserImplHelper: JSONParserImplHelper) => {
+  match (expectCodePointAndAdvance(0x7B, parserImplHelper)) {
+    // '{'
+    Some(e) => Err(e),
+    None => {
+      let mut err = None
+
+      let mut entries = []: List<(String, JSON)>
+
+      let mut done = false
+      let mut first = true
+
+      // one iteration of this loop should correspond to a key-value pair
+      while (!done) {
+        skipWhiteSpace(parserImplHelper)
+
+        let c = parserImplHelper.currentCodePoint
+        match (c) {
+          -1 => {
+            let detail = "expected a key-value pair or the end of the object"
+            err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+            break
+          },
+          0x2C => { // ','
+            if (first) {
+              let detail = "expected a key-value pair or the end of the object, found ','"
+              err = Some(buildUnexpectedTokenError(parserImplHelper, detail))
+              break
+            } else {
+              next(parserImplHelper)
+              void
+            }
+          },
+          0x7D => { // '}'
+            next(parserImplHelper)
+            done = true
+            break
+          },
+          _ => {
+            // A new entry in current object.
+            // Just call parseString directly. In case the current character id not '"', it will return an error we can pass along.
+            match (parseString(parserImplHelper)) {
+              Ok(key) => {
+                skipWhiteSpace(parserImplHelper)
+
+                match (expectCodePointAndAdvance(0x3A, parserImplHelper)) {
+                  // ':'
+                  None => {
+                    // note that parseValue skips initial and final whitespace
+                    match (parseValue(parserImplHelper)) {
+                      Ok(value) => {
+                        entries = [(key, value), ...entries]
+                        first = false
+                        void
+                      },
+                      Err(e) => {
+                        err = Some(e)
+                        break
+                      },
+                    }
+                  },
+                  Some(e) => {
+                    err = Some(e)
+                    break
+                  },
+                }
+              },
+              Err(e) => {
+                err = Some(e)
+                break
+              },
+            }
+          },
+        }
+      }
+      // end of entry loop
+
+      match (err) {
+        Some(e) => Err(e),
+        None => {
+          if (done) {
+            Ok(JSONObject(List.reverse(entries)))
+          } else {
+            // This brand is not expected to actually execute,
+            // but in case it does, may just as well do the right thing.
+            Err(
+              buildUnexpectedTokenError(
+                parserImplHelper,
+                "unexpected end of object"
+              )
+            )
+          }
+        },
+      }
+    },
+  }
+}
+
+/**
+ * Parses JSON input from a string into a `JSON` object.
+ * 
+ * @param str: The JSON text string
+ * @returns A `Result` object with either the parsed `JSON` object or an error.
+ *
+ * Example output:
+ * ```
+ * Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+ * ```
+ * 
+ * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
+ */
+export let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
+  let parserImplHelper = {
+    string: str,
+    bufferParse: Buffer.make(16),
+    currentCodePoint: readCodePoint(0, str),
+    pos: 0,
+    bytePos: 0,
+  }: JSONParserImplHelper
+
+  let root = parseValue(parserImplHelper)
+
+  skipWhiteSpace(parserImplHelper)
+
+  if (isAtEndOfInput(parserImplHelper)) {
+    root
+  } else {
+    match (root) {
+      Ok(_) => {
+        let detail = "expected end of input, found " ++
+          formatCodePointOrEOF(parserImplHelper.currentCodePoint)
+        Err(buildUnexpectedTokenError(parserImplHelper, detail))
+      },
+      e => e,
+    }
+  }
+}

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1,5 +1,19 @@
 /**
  * JSON (JavaScript Object Notation) parsing, printing, and access utilities.
+ *
+ * @example include "json"
+ * @example
+ * Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
+ *   ("currency", JsonString("€")),
+ *   ("price", JsonNumber(99.99)),
+ * ])
+ * @example
+ * print(
+ *   toString(
+ *     format=Pretty,
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+ *   )
+ * )
  */
 
 module Json
@@ -293,7 +307,6 @@ provide enum FormattingChoices {
    * ··"currency":·"€",↵
    * ··"price":·99.9,↵
    * ··"currencyDescription":·"EURO\u007f",↵
-   * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
    * }
    * ```
    *
@@ -365,7 +378,7 @@ provide enum FormattingChoices {
    *
    * @since v0.6.0
    */
-  PrettyAndSafeFormat,
+  PrettyAndSafe,
   /**
    * Compact and conservative formatting to maximize compatibility and
    * embeddability of the resulting JSON.
@@ -395,7 +408,7 @@ provide enum FormattingChoices {
    *
    * @since v0.6.0
    */
-  CompactAndSafeFormat,
+  CompactAndSafe,
   /**
    * Allows for fined grained control of the formatting output.
    *
@@ -416,7 +429,7 @@ provide enum FormattingChoices {
 record JsonWriterConfig {
   format: FormattingSettings,
   buffer: Buffer.Buffer,
-  emitEscapedQuotedStringPretty: String => Void,
+  emitEscapedQuotedString: String => Void,
   printNewLine: Option<() => Void>,
   printIndentation: Option<Number => Void>,
 }
@@ -542,8 +555,6 @@ let printBool = (b: Bool, buffer: Buffer.Buffer) => {
   }
 }
 
-exception UnknownNumberTag
-
 @unsafe
 let printNumberWasmI32 = (value: WasmI32, buffer: Buffer.Buffer) => {
   let s = NumberUtils.itoa32(value, 10n)
@@ -630,25 +641,25 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             printNumberWasmF64(asWasmF64, buffer)
           },
           _ => {
-            throw UnknownNumberTag
+            fail "Impossible: Json.toString encountered an unknown number tag"
           },
         }
       },
       _ => {
-        throw UnknownNumberTag
+        fail "Impossible: Json.toString encountered an unknown number tag"
       },
     }
   } else {
-    throw UnknownNumberTag
+    fail "Impossible: Json.toString encountered an unknown number tag"
   }
   ignore(value)
   ret
 }
 
-// Note that this could relatively easily be integrated with
-// printElementCompact to avoid code duplication, but it would mean
-// compromising peak performance and also increasing complexity in other ways.
-let rec printElementPretty =
+// Note that this compromises on peak performance by also handling
+// the compact printing case, merging these two together greatly simplifies the amount
+// of code we need to maintain so it seems worth it.
+let rec printElement =
   (
     json: Json,
     implHelper: JsonWriterConfig,
@@ -666,7 +677,7 @@ let rec printElementPretty =
     },
     JsonNumber(n) => return printNumber(n, buffer),
     JsonString(s) => {
-      implHelper.emitEscapedQuotedStringPretty(s)
+      implHelper.emitEscapedQuotedString(s)
       return None
     },
     JsonArray(elems) => {
@@ -700,7 +711,7 @@ let rec printElementPretty =
             }
           }
 
-          match (printElementPretty(e, implHelper, elemLevel)) {
+          match (printElement(e, implHelper, elemLevel)) {
             None => void,
             err => return err,
           }
@@ -759,7 +770,7 @@ let rec printElementPretty =
               }
             }
 
-            match (printElementPretty(currentHead, implHelper, elemLevel)) {
+            match (printElement(currentHead, implHelper, elemLevel)) {
               None => void,
               err => return err,
             }
@@ -818,7 +829,7 @@ let rec printElementPretty =
             }
           }
 
-          implHelper.emitEscapedQuotedStringPretty(key)
+          implHelper.emitEscapedQuotedString(key)
 
           Buffer.addChar(':', buffer)
           match (format.objectFormat) {
@@ -828,7 +839,7 @@ let rec printElementPretty =
             },
           }
 
-          match (printElementPretty(value, implHelper, elemLevel)) {
+          match (printElement(value, implHelper, elemLevel)) {
             None => void,
             err => return err,
           }
@@ -889,7 +900,7 @@ let rec printElementPretty =
 
             let (key, value) = currentHead
 
-            implHelper.emitEscapedQuotedStringPretty(key)
+            implHelper.emitEscapedQuotedString(key)
 
             Buffer.addChar(':', buffer)
             match (format.objectFormat) {
@@ -899,7 +910,7 @@ let rec printElementPretty =
               },
             }
 
-            match (printElementPretty(value, implHelper, elemLevel)) {
+            match (printElement(value, implHelper, elemLevel)) {
               None => void,
               err => return err,
             }
@@ -1136,14 +1147,14 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   let implHelper = {
     format,
     buffer,
-    emitEscapedQuotedStringPretty: emitEscapedQuotedString,
+    emitEscapedQuotedString,
     printNewLine,
     printIndentation,
   }: JsonWriterConfig
 
   {
     emit: json => {
-      match (printElementPretty(json, implHelper, 0)) {
+      match (printElement(json, implHelper, 0)) {
         None => void,
         err => return err,
       }
@@ -1161,27 +1172,10 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
 /**
  * Prints the JSON object into a string with specific formatting settings.
  *
- * @param format: formatting option
+ * @param format: Formatting options
  * @param json: The JSON object to print
- * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
+ * @returns `Ok(str)` containing the printed JSON or `Err(err)` if the inputted object cannot be represented in the JSON format.,
  *
- * @example
- * print(
- *   toString(
- *     format=Custom{
- *      indentation: NoIndentation,
- *      arrayFormat: CompactArrayEntries,
- *      objectFormat: CompactObjectEntries,
- *      lineEnding: NoLineEnding,
- *      finishWithNewLine: false,
- *      escapeAllControlPoints: true,
- *      escapeHTMLUnsafeSequences: true,
- *      escapeNonASCII: true,
- *     },
- *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *   )
- * )
- * // Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
  * @example
  * print(
  *   toString(
@@ -1208,6 +1202,23 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
  * // \"currency\": \"€\",
  * // \"price\": 99.9
  * //}")
+ * @example
+ * print(
+ *   toString(
+ *     format=Custom{
+ *      indentation: NoIndentation,
+ *      arrayFormat: CompactArrayEntries,
+ *      objectFormat: CompactObjectEntries,
+ *      lineEnding: NoLineEnding,
+ *      finishWithNewLine: false,
+ *      escapeAllControlPoints: true,
+ *      escapeHTMLUnsafeSequences: true,
+ *      escapeNonASCII: true,
+ *     },
+ *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+ *   )
+ * )
+ * // Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
  *
  * @since v0.6.0
  */
@@ -1236,7 +1247,7 @@ provide let toString = (format=Compact, json: Json) => {
         escapeHTMLUnsafeSequences: false,
         escapeNonASCII: false,
       },
-    PrettyAndSafeFormat =>
+    PrettyAndSafe =>
       {
         indentation: IndentWithSpaces(2),
         arrayFormat: OneArrayEntryPerLine,
@@ -1247,7 +1258,7 @@ provide let toString = (format=Compact, json: Json) => {
         escapeHTMLUnsafeSequences: true,
         escapeNonASCII: true,
       },
-    CompactAndSafeFormat =>
+    CompactAndSafe =>
       {
         indentation: NoIndentation,
         arrayFormat: CompactArrayEntries,
@@ -1342,7 +1353,9 @@ let rec readCodePoint = (bytePosition: Number, string: String) => {
 
 let codePointUTF8ByteCount = (usv: Number) => {
   if (!Char.isValid(usv)) {
-    throw InvalidArgument("Invalid unicode scalar value")
+    throw InvalidArgument(
+      "Impossible: JSON parser encountered an invalid unicode scalar value"
+    )
   }
 
   if (usv <= 0x7f) {
@@ -2060,7 +2073,7 @@ and parseObject = (parserState: JsonParserState) => {
  * Parses JSON string into a `Json` data structure.
  *
  * @param str: The JSON text string
- * @returns A `Result` object with either the parsed `JSON` object or an error.
+ * @returns `Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise.
  *
  * @example
  * assert parse("{\"currency\":\"$\",\"price\":119}") == Ok(

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -37,6 +37,11 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
 /**
  * Data structure representing the result of parsing and the input of printing JSON.
  *
+ * This data structure is semantically equivalent to the JSON format allowing
+ * mostly lossless round trips of printing and parsing. Exceptions to this are
+ * whitespace, multiple ways JSON allows escaping characters in strings, and
+ * some edge cases related to Grain's `Number` type.
+ *
  * @example
  * Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
  *   ("currency", JsonString("€")),
@@ -48,11 +53,6 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
  *   ("currency", JsonString("€")),
  *   ("price", JsonNumber(99.99)),
  * ])
- *
- * This data structure is semantically equivalent to the JSON format allowing
- * mostly lossless round trips of printing and parsing. Exceptions to this are
- * whitespace, multiple ways JSON allows escaping characters in strings, and
- * some edge cases related to Grain's `Number` type.
  */
 provide enum rec Json {
   JsonNull,
@@ -251,10 +251,10 @@ provide enum LineEnding {
   CarriageReturn,
 }
 
-/**
+/*
  * Allows fine-grained control of formatting in JSON printing.
  */
-provide record FormattingSettings {
+record FormattingSettings {
   indentation: IndentationFormat,
   arrayFormat: ArrayFormat,
   objectFormat: ObjectFormat,
@@ -271,9 +271,20 @@ provide record FormattingSettings {
 provide enum FormattingChoices {
   Pretty,
   Compact,
-  Custom(FormattingSettings),
+  PrettyAndSafeFormat,
+  CompactAndSafeFormat,
+  Custom{
+    indentation: IndentationFormat,
+    arrayFormat: ArrayFormat,
+    objectFormat: ObjectFormat,
+    lineEnding: LineEnding,
+    finishWithNewLine: Bool,
+    escapeAllControlPoints: Bool,
+    escapeHTMLUnsafeSequences: Bool,
+    escapeNonASCII: Bool,
+  },
 }
-/**
+/*
  * Compact formatting that minimizes the size of resulting JSON at cost of not
  * being easily human readable.
  *
@@ -286,10 +297,8 @@ provide enum FormattingChoices {
  * ```
  * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
  * ```
- *
- * @since v0.6.0
  */
-provide let defaultCompactFormat = {
+let defaultCompactFormat = {
   indentation: NoIndentation,
   arrayFormat: CompactArrayEntries,
   objectFormat: CompactObjectEntries,
@@ -300,7 +309,7 @@ provide let defaultCompactFormat = {
   escapeNonASCII: false,
 }: FormattingSettings
 
-/**
+/*
  * Recommended human readable formatting.
  *
  * Escapes all control points for the sake of clarity, but prints unicode
@@ -317,10 +326,8 @@ provide let defaultCompactFormat = {
  * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
  * }
  * ```
- *
- * @since v0.6.0
  */
-provide let defaultPrettyFormat = {
+let defaultPrettyFormat = {
   indentation: IndentWithSpaces(2),
   arrayFormat: OneArrayEntryPerLine,
   objectFormat: OneObjectEntryPerLine,
@@ -343,10 +350,8 @@ provide let defaultPrettyFormat = {
  * ```
  * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
  * ```
- *
- * @since v0.6.0
  */
-provide let defaultCompactAndSafeFormat = {
+let defaultCompactAndSafeFormat = {
   indentation: NoIndentation,
   arrayFormat: CompactArrayEntries,
   objectFormat: CompactObjectEntries,
@@ -374,10 +379,8 @@ provide let defaultCompactAndSafeFormat = {
  * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
  * }
  * ```
- *
- * @since v0.6.0
  */
-provide let defaultPrettyAndSafeFormat = {
+let defaultPrettyAndSafeFormat = {
   indentation: IndentWithSpaces(2),
   arrayFormat: OneArrayEntryPerLine,
   objectFormat: OneObjectEntryPerLine,
@@ -668,7 +671,7 @@ let rec printElementCompact =
       // the allocation of closures, this makes this function a little ugly but it seems
       // like a valid trade-off
       // Another approach would be to allocate a function for the
-      // formattng arrays just once at the start of formatting and pass
+      // formatting arrays just once at the start of formatting and pass
       // it in emitJSONElement.
       match (elems) {
         [] => {
@@ -1253,7 +1256,16 @@ let makePrettyPrintJsonWriter =
  * @example
  * print(
  *   toString(
- *     format=Custom(defaultCompactAndSafeFormat),
+ *     format=Custom{
+ *      indentation: NoIndentation,
+ *      arrayFormat: CompactArrayEntries,
+ *      objectFormat: CompactObjectEntries,
+ *      lineEnding: NoLineEnding,
+ *      finishWithNewLine: false,
+ *      escapeAllControlPoints: true,
+ *      escapeHTMLUnsafeSequences: true,
+ *      escapeNonASCII: true,
+ *     },
  *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *   )
  * )
@@ -1292,7 +1304,33 @@ provide let toString = (format=Compact, json: Json) => {
   let writer = match (format) {
     Pretty => makePrettyPrintJsonWriter(defaultPrettyFormat, buf),
     Compact => makeCompactJsonWriter(buf),
-    Custom(format) => makePrettyPrintJsonWriter(format, buf),
+    PrettyAndSafeFormat =>
+      makePrettyPrintJsonWriter(defaultPrettyAndSafeFormat, buf),
+    CompactAndSafeFormat =>
+      makePrettyPrintJsonWriter(defaultCompactAndSafeFormat, buf),
+    Custom{
+      indentation,
+      arrayFormat,
+      objectFormat,
+      lineEnding,
+      finishWithNewLine,
+      escapeAllControlPoints,
+      escapeHTMLUnsafeSequences,
+      escapeNonASCII,
+    } =>
+      makePrettyPrintJsonWriter(
+        {
+          indentation,
+          arrayFormat,
+          objectFormat,
+          lineEnding,
+          finishWithNewLine,
+          escapeAllControlPoints,
+          escapeHTMLUnsafeSequences,
+          escapeNonASCII,
+        }: FormattingSettings,
+        buf
+      ),
   }
   let error = writer.emit(json)
 

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -26,8 +26,14 @@ include "runtime/dataStructures"
 include "runtime/bigint" as BI
 from RunTimeString use { toString as runtimeToString }
 from Numbers use { coerceNumberToWasmI32 }
-from DataStructures use { tagSimpleNumber, newFloat64 }
+from DataStructures use { tagSimpleNumber, newFloat64, untagSimpleNumber }
 
+// Primitive Offsets
+// TODO(703): Get these offsets from the runtime
+@unsafe
+let _INT64_BOXED_VALUE_OFFSET = 8n
+@unsafe
+let _Float64_BOXED_VALUE_OFFSET = 8n
 /**
  * Data structure representing the result of parsing and the input of printing
  * JSON.
@@ -238,6 +244,14 @@ provide record FormattingSettings {
 }
 
 /**
+ * Allows control of formatting in JSON printing.
+ */
+provide enum FormattingChoices {
+  Pretty,
+  Compact,
+  Custom(FormattingSettings),
+}
+/**
  * Compact formatting that minimizes the size of resulting JSON at cost of not
  * being easily human readable.
  *
@@ -250,18 +264,19 @@ provide record FormattingSettings {
  * ```
  * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
  * ```
+ *
+ * @since v0.6.0
  */
-provide let defaultCompactFormat = () =>
-  {
-    indentation: NoIndentation,
-    arrayFormat: CompactArrayEntries,
-    objectFormat: CompactObjectEntries,
-    lineEnding: NoLineEnding,
-    finishWithNewLine: false,
-    escapeAllControlPoints: false,
-    escapeHTMLUnsafeSequences: false,
-    escapeNonASCII: false,
-  }: FormattingSettings
+provide let defaultCompactFormat = {
+  indentation: NoIndentation,
+  arrayFormat: CompactArrayEntries,
+  objectFormat: CompactObjectEntries,
+  lineEnding: NoLineEnding,
+  finishWithNewLine: false,
+  escapeAllControlPoints: false,
+  escapeHTMLUnsafeSequences: false,
+  escapeNonASCII: false,
+}: FormattingSettings
 
 /**
  * Recommended human readable formatting.
@@ -280,18 +295,19 @@ provide let defaultCompactFormat = () =>
  * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
  * }
  * ```
+ *
+ * @since v0.6.0
  */
-provide let defaultPrettyFormat = () =>
-  {
-    indentation: IndentWithSpaces(2),
-    arrayFormat: OneArrayEntryPerLine,
-    objectFormat: OneObjectEntryPerLine,
-    lineEnding: LineFeed,
-    finishWithNewLine: true,
-    escapeAllControlPoints: true,
-    escapeHTMLUnsafeSequences: false,
-    escapeNonASCII: false,
-  }: FormattingSettings
+provide let defaultPrettyFormat = {
+  indentation: IndentWithSpaces(2),
+  arrayFormat: OneArrayEntryPerLine,
+  objectFormat: OneObjectEntryPerLine,
+  lineEnding: LineFeed,
+  finishWithNewLine: true,
+  escapeAllControlPoints: true,
+  escapeHTMLUnsafeSequences: false,
+  escapeNonASCII: false,
+}: FormattingSettings
 
 /**
  * Compact and conservative formatting to maximize compatibility and
@@ -305,18 +321,19 @@ provide let defaultPrettyFormat = () =>
  * ```
  * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
  * ```
+ *
+ * @since v0.6.0
  */
-provide let defaultCompactAndSafeFormat = () =>
-  {
-    indentation: NoIndentation,
-    arrayFormat: CompactArrayEntries,
-    objectFormat: CompactObjectEntries,
-    lineEnding: NoLineEnding,
-    finishWithNewLine: false,
-    escapeAllControlPoints: true,
-    escapeHTMLUnsafeSequences: true,
-    escapeNonASCII: true,
-  }: FormattingSettings
+provide let defaultCompactAndSafeFormat = {
+  indentation: NoIndentation,
+  arrayFormat: CompactArrayEntries,
+  objectFormat: CompactObjectEntries,
+  lineEnding: NoLineEnding,
+  finishWithNewLine: false,
+  escapeAllControlPoints: true,
+  escapeHTMLUnsafeSequences: true,
+  escapeNonASCII: true,
+}: FormattingSettings
 
 /**
  * Pretty and conservative formatting to maximize compatibility and
@@ -335,18 +352,19 @@ provide let defaultCompactAndSafeFormat = () =>
  * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
  * }
  * ```
+ *
+ * @since v0.6.0
  */
-provide let defaultPrettyAndSafeFormat = () =>
-  {
-    indentation: IndentWithSpaces(2),
-    arrayFormat: OneArrayEntryPerLine,
-    objectFormat: OneObjectEntryPerLine,
-    lineEnding: LineFeed,
-    finishWithNewLine: true,
-    escapeAllControlPoints: true,
-    escapeHTMLUnsafeSequences: true,
-    escapeNonASCII: true,
-  }: FormattingSettings
+provide let defaultPrettyAndSafeFormat = {
+  indentation: IndentWithSpaces(2),
+  arrayFormat: OneArrayEntryPerLine,
+  objectFormat: OneObjectEntryPerLine,
+  lineEnding: LineFeed,
+  finishWithNewLine: true,
+  escapeAllControlPoints: true,
+  escapeHTMLUnsafeSequences: true,
+  escapeNonASCII: true,
+}: FormattingSettings
 
 record JSONWriterCompactImplHelper {
   buffer: Buffer.Buffer,
@@ -553,9 +571,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
 
   let ptr = WasmI32.fromGrain(value)
   if ((ptr & 1n) != 0n) {
-    // FIXME expose runtime/numbers.untagSimple?
-    let asWasmI32 = ptr >> 1n
-    printNumberWasmI32(asWasmI32, buffer)
+    printNumberWasmI32(untagSimpleNumber(value), buffer)
     None
   } else if ((ptr & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
     let tag = WasmI32.load(ptr, 0n)
@@ -564,8 +580,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
         let numberTag = WasmI32.load(ptr, 4n)
         match (numberTag) {
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
-            let asWasmI64 = WasmI64.load(ptr, 8n)
-            // FIXME magic numbers
+            let asWasmI64 = WasmI64.load(ptr, _INT64_BOXED_VALUE_OFFSET)
             printNumberWasmI64(asWasmI64, buffer)
             None
           },
@@ -596,8 +611,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             printNumberWasmF64(asWasmF64, buffer)
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
-            let asWasmF64 = WasmF64.load(ptr, 8n)
-            // FIXME magic numbers
+            let asWasmF64 = WasmF64.load(ptr, _Float64_BOXED_VALUE_OFFSET)
             printNumberWasmF64(asWasmF64, buffer)
           },
           _ => {
@@ -626,16 +640,16 @@ let rec printElementCompact =
   match (json) {
     JSONNull => {
       printNull(buffer)
-      None
+      return None
     },
     JSONBoolean(b) => {
       printBool(b, buffer)
-      None
+      return None
     },
-    JSONNumber(n) => printNumber(n, buffer),
+    JSONNumber(n) => return printNumber(n, buffer),
     JSONString(s) => {
       implHelper.emitEscapedQuotedString(s)
-      None
+      return None
     },
     JSONArray(elems) => {
       // Here I'm not using List.forEachi or similar in order to avoid
@@ -648,18 +662,15 @@ let rec printElementCompact =
         [] => {
           Buffer.addChar('[', buffer)
           Buffer.addChar(']', buffer)
-          None
+          return None
         },
         [e] => {
           Buffer.addChar('[', buffer)
 
           let err = printElementCompact(e, implHelper)
-
-          if (Option.isNone(err)) {
-            Buffer.addChar(']', buffer)
-          }
-
-          err
+          if (Option.isSome(err)) return err
+          Buffer.addChar(']', buffer)
+          return None
         },
         [initialHead, ...initialRest] => {
           Buffer.addChar('[', buffer)
@@ -667,15 +678,13 @@ let rec printElementCompact =
           let mut currentHead = initialHead
           let mut currentRest = initialRest
 
-          let mut err = None
-
           for (let mut index = 0; ; index += 1) {
             if (index > 0) {
               Buffer.addChar(',', buffer)
             }
 
-            err = printElementCompact(currentHead, implHelper)
-            if (Option.isSome(err)) break
+            let err = printElementCompact(currentHead, implHelper)
+            if (Option.isSome(err)) return err
 
             match (currentRest) {
               [] => break,
@@ -686,11 +695,9 @@ let rec printElementCompact =
             }
           }
 
-          if (Option.isNone(err)) {
-            Buffer.addChar(']', buffer)
-          }
+          Buffer.addChar(']', buffer)
 
-          err
+          return None
         },
       }
     },
@@ -699,7 +706,7 @@ let rec printElementCompact =
         [] => {
           Buffer.addChar('{', buffer)
           Buffer.addChar('}', buffer)
-          None
+          return None
         },
         [(key, value)] => {
           Buffer.addChar('{', buffer)
@@ -709,20 +716,17 @@ let rec printElementCompact =
           Buffer.addChar(':', buffer)
 
           let err = printElementCompact(value, implHelper)
+          if (Option.isSome(err)) return err
 
-          if (Option.isNone(err)) {
-            Buffer.addChar('}', buffer)
-          }
+          Buffer.addChar('}', buffer)
 
-          err
+          return None
         },
         [initialHead, ...initialRest] => {
           Buffer.addChar('{', buffer)
 
           let mut currentHead = initialHead
           let mut currentRest = initialRest
-
-          let mut err = None
 
           for (let mut index = 0; ; index += 1) {
             if (index > 0) {
@@ -735,11 +739,9 @@ let rec printElementCompact =
 
             Buffer.addChar(':', buffer)
 
-            err = printElementCompact(value, implHelper)
+            let err = printElementCompact(value, implHelper)
 
-            if (Option.isSome(err)) {
-              break
-            }
+            if (Option.isSome(err)) return err
 
             match (currentRest) {
               [] => break,
@@ -750,11 +752,9 @@ let rec printElementCompact =
             }
           }
 
-          if (Option.isNone(err)) {
-            Buffer.addChar('}', buffer)
-          }
+          Buffer.addChar('}', buffer)
 
-          err
+          return None
         },
       }
     },
@@ -814,23 +814,23 @@ let rec printElementPretty =
   match (json) {
     JSONNull => {
       printNull(buffer)
-      None
+      return None
     },
     JSONBoolean(b) => {
       printBool(b, buffer)
-      None
+      return None
     },
-    JSONNumber(n) => printNumber(n, buffer),
+    JSONNumber(n) => return printNumber(n, buffer),
     JSONString(s) => {
       implHelper.emitEscapedQuotedStringPretty(s)
-      None
+      return None
     },
     JSONArray(elems) => {
       match (elems) {
         [] => {
           Buffer.addChar('[', buffer)
           Buffer.addChar(']', buffer)
-          None
+          return None
         },
         [e] => {
           let format = implHelper.format
@@ -848,17 +848,16 @@ let rec printElementPretty =
           }
 
           let err = printElementPretty(e, implHelper, elemLevel)
+          if (Option.isSome(err)) return err
 
-          if (Option.isNone(err)) {
-            if (format.arrayFormat == OneArrayEntryPerLine) {
-              implHelper.printNewLine()
-              implHelper.printIndentation(indentationLevel)
-            }
-
-            Buffer.addChar(']', buffer)
+          if (format.arrayFormat == OneArrayEntryPerLine) {
+            implHelper.printNewLine()
+            implHelper.printIndentation(indentationLevel)
           }
 
-          err
+          Buffer.addChar(']', buffer)
+
+          return None
         },
         [initialHead, ...initialRest] => {
           let format = implHelper.format
@@ -871,8 +870,6 @@ let rec printElementPretty =
 
           let mut currentHead = initialHead
           let mut currentRest = initialRest
-
-          let mut err = None
 
           let elemLevel = indentationLevel + 1
 
@@ -889,10 +886,8 @@ let rec printElementPretty =
               implHelper.printIndentation(elemLevel)
             }
 
-            err = printElementPretty(currentHead, implHelper, elemLevel)
-            if (Option.isSome(err)) {
-              break
-            }
+            let err = printElementPretty(currentHead, implHelper, elemLevel)
+            if (Option.isSome(err)) return err
 
             match (currentRest) {
               [] => break,
@@ -903,16 +898,14 @@ let rec printElementPretty =
             }
           }
 
-          if (Option.isNone(err)) {
-            if (format.arrayFormat == OneArrayEntryPerLine) {
-              implHelper.printNewLine()
-              implHelper.printIndentation(indentationLevel)
-            }
-
-            Buffer.addChar(']', buffer)
+          if (format.arrayFormat == OneArrayEntryPerLine) {
+            implHelper.printNewLine()
+            implHelper.printIndentation(indentationLevel)
           }
 
-          err
+          Buffer.addChar(']', buffer)
+
+          return None
         },
       }
     },
@@ -921,7 +914,7 @@ let rec printElementPretty =
         [] => {
           Buffer.addChar('{', buffer)
           Buffer.addChar('}', buffer)
-          None
+          return None
         },
         [(key, value)] => {
           let format = implHelper.format
@@ -948,17 +941,16 @@ let rec printElementPretty =
           }
 
           let err = printElementPretty(value, implHelper, elemLevel)
+          if (Option.isSome(err)) return err
 
-          if (Option.isNone(err)) {
-            if (format.objectFormat == OneObjectEntryPerLine) {
-              implHelper.printNewLine()
-              implHelper.printIndentation(indentationLevel)
-            }
-
-            Buffer.addChar('}', buffer)
+          if (format.objectFormat == OneObjectEntryPerLine) {
+            implHelper.printNewLine()
+            implHelper.printIndentation(indentationLevel)
           }
 
-          err
+          Buffer.addChar('}', buffer)
+
+          return None
         },
         [initialHead, ...initialRest] => {
           let format = implHelper.format
@@ -971,8 +963,6 @@ let rec printElementPretty =
 
           let mut currentHead = initialHead
           let mut currentRest = initialRest
-
-          let mut err = None
 
           let elemLevel = indentationLevel + 1
 
@@ -1003,11 +993,8 @@ let rec printElementPretty =
               },
             }
 
-            err = printElementPretty(value, implHelper, elemLevel)
-
-            if (Option.isSome(err)) {
-              break
-            }
+            let err = printElementPretty(value, implHelper, elemLevel)
+            if (Option.isSome(err)) return err
 
             match (currentRest) {
               [] => break,
@@ -1018,16 +1005,14 @@ let rec printElementPretty =
             }
           }
 
-          if (Option.isNone(err)) {
-            if (format.objectFormat == OneObjectEntryPerLine) {
-              implHelper.printNewLine()
-              implHelper.printIndentation(indentationLevel)
-            }
-
-            Buffer.addChar('}', buffer)
+          if (format.objectFormat == OneObjectEntryPerLine) {
+            implHelper.printNewLine()
+            implHelper.printIndentation(indentationLevel)
           }
 
-          err
+          Buffer.addChar('}', buffer)
+
+          return None
         },
       }
     },
@@ -1236,12 +1221,9 @@ let makePrettyPrintJSONWriter =
   {
     emit: json => {
       let error = printElementPretty(json, implHelper, 0)
-
-      if (format.finishWithNewLine && Option.isNone(error)) {
-        printNewLine()
-      }
-
-      error
+      if (Option.isSome(error)) return error
+      if (format.finishWithNewLine) printNewLine()
+      return None
     },
   }: JSONWriter
 }
@@ -1250,21 +1232,62 @@ let makePrettyPrintJSONWriter =
  * Prints the JSON object into a string with specific formatting settings.
  *
  * @param json: The JSON object to print
- * @param format: Custom formatting setttings
+ * @param format: formatting option
  * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
  *
- * @example print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
+ * @example
+ * print(
+ *   Result.unwrap(
+ *     toString(
+ *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       format=Custom(defaultCompactAndSafeFormat)
+ *     )
+ *   )
+ * )
+ * // Output: {"currency":"\u20ac","price":99.9}"
+ * @example
+ * print(
+ *   Result.unwrap(
+ *     toString(
+ *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]
+ *     )
+ *   )
+ * )
+ * // Output: {"currency":"€","price":99.9}
+ * @example
+ * print(
+ *   Result.unwrap(
+ *     toString(
+ *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       format=Compact
+ *      )
+ *   )
+ * )
+ * // Output: {"currency":"€","price":99.9}
+ * @example
+ * print(
+ *   Result.unwrap(
+ *     toString(
+ *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       format=Pretty
+ *     )
+ *   )
+ * )
+ * // Output:
+ * // {
+ * // "currency": "€",
+ * // "price": 99.9
+ * //}
  *
- * Example output:
- * ```json
- * {"currency":"\u20ac","price":99.9}
- * ```
+ * @since v0.6.0
  */
-provide let toString = (json: JSON, format: FormattingSettings) => {
+provide let toString = (json: JSON, format=Compact) => {
   let buf = Buffer.make(16)
-
-  let writer = makePrettyPrintJSONWriter(format, buf)
-
+  let writer = match (format) {
+    Pretty => makePrettyPrintJSONWriter(defaultPrettyFormat, buf),
+    Compact => makeCompactJSONWriter(buf),
+    Custom(format) => makePrettyPrintJSONWriter(format, buf),
+  }
   let error = writer.emit(json)
 
   match (error) {
@@ -1272,59 +1295,6 @@ provide let toString = (json: JSON, format: FormattingSettings) => {
     Some(e) => Err(e),
   }
 }
-
-/**
- * Prints the JSON object into a string with compact formatting optimized for
- * small size. Recommended for all uses where the intended consumer is a
- * machine program. For example in REST APIs.
- *
- * Using this function can be preferred over `toString` with compact formatting
- * settings since it can be slightly faster.
- *
- * @param json: The JSON object to print
- * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
- *
- * @example print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
- *
- * Example output:
- * ```json
- * {"currency":"€","price":99.9}
- * ```
- */
-provide let toStringCompact = (json: JSON) => {
-  let buf = Buffer.make(16)
-
-  let writer = makeCompactJSONWriter(buf)
-
-  let error = writer.emit(json)
-
-  match (error) {
-    None => Ok(Buffer.toString(buf)),
-    Some(e) => Err(e),
-  }
-}
-
-/**
- * Prints the JSON object into a string with default pretty formatting
- * settings. Recommended for uses where the intended consumer is a person or
- * the text should be easily inspectable. For example configuration files or
- * document file formats.
- *
- * @param json: The JSON object to print
- * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
- *
- * Example output:
- * ```json
- * {
- *   "currency": "€",
- *   "price": 99.9
- * }
- * ```
- *
- * @example print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
- */
-provide let toStringPretty = (json: JSON) =>
-  toString(json, defaultPrettyFormat())
 
 /**
  * Represents errors for JSON parsing along with a human readable text message.
@@ -1931,8 +1901,6 @@ parseNumberValue = (parserState: JSONParserState) => {
     c = next(parserState)
   }
 
-  let mut err = None
-
   // After that, the first/second char can only be a decimal digit ('0'..'9').
   match (c) {
     0x30 => { // '0'
@@ -1964,11 +1932,11 @@ parseNumberValue = (parserState: JSONParserState) => {
       // JSON doesn't allow numbers starting with decimal separator like ".1".
       let detail = "expected a decimal digit, found " ++
         formatCodePointOrEOF(unexpectedCodePoint)
-      err = Some(buildUnexpectedTokenError(parserState, detail))
+      return Err(buildUnexpectedTokenError(parserState, detail))
     },
   }
   // Optional fractional part of the number.
-  if (Option.isNone(err) && c == 0x2E) { // '.'
+  if (c == 0x2E) { // '.'
     isFloat = true
     Buffer.addChar('.', buffer)
     c = next(parserState)
@@ -1979,7 +1947,7 @@ parseNumberValue = (parserState: JSONParserState) => {
       c = next(parserState)
     }
     if (!hasHitDigit)
-      err = Some(
+      return Err(
         buildUnexpectedTokenError(
           parserState,
           "exponent part is missing in number"
@@ -1987,7 +1955,7 @@ parseNumberValue = (parserState: JSONParserState) => {
       )
   }
   // Optional exponential part of the number.
-  if (Option.isNone(err) && (c == 0x65 || c == 0x45)) { // 'e' or 'E'
+  if (c == 0x65 || c == 0x45) { // 'e' or 'E'
     isFloat = true
     Buffer.addChar('e', buffer)
     c = next(parserState)
@@ -2010,7 +1978,7 @@ parseNumberValue = (parserState: JSONParserState) => {
       c = next(parserState)
     }
     if (!hasHitDigit)
-      err = Some(
+      return Err(
         buildUnexpectedTokenError(
           parserState,
           "exponent part is missing in number"
@@ -2023,23 +1991,18 @@ parseNumberValue = (parserState: JSONParserState) => {
   // character like ('"' for strings, ']' for arrays,'}' for objects etc). We
   // just leave the parser state at current position and the reading of next
   // token will succeed or fail, but number parsing just ends here.
-  match (err) {
-    Some(e) => Err(e),
-    None => {
-      let result = match (isFloat) {
-        false => atoiFast(buffer),
-        true => {
-          let str = Buffer.toString(buffer)
-          match (Number.parseFloat(str)) {
-            Err(err) => fail "Impossible",
-            Ok(n) => n,
-          }
-        },
+  let result = match (isFloat) {
+    false => atoiFast(buffer),
+    true => {
+      let str = Buffer.toString(buffer)
+      match (Number.parseFloat(str)) {
+        Err(err) => fail "Impossible",
+        Ok(n) => n,
       }
-      if (result == 0 && isNegative) Ok(JSONNumber(-0.0))
-      else Ok(JSONNumber(if (isNegative) result * -1 else result))
     },
   }
+  if (result == 0 && isNegative) return Ok(JSONNumber(-0.0))
+  else return Ok(JSONNumber(if (isNegative) result * -1 else result))
 },
 parseArray = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x5B, parserState)) {
@@ -2226,12 +2189,15 @@ parseObject = (parserState: JSONParserState) => {
  * @param str: The JSON text string
  * @returns A `Result` object with either the parsed `JSON` object or an error.
  *
+ *
+ * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
+ *
  * Example output:
  * ```
  * Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
  * ```
  *
- * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
+ * @since v0.6.0
  */
 provide let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
   let parserState = {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1418,39 +1418,27 @@ let getCodePoint = (ptr: WasmI32) => {
   result: WasmI32
 }
 
-@disableGC
+@unsafe
 let rec readCodePoint = (bytePosition: Number, string: String) => {
-  let (>>>) = WasmI32.shrU
   let (+) = WasmI32.add
-  let (-) = WasmI32.sub
-  let (&) = WasmI32.and
   let (<) = WasmI32.ltU
-  let (<=) = WasmI32.leU
-  let (==) = WasmI32.eq
 
   let strPtr = WasmI32.fromGrain(string)
 
   let byteSize = WasmI32.load(strPtr, 4n)
 
-  Memory.incRef(WasmI32.fromGrain(coerceNumberToWasmI32))
-  Memory.incRef(WasmI32.fromGrain(bytePosition))
   let bytePositionW32 = coerceNumberToWasmI32(bytePosition)
 
-  let ptr = WasmI32.add(WasmI32.add(strPtr, 8n), bytePositionW32)
+  let ptr = strPtr + 8n + bytePositionW32
 
   let mut idx = 0n
-  let result = if (bytePositionW32 < byteSize) {
+  
+  if (bytePositionW32 < byteSize) {
     let codePoint = getCodePoint(ptr)
     tagSimpleNumber(codePoint)
   } else {
     _END_OF_INPUT
   }
-
-  Memory.decRef(WasmI32.fromGrain(bytePosition))
-  Memory.decRef(WasmI32.fromGrain(string))
-  Memory.decRef(WasmI32.fromGrain(readCodePoint))
-
-  result
 }
 
 let codePointUTF8ByteCount = (usv: Number) => {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -530,7 +530,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
 }
 
 @unsafe
-let rec printNumber = (value: Number, buffer: Buffer.Buffer) => {
+let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   let (&) = WasmI32.and
   let (==) = WasmI32.eq
   let (!=) = WasmI32.ne
@@ -1517,7 +1517,7 @@ let buildUnexpectedTokenError =
 }
 
 @unsafe
-let rec toHex = (n: Number) => {
+let toHex = (n: Number) => {
   let x = coerceNumberToWasmI32(n)
   NumberUtils.itoa32(x, 16n)
 }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -101,8 +101,8 @@ provide enum IndentationFormat {
    *
    * ```json
    * {
-   *   "currency": "€",
-   *   "price": 99.9
+   * 	"currency": "€",
+   * 	"price": 99.9
    * }
    * ```
    */

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -9,23 +9,19 @@ include "runtime/dataStructures"
 include "runtime/numbers"
 include "runtime/numberUtils"
 include "runtime/string" as RuntimeString
-include "runtime/unsafe/memory"
-include "runtime/unsafe/memory"
 include "runtime/unsafe/tags"
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/wasmi64"
-include "runtime/unsafe/wasmf32"
 include "runtime/unsafe/wasmf64"
+include "runtime/atof/parse" as Atof
 include "buffer"
 include "char"
 include "string"
 include "list"
-include "number"
-include "option"
 include "uint8"
 from RuntimeString use { toString as runtimeToString, getCodePoint }
 from Numbers use { coerceNumberToWasmI32 }
-from DataStructures use { tagSimpleNumber, newFloat64, untagSimpleNumber }
+from DataStructures use { tagSimpleNumber, untagSimpleNumber }
 
 // Primitive offsets
 // TODO(#703): Get these offsets from the runtime
@@ -87,7 +83,7 @@ provide enum JsonToStringError {
  * Controls how indentation is performed in custom formatting.
  *
  * Following examples have whitespaces and line breaks replaced with visible
- * charactes for illustrative purposes.
+ * characters for illustrative purposes.
  *
  * `NoIndentation`
  * ```
@@ -433,15 +429,11 @@ record JsonWriter {
   emit: Json => Option<JsonToStringError>,
 }
 
-let addCharFromCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
-  Buffer.addChar(Char.fromCode(codePoint), buffer)
-}
-
 let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
   // Emit the "\u" followed by hexadecimal representation of the codepoint
   // with fixed length of 4 hexadecimal digits corresponding to the two byte
   // codepoint. No checks are performed here if the codepoint is in the
-  // "Basic Multilingual Plane" (0000-FFFF) as this funcion is only called
+  // "Basic Multilingual Plane" (0000-FFFF) as this function is only called
   // internally.
   // An alternative was to this implementation was to use NumberUtils.itoa32,
   // but this avoids unnecessary heap allocations. As a possible future
@@ -475,7 +467,7 @@ let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
       digit + 87
     }
 
-    addCharFromCodePoint(hexDigitCodePoint, buffer)
+    Buffer.addCharFromCodePoint(hexDigitCodePoint, buffer)
   }
 }
 
@@ -589,7 +581,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     // (Float64 as well as Number). This is the only reason that the
     // formatting needs to return a Result and not just a String
     // directly. Other possible choices were to throw exceptions or to
-    // coninue formatting without representing these values correctly
+    // continue formatting without representing these values correctly
     // (like JavaScript's JSON.stringify).
     if (isNaN(value)) {
       Some(InvalidNumber("NaN is not allowed in JsonNumber"))
@@ -708,8 +700,10 @@ let rec printElementPretty =
             }
           }
 
-          let err = printElementPretty(e, implHelper, elemLevel)
-          if (Option.isSome(err)) return err
+          match (printElementPretty(e, implHelper, elemLevel)) {
+            None => void,
+            err => return err,
+          }
 
           if (format.arrayFormat == OneArrayEntryPerLine) {
             match (implHelper.printNewLine) {
@@ -765,8 +759,10 @@ let rec printElementPretty =
               }
             }
 
-            let err = printElementPretty(currentHead, implHelper, elemLevel)
-            if (Option.isSome(err)) return err
+            match (printElementPretty(currentHead, implHelper, elemLevel)) {
+              None => void,
+              err => return err,
+            }
 
             match (currentRest) {
               [] => break,
@@ -832,8 +828,10 @@ let rec printElementPretty =
             },
           }
 
-          let err = printElementPretty(value, implHelper, elemLevel)
-          if (Option.isSome(err)) return err
+          match (printElementPretty(value, implHelper, elemLevel)) {
+            None => void,
+            err => return err,
+          }
 
           if (format.objectFormat == OneObjectEntryPerLine) {
             match (implHelper.printNewLine) {
@@ -901,8 +899,10 @@ let rec printElementPretty =
               },
             }
 
-            let err = printElementPretty(value, implHelper, elemLevel)
-            if (Option.isSome(err)) return err
+            match (printElementPretty(value, implHelper, elemLevel)) {
+              None => void,
+              err => return err,
+            }
 
             match (currentRest) {
               [] => break,
@@ -973,28 +973,22 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   let printIndentation = match (format.indentation) {
     IndentWithTab =>
       Some(indentationLevel => {
-        let mut count = 0
-        while (count < indentationLevel) {
+        for (let mut count = 0; count < indentationLevel; count += 1) {
           Buffer.addChar('\t', buffer)
-          count += 1
         }
       }),
     IndentWithSpaces(spacesPerIndentation) when spacesPerIndentation == 2 =>
       Some(indentationLevel => {
-        let mut count = 0
         let spaceCount = indentationLevel * 2
-        while (count < spaceCount) {
+        for (let mut count = 0; count < spaceCount; count += 1) {
           Buffer.addChar(' ', buffer)
-          count += 1
         }
       }),
     IndentWithSpaces(spacesPerIndentation) =>
       Some(indentationLevel => {
-        let mut count = 0
         let spaceCount = indentationLevel * spacesPerIndentation
-        while (count < spaceCount) {
+        for (let mut count = 0; count < spaceCount; count += 1) {
           Buffer.addChar(' ', buffer)
-          count += 1
         }
       }),
     NoIndentation => None,
@@ -1027,14 +1021,14 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   ) {
     (codePoint: Number) => {
       if (codePoint > 31 && codePoint != 0x0022 && codePoint != 0x005C) {
-        addCharFromCodePoint(codePoint, buffer)
+        Buffer.addCharFromCodePoint(codePoint, buffer)
       } else {
         emitEscapedCodePoint(codePoint, buffer)
       }
     }
   } else if (!format.escapeAllControlPoints && format.escapeNonASCII) {
     // If desired, escape all non ASCII code points. So the only non
-    // escaped code points are those in the range of ASCII chacarcters
+    // escaped code points are those in the range of ASCII characters
     // from 31 to 127.
     (codePoint: Number) => {
       if (
@@ -1043,7 +1037,7 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
         codePoint != 0x005C &&
         codePoint < 128
       ) {
-        addCharFromCodePoint(codePoint, buffer)
+        Buffer.addCharFromCodePoint(codePoint, buffer)
       } else {
         emitEscapedCodePoint(codePoint, buffer)
       }
@@ -1061,7 +1055,7 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
         codePoint < 127 ||
         codePoint > 159
       ) {
-        addCharFromCodePoint(codePoint, buffer)
+        Buffer.addCharFromCodePoint(codePoint, buffer)
       } else {
         emitEscapedCodePoint(codePoint, buffer)
       }
@@ -1079,7 +1073,7 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
         codePoint < 127
       ) {
         // fast path for chars that never need any escaping
-        addCharFromCodePoint(codePoint, buffer)
+        Buffer.addCharFromCodePoint(codePoint, buffer)
       } else {
         emitEscapedCodePoint(codePoint, buffer)
       }
@@ -1117,7 +1111,7 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
             Buffer.addChar('/', buffer)
           } else {
             // otherwise just emit the slash as-is
-            addCharFromCodePoint(codePoint, buffer)
+            Buffer.addChar('/', buffer)
           }
         } else {
           emitCodePoint(codePoint)
@@ -1140,8 +1134,10 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
 
   {
     emit: json => {
-      let error = printElementPretty(json, implHelper, 0)
-      if (Option.isSome(error)) return error
+      match (printElementPretty(json, implHelper, 0)) {
+        None => void,
+        err => return err,
+      }
       if (format.finishWithNewLine) {
         match (printNewLine) {
           Some(printNewLine) => printNewLine(),
@@ -1408,7 +1404,7 @@ let toHexWithZeroPadding = (n: Number, padTo: Number) => {
   // Note that this function is only called in exceptional cases so no effort
   // was made to optimize it.
   let mut result = toHex(n)
-  while (String.length(result) < padTo) {
+  for (let mut i = String.length(result); i < padTo; i += 1) {
     result = "0" ++ result
   }
   result
@@ -1574,9 +1570,8 @@ and parseFalseValue = (parserState: JsonParserState) => {
 and parseString = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x22, parserState)) {
     // '"'
-    Some(e) => Err(e),
+    Some(e) => return Err(e),
     None => {
-      let mut err = None
       let mut done = false
       let buffer = parserState.bufferParse
       Buffer.clear(buffer)
@@ -1688,8 +1683,7 @@ and parseString = (parserState: JsonParserState) => {
                       let digitsSoFar = 3 - digitIndex
                       let detail = "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
                         runtimeToString(digitsSoFar)
-                      err = Some(buildUnexpectedTokenError(parserState, detail))
-                      break
+                      return Err(buildUnexpectedTokenError(parserState, detail))
                     }
 
                     let shift = digitIndex * 4
@@ -1706,12 +1700,16 @@ and parseString = (parserState: JsonParserState) => {
                     // Plane (U+0000..U+FFFF).
                     if (isHighSurrogate(codeUnit)) {
                       // Next characters should be "\u"
-                      err = expectCodePointAndAdvance(0x5C, parserState)
                       // '\'
-                      if (Option.isSome(err)) break
-                      err = expectCodePointAndAdvance(0x75, parserState)
+                      match (expectCodePointAndAdvance(0x5C, parserState)) {
+                        Some(e) => return Err(e),
+                        None => void,
+                      }
                       // 'u'
-                      if (Option.isSome(err)) break
+                      match (expectCodePointAndAdvance(0x75, parserState)) {
+                        Some(e) => return Err(e),
+                        None => void,
+                      }
 
                       // Keep the high surrogate and proceed to the second
                       // iteration of the loop.
@@ -1721,7 +1719,7 @@ and parseString = (parserState: JsonParserState) => {
                       !isLowSurrogate(codeUnit)
                     ) {
                       let codePoint = codeUnit
-                      addCharFromCodePoint(codePoint, buffer)
+                      Buffer.addCharFromCodePoint(codePoint, buffer)
                       break
                     } else {
                       let message = "Invalid character escape sequence at position " ++
@@ -1729,8 +1727,7 @@ and parseString = (parserState: JsonParserState) => {
                         ": expected a Unicode code point in Basic Multilingual Plane (U+0000..U+FFFF) or a high surrogate (0xD800..0xDBFF) of a UTF-16 surrogate pair, found " ++
                         "0x" ++
                         toHexWithZeroPadding(codeUnit, 4)
-                      err = Some(InvalidUTF16SurrogatePair(message))
-                      break
+                      return Err(InvalidUTF16SurrogatePair(message))
                     }
                   } else {
                     // This is the second iteration of the loop.
@@ -1741,7 +1738,7 @@ and parseString = (parserState: JsonParserState) => {
                         highSurrogate,
                         lowSurrogate
                       )
-                      addCharFromCodePoint(combinedCodePoint, buffer)
+                      Buffer.addCharFromCodePoint(combinedCodePoint, buffer)
                       break
                     } else {
                       let message = "Invalid character escape sequence at position " ++
@@ -1749,56 +1746,46 @@ and parseString = (parserState: JsonParserState) => {
                         ": expected a low surrogate (0xDC00..0xDFFF) in the second code unit of the UTF-16 sequence, found " ++
                         "0x" ++
                         toHexWithZeroPadding(codeUnit, 4)
-                      err = Some(InvalidUTF16SurrogatePair(message))
-                      break
+                      return Err(InvalidUTF16SurrogatePair(message))
                     }
                   }
                 }
-
-                if (Option.isSome(err)) break
               },
               unexpectedCodePoint => {
                 // JSON doesn't allow arbitrary characters to be preceded by backslash escape.
                 // Only the ones above.
                 let detail = "expected a valid escape sequence or the end of string, found " ++
                   formatCodePointOrEOF(unexpectedCodePoint)
-                err = Some(buildUnexpectedTokenError(parserState, detail))
-                break
+                return Err(buildUnexpectedTokenError(parserState, detail))
               },
             }
           },
           c => {
             if (c >= 0x00 && c <= 0x1F) {
-              err = Some(
+              return Err(
                 buildUnexpectedTokenError(
                   parserState,
                   "Bad control character in string literal"
                 )
               )
-              break
             }
             // Finally the happy case of a simple unescaped code point.
             next(parserState)
-            addCharFromCodePoint(c, buffer)
+            Buffer.addCharFromCodePoint(c, buffer)
           },
         }
       }
 
-      match (err) {
-        None => {
-          if (done) {
-            let s = Buffer.toString(buffer)
-            Ok(s)
-          } else {
-            Err(
-              buildUnexpectedTokenError(
-                parserState,
-                "unexpected end of string value"
-              )
-            )
-          }
-        },
-        Some(e) => Err(e),
+      if (done) {
+        let s = Buffer.toString(buffer)
+        return Ok(s)
+      } else {
+        return Err(
+          buildUnexpectedTokenError(
+            parserState,
+            "unexpected end of string value"
+          )
+        )
       }
     },
   }
@@ -1835,12 +1822,12 @@ and parseNumberValue = (parserState: JsonParserState) => {
       // this function finishes with the parser positioned on a digit
       // and not on a token expected after a number like ',', ']', '}' or
       // EOF.
-      addCharFromCodePoint(c, buffer)
+      Buffer.addCharFromCodePoint(c, buffer)
       c = next(parserState)
     },
     x when x >= 0x31 && x <= 0x39 => { // '1'..'9'
-      for (;;) {
-        addCharFromCodePoint(c, buffer)
+      while (true) {
+        Buffer.addCharFromCodePoint(c, buffer)
         c = next(parserState)
         if (c < 0x30 || c > 0x39) {
           break
@@ -1864,7 +1851,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
     let mut hasHitDigit = false
     for (; c >= 0x30 && c <= 0x39;) {
       hasHitDigit = true
-      addCharFromCodePoint(c, buffer)
+      Buffer.addCharFromCodePoint(c, buffer)
       c = next(parserState)
     }
     if (!hasHitDigit)
@@ -1895,7 +1882,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
     let mut hasHitDigit = false
     for (; c >= 0x30 && c <= 0x39;) {
       hasHitDigit = true
-      addCharFromCodePoint(c, buffer)
+      Buffer.addCharFromCodePoint(c, buffer)
       c = next(parserState)
     }
     if (!hasHitDigit)
@@ -1916,7 +1903,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
     false => atoiFast(buffer),
     true => {
       let str = Buffer.toString(buffer)
-      match (Number.parseFloat(str)) {
+      match (Atof.parseFloat(str)) {
         Err(err) => fail "Impossible: Json parse float on invalid float",
         Ok(n) => n,
       }
@@ -1928,10 +1915,9 @@ and parseNumberValue = (parserState: JsonParserState) => {
 and parseArray = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x5B, parserState)) {
     // '['
-    Some(e) => Err(e),
+    Some(e) => return Err(e),
     None => {
       skipWhiteSpace(parserState)
-      let mut err = None
 
       let mut elems = []: List<Json>
 
@@ -1944,13 +1930,12 @@ and parseArray = (parserState: JsonParserState) => {
           0x2C => { // ','
             trailingComma = true
             if (first) {
-              err = Some(
+              return Err(
                 buildUnexpectedTokenError(
                   parserState,
                   "unexpected comma at beginning of array"
                 )
               )
-              break
             }
             next(parserState)
             skipWhiteSpace(parserState)
@@ -1973,30 +1958,22 @@ and parseArray = (parserState: JsonParserState) => {
                 elems = [elem, ...elems]
                 void
               },
-              Err(e) => {
-                err = Some(e)
-                break
-              },
+              Err(e) => return Err(e),
             }
           },
         }
       }
 
-      match (err) {
-        Some(e) => Err(e),
-        None => {
-          if (trailingComma) {
-            Err(
-              buildUnexpectedTokenError(parserState, "unexpected end of array")
-            )
-          } else if (done) {
-            Ok(JsonArray(List.reverse(elems)))
-          } else {
-            Err(
-              buildUnexpectedTokenError(parserState, "unexpected end of array")
-            )
-          }
-        },
+      if (trailingComma) {
+        return Err(
+          buildUnexpectedTokenError(parserState, "unexpected end of array")
+        )
+      } else if (done) {
+        return Ok(JsonArray(List.reverse(elems)))
+      } else {
+        return Err(
+          buildUnexpectedTokenError(parserState, "unexpected end of array")
+        )
       }
     },
   }
@@ -2004,10 +1981,8 @@ and parseArray = (parserState: JsonParserState) => {
 and parseObject = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x7B, parserState)) {
     // '{'
-    Some(e) => Err(e),
+    Some(e) => return Err(e),
     None => {
-      let mut err = None
-
       let mut entries = []: List<(String, Json)>
 
       let mut done = false
@@ -2022,15 +1997,13 @@ and parseObject = (parserState: JsonParserState) => {
         match (c) {
           -1 => {
             let detail = "expected a key-value pair or the end of the object"
-            err = Some(buildUnexpectedTokenError(parserState, detail))
-            break
+            return Err(buildUnexpectedTokenError(parserState, detail))
           },
           0x2C => { // ','
             trailingComma = true
             if (first) {
               let detail = "expected a key-value pair or the end of the object, found ','"
-              err = Some(buildUnexpectedTokenError(parserState, detail))
-              break
+              return Err(buildUnexpectedTokenError(parserState, detail))
             } else {
               next(parserState)
               void
@@ -2039,8 +2012,7 @@ and parseObject = (parserState: JsonParserState) => {
           0x7D => { // '}'
             if (trailingComma) {
               let detail = "unexpected trailing comma in object"
-              err = Some(buildUnexpectedTokenError(parserState, detail))
-              break
+              return Err(buildUnexpectedTokenError(parserState, detail))
             }
             next(parserState)
             done = true
@@ -2064,41 +2036,27 @@ and parseObject = (parserState: JsonParserState) => {
                         first = false
                         void
                       },
-                      Err(e) => {
-                        err = Some(e)
-                        break
-                      },
+                      Err(e) => return Err(e),
                     }
                   },
-                  Some(e) => {
-                    err = Some(e)
-                    break
-                  },
+                  Some(e) => return Err(e),
                 }
               },
-              Err(e) => {
-                err = Some(e)
-                break
-              },
+              Err(e) => return Err(e),
             }
           },
         }
       }
       // end of entry loop
 
-      match (err) {
-        Some(e) => Err(e),
-        None => {
-          if (done) {
-            Ok(JsonObject(List.reverse(entries)))
-          } else {
-            // This branch is not expected to actually execute,
-            // but in case it does, may just as well do the right thing.
-            Err(
-              buildUnexpectedTokenError(parserState, "unexpected end of object")
-            )
-          }
-        },
+      if (done) {
+        return Ok(JsonObject(List.reverse(entries)))
+      } else {
+        // This branch is not expected to actually execute,
+        // but in case it does, may just as well do the right thing.
+        return Err(
+          buildUnexpectedTokenError(parserState, "unexpected end of object")
+        )
       }
     },
   }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1,48 +1,48 @@
 /**
- * JSON (JavaScript Object Notation) parsing and printing.
+ * JSON (JavaScript Object Notation) parsing, printing, and access utilities.
  */
 
 module Json
 
-include "string"
-include "char"
-include "list"
-include "option"
-include "number"
-include "uint8"
+include "runtime/bigint" as BI
+include "runtime/dataStructures"
+include "runtime/numbers"
+include "runtime/numberUtils"
+include "runtime/string" as RunTimeString
+include "runtime/unsafe/memory"
+include "runtime/unsafe/memory"
+include "runtime/unsafe/tags"
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/wasmi64"
 include "runtime/unsafe/wasmf32"
 include "runtime/unsafe/wasmf64"
-include "runtime/numberUtils"
-include "runtime/unsafe/tags"
-include "runtime/numbers"
-include "runtime/unsafe/memory"
 include "buffer"
-include "runtime/string" as RunTimeString
-include "runtime/numbers"
-include "runtime/unsafe/memory"
-include "runtime/dataStructures"
-include "runtime/bigint" as BI
+include "char"
+include "string"
+include "list"
+include "number"
+include "option"
+include "uint8"
 from RunTimeString use { toString as runtimeToString, getCodePoint }
 from Numbers use { coerceNumberToWasmI32 }
 from DataStructures use { tagSimpleNumber, newFloat64, untagSimpleNumber }
 
-// Primitive Offsets
+// Primitive offsets
 // TODO(703): Get these offsets from the runtime
 @unsafe
 let _INT64_BOXED_VALUE_OFFSET = 8n
 @unsafe
 let _Float64_BOXED_VALUE_OFFSET = 8n
+
 /**
  * Data structure representing the result of parsing and the input of printing
  * JSON.
  *
  * For example this object
  * ```grain
- * JSONObject([
- *   ("currency", JSONString("€")),
- *   ("price", JSONNumber(99.99)),
+ * JsonObject([
+ *   ("currency", JsonString("€")),
+ *   ("price", JsonNumber(99.99)),
  * ])
  * ```
  * is equivalent to the following JSON:
@@ -52,8 +52,8 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
  *
  * This data structure is semantically equivalent to the JSON format allowing
  * mostly lossless round trips of printing and parsing. Exceptions to this are
- * white spaces, multiple ways JSON allows escaping characters in strings and
- * some edge-cases related to Grain's `Number` type.
+ * whitespace, multiple ways JSON allows escaping characters in strings, and
+ * some edge cases related to Grain's `Number` type.
  *
  * For example parsing the following JSON text will also result in the same
  * `JSON` object as above.
@@ -64,12 +64,12 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
  * }
  * ```
  */
-provide enum JSON {
-  JSONNull,
-  JSONBoolean(Bool),
-  JSONNumber(Number),
-  JSONString(String),
-  JSONArray(List<JSON>),
+provide enum Json {
+  JsonNull,
+  JsonBoolean(Bool),
+  JsonNumber(Number),
+  JsonString(String),
+  JsonArray(List<Json>),
   // Note that JSONObject here is deliberately defined as a simple list of key value pair tuples as opposed
   // to for example a Map in order to accomodate the fact that the ECMA-404 standard doesn't prohibit
   // duplicate names in Objects. Such JSON should be representable by the JSON data structure for lossless
@@ -77,7 +77,7 @@ provide enum JSON {
   // has the benefit of List's immutability. It's a concious decision that sacrifices ease of use of the
   // API for lossless handing of these edge cases with intention of later building more ergonomic APIs on a
   // higher level of abstraction.
-  JSONObject(List<(String, JSON)>),
+  JsonObject(List<(String, Json)>),
 }
 
 /**
@@ -85,7 +85,7 @@ provide enum JSON {
  * JSON format along with a human readable text message. This can happen when
  * it contains number values `NaN`, `Infinity` or `-Infinity`.
  */
-provide enum JSONToStringError {
+provide enum JsonToStringError {
   InvalidNumber(String),
 }
 
@@ -230,7 +230,7 @@ provide enum LineEnding {
 }
 
 /**
- * Allows fine grained control of formatting in JSON printing.
+ * Allows fine-grained control of formatting in JSON printing.
  */
 provide record FormattingSettings {
   indentation: IndentationFormat,
@@ -366,16 +366,14 @@ provide let defaultPrettyAndSafeFormat = {
   escapeNonASCII: true,
 }: FormattingSettings
 
-record JSONWriterCompactImplHelper {
+record JsonWriterCompactImplHelper {
   buffer: Buffer.Buffer,
   emitEscapedQuotedString: String -> Void,
 }
 
-record JSONWriterPrettyImplHelper {
+record JsonWriterPrettyImplHelper {
   format: FormattingSettings,
-  // Note that the "Pretty" suffix here is a workaround for a Grain compiler bug.
-  // It generates warnings just because two record types have some field names in common.
-  // Unless there's something I don't understand about its type system.
+  //TODO(#775): Note that the "Pretty" suffix here is a workaround for a Grain compiler bug.
   bufferPretty: Buffer.Buffer,
   emitEscapedQuotedStringPretty: String -> Void,
   printNewLine: () -> Void,
@@ -386,8 +384,8 @@ record JSONWriterPrettyImplHelper {
 // For now this is not exposed and remains an internal implementation detail.
 // It may make sense in the future to expose it and let the user reuse a writer for multiple
 // JSON emit operations without reallocating new closures and buffers each time.
-record JSONWriter {
-  emit: JSON -> Option<JSONToStringError>,
+record JsonWriter {
+  emit: Json -> Option<JsonToStringError>,
 }
 
 let addCharFromCodePoint = (codePoint: Number, buffer: Buffer.Buffer) => {
@@ -401,7 +399,7 @@ let emitUTF16EscapeSequence = (codePoint: Number, buffer: Buffer.Buffer) => {
   // "Basic Multilingual Plane" (0000-FFFF) as this funcion is only called
   // internally.
   // An alternative was to this implementation was to use NumberUtils.itoa32,
-  // but I wanted to avoid unnecessary heap allocations. As a possible future
+  // but this avoids unnecessary heap allocations. As a possible future
   // optimization this loop could be unrolled possibly even converted to be
   // branchless and SIMD optimized, but it could be a bit of an overkill as
   // this codepath is only for escape sequences, which probably aren't all
@@ -550,11 +548,11 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     // coninue formatting without representing these values correctly
     // (like JavaScript's JSON.stringify).
     if (isNaN(value)) {
-      Some(InvalidNumber("NaN is not allowed in JSONNumber"))
+      Some(InvalidNumber("NaN is not allowed in JsonNumber"))
     } else if (value < 0.0W) {
-      Some(InvalidNumber("-Infinity is not allowed in JSONNumber"))
+      Some(InvalidNumber("-Infinity is not allowed in JsonNumber"))
     } else {
-      Some(InvalidNumber("Infinity is not allowed in JSONNumber"))
+      Some(InvalidNumber("Infinity is not allowed in JsonNumber"))
     }
   }
 }
@@ -566,6 +564,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   let ptr = WasmI32.fromGrain(value)
   if ((ptr & 1n) != 0n) {
     printNumberWasmI32(untagSimpleNumber(value), buffer)
+    ignore(value)
     None
   } else if ((ptr & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
     let tag = WasmI32.load(ptr, 0n)
@@ -576,10 +575,12 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
             let asWasmI64 = WasmI64.load(ptr, _INT64_BOXED_VALUE_OFFSET)
             printNumberWasmI64(asWasmI64, buffer)
+            ignore(value)
             None
           },
           t when t == Tags._GRAIN_BIGINT_BOXED_NUM_TAG => {
             Buffer.addString(BI.bigIntToString10(ptr), buffer)
+            ignore(value)
             None
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
@@ -602,11 +603,15 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             ) /
               WasmF64.convertI32S(Numbers.boxedRationalDenominator(ptr))
 
-            printNumberWasmF64(asWasmF64, buffer)
+            let val = printNumberWasmF64(asWasmF64, buffer)
+            ignore(value)
+            val
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
             let asWasmF64 = WasmF64.load(ptr, _Float64_BOXED_VALUE_OFFSET)
-            printNumberWasmF64(asWasmF64, buffer)
+            let val = printNumberWasmF64(asWasmF64, buffer)
+            ignore(value)
+            val
           },
           _ => {
             throw UnknownNumberTag
@@ -622,30 +627,27 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   }
 }
 
-// Note that this function is not allocated with the JSONWriter because currently
-// Grain leaks memory each time a recursive closure is allocated. Not reallocating
-// it may also be a better thing to do.
 let rec printElementCompact =
   (
-    json: JSON,
-    implHelper: JSONWriterCompactImplHelper,
+    json: Json,
+    implHelper: JsonWriterCompactImplHelper,
   ) => {
   let buffer = implHelper.buffer
   match (json) {
-    JSONNull => {
+    JsonNull => {
       printNull(buffer)
       return None
     },
-    JSONBoolean(b) => {
+    JsonBoolean(b) => {
       printBool(b, buffer)
       return None
     },
-    JSONNumber(n) => return printNumber(n, buffer),
-    JSONString(s) => {
+    JsonNumber(n) => return printNumber(n, buffer),
+    JsonString(s) => {
       implHelper.emitEscapedQuotedString(s)
       return None
     },
-    JSONArray(elems) => {
+    JsonArray(elems) => {
       // Here I'm not using List.forEachi or similar in order to avoid
       // allocations of closures. The code is verbose and a bit ugly as a
       // consequence, but I think it's an OK price for performance gain.
@@ -695,7 +697,7 @@ let rec printElementCompact =
         },
       }
     },
-    JSONObject(entries) => {
+    JsonObject(entries) => {
       match (entries) {
         [] => {
           Buffer.addChar('{', buffer)
@@ -755,9 +757,9 @@ let rec printElementCompact =
   }
 }
 
-let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
+let makeCompactJsonWriter = (buffer: Buffer.Buffer) => {
   // As an optimization prepare a closure function to execute for each code
-  // point of the input. It's important that this is not inlide in the
+  // point of the input. It's important that this is not inline in the
   // emitEscapedQuotedString function directly to avoid allocating the closue
   // for each input string.
   let emitCodePoint = (codePoint: Number) => {
@@ -784,7 +786,7 @@ let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
   let implHelper = {
     buffer,
     emitEscapedQuotedString,
-  }: JSONWriterCompactImplHelper
+  }: JsonWriterCompactImplHelper
 
   {
     emit: json => {
@@ -792,7 +794,7 @@ let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
 
       error
     },
-  }: JSONWriter
+  }: JsonWriter
 }
 
 // Note that this could relatively easily be integrated with
@@ -800,26 +802,26 @@ let makeCompactJSONWriter = (buffer: Buffer.Buffer) => {
 // compromising peak performance and also increasing complexity in other ways.
 let rec printElementPretty =
   (
-    json: JSON,
-    implHelper: JSONWriterPrettyImplHelper,
+    json: Json,
+    implHelper: JsonWriterPrettyImplHelper,
     indentationLevel: Number,
   ) => {
   let buffer = implHelper.bufferPretty
   match (json) {
-    JSONNull => {
+    JsonNull => {
       printNull(buffer)
       return None
     },
-    JSONBoolean(b) => {
+    JsonBoolean(b) => {
       printBool(b, buffer)
       return None
     },
-    JSONNumber(n) => return printNumber(n, buffer),
-    JSONString(s) => {
+    JsonNumber(n) => return printNumber(n, buffer),
+    JsonString(s) => {
       implHelper.emitEscapedQuotedStringPretty(s)
       return None
     },
-    JSONArray(elems) => {
+    JsonArray(elems) => {
       match (elems) {
         [] => {
           Buffer.addChar('[', buffer)
@@ -903,7 +905,7 @@ let rec printElementPretty =
         },
       }
     },
-    JSONObject(entries) => {
+    JsonObject(entries) => {
       match (entries) {
         [] => {
           Buffer.addChar('{', buffer)
@@ -1032,7 +1034,7 @@ let combineSurrogatePairToCodePoint =
   ((highSurrogate - 0xD800) << 10) + (lowSurrogate - 0xDC00) + 0x10000
 }
 
-let makePrettyPrintJSONWriter =
+let makePrettyPrintJsonWriter =
   (
     format: FormattingSettings,
     buffer: Buffer.Buffer,
@@ -1210,7 +1212,7 @@ let makePrettyPrintJSONWriter =
     },
     printNewLine,
     printIndentation,
-  }: JSONWriterPrettyImplHelper
+  }: JsonWriterPrettyImplHelper
 
   {
     emit: json => {
@@ -1219,7 +1221,7 @@ let makePrettyPrintJSONWriter =
       if (format.finishWithNewLine) printNewLine()
       return None
     },
-  }: JSONWriter
+  }: JsonWriter
 }
 
 /**
@@ -1233,7 +1235,7 @@ let makePrettyPrintJSONWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
  *       format=Custom(defaultCompactAndSafeFormat)
  *     )
  *   )
@@ -1243,7 +1245,7 @@ let makePrettyPrintJSONWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
  *     )
  *   )
  * )
@@ -1252,7 +1254,7 @@ let makePrettyPrintJSONWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
  *       format=Compact
  *      )
  *   )
@@ -1262,7 +1264,7 @@ let makePrettyPrintJSONWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
  *       format=Pretty
  *     )
  *   )
@@ -1275,12 +1277,12 @@ let makePrettyPrintJSONWriter =
  *
  * @since v0.6.0
  */
-provide let toString = (json: JSON, format=Compact) => {
+provide let toString = (json: Json, format=Compact) => {
   let buf = Buffer.make(16)
   let writer = match (format) {
-    Pretty => makePrettyPrintJSONWriter(defaultPrettyFormat, buf),
-    Compact => makeCompactJSONWriter(buf),
-    Custom(format) => makePrettyPrintJSONWriter(format, buf),
+    Pretty => makePrettyPrintJsonWriter(defaultPrettyFormat, buf),
+    Compact => makeCompactJsonWriter(buf),
+    Custom(format) => makePrettyPrintJsonWriter(format, buf),
   }
   let error = writer.emit(json)
 
@@ -1293,7 +1295,7 @@ provide let toString = (json: JSON, format=Compact) => {
 /**
  * Represents errors for JSON parsing along with a human readable text message.
  */
-provide enum JSONParseError {
+provide enum JsonParseError {
   UnexpectedEndOfInput(String),
   UnexpectedToken(String),
   InvalidUTF16SurrogatePair(String),
@@ -1302,7 +1304,7 @@ provide enum JSONParseError {
 /**
  * Internal data structure used during parsing.
  */
-record JSONParserState {
+record JsonParserState {
   string: String,
   bufferParse: Buffer.Buffer,
   mut currentCodePoint: Number,
@@ -1360,11 +1362,11 @@ let codePointUTF8ByteCount = (usv: Number) => {
   }
 }
 
-let isAtEndOfInput = (parserState: JSONParserState) => {
+let isAtEndOfInput = (parserState: JsonParserState) => {
   parserState.currentCodePoint == _END_OF_INPUT
 }
 
-let next = (parserState: JSONParserState) => {
+let next = (parserState: JsonParserState) => {
   let mut c = parserState.currentCodePoint
   if (c != _END_OF_INPUT) {
     parserState.bytePos += codePointUTF8ByteCount(c)
@@ -1377,7 +1379,7 @@ let next = (parserState: JSONParserState) => {
   c
 }
 
-let skipWhiteSpace = (parserState: JSONParserState) => {
+let skipWhiteSpace = (parserState: JsonParserState) => {
   // isAtEndOfInput is not strictly necessary here
   // could remove as an optimization
   while (
@@ -1391,7 +1393,7 @@ let skipWhiteSpace = (parserState: JSONParserState) => {
 
 let buildUnexpectedTokenError =
   (
-    parserState: JSONParserState,
+    parserState: JsonParserState,
     detail: String,
   ) => {
   let codePoint = parserState.currentCodePoint
@@ -1425,7 +1427,7 @@ let toHexWithZeroPadding = (n: Number, padTo: Number) => {
 
 let formatCodePointOrEOF = (codePoint: Number) => {
   if (codePoint >= 32 && codePoint <= 126) {
-    // If the codepoint is in the range of printable ASCII charactes, then
+    // If the codepoint is in the range of printable ASCII characters, then
     // display the character itself . Whether it's a good idea to display
     // all of them, especially space is up for debate.
     "'" ++ runtimeToString(Char.fromCode(codePoint)) ++ "'"
@@ -1441,7 +1443,7 @@ let formatCodePointOrEOF = (codePoint: Number) => {
 let expectCodePointAndAdvance =
   (
     expectedCodePoint: Number,
-    parserState: JSONParserState,
+    parserState: JsonParserState,
   ) => {
   let c = parserState.currentCodePoint
   if (c == expectedCodePoint) {
@@ -1466,7 +1468,7 @@ let atoiFast = buffer => {
   }
   result
 }
-let rec parseValue = (parserState: JSONParserState) => {
+let rec parseValue = (parserState: JsonParserState) => {
   skipWhiteSpace(parserState)
 
   let result = match (parserState.currentCodePoint) {
@@ -1498,8 +1500,8 @@ let rec parseValue = (parserState: JSONParserState) => {
   skipWhiteSpace(parserState)
 
   result
-},
-parseNullValue = (parserState: JSONParserState) => {
+}
+and parseNullValue = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x6E, parserState)) {
     // 'n'
     Some(e) => Err(e),
@@ -1515,7 +1517,7 @@ parseNullValue = (parserState: JSONParserState) => {
               match (expectCodePointAndAdvance(0x6C, parserState)) {
                 // 'l'
                 Some(e) => Err(e),
-                None => Ok(JSONNull),
+                None => Ok(JsonNull),
               }
             },
           }
@@ -1523,8 +1525,8 @@ parseNullValue = (parserState: JSONParserState) => {
       }
     },
   }
-},
-parseTrueValue = (parserState: JSONParserState) => {
+}
+and parseTrueValue = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x74, parserState)) {
     // 't'
     Some(e) => Err(e),
@@ -1540,7 +1542,7 @@ parseTrueValue = (parserState: JSONParserState) => {
               match (expectCodePointAndAdvance(0x65, parserState)) {
                 // 'e'
                 Some(e) => Err(e),
-                None => Ok(JSONBoolean(true)),
+                None => Ok(JsonBoolean(true)),
               }
             },
           }
@@ -1548,8 +1550,8 @@ parseTrueValue = (parserState: JSONParserState) => {
       }
     },
   }
-},
-parseFalseValue = (parserState: JSONParserState) => {
+}
+and parseFalseValue = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x66, parserState)) {
     // 'f'
     Some(e) => Err(e),
@@ -1569,7 +1571,7 @@ parseFalseValue = (parserState: JSONParserState) => {
                   match (expectCodePointAndAdvance(0x65, parserState)) {
                     // 'e'
                     Some(e) => Err(e),
-                    None => Ok(JSONBoolean(false)),
+                    None => Ok(JsonBoolean(false)),
                   }
                 },
               }
@@ -1579,8 +1581,8 @@ parseFalseValue = (parserState: JSONParserState) => {
       }
     },
   }
-},
-parseString = (parserState: JSONParserState) => {
+}
+and parseString = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x22, parserState)) {
     // '"'
     Some(e) => Err(e),
@@ -1811,15 +1813,15 @@ parseString = (parserState: JSONParserState) => {
       }
     },
   }
-},
-parseStringValue = (parserState: JSONParserState) => {
+}
+and parseStringValue = (parserState: JsonParserState) => {
   match (parseString(parserState)) {
-    Ok(s) => Ok(JSONString(s)),
+    Ok(s) => Ok(JsonString(s)),
     Err(e) => Err(e),
   }
-},
-parseNumberValue = (parserState: JSONParserState) => {
-  // TODO: Use A Streaming Optimized Way For Parsing The Numbers
+}
+and parseNumberValue = (parserState: JsonParserState) => {
+  // TODO: Use a streaming-optimized way to parse numbers
   let buffer = parserState.bufferParse
   Buffer.clear(buffer)
   // First char can optionally be a minus sign.
@@ -1931,10 +1933,10 @@ parseNumberValue = (parserState: JSONParserState) => {
       }
     },
   }
-  if (result == 0 && isNegative) return Ok(JSONNumber(-0.0))
-  else return Ok(JSONNumber(if (isNegative) result * -1 else result))
-},
-parseArray = (parserState: JSONParserState) => {
+  if (result == 0 && isNegative) return Ok(JsonNumber(-0.0))
+  else return Ok(JsonNumber(if (isNegative) result * -1 else result))
+}
+and parseArray = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x5B, parserState)) {
     // '['
     Some(e) => Err(e),
@@ -1942,7 +1944,7 @@ parseArray = (parserState: JSONParserState) => {
       skipWhiteSpace(parserState)
       let mut err = None
 
-      let mut elems = []: List<JSON>
+      let mut elems = []: List<Json>
 
       let mut done = false
       let mut first = true
@@ -1999,7 +2001,7 @@ parseArray = (parserState: JSONParserState) => {
               buildUnexpectedTokenError(parserState, "unexpected end of array")
             )
           } else if (done) {
-            Ok(JSONArray(List.reverse(elems)))
+            Ok(JsonArray(List.reverse(elems)))
           } else {
             Err(
               buildUnexpectedTokenError(parserState, "unexpected end of array")
@@ -2009,15 +2011,15 @@ parseArray = (parserState: JSONParserState) => {
       }
     },
   }
-},
-parseObject = (parserState: JSONParserState) => {
+}
+and parseObject = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x7B, parserState)) {
     // '{'
     Some(e) => Err(e),
     None => {
       let mut err = None
 
-      let mut entries = []: List<(String, JSON)>
+      let mut entries = []: List<(String, Json)>
 
       let mut done = false
       let mut first = true
@@ -2099,9 +2101,9 @@ parseObject = (parserState: JSONParserState) => {
         Some(e) => Err(e),
         None => {
           if (done) {
-            Ok(JSONObject(List.reverse(entries)))
+            Ok(JsonObject(List.reverse(entries)))
           } else {
-            // This brand is not expected to actually execute,
+            // This branch is not expected to actually execute,
             // but in case it does, may just as well do the right thing.
             Err(
               buildUnexpectedTokenError(parserState, "unexpected end of object")
@@ -2124,19 +2126,19 @@ parseObject = (parserState: JSONParserState) => {
  *
  * Example output:
  * ```
- * Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+ * Ok(JsonObject([("currency", JsonString("$")), ("price", JsonNumber(119))]))
  * ```
  *
  * @since v0.6.0
  */
-provide let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
+provide let parse: String -> Result<Json, JsonParseError> = (str: String) => {
   let parserState = {
     string: str,
     bufferParse: Buffer.make(16),
     currentCodePoint: readCodePoint(0, str),
     pos: 0,
     bytePos: 0,
-  }: JSONParserState
+  }: JsonParserState
 
   let root = parseValue(parserState)
 

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1,5 +1,5 @@
 /**
- * @module Json: JSON (JavaScript Object Notation) parsing and printing.
+ * JSON (JavaScript Object Notation) parsing and printing.
  */
 
 module Json
@@ -262,7 +262,7 @@ provide enum FormattingChoices {
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
- * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+ * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
  * ```
  *
  * @since v0.6.0
@@ -292,7 +292,7 @@ provide let defaultCompactFormat = {
  * ··"currency":·"€",↵
  * ··"price":·99.9,↵
  * ··"currencyDescription":·"EURO\u007f",↵
- * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
+ * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
  * }
  * ```
  *
@@ -319,7 +319,7 @@ provide let defaultPrettyFormat = {
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
- * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+ * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
  * ```
  *
  * @since v0.6.0
@@ -349,7 +349,7 @@ provide let defaultCompactAndSafeFormat = {
  * ··"currency":·"\u20ac",↵
  * ··"price":·99.9,↵
  * ··"currencyDescription":·"EURO\u007f",↵
- * ··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
+ * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
  * }
  * ```
  *

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -44,9 +44,7 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
  * Data structure representing the result of parsing and the input of printing JSON.
  *
  * This data structure is semantically equivalent to the JSON format allowing
- * mostly lossless round trips of printing and parsing. Exceptions to this are
- * whitespace, multiple ways JSON allows escaping characters in strings, and
- * some edge cases related to Grain's `Number` type.
+ * mostly lossless round trips of printing and parsing.
  *
  * @example
  * assert Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
@@ -666,6 +664,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   } else {
     fail "Impossible: Json.toString encountered an unknown number tag"
   }
+  // This keeps the gc from prematurely freeing the value
   ignore(value)
   ret
 }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -562,9 +562,8 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   from WasmI32 use { (&), (==), (!=), (<<), (>>) }
 
   let ptr = WasmI32.fromGrain(value)
-  if ((ptr & 1n) != 0n) {
+  let ret = if ((ptr & 1n) != 0n) {
     printNumberWasmI32(untagSimpleNumber(value), buffer)
-    ignore(value)
     None
   } else if ((ptr & 7n) == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
     let tag = WasmI32.load(ptr, 0n)
@@ -575,12 +574,10 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
             let asWasmI64 = WasmI64.load(ptr, _INT64_BOXED_VALUE_OFFSET)
             printNumberWasmI64(asWasmI64, buffer)
-            ignore(value)
             None
           },
           t when t == Tags._GRAIN_BIGINT_BOXED_NUM_TAG => {
             Buffer.addString(BI.bigIntToString10(ptr), buffer)
-            ignore(value)
             None
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
@@ -603,15 +600,11 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             ) /
               WasmF64.convertI32S(Numbers.boxedRationalDenominator(ptr))
 
-            let val = printNumberWasmF64(asWasmF64, buffer)
-            ignore(value)
-            val
+            printNumberWasmF64(asWasmF64, buffer)
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
             let asWasmF64 = WasmF64.load(ptr, _Float64_BOXED_VALUE_OFFSET)
-            let val = printNumberWasmF64(asWasmF64, buffer)
-            ignore(value)
-            val
+            printNumberWasmF64(asWasmF64, buffer)
           },
           _ => {
             throw UnknownNumberTag
@@ -625,6 +618,8 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   } else {
     throw UnknownNumberTag
   }
+  ignore(value)
+  ret
 }
 
 let rec printElementCompact =
@@ -1338,8 +1333,6 @@ let rec readCodePoint = (bytePosition: Number, string: String) => {
   let bytePositionW32 = coerceNumberToWasmI32(bytePosition)
 
   let ptr = strPtr + 8n + bytePositionW32
-
-  let mut idx = 0n
 
   if (bytePositionW32 < byteSize) {
     let codePoint = getCodePoint(ptr)

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -2,11 +2,7 @@
  * JSON (JavaScript Object Notation) parsing, printing, and access utilities.
  *
  * @example include "json"
- * @example
- * Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
- *   ("currency", JsonString("€")),
- *   ("price", JsonNumber(99.99)),
- * ])
+ * @example Json.parse("{\"currency\":\"€\",\"price\":99.99}")
  * @example
  * print(
  *   toString(
@@ -53,13 +49,13 @@ let _Float64_BOXED_VALUE_OFFSET = 8n
  * some edge cases related to Grain's `Number` type.
  *
  * @example
- * Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
+ * assert Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
  *   ("currency", JsonString("€")),
  *   ("price", JsonNumber(99.99)),
  * ])
  *
  * @example
- * Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
+ * assert Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
  *   ("currency", JsonString("€")),
  *   ("price", JsonNumber(99.99)),
  * ])
@@ -1177,48 +1173,36 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
  * @returns `Ok(str)` containing the printed JSON or `Err(err)` if the inputted object cannot be represented in the JSON format.,
  *
  * @example
- * print(
- *   toString(
- *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
- *   )
- * )
- * // Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
+ * assert toString(
+ *   JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
+ * ) == Ok("{\"currency\":\"€\",\"price\":99.9}")
  * @example
- * print(
- *   toString(
- *     format=Compact
- *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *   )
- * )
- * // Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
+ * assert toString(
+ *   format=Compact
+ *   JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+ * ) == Ok("{\"currency\":\"€\",\"price\":99.9}")
  * @example
- * print(
- *   toString(
- *     format=Pretty,
- *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *   )
- * )
- * // Output: Ok("{
- * // \"currency\": \"€\",
- * // \"price\": 99.9
- * //}")
+ * assert toString(
+ *   format=Pretty,
+ *   JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+ * ) == Ok("{
+ *   \"currency\": \"€\",
+ *   \"price\": 99.9
+ * }")
  * @example
- * print(
- *   toString(
- *     format=Custom{
- *      indentation: NoIndentation,
- *      arrayFormat: CompactArrayEntries,
- *      objectFormat: CompactObjectEntries,
- *      lineEnding: NoLineEnding,
- *      finishWithNewLine: false,
- *      escapeAllControlPoints: true,
- *      escapeHTMLUnsafeSequences: true,
- *      escapeNonASCII: true,
- *     },
- *     JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
- *   )
- * )
- * // Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
+ * assert toString(
+ *   format=Custom{
+ *     indentation: NoIndentation,
+ *     arrayFormat: CompactArrayEntries,
+ *     objectFormat: CompactObjectEntries,
+ *     lineEnding: NoLineEnding,
+ *     finishWithNewLine: false,
+ *     escapeAllControlPoints: true,
+ *     escapeHTMLUnsafeSequences: true,
+ *     escapeNonASCII: true,
+ *   },
+ *   JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+ * ) == Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
  *
  * @since v0.6.0
  */

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -2,28 +2,36 @@
  * @module Json: JSON (JavaScript Object Notation) parsing and printing.
  */
 
-import String from "string"
-import Char from "char"
-import List from "list"
-import Option from "option"
-import Number from "number"
-import WasmI32 from "runtime/unsafe/wasmi32"
-import WasmI64 from "runtime/unsafe/wasmi64"
-import WasmF32 from "runtime/unsafe/wasmf32"
-import WasmF64 from "runtime/unsafe/wasmf64"
-import NumberUtils from "runtime/numberUtils"
-import Tags from "runtime/unsafe/tags"
-import Numbers from "runtime/numbers"
-import Memory from "runtime/unsafe/memory"
-import Buffer from "buffer"
-import { toString as runtimeToString } from "runtime/string"
-import { coerceNumberToWasmI32 } from "runtime/numbers"
-import { tagSimpleNumber } from "runtime/dataStructures"
+module Json
+
+include "string"
+include "char"
+include "list"
+include "option"
+include "number"
+include "uint8"
+include "runtime/unsafe/wasmi32"
+include "runtime/unsafe/wasmi64"
+include "runtime/unsafe/wasmf32"
+include "runtime/unsafe/wasmf64"
+include "runtime/numberUtils"
+include "runtime/unsafe/tags"
+include "runtime/numbers"
+include "runtime/unsafe/memory"
+include "buffer"
+include "runtime/string" as RunTimeString
+include "runtime/numbers"
+include "runtime/unsafe/memory"
+include "runtime/dataStructures"
+include "runtime/bigint" as BI
+from RunTimeString use { toString as runtimeToString }
+from Numbers use { coerceNumberToWasmI32 }
+from DataStructures use { tagSimpleNumber, newFloat64 }
 
 /**
  * Data structure representing the result of parsing and the input of printing
  * JSON.
- * 
+ *
  * For example this object
  * ```grain
  * JSONObject([
@@ -35,12 +43,12 @@ import { tagSimpleNumber } from "runtime/dataStructures"
  * ```json
  * {"currency":"€","price":99.99}
  * ```
- * 
+ *
  * This data structure is semantically equivalent to the JSON format allowing
  * mostly lossless round trips of printing and parsing. Exceptions to this are
  * white spaces, multiple ways JSON allows escaping characters in strings and
  * some edge-cases related to Grain's `Number` type.
- * 
+ *
  * For example parsing the following JSON text will also result in the same
  * `JSON` object as above.
  * ```json
@@ -50,7 +58,7 @@ import { tagSimpleNumber } from "runtime/dataStructures"
  * }
  * ```
  */
-export enum JSON {
+provide enum JSON {
   JSONNull,
   JSONBoolean(Bool),
   JSONNumber(Number),
@@ -71,16 +79,16 @@ export enum JSON {
  * JSON format along with a human readable text message. This can happen when
  * it contains number values `NaN`, `Infinity` or `-Infinity`.
  */
-export enum JSONToStringError {
+provide enum JSONToStringError {
   InvalidNumber(String),
 }
 
 /**
  * Controls how indentation is performed in custom formatting.
- * 
+ *
  * Following examples have whitespaces and line breaks replaced with visible
  * charactes for illustrative purposes.
- * 
+ *
  * `NoIndentation`
  * ```
  * {↵
@@ -88,7 +96,7 @@ export enum JSONToStringError {
  * "price":·99.9↵
  * }
  * ```
- * 
+ *
  * `IndentWithTab`
  * ```
  * {↵
@@ -96,7 +104,7 @@ export enum JSONToStringError {
  * →"price":·99.9↵
  * }
  * ```
- * 
+ *
  * `IndentWithSpaces(2)`
  * ```
  * {↵
@@ -104,7 +112,7 @@ export enum JSONToStringError {
  * ··"price":·99.9↵
  * }
  * ```
- * 
+ *
  * `IndentWithSpaces(4)`
  * ```
  * {↵
@@ -113,7 +121,7 @@ export enum JSONToStringError {
  * }
  * ```
  */
-export enum IndentationFormat {
+provide enum IndentationFormat {
   NoIndentation,
   IndentWithTab,
   IndentWithSpaces(Number),
@@ -121,34 +129,34 @@ export enum IndentationFormat {
 
 /**
  * Controls how arrays are printed in custom formatting.
- * 
+ *
  * Following examples have whitespaces and line breaks replaced with visible
  * charactes for illustrative purposes.
- * 
+ *
  * `CompactArrayEntries`
  * ```
  * []
  * ```
- * 
+ *
  * ```
  * [1]
  * ```
- * 
+ *
  * ```
  * [1,2,3]
  * ```
- * 
+ *
  * `OneArrayEntryPerLine`
  * ```
  * []
  * ```
- * 
+ *
  * ```
  * [↵
  * ··1↵
  * ]
  * ```
- * 
+ *
  * ```
  * [↵
  * ··1,↵
@@ -157,41 +165,41 @@ export enum IndentationFormat {
  * ]
  * ```
  */
-export enum ArrayFormat {
+provide enum ArrayFormat {
   CompactArrayEntries,
   OneArrayEntryPerLine,
 }
 
 /**
  * Controls how objects are printed in custom formatting.
- * 
+ *
  * Following examples have whitespaces and line breaks replaced with visible
  * charactes for illustrative purposes.
- * 
+ *
  * `CompactObjectEntries`
  * ```
  * {}
  * ```
- * 
+ *
  * ```
  * {"a":1}
  * ```
- * 
+ *
  * ```
  * {"a":1,"b":2,"c":3}
  * ```
- * 
+ *
  * `OneObjectEntryPerLine`
  * ```
  * {}
  * ```
- * 
+ *
  * ```
  * {↵
  * ··"a":·1↵
  * }
  * ```
- * 
+ *
  * ```
  * {↵
  * ··"a":·1,↵
@@ -200,7 +208,7 @@ export enum ArrayFormat {
  * }
  * ```
  */
-export enum ObjectFormat {
+provide enum ObjectFormat {
   CompactObjectEntries,
   OneObjectEntryPerLine,
 }
@@ -208,7 +216,7 @@ export enum ObjectFormat {
 /**
  * Controls line ending type in custom formatting.
  */
-export enum LineEnding {
+provide enum LineEnding {
   NoLineEnding,
   LineFeed,
   CarriageReturnLineFeed,
@@ -218,7 +226,7 @@ export enum LineEnding {
 /**
  * Allows fine grained control of formatting in JSON printing.
  */
-export record FormattingSettings {
+provide record FormattingSettings {
   indentation: IndentationFormat,
   arrayFormat: ArrayFormat,
   objectFormat: ObjectFormat,
@@ -232,18 +240,18 @@ export record FormattingSettings {
 /**
  * Compact formatting that minimizes the size of resulting JSON at cost of not
  * being easily human readable.
- * 
+ *
  * Only performs minimal string escaping as required by the ECMA-404 standard,
  * so the result needs to be treated as proper unicode and is not safe to be
  * transported in ASCII encoding.
- * 
+ *
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
  * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
  * ```
  */
-export let defaultCompactFormat = () =>
+provide let defaultCompactFormat = () =>
   {
     indentation: NoIndentation,
     arrayFormat: CompactArrayEntries,
@@ -257,11 +265,11 @@ export let defaultCompactFormat = () =>
 
 /**
  * Recommended human readable formatting.
- * 
+ *
  * Escapes all control points for the sake of clarity, but prints unicode
  * codepoints directly so the result needs to be treated as proper unicode and
  * is not safe to be transported in ASCII encoding.
- * 
+ *
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
@@ -273,7 +281,7 @@ export let defaultCompactFormat = () =>
  * }
  * ```
  */
-export let defaultPrettyFormat = () =>
+provide let defaultPrettyFormat = () =>
   {
     indentation: IndentWithSpaces(2),
     arrayFormat: OneArrayEntryPerLine,
@@ -288,17 +296,17 @@ export let defaultPrettyFormat = () =>
 /**
  * Compact and conservative formatting to maximize compatibility and
  * embeddability of the resulting JSON.
- * 
+ *
  * Should be safe to copy and paste directly into HTML and to transported in
  * plain ASCII.
- * 
+ *
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
  * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
  * ```
  */
-export let defaultCompactAndSafeFormat = () =>
+provide let defaultCompactAndSafeFormat = () =>
   {
     indentation: NoIndentation,
     arrayFormat: CompactArrayEntries,
@@ -313,10 +321,10 @@ export let defaultCompactAndSafeFormat = () =>
 /**
  * Pretty and conservative formatting to maximize compatibility and
  * embeddability of the resulting JSON.
- * 
+ *
  * Should be safe to copy and paste directly into HTML and to transported in
  * plain ASCII.
- * 
+ *
  * The following example have whitespaces, line breaks and control points
  * replaced with visible characters.
  * ```
@@ -328,7 +336,7 @@ export let defaultCompactAndSafeFormat = () =>
  * }
  * ```
  */
-export let defaultPrettyAndSafeFormat = () =>
+provide let defaultPrettyAndSafeFormat = () =>
   {
     indentation: IndentWithSpaces(2),
     arrayFormat: OneArrayEntryPerLine,
@@ -498,12 +506,14 @@ let printNumberWasmI64 = (value: WasmI64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let isFinite = (value: WasmF64) => {
-  WasmF64.eq(WasmF64.sub(value, value), 0.W)
+  from WasmF64 use { eq as (==), sub as (-) }
+  value - value == 0.0W
 }
 
 @unsafe
 let isNaN = (value: WasmF64) => {
-  WasmF64.ne(value, value)
+  from WasmF64 use { ne as (!=) }
+  value != value
 }
 
 @unsafe
@@ -513,6 +523,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     Buffer.addString(s, buffer)
     None
   } else {
+    from WasmF64 use { lt as (<) }
     // JSON standard doesn't allow NaN or infinite values in numbers,
     // but WASM f64 (IEEE 754-2008), as well as Grain's number types do
     // (Float64 as well as Number). This is the only reason that the
@@ -522,7 +533,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     // (like JavaScript's JSON.stringify).
     if (isNaN(value)) {
       Some(InvalidNumber("NaN is not allowed in JSONNumber"))
-    } else if (WasmF64.lt(value, 0.0W)) {
+    } else if (value < 0.0W) {
       Some(InvalidNumber("-Infinity is not allowed in JSONNumber"))
     } else {
       Some(InvalidNumber("Infinity is not allowed in JSONNumber"))
@@ -532,11 +543,13 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let printNumber = (value: Number, buffer: Buffer.Buffer) => {
-  let (&) = WasmI32.and
-  let (==) = WasmI32.eq
-  let (!=) = WasmI32.ne
-  let (<<) = WasmI32.shl
-  let (>>) = WasmI32.shrS
+  from WasmI32 use {
+    and as (&),
+    eq as (==),
+    ne as (!=),
+    shl as (<<),
+    shrS as (>>),
+  }
 
   let ptr = WasmI32.fromGrain(value)
   if ((ptr & 1n) != 0n) {
@@ -550,19 +563,18 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
       t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
         let numberTag = WasmI32.load(ptr, 4n)
         match (numberTag) {
-          t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-            let asWasmI32 = WasmI32.load(ptr, 8n)
-            // FIXME magic numbers
-            printNumberWasmI32(asWasmI32, buffer)
-            None
-          },
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
             let asWasmI64 = WasmI64.load(ptr, 8n)
             // FIXME magic numbers
             printNumberWasmI64(asWasmI64, buffer)
             None
           },
+          t when t == Tags._GRAIN_BIGINT_BOXED_NUM_TAG => {
+            Buffer.addString(BI.bigIntToString10(ptr), buffer)
+            None
+          },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
+            from WasmF64 use { div as (/) }
             // As a compromnise, convert the rational into a float
             // and then print that. This means there can be
             // precision loss even for values that could be printed
@@ -576,17 +588,11 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             // least for some numbers try printing the exact
             // number. For example those that have a power of 10
             // in the denominator.
-            let asWasmF64 = WasmF64.div(
-              WasmF64.convertI32S(Numbers.boxedRationalNumerator(ptr)),
+            let asWasmF64 = WasmF64.convertI32S(
+              Numbers.boxedRationalNumerator(ptr)
+            ) /
               WasmF64.convertI32S(Numbers.boxedRationalDenominator(ptr))
-            )
 
-            printNumberWasmF64(asWasmF64, buffer)
-          },
-          t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-            let asWasmF32 = WasmF32.load(ptr, 8n)
-            // FIXME magic numbers
-            let asWasmF64 = WasmF64.promoteF32(asWasmF32)
             printNumberWasmF64(asWasmF64, buffer)
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
@@ -1030,7 +1036,7 @@ let rec printElementPretty =
 
 let isCodePointInBasicMultilingualPlane = (code: Number) =>
   code >= 0x0000 &&
-  code <= 0xFFFF
+    code <= 0xFFFF
 
 let isHighSurrogate = (code: Number) => code >= 0xD800 && code <= 0xDBFF
 
@@ -1044,7 +1050,7 @@ let combineSurrogatePairToCodePoint =
   // If this was a method exposed by itself in a library then it should check the
   // ranges of the input surrogates, but here it's necessary because checks are made
   // as part of the parsing logic.
-  (highSurrogate - 0xD800 << 10) + (lowSurrogate - 0xDC00) + 0x10000
+  ((highSurrogate - 0xD800) << 10) + (lowSurrogate - 0xDC00) + 0x10000
 }
 
 let makePrettyPrintJSONWriter =
@@ -1242,19 +1248,19 @@ let makePrettyPrintJSONWriter =
 
 /**
  * Prints the JSON object into a string with specific formatting settings.
- * 
+ *
  * @param json: The JSON object to print
  * @param format: Custom formatting setttings
  * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
  *
  * @example print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
- * 
+ *
  * Example output:
  * ```json
  * {"currency":"\u20ac","price":99.9}
  * ```
  */
-export let toString = (json: JSON, format: FormattingSettings) => {
+provide let toString = (json: JSON, format: FormattingSettings) => {
   let buf = Buffer.make(16)
 
   let writer = makePrettyPrintJSONWriter(format, buf)
@@ -1271,21 +1277,21 @@ export let toString = (json: JSON, format: FormattingSettings) => {
  * Prints the JSON object into a string with compact formatting optimized for
  * small size. Recommended for all uses where the intended consumer is a
  * machine program. For example in REST APIs.
- * 
+ *
  * Using this function can be preferred over `toString` with compact formatting
  * settings since it can be slightly faster.
- * 
+ *
  * @param json: The JSON object to print
  * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
  *
  * @example print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
- * 
+ *
  * Example output:
  * ```json
  * {"currency":"€","price":99.9}
  * ```
  */
-export let toStringCompact = (json: JSON) => {
+provide let toStringCompact = (json: JSON) => {
   let buf = Buffer.make(16)
 
   let writer = makeCompactJSONWriter(buf)
@@ -1303,10 +1309,10 @@ export let toStringCompact = (json: JSON) => {
  * settings. Recommended for uses where the intended consumer is a person or
  * the text should be easily inspectable. For example configuration files or
  * document file formats.
- * 
+ *
  * @param json: The JSON object to print
  * @returns A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
- * 
+ *
  * Example output:
  * ```json
  * {
@@ -1317,13 +1323,13 @@ export let toStringCompact = (json: JSON) => {
  *
  * @example print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
  */
-export let toStringPretty = (json: JSON) =>
+provide let toStringPretty = (json: JSON) =>
   toString(json, defaultPrettyFormat())
 
 /**
  * Represents errors for JSON parsing along with a human readable text message.
  */
-export enum JSONParseError {
+provide enum JSONParseError {
   UnexpectedEndOfInput(String),
   UnexpectedToken(String),
   InvalidUTF16SurrogatePair(String),
@@ -1357,16 +1363,18 @@ exception MalformedUnicode
 // This function has been copied from the String module as a temporary
 // solution. This will likely be replaced by a more robust solution for
 // iterating over strings in the near future.
-@disableGC
+@unsafe
 let getCodePoint = (ptr: WasmI32) => {
   // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
-  let (+) = WasmI32.add
-  let (==) = WasmI32.eq
-  let (>=) = WasmI32.geU
-  let (<=) = WasmI32.leU
-  let (<<) = WasmI32.shl
-  let (&) = WasmI32.and
-  let (|) = WasmI32.or
+  from WasmI32 use {
+    add as (+),
+    and as (&),
+    or as (|),
+    shl as (<<),
+    leU as (<=),
+    geU as (>=),
+    eq as (==),
+  }
 
   let mut codePoint = 0n
   let mut bytesSeen = 0n
@@ -1376,15 +1384,12 @@ let getCodePoint = (ptr: WasmI32) => {
 
   let mut offset = 0n
 
-  let mut result = 0n
-
   while (true) {
     let byte = WasmI32.load8U(ptr + offset, 0n)
     offset += 1n
     if (bytesNeeded == 0n) {
       if (byte >= 0x00n && byte <= 0x7Fn) {
-        result = byte
-        break
+        return byte
       } else if (byte >= 0xC2n && byte <= 0xDFn) {
         bytesNeeded = 1n
         codePoint = byte & 0x1Fn
@@ -1411,17 +1416,15 @@ let getCodePoint = (ptr: WasmI32) => {
     codePoint = codePoint << 6n | byte & 0x3Fn
     bytesSeen += 1n
     if (bytesSeen == bytesNeeded) {
-      result = codePoint
-      break
+      return codePoint
     }
   }
-  result: WasmI32
+  return 0n
 }
 
 @unsafe
 let rec readCodePoint = (bytePosition: Number, string: String) => {
-  let (+) = WasmI32.add
-  let (<) = WasmI32.ltU
+  from WasmI32 use { add as (+), ltU as (<) }
 
   let strPtr = WasmI32.fromGrain(string)
 
@@ -1432,7 +1435,7 @@ let rec readCodePoint = (bytePosition: Number, string: String) => {
   let ptr = strPtr + 8n + bytePositionW32
 
   let mut idx = 0n
-  
+
   if (bytePositionW32 < byteSize) {
     let codePoint = getCodePoint(ptr)
     tagSimpleNumber(codePoint)
@@ -1464,13 +1467,12 @@ let isAtEndOfInput = (parserState: JSONParserState) => {
 let next = (parserState: JSONParserState) => {
   let mut c = parserState.currentCodePoint
   if (c != _END_OF_INPUT) {
-    parserState.bytePos = parserState.bytePos +
-    codePointUTF8ByteCount(c)
+    parserState.bytePos += codePointUTF8ByteCount(c)
 
     c = readCodePoint(parserState.bytePos, parserState.string)
 
     parserState.currentCodePoint = c
-    parserState.pos = parserState.pos + 1
+    parserState.pos += 1
   }
   c
 }
@@ -1553,7 +1555,17 @@ let expectCodePointAndAdvance =
     Some(buildUnexpectedTokenError(parserState, detail))
   }
 }
-
+let atoiFast = buffer => {
+  let bufLen = Buffer.length(buffer)
+  let mut result = 0
+  for (let mut i = 0; i < bufLen; i += 1) {
+    from Uint8 use { (-) }
+    result = (result << 1) +
+      (result << 3) +
+      Uint8.toNumber(Buffer.getUint8(i, buffer) - 48us)
+  }
+  result
+}
 let rec parseValue = (parserState: JSONParserState) => {
   skipWhiteSpace(parserState)
 
@@ -1564,9 +1576,18 @@ let rec parseValue = (parserState: JSONParserState) => {
     0x74 => parseTrueValue(parserState), // 't'
     0x66 => parseFalseValue(parserState), // 'f'
     0x6E => parseNullValue(parserState), // 'n'
-    // TODO Check if having a match case for each digit would be faster or not.
-    c when c >= 0x30 && c <= 0x39 || c == 0x2D =>
-      parseNumberValue(parserState), // '0'..'9' or '-'
+    // Numbers
+    0x30 => parseNumberValue(parserState), // '0'
+    0x31 => parseNumberValue(parserState), // '1'
+    0x32 => parseNumberValue(parserState), // '2'
+    0x33 => parseNumberValue(parserState), // '3'
+    0x34 => parseNumberValue(parserState), // '4'
+    0x35 => parseNumberValue(parserState), // '5'
+    0x36 => parseNumberValue(parserState), // '6'
+    0x37 => parseNumberValue(parserState), // '7'
+    0x38 => parseNumberValue(parserState), // '8'
+    0x39 => parseNumberValue(parserState), // '9'
+    0x2D => parseNumberValue(parserState), // '-'
     c => {
       let detail = "expected start of a JSON value, found " ++
         formatCodePointOrEOF(c)
@@ -1577,7 +1598,8 @@ let rec parseValue = (parserState: JSONParserState) => {
   skipWhiteSpace(parserState)
 
   result
-}, parseNullValue = (parserState: JSONParserState) => {
+},
+parseNullValue = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x6E, parserState)) {
     // 'n'
     Some(e) => Err(e),
@@ -1601,7 +1623,8 @@ let rec parseValue = (parserState: JSONParserState) => {
       }
     },
   }
-}, parseTrueValue = (parserState: JSONParserState) => {
+},
+parseTrueValue = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x74, parserState)) {
     // 't'
     Some(e) => Err(e),
@@ -1625,7 +1648,8 @@ let rec parseValue = (parserState: JSONParserState) => {
       }
     },
   }
-}, parseFalseValue = (parserState: JSONParserState) => {
+},
+parseFalseValue = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x66, parserState)) {
     // 'f'
     Some(e) => Err(e),
@@ -1655,7 +1679,8 @@ let rec parseValue = (parserState: JSONParserState) => {
       }
     },
   }
-}, parseString = (parserState: JSONParserState) => {
+},
+parseString = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x22, parserState)) {
     // '"'
     Some(e) => Err(e),
@@ -1772,9 +1797,7 @@ let rec parseValue = (parserState: JSONParserState) => {
                       let digitsSoFar = 3 - digitIndex
                       let detail = "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
                         runtimeToString(digitsSoFar)
-                      err = Some(
-                        buildUnexpectedTokenError(parserState, detail)
-                      )
+                      err = Some(buildUnexpectedTokenError(parserState, detail))
                       break
                     }
 
@@ -1854,6 +1877,15 @@ let rec parseValue = (parserState: JSONParserState) => {
             }
           },
           c => {
+            if (c >= 0x00 && c <= 0x1F) {
+              err = Some(
+                buildUnexpectedTokenError(
+                  parserState,
+                  "Bad control character in string literal"
+                )
+              )
+              break
+            }
             // Finally the happy case of a simple unescaped code point.
             next(parserState)
             addCharFromCodePoint(c, buffer)
@@ -1879,14 +1911,20 @@ let rec parseValue = (parserState: JSONParserState) => {
       }
     },
   }
-}, parseStringValue = (parserState: JSONParserState) => {
+},
+parseStringValue = (parserState: JSONParserState) => {
   match (parseString(parserState)) {
     Ok(s) => Ok(JSONString(s)),
     Err(e) => Err(e),
   }
-}, parseNumberValue = (parserState: JSONParserState) => {
+},
+parseNumberValue = (parserState: JSONParserState) => {
+  // TODO: Use A Streaming Optimized Way For Parsing The Numbers
+  let buffer = parserState.bufferParse
+  Buffer.clear(buffer)
   // First char can optionally be a minus sign.
   let mut c = parserState.currentCodePoint
+  let mut isFloat = false
   let isNegative = c == 0x2D
   // '-'
   if (isNegative) {
@@ -1894,21 +1932,6 @@ let rec parseValue = (parserState: JSONParserState) => {
   }
 
   let mut err = None
-
-  let mut significand = 0
-  let mut exponent = 0
-  let mut isExponentNegative = false
-
-  // Note on performance: the hope here is to keep calculations in a way to
-  // do at least the intermediate operations with Simple Numbers (non heap
-  // allocated). If there's no fractional part then the resulting number
-  // itself is packed into the "pointer" / value and only an instance of
-  // JSONNumber is allocated on the heap. If the number has a fractional part
-  // or a negative exponent then the final number will be heap allocated.
-  // If the number doesn't fit 31 bits then intermetdiate calculations will
-  // allocate numbers on the heap. This could be alleviated by doing
-  // intermediate calculations with raw wasm numbers, but it would add some
-  // complexity.
 
   // After that, the first/second char can only be a decimal digit ('0'..'9').
   match (c) {
@@ -1923,21 +1946,17 @@ let rec parseValue = (parserState: JSONParserState) => {
       // this function finishes with the parser positioned on a digit
       // and not on a token expected after a number like ',', ']', '}' or
       // EOF.
+      addCharFromCodePoint(c, buffer)
       c = next(parserState)
     },
     x when x >= 0x31 && x <= 0x39 => { // '1'..'9'
       for (;;) {
-        let digit = c - 0x30
-
-        significand = significand * 10 + digit
-
+        addCharFromCodePoint(c, buffer)
         c = next(parserState)
-
         if (c < 0x30 || c > 0x39) {
           break
         }
       }
-
       void
     },
     unexpectedCodePoint => {
@@ -1948,115 +1967,107 @@ let rec parseValue = (parserState: JSONParserState) => {
       err = Some(buildUnexpectedTokenError(parserState, detail))
     },
   }
-
   // Optional fractional part of the number.
   if (Option.isNone(err) && c == 0x2E) { // '.'
+    isFloat = true
+    Buffer.addChar('.', buffer)
     c = next(parserState)
-
-    // let mut decimalPos = 10
-    // let mut denominator = 1
+    let mut hasHitDigit = false
     for (; c >= 0x30 && c <= 0x39;) {
-      let digit = c - 0x30
-
-      significand = significand * 10 + digit
-
-      // denominator = denominator * 10
-
+      hasHitDigit = true
+      addCharFromCodePoint(c, buffer)
       c = next(parserState)
-
-      exponent -= 1
     }
-    // result /= denominator
+    if (!hasHitDigit)
+      err = Some(
+        buildUnexpectedTokenError(
+          parserState,
+          "exponent part is missing in number"
+        )
+      )
   }
-
   // Optional exponential part of the number.
   if (Option.isNone(err) && (c == 0x65 || c == 0x45)) { // 'e' or 'E'
+    isFloat = true
+    Buffer.addChar('e', buffer)
     c = next(parserState)
-
     // can start with optional plus or minus sign
-    isExponentNegative = match (c) {
+    match (c) {
       0x2D => { // '-'
         c = next(parserState)
-        true
+        Buffer.addChar('-', buffer)
       },
       0x2B => { // '+'
         c = next(parserState)
-        false
       },
-      _ => {
-        false
-      },
+      _ => void,
     }
-
     // followed by one or more digits (0-9)
-
-    let mut explicitExponent = 0
+    let mut hasHitDigit = false
     for (; c >= 0x30 && c <= 0x39;) {
-      let digit = c - 0x30
-
-      explicitExponent = explicitExponent * 10 + digit
-
+      hasHitDigit = true
+      addCharFromCodePoint(c, buffer)
       c = next(parserState)
     }
-
-    if (isExponentNegative) {
-      exponent -= explicitExponent
-    } else {
-      exponent += explicitExponent
-    }
+    if (!hasHitDigit)
+      err = Some(
+        buildUnexpectedTokenError(
+          parserState,
+          "exponent part is missing in number"
+        )
+      )
 
     void
   }
-
   // Note that unlike all other JSON value types there's no explicit ending
   // character like ('"' for strings, ']' for arrays,'}' for objects etc). We
   // just leave the parser state at current position and the reading of next
   // token will succeed or fail, but number parsing just ends here.
-
   match (err) {
     Some(e) => Err(e),
     None => {
-      let mut result = significand
-
-      if (exponent != 0) {
-        // This is just a temporary naive implementation.
-
-        if (exponent > 0) {
-          let mut factor = 1
-          for (let mut i = 0; i < exponent; i += 1) {
-            factor *= 10
+      let result = match (isFloat) {
+        false => atoiFast(buffer),
+        true => {
+          let str = Buffer.toString(buffer)
+          match (Number.parseFloat(str)) {
+            Err(err) => fail "Impossible",
+            Ok(n) => n,
           }
-          result *= factor
-        } else {
-          let mut factor = 1
-          for (let mut i = 0; i < 0 - exponent; i += 1) {
-            factor *= 10
-          }
-          result /= factor
-        }
+        },
       }
-
-      if (isNegative) {
-        result = 0 - result
-      }
-      Ok(JSONNumber(result))
+      if (result == 0 && isNegative) Ok(JSONNumber(-0.0))
+      else Ok(JSONNumber(if (isNegative) result * -1 else result))
     },
   }
-}, parseArray = (parserState: JSONParserState) => {
+},
+parseArray = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x5B, parserState)) {
     // '['
     Some(e) => Err(e),
     None => {
+      skipWhiteSpace(parserState)
       let mut err = None
 
       let mut elems = []: List<JSON>
 
       let mut done = false
-
+      let mut first = true
+      let mut trailingComma = false
       while (!done) {
         let c = parserState.currentCodePoint
         match (c) {
           0x2C => { // ','
+            trailingComma = true
+            if (first) {
+              err = Some(
+                buildUnexpectedTokenError(
+                  parserState,
+                  "unexpected comma at beginning of array"
+                )
+              )
+              break
+            }
             next(parserState)
             skipWhiteSpace(parserState)
           },
@@ -2070,6 +2081,8 @@ let rec parseValue = (parserState: JSONParserState) => {
             break
           },
           _ => {
+            first = false
+            trailingComma = false
             // note that parseValue skips initial and final whitespace
             match (parseValue(parserState)) {
               Ok(elem) => {
@@ -2088,21 +2101,23 @@ let rec parseValue = (parserState: JSONParserState) => {
       match (err) {
         Some(e) => Err(e),
         None => {
-          if (done) {
+          if (trailingComma) {
+            Err(
+              buildUnexpectedTokenError(parserState, "unexpected end of array")
+            )
+          } else if (done) {
             Ok(JSONArray(List.reverse(elems)))
           } else {
             Err(
-              buildUnexpectedTokenError(
-                parserState,
-                "unexpected end of array"
-              )
+              buildUnexpectedTokenError(parserState, "unexpected end of array")
             )
           }
         },
       }
     },
   }
-}, parseObject = (parserState: JSONParserState) => {
+},
+parseObject = (parserState: JSONParserState) => {
   match (expectCodePointAndAdvance(0x7B, parserState)) {
     // '{'
     Some(e) => Err(e),
@@ -2115,6 +2130,7 @@ let rec parseValue = (parserState: JSONParserState) => {
       let mut first = true
 
       // one iteration of this loop should correspond to a key-value pair
+      let mut trailingComma = false
       while (!done) {
         skipWhiteSpace(parserState)
 
@@ -2126,6 +2142,7 @@ let rec parseValue = (parserState: JSONParserState) => {
             break
           },
           0x2C => { // ','
+            trailingComma = true
             if (first) {
               let detail = "expected a key-value pair or the end of the object, found ','"
               err = Some(buildUnexpectedTokenError(parserState, detail))
@@ -2136,11 +2153,17 @@ let rec parseValue = (parserState: JSONParserState) => {
             }
           },
           0x7D => { // '}'
+            if (trailingComma) {
+              let detail = "unexpected trailing comma in object"
+              err = Some(buildUnexpectedTokenError(parserState, detail))
+              break
+            }
             next(parserState)
             done = true
             break
           },
           _ => {
+            trailingComma = false
             // A new entry in current object.
             // Just call parseString directly. In case the current character id not '"', it will return an error we can pass along.
             match (parseString(parserState)) {
@@ -2188,10 +2211,7 @@ let rec parseValue = (parserState: JSONParserState) => {
             // This brand is not expected to actually execute,
             // but in case it does, may just as well do the right thing.
             Err(
-              buildUnexpectedTokenError(
-                parserState,
-                "unexpected end of object"
-              )
+              buildUnexpectedTokenError(parserState, "unexpected end of object")
             )
           }
         },
@@ -2202,7 +2222,7 @@ let rec parseValue = (parserState: JSONParserState) => {
 
 /**
  * Parses JSON input from a string into a `JSON` object.
- * 
+ *
  * @param str: The JSON text string
  * @returns A `Result` object with either the parsed `JSON` object or an error.
  *
@@ -2210,10 +2230,10 @@ let rec parseValue = (parserState: JSONParserState) => {
  * ```
  * Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
  * ```
- * 
+ *
  * @example print(parse("{\"currency\":\"$\",\"price\":119}"))
  */
-export let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
+provide let parse: String -> Result<JSON, JSONParseError> = (str: String) => {
   let parserState = {
     string: str,
     bufferParse: Buffer.make(16),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -417,15 +417,9 @@ provide enum FormattingChoices {
   },
 }
 
-record JsonWriterCompactImplHelper {
-  buffer: Buffer.Buffer,
-  emitEscapedQuotedString: String => Void,
-}
-
-record JsonWriterPrettyImplHelper {
+record JsonWriterImplHelper {
   format: FormattingSettings,
-  //TODO(#775): Note that the "Pretty" suffix here is a workaround for a Grain compiler bug.
-  bufferPretty: Buffer.Buffer,
+  buffer: Buffer.Buffer,
   emitEscapedQuotedStringPretty: String => Void,
   printNewLine: () => Void,
   printIndentation: Number => Void,
@@ -659,180 +653,16 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
   ret
 }
 
-let rec printElementCompact =
-  (
-    json: Json,
-    implHelper: JsonWriterCompactImplHelper,
-  ) => {
-  let buffer = implHelper.buffer
-  match (json) {
-    JsonNull => {
-      printNull(buffer)
-      return None
-    },
-    JsonBoolean(b) => {
-      printBool(b, buffer)
-      return None
-    },
-    JsonNumber(n) => return printNumber(n, buffer),
-    JsonString(s) => {
-      implHelper.emitEscapedQuotedString(s)
-      return None
-    },
-    JsonArray(elems) => {
-      // In order to gain more performance, List.forEachi is avoided in order to avoid
-      // the allocation of closures, this makes this function a little ugly but it seems
-      // like a valid trade-off
-      // Another approach would be to allocate a function for the
-      // formatting arrays just once at the start of formatting and pass
-      // it in emitJSONElement.
-      match (elems) {
-        [] => {
-          Buffer.addChar('[', buffer)
-          Buffer.addChar(']', buffer)
-          return None
-        },
-        [e] => {
-          Buffer.addChar('[', buffer)
-
-          let err = printElementCompact(e, implHelper)
-          if (Option.isSome(err)) return err
-          Buffer.addChar(']', buffer)
-          return None
-        },
-        [initialHead, ...initialRest] => {
-          Buffer.addChar('[', buffer)
-
-          let mut currentHead = initialHead
-          let mut currentRest = initialRest
-
-          for (let mut index = 0; ; index += 1) {
-            if (index > 0) {
-              Buffer.addChar(',', buffer)
-            }
-
-            let err = printElementCompact(currentHead, implHelper)
-            if (Option.isSome(err)) return err
-
-            match (currentRest) {
-              [] => break,
-              [newHead, ...newRest] => {
-                currentHead = newHead
-                currentRest = newRest
-              },
-            }
-          }
-
-          Buffer.addChar(']', buffer)
-
-          return None
-        },
-      }
-    },
-    JsonObject(entries) => {
-      match (entries) {
-        [] => {
-          Buffer.addChar('{', buffer)
-          Buffer.addChar('}', buffer)
-          return None
-        },
-        [(key, value)] => {
-          Buffer.addChar('{', buffer)
-
-          implHelper.emitEscapedQuotedString(key)
-
-          Buffer.addChar(':', buffer)
-
-          let err = printElementCompact(value, implHelper)
-          if (Option.isSome(err)) return err
-
-          Buffer.addChar('}', buffer)
-
-          return None
-        },
-        [initialHead, ...initialRest] => {
-          Buffer.addChar('{', buffer)
-
-          let mut currentHead = initialHead
-          let mut currentRest = initialRest
-
-          for (let mut index = 0; ; index += 1) {
-            if (index > 0) {
-              Buffer.addChar(',', buffer)
-            }
-
-            let (key, value) = currentHead
-
-            implHelper.emitEscapedQuotedString(key)
-
-            Buffer.addChar(':', buffer)
-
-            let err = printElementCompact(value, implHelper)
-
-            if (Option.isSome(err)) return err
-
-            match (currentRest) {
-              [] => break,
-              [newHead, ...newRest] => {
-                currentHead = newHead
-                currentRest = newRest
-              },
-            }
-          }
-
-          Buffer.addChar('}', buffer)
-
-          return None
-        },
-      }
-    },
-  }
-}
-
-let makeCompactJsonWriter = (buffer: Buffer.Buffer) => {
-  // As an optimization prepare a closure function to execute for each code
-  // point of the input. It's important that this is not inline in the
-  // emitEscapedQuotedString function directly to avoid allocating the closue
-  // for each input string.
-  let emitCodePoint = (codePoint: Number) => {
-    // For the compact formatting only escape backslash, double quotes and
-    // code points 0..31 (the so called "C0" control point group) as
-    // required by ECMA-404. For the non pretty printed case we don't want
-    // to escape more than what is stricty required to avoid increasing the
-    // output size.
-    if (codePoint > 31 && codePoint != 0x0022 && codePoint != 0x005C) {
-      addCharFromCodePoint(codePoint, buffer)
-    } else {
-      emitEscapedCodePoint(codePoint, buffer)
-    }
-  }
-
-  let emitEscapedQuotedString = (s: String) => {
-    Buffer.addChar('"', buffer)
-
-    String.forEachCodePoint(emitCodePoint, s)
-
-    Buffer.addChar('"', buffer)
-  }
-
-  let implHelper = {
-    buffer,
-    emitEscapedQuotedString,
-  }: JsonWriterCompactImplHelper
-
-  { emit: json => printElementCompact(json, implHelper), }: JsonWriter
-}
-
 // Note that this could relatively easily be integrated with
 // printElementCompact to avoid code duplication, but it would mean
 // compromising peak performance and also increasing complexity in other ways.
 let rec printElementPretty =
   (
     json: Json,
-    implHelper: JsonWriterPrettyImplHelper,
+    implHelper: JsonWriterImplHelper,
     indentationLevel: Number,
   ) => {
-  let buffer = implHelper.bufferPretty
+  let buffer = implHelper.buffer
   match (json) {
     JsonNull => {
       printNull(buffer)
@@ -1068,11 +898,7 @@ let combineSurrogatePairToCodePoint =
   ((highSurrogate - 0xD800) << 10) + (lowSurrogate - 0xDC00) + 0x10000
 }
 
-let makePrettyPrintJsonWriter =
-  (
-    format: FormattingSettings,
-    buffer: Buffer.Buffer,
-  ) => {
+let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   let printNewLine = match (format.lineEnding) {
     NoLineEnding => () => void,
     LineFeed =>
@@ -1243,11 +1069,11 @@ let makePrettyPrintJsonWriter =
 
   let implHelper = {
     format,
-    bufferPretty: buffer,
+    buffer,
     emitEscapedQuotedStringPretty: emitEscapedQuotedString,
     printNewLine,
     printIndentation,
-  }: JsonWriterPrettyImplHelper
+  }: JsonWriterImplHelper
 
   {
     emit: json => {
@@ -1314,50 +1140,51 @@ let makePrettyPrintJsonWriter =
  */
 provide let toString = (format=Compact, json: Json) => {
   let buf = Buffer.make(16)
-  let writer = match (format) {
+  let format = match (format) {
     Pretty =>
-      makePrettyPrintJsonWriter(
-        {
-          indentation: IndentWithSpaces(2),
-          arrayFormat: OneArrayEntryPerLine,
-          objectFormat: OneObjectEntryPerLine,
-          lineEnding: LineFeed,
-          finishWithNewLine: true,
-          escapeAllControlPoints: true,
-          escapeHTMLUnsafeSequences: false,
-          escapeNonASCII: false,
-        },
-        buf
-      ),
-    Compact => makeCompactJsonWriter(buf),
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: OneObjectEntryPerLine,
+        lineEnding: LineFeed,
+        finishWithNewLine: true,
+        escapeAllControlPoints: true,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      },
+    Compact =>
+      {
+        indentation: NoIndentation,
+        arrayFormat: CompactArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: NoLineEnding,
+        finishWithNewLine: false,
+        escapeAllControlPoints: false,
+        escapeHTMLUnsafeSequences: false,
+        escapeNonASCII: false,
+      },
     PrettyAndSafeFormat =>
-      makePrettyPrintJsonWriter(
-        {
-          indentation: IndentWithSpaces(2),
-          arrayFormat: OneArrayEntryPerLine,
-          objectFormat: OneObjectEntryPerLine,
-          lineEnding: LineFeed,
-          finishWithNewLine: true,
-          escapeAllControlPoints: true,
-          escapeHTMLUnsafeSequences: true,
-          escapeNonASCII: true,
-        },
-        buf
-      ),
+      {
+        indentation: IndentWithSpaces(2),
+        arrayFormat: OneArrayEntryPerLine,
+        objectFormat: OneObjectEntryPerLine,
+        lineEnding: LineFeed,
+        finishWithNewLine: true,
+        escapeAllControlPoints: true,
+        escapeHTMLUnsafeSequences: true,
+        escapeNonASCII: true,
+      },
     CompactAndSafeFormat =>
-      makePrettyPrintJsonWriter(
-        {
-          indentation: NoIndentation,
-          arrayFormat: CompactArrayEntries,
-          objectFormat: CompactObjectEntries,
-          lineEnding: NoLineEnding,
-          finishWithNewLine: false,
-          escapeAllControlPoints: true,
-          escapeHTMLUnsafeSequences: true,
-          escapeNonASCII: true,
-        },
-        buf
-      ),
+      {
+        indentation: NoIndentation,
+        arrayFormat: CompactArrayEntries,
+        objectFormat: CompactObjectEntries,
+        lineEnding: NoLineEnding,
+        finishWithNewLine: false,
+        escapeAllControlPoints: true,
+        escapeHTMLUnsafeSequences: true,
+        escapeNonASCII: true,
+      },
     Custom{
       indentation,
       arrayFormat,
@@ -1368,20 +1195,18 @@ provide let toString = (format=Compact, json: Json) => {
       escapeHTMLUnsafeSequences,
       escapeNonASCII,
     } =>
-      makePrettyPrintJsonWriter(
-        {
-          indentation,
-          arrayFormat,
-          objectFormat,
-          lineEnding,
-          finishWithNewLine,
-          escapeAllControlPoints,
-          escapeHTMLUnsafeSequences,
-          escapeNonASCII,
-        },
-        buf
-      ),
+      {
+        indentation,
+        arrayFormat,
+        objectFormat,
+        lineEnding,
+        finishWithNewLine,
+        escapeAllControlPoints,
+        escapeHTMLUnsafeSequences,
+        escapeNonASCII,
+      },
   }
+  let writer = makeJsonWriter(format, buf)
   let error = writer.emit(json)
 
   match (error) {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1415,7 +1415,7 @@ let formatCodePointOrEOF = (codePoint: Number) => {
     // If the codepoint is in the range of printable ASCII characters, then
     // display the character itself . Whether it's a good idea to display
     // all of them, especially space is up for debate.
-    "'" ++ runtimeToString(Char.fromCode(codePoint)) ++ "'"
+    "'" ++ Char.toString(Char.fromCode(codePoint)) ++ "'"
   } else if (codePoint == -1) {
     // Special case for value used by the parsing code to avoid heap allocations.
     "end of input"
@@ -1928,7 +1928,6 @@ and parseArray = (parserState: JsonParserState) => {
         let c = parserState.currentCodePoint
         match (c) {
           0x2C => { // ','
-            trailingComma = true
             if (first) {
               return Err(
                 buildUnexpectedTokenError(
@@ -1937,6 +1936,7 @@ and parseArray = (parserState: JsonParserState) => {
                 )
               )
             }
+            trailingComma = true
             next(parserState)
             skipWhiteSpace(parserState)
           },
@@ -1950,11 +1950,11 @@ and parseArray = (parserState: JsonParserState) => {
             break
           },
           _ => {
-            first = false
-            trailingComma = false
             // note that parseValue skips initial and final whitespace
             match (parseValue(parserState)) {
               Ok(elem) => {
+                first = false
+                trailingComma = false
                 elems = [elem, ...elems]
                 void
               },

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -1354,9 +1354,7 @@ let rec readCodePoint = (bytePosition: Number, string: String) => {
 
 let codePointUTF8ByteCount = (usv: Number) => {
   if (!Char.isValid(usv)) {
-    throw InvalidArgument(
-      "Impossible: JSON parser encountered an invalid unicode scalar value"
-    )
+    fail "Impossible: JSON parser encountered an invalid unicode scalar value in codePointUTF8ByteCount"
   }
 
   if (usv <= 0x7f) {

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -11,27 +11,26 @@
  *   )
  * )
  */
-
 module Json
 
-include "runtime/bigint" as BI
-include "runtime/dataStructures"
-include "runtime/numbers"
-include "runtime/numberUtils"
-include "runtime/string" as RuntimeString
-include "runtime/unsafe/tags"
-include "runtime/unsafe/wasmi32"
-include "runtime/unsafe/wasmi64"
-include "runtime/unsafe/wasmf64"
-include "runtime/atof/parse" as Atof
-include "buffer"
-include "char"
-include "string"
-include "list"
-include "uint8"
-from RuntimeString use { toString as runtimeToString, getCodePoint }
-from Numbers use { coerceNumberToWasmI32 }
-from DataStructures use { tagSimpleNumber, untagSimpleNumber }
+from "runtime/bigint" include Bigint as BI
+from "runtime/dataStructures" include DataStructures
+from "runtime/numbers" include Numbers
+from "runtime/numberUtils" include NumberUtils
+from "runtime/string" include String as RuntimeString
+from "runtime/unsafe/tags" include Tags
+from "runtime/unsafe/wasmi32" include WasmI32
+from "runtime/unsafe/wasmi64" include WasmI64
+from "runtime/unsafe/wasmf64" include WasmF64
+from "runtime/atof/parse" include Parse as Atof
+from "buffer" include Buffer
+from "char" include Char
+from "string" include String
+from "list" include List
+from "uint8" include Uint8
+use RuntimeString.{ toString as runtimeToString, getCodePoint }
+use Numbers.{ coerceNumberToWasmI32 }
+use DataStructures.{ tagSimpleNumber, untagSimpleNumber }
 
 // Primitive offsets
 // TODO(#703): Get these offsets from the runtime
@@ -578,13 +577,13 @@ let printNumberWasmI64 = (value: WasmI64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let isFinite = (value: WasmF64) => {
-  from WasmF64 use { (==), (-) }
+  use WasmF64.{ (==), (-) }
   value - value == 0.0W
 }
 
 @unsafe
 let isNaN = (value: WasmF64) => {
-  from WasmF64 use { (!=) }
+  use WasmF64.{ (!=) }
   value != value
 }
 
@@ -595,7 +594,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     Buffer.addString(s, buffer)
     None
   } else {
-    from WasmF64 use { (<) }
+    use WasmF64.{ (<) }
     // JSON standard doesn't allow NaN or infinite values in numbers,
     // but WASM f64 (IEEE 754-2008), as well as Grain's number types do
     // (Float64 as well as Number). This is the only reason that the
@@ -615,7 +614,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let printNumber = (value: Number, buffer: Buffer.Buffer) => {
-  from WasmI32 use { (&), (==), (!=), (<<), (>>) }
+  use WasmI32.{ (&), (==), (!=), (<<), (>>) }
 
   let ptr = WasmI32.fromGrain(value)
   let ret = if ((ptr & 1n) != 0n) {
@@ -669,12 +668,11 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
 // Note that this compromises on peak performance by also handling
 // the compact printing case, merging these two together greatly simplifies the amount
 // of code we need to maintain so it seems worth it.
-let rec printElement =
-  (
-    json: Json,
-    implHelper: JsonWriterConfig,
-    indentationLevel: Number,
-  ) => {
+let rec printElement = (
+  json: Json,
+  implHelper: JsonWriterConfig,
+  indentationLevel: Number,
+) => {
   let buffer = implHelper.buffer
   match (json) {
     JsonNull => {
@@ -758,7 +756,7 @@ let rec printElement =
 
           let elemLevel = indentationLevel + 1
 
-          for (let mut index = 0; ; index += 1) {
+          for (let mut index = 0;; index += 1) {
             if (index > 0) {
               Buffer.addChar(',', buffer)
               if (format.arrayFormat == SpacedArrayEntries) {
@@ -886,7 +884,7 @@ let rec printElement =
 
           let elemLevel = indentationLevel + 1
 
-          for (let mut index = 0; ; index += 1) {
+          for (let mut index = 0;; index += 1) {
             if (index > 0) {
               Buffer.addChar(',', buffer)
               if (format.objectFormat == SpacedObjectEntries) {
@@ -955,18 +953,16 @@ let rec printElement =
 }
 
 let isCodePointInBasicMultilingualPlane = (code: Number) =>
-  code >= 0x0000 &&
-    code <= 0xFFFF
+  code >= 0x0000 && code <= 0xFFFF
 
 let isHighSurrogate = (code: Number) => code >= 0xD800 && code <= 0xDBFF
 
 let isLowSurrogate = (code: Number) => code >= 0xDC00 && code <= 0xDFFF
 
-let combineSurrogatePairToCodePoint =
-  (
-    highSurrogate: Number,
-    lowSurrogate: Number,
-  ) => {
+let combineSurrogatePairToCodePoint = (
+  highSurrogate: Number,
+  lowSurrogate: Number,
+) => {
   // If this was a method exposed by itself in a library then it should check the
   // ranges of the input surrogates, but here it's necessary because checks are made
   // as part of the parsing logic.
@@ -976,28 +972,24 @@ let combineSurrogatePairToCodePoint =
 let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   let printNewLine = match (format.lineEnding) {
     NoLineEnding => None,
-    LineFeed =>
-      Some(() => {
-        Buffer.addChar('\n', buffer)
-      }),
-    CarriageReturnLineFeed =>
-      Some(() => {
-        Buffer.addChar('\r', buffer)
-        Buffer.addChar('\n', buffer)
-      }),
-    CarriageReturn =>
-      Some(() => {
-        Buffer.addChar('\r', buffer)
-      }),
+    LineFeed => Some(() => {
+      Buffer.addChar('\n', buffer)
+    }),
+    CarriageReturnLineFeed => Some(() => {
+      Buffer.addChar('\r', buffer)
+      Buffer.addChar('\n', buffer)
+    }),
+    CarriageReturn => Some(() => {
+      Buffer.addChar('\r', buffer)
+    }),
   }
 
   let printIndentation = match (format.indentation) {
-    IndentWithTab =>
-      Some(indentationLevel => {
-        for (let mut count = 0; count < indentationLevel; count += 1) {
-          Buffer.addChar('\t', buffer)
-        }
-      }),
+    IndentWithTab => Some(indentationLevel => {
+      for (let mut count = 0; count < indentationLevel; count += 1) {
+        Buffer.addChar('\t', buffer)
+      }
+    }),
     // Implement fast path, for common indentation level to avoid closure
     IndentWithSpaces(spacesPerIndentation) when spacesPerIndentation == 2 =>
       Some(indentationLevel => {
@@ -1014,13 +1006,12 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
           Buffer.addChar(' ', buffer)
         }
       }),
-    IndentWithSpaces(spacesPerIndentation) =>
-      Some(indentationLevel => {
-        let spaceCount = indentationLevel * spacesPerIndentation
-        for (let mut count = 0; count < spaceCount; count += 1) {
-          Buffer.addChar(' ', buffer)
-        }
-      }),
+    IndentWithSpaces(spacesPerIndentation) => Some(indentationLevel => {
+      let spaceCount = indentationLevel * spacesPerIndentation
+      for (let mut count = 0; count < spaceCount; count += 1) {
+        Buffer.addChar(' ', buffer)
+      }
+    }),
     NoIndentation => None,
   }
 
@@ -1047,7 +1038,8 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
   // escapes it when needed, but requires to keep track of the previous code
   // point in the iteration so it's more complicated and handled separately.
   let emitCodePoint = if (
-    !format.escapeAllControlPoints && !format.escapeNonASCII
+    !format.escapeAllControlPoints &&
+    !format.escapeNonASCII
   ) {
     (codePoint: Number) => {
       if (codePoint > 31 && codePoint != 0x0022 && codePoint != 0x005C) {
@@ -1080,9 +1072,9 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
     (codePoint: Number) => {
       if (
         codePoint > 31 &&
-        codePoint != 0x0022 &&
-        codePoint != 0x005C &&
-        codePoint < 127 ||
+          codePoint != 0x0022 &&
+          codePoint != 0x005C &&
+          codePoint < 127 ||
         codePoint > 159
       ) {
         Buffer.addCharFromCodePoint(codePoint, buffer)
@@ -1162,21 +1154,19 @@ let makeJsonWriter = (format: FormattingSettings, buffer: Buffer.Buffer) => {
     printIndentation,
   }: JsonWriterConfig
 
-  {
-    emit: json => {
-      match (printElement(json, implHelper, 0)) {
+  { emit: json => {
+    match (printElement(json, implHelper, 0)) {
+      None => void,
+      err => return err,
+    }
+    if (format.finishWithNewLine) {
+      match (printNewLine) {
+        Some(printNewLine) => printNewLine(),
         None => void,
-        err => return err,
       }
-      if (format.finishWithNewLine) {
-        match (printNewLine) {
-          Some(printNewLine) => printNewLine(),
-          None => void,
-        }
-      }
-      return None
-    },
-  }: JsonWriter
+    }
+    return None
+  }, }: JsonWriter
 }
 
 /**
@@ -1331,7 +1321,7 @@ let _END_OF_INPUT = -1
 
 @unsafe
 let rec readCodePoint = (bytePosition: Number, string: String) => {
-  from WasmI32 use { (+), (<) }
+  use WasmI32.{ (+), (<) }
 
   let strPtr = WasmI32.fromGrain(string)
 
@@ -1394,20 +1384,16 @@ let skipWhiteSpace = (parserState: JsonParserState) => {
   }
 }
 
-let buildUnexpectedTokenError =
-  (
-    parserState: JsonParserState,
-    detail: String,
-  ) => {
+let buildUnexpectedTokenError = (parserState: JsonParserState, detail: String) => {
   let codePoint = parserState.currentCodePoint
   let pos = parserState.pos
   if (codePoint == _END_OF_INPUT) {
     UnexpectedEndOfInput(
-      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail
+      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail,
     )
   } else {
     UnexpectedToken(
-      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail
+      "Unexpected token at position " ++ runtimeToString(pos) ++ ": " ++ detail,
     )
   }
 }
@@ -1443,11 +1429,10 @@ let formatCodePointOrEOF = (codePoint: Number) => {
   }
 }
 
-let expectCodePointAndAdvance =
-  (
-    expectedCodePoint: Number,
-    parserState: JsonParserState,
-  ) => {
+let expectCodePointAndAdvance = (
+  expectedCodePoint: Number,
+  parserState: JsonParserState,
+) => {
   let c = parserState.currentCodePoint
   if (c == expectedCodePoint) {
     next(parserState)
@@ -1464,7 +1449,7 @@ let atoiFast = buffer => {
   let bufLen = Buffer.length(buffer)
   let mut result = 0
   for (let mut i = 0; i < bufLen; i += 1) {
-    from Uint8 use { (-) }
+    use Uint8.{ (-) }
     result = (result << 1) +
       (result << 3) +
       Uint8.toNumber(Buffer.getUint8(i, buffer) - 48us)
@@ -1677,22 +1662,23 @@ and parseString = (parserState: JsonParserState) => {
 
                     let mut digit = hexDigitCodePoint
 
-                    if (
-                      hexDigitCodePoint >= 48 && hexDigitCodePoint <= 57
-                    ) { // 0..9
+                    if (hexDigitCodePoint >= 48 && hexDigitCodePoint <= 57) { // 0..9
                       digit -= 48
                     } else if (
-                      hexDigitCodePoint >= 65 && hexDigitCodePoint <= 70
+                      hexDigitCodePoint >= 65 &&
+                      hexDigitCodePoint <= 70
                     ) { // A..F
                       digit -= 55 // (65 - 10)
                     } else if (
-                      hexDigitCodePoint >= 97 && hexDigitCodePoint <= 102
+                      hexDigitCodePoint >= 97 &&
+                      hexDigitCodePoint <= 102
                     ) { // a..f
                       digit -= 87 // (97 - 10)
                     } else {
                       let digitsSoFar = 3 - digitIndex
-                      let detail = "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
-                        runtimeToString(digitsSoFar)
+                      let detail =
+                        "expected exactly 4 hexadecimal digits in the UTF-16 escape sequence, found only " ++
+                          runtimeToString(digitsSoFar)
                       return Err(buildUnexpectedTokenError(parserState, detail))
                     }
 
@@ -1731,11 +1717,12 @@ and parseString = (parserState: JsonParserState) => {
                       Buffer.addCharFromCodePoint(codePoint, buffer)
                       break
                     } else {
-                      let message = "Invalid character escape sequence at position " ++
-                        runtimeToString(escapeStartPos) ++
-                        ": expected a Unicode code point in Basic Multilingual Plane (U+0000..U+FFFF) or a high surrogate (0xD800..0xDBFF) of a UTF-16 surrogate pair, found " ++
-                        "0x" ++
-                        toHexWithZeroPadding(codeUnit, 4)
+                      let message =
+                        "Invalid character escape sequence at position " ++
+                          runtimeToString(escapeStartPos) ++
+                          ": expected a Unicode code point in Basic Multilingual Plane (U+0000..U+FFFF) or a high surrogate (0xD800..0xDBFF) of a UTF-16 surrogate pair, found " ++
+                          "0x" ++
+                          toHexWithZeroPadding(codeUnit, 4)
                       return Err(InvalidUTF16SurrogatePair(message))
                     }
                   } else {
@@ -1750,11 +1737,12 @@ and parseString = (parserState: JsonParserState) => {
                       Buffer.addCharFromCodePoint(combinedCodePoint, buffer)
                       break
                     } else {
-                      let message = "Invalid character escape sequence at position " ++
-                        runtimeToString(escapeStartPos) ++
-                        ": expected a low surrogate (0xDC00..0xDFFF) in the second code unit of the UTF-16 sequence, found " ++
-                        "0x" ++
-                        toHexWithZeroPadding(codeUnit, 4)
+                      let message =
+                        "Invalid character escape sequence at position " ++
+                          runtimeToString(escapeStartPos) ++
+                          ": expected a low surrogate (0xDC00..0xDFFF) in the second code unit of the UTF-16 sequence, found " ++
+                          "0x" ++
+                          toHexWithZeroPadding(codeUnit, 4)
                       return Err(InvalidUTF16SurrogatePair(message))
                     }
                   }
@@ -1763,8 +1751,9 @@ and parseString = (parserState: JsonParserState) => {
               unexpectedCodePoint => {
                 // JSON doesn't allow arbitrary characters to be preceded by backslash escape.
                 // Only the ones above.
-                let detail = "expected a valid escape sequence or the end of string, found " ++
-                  formatCodePointOrEOF(unexpectedCodePoint)
+                let detail =
+                  "expected a valid escape sequence or the end of string, found " ++
+                    formatCodePointOrEOF(unexpectedCodePoint)
                 return Err(buildUnexpectedTokenError(parserState, detail))
               },
             }
@@ -1775,7 +1764,7 @@ and parseString = (parserState: JsonParserState) => {
                 buildUnexpectedTokenError(
                   parserState,
                   "Bad control character in string literal"
-                )
+                ),
               )
             }
             // Finally the happy case of a simple unescaped code point.
@@ -1793,7 +1782,7 @@ and parseString = (parserState: JsonParserState) => {
           buildUnexpectedTokenError(
             parserState,
             "unexpected end of string value"
-          )
+          ),
         )
       }
     },
@@ -1867,7 +1856,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
         buildUnexpectedTokenError(
           parserState,
           "exponent part is missing in number"
-        )
+        ),
       )
   }
   // Optional exponential part of the number.
@@ -1898,7 +1887,7 @@ and parseNumberValue = (parserState: JsonParserState) => {
         buildUnexpectedTokenError(
           parserState,
           "exponent part is missing in number"
-        )
+        ),
       )
   }
   // Note that unlike all other JSON value types there's no explicit ending
@@ -1915,8 +1904,10 @@ and parseNumberValue = (parserState: JsonParserState) => {
       }
     },
   }
-  if (result == 0 && isNegative) return Ok(JsonNumber(-0.0))
-  else return Ok(JsonNumber(if (isNegative) result * -1 else result))
+  if (result == 0 && isNegative)
+    return Ok(JsonNumber(-0.0))
+  else
+    return Ok(JsonNumber(if (isNegative) result * -1 else result))
 }
 and parseArray = (parserState: JsonParserState) => {
   match (expectCodePointAndAdvance(0x5B, parserState)) {
@@ -1939,7 +1930,7 @@ and parseArray = (parserState: JsonParserState) => {
                 buildUnexpectedTokenError(
                   parserState,
                   "unexpected comma at beginning of array"
-                )
+                ),
               )
             }
             trailingComma = true
@@ -1971,13 +1962,13 @@ and parseArray = (parserState: JsonParserState) => {
 
       if (trailingComma) {
         return Err(
-          buildUnexpectedTokenError(parserState, "unexpected end of array")
+          buildUnexpectedTokenError(parserState, "unexpected end of array"),
         )
       } else if (done) {
         return Ok(JsonArray(List.reverse(elems)))
       } else {
         return Err(
-          buildUnexpectedTokenError(parserState, "unexpected end of array")
+          buildUnexpectedTokenError(parserState, "unexpected end of array"),
         )
       }
     },
@@ -2007,7 +1998,8 @@ and parseObject = (parserState: JsonParserState) => {
           0x2C => { // ','
             trailingComma = true
             if (first) {
-              let detail = "expected a key-value pair or the end of the object, found ','"
+              let detail =
+                "expected a key-value pair or the end of the object, found ','"
               return Err(buildUnexpectedTokenError(parserState, detail))
             } else {
               ignore(next(parserState))
@@ -2058,7 +2050,7 @@ and parseObject = (parserState: JsonParserState) => {
         // This branch is not expected to actually execute,
         // but in case it does, may just as well do the right thing.
         return Err(
-          buildUnexpectedTokenError(parserState, "unexpected end of object")
+          buildUnexpectedTokenError(parserState, "unexpected end of object"),
         )
       }
     },
@@ -2081,10 +2073,7 @@ and parseObject = (parserState: JsonParserState) => {
  *
  * @since v0.6.0
  */
-provide let parse: (str: String) => Result<Json, JsonParseError> =
-  (
-    str: String,
-  ) => {
+provide let parse: (str: String) => Result<Json, JsonParseError> = (str: String) => {
   let parserState = {
     string: str,
     bufferParse: Buffer.make(16),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -648,9 +648,9 @@ let rec printElementCompact =
       return None
     },
     JsonArray(elems) => {
-      // Here I'm not using List.forEachi or similar in order to avoid
-      // allocations of closures. The code is verbose and a bit ugly as a
-      // consequence, but I think it's an OK price for performance gain.
+      // In order to gain more performance, List.forEachi is avoided in order to avoid
+      // the allocation of closures, this makes this function a little ugly but it seems
+      // like a valid trade-off
       // Another approach would be to allocate a function for the
       // formattng arrays just once at the start of formatting and pass
       // it in emitJSONElement.
@@ -1077,17 +1077,20 @@ let makePrettyPrintJsonWriter =
     NoIndentation => indentationLevel => void,
   }
 
-  // As an optimization prepare a different closure function for each
-  // combination of escaping options. This ways we can avoid unnecessary
-  // branching in the code executed for each character. What is most
-  // important here is to optimize for the non pretty printed format as this
-  // is where the performance is most likely to matter. In every case escape
-  // code points 0..31 as required by ECMA-404 (the so called "C0" control
-  // point group). For the non pretty printed case we don't want to escape
-  // more than what is stricty required to avoid increasing the output size.
-  // But for pretty printing or compatiblity it may be desirable to escape
-  // other control points or even everything other than printable ASCII
-  // characters. Thus I've decided to expose options for this, but otherwise
+  // A possible optimization to make this faster would be to
+  // prepare a different closure for each combination fo escaping options.
+  // This way unnecessary branching is avoided.
+  // The most important thing is that the non pretty printed format is optimized for
+  // as this is where the performance is most likely to matter.
+
+  // In every case code points 0..31 must be escaped as
+  // required by ECMA-404 (the so called "C0" control point group).
+
+  // For the non pretty printed case it is fastest to escape only what is
+  // strictly required to avoid increasing output size
+  // But for pretty printing or compatibility it may be desirable to escape other control points
+  // or even everything other than printable ASCII characters.
+  // for this reason options for this control has been exposed otherwise
   // just a sane default would suffice.
   // Additionally many JSON libraries escape additional two character
   // sequences for direct embedding into html for example. This is
@@ -1235,8 +1238,8 @@ let makePrettyPrintJsonWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
- *       format=Custom(defaultCompactAndSafeFormat)
+ *       format=Custom(defaultCompactAndSafeFormat),
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *     )
  *   )
  * )
@@ -1254,8 +1257,8 @@ let makePrettyPrintJsonWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
  *       format=Compact
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *      )
  *   )
  * )
@@ -1264,8 +1267,8 @@ let makePrettyPrintJsonWriter =
  * print(
  *   Result.unwrap(
  *     toString(
- *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]),
- *       format=Pretty
+ *       format=Pretty,
+ *       JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
  *     )
  *   )
  * )
@@ -1277,7 +1280,7 @@ let makePrettyPrintJsonWriter =
  *
  * @since v0.6.0
  */
-provide let toString = (json: Json, format=Compact) => {
+provide let toString = (format=Compact, json: Json) => {
   let buf = Buffer.make(16)
   let writer = match (format) {
     Pretty => makePrettyPrintJsonWriter(defaultPrettyFormat, buf),

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -269,10 +269,142 @@ record FormattingSettings {
  * Allows control of formatting in JSON printing.
  */
 provide enum FormattingChoices {
+  /**
+   * Recommended human readable formatting.
+   *
+   * Escapes all control points for the sake of clarity, but prints unicode
+   * codepoints directly so the result needs to be treated as proper unicode and
+   * is not safe to be transported in ASCII encoding.
+   *
+   * Roughly Equivalent to:
+   * ```
+   * Custom{
+   *  indentation: IndentWithSpaces(2),
+   *  arrayFormat: OneArrayEntryPerLine,
+   *  objectFormat: OneObjectEntryPerLine,
+   *  lineEnding: LineFeed,
+   *  finishWithNewLine: true,
+   *  escapeAllControlPoints: true,
+   *  escapeHTMLUnsafeSequences: false,
+   *  escapeNonASCII: false,
+   * }
+   * ```
+   *
+   * The following example have whitespaces, line breaks and control points
+   * replaced with visible characters.
+   * ```
+   * {↵
+   * ··"currency":·"€",↵
+   * ··"price":·99.9,↵
+   * ··"currencyDescription":·"EURO\u007f",↵
+   * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
+   * }
+   * ```
+   *
+   * @since v0.6.0
+   */
   Pretty,
+  /**
+   * Compact formatting that minimizes the size of resulting JSON at cost of not
+   * being easily human readable.
+   *
+   * Only performs minimal string escaping as required by the ECMA-404 standard,
+   * so the result needs to be treated as proper unicode and is not safe to be
+   * transported in ASCII encoding.
+   *
+   * Roughly Equivalent to:
+   * ```
+   * Custom{
+   *  indentation: NoIndentation,
+   *  arrayFormat: CompactArrayEntries,
+   *  objectFormat: CompactObjectEntries,
+   *  lineEnding: NoLineEnding,
+   *  finishWithNewLine: false,
+   *  escapeAllControlPoints: false,
+   *  escapeHTMLUnsafeSequences: false,
+   *  escapeNonASCII: false,
+   * }
+   * ```
+   *
+   * The following example have whitespaces, line breaks and control points
+   * replaced with visible characters.
+   * ```
+   * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+   * ```
+   *
+   * @since v0.6.0
+   */
   Compact,
+  /**
+   * Pretty and conservative formatting to maximize compatibility and
+   * embeddability of the resulting JSON.
+   *
+   * Should be safe to copy and paste directly into HTML and to transported in
+   * plain ASCII.
+   *
+   * Roughly Equivalent to:
+   * ```
+   * Custom{
+   *  indentation: IndentWithSpaces(2),
+   *  arrayFormat: OneArrayEntryPerLine,
+   *  objectFormat: OneObjectEntryPerLine,
+   *  lineEnding: LineFeed,
+   *  finishWithNewLine: true,
+   *  escapeAllControlPoints: true,
+   *  escapeHTMLUnsafeSequences: true,
+   *  escapeNonASCII: true,
+   * }
+   * ```
+   *
+   * The following example have whitespaces, line breaks and control points
+   * replaced with visible characters.
+   * ```
+   * {↵
+   * ··"currency":·"\u20ac",↵
+   * ··"price":·99.9,↵
+   * ··"currencyDescription":·"EURO\u007f",↵
+   * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
+   * }
+   * ```
+   *
+   * @since v0.6.0
+   */
   PrettyAndSafeFormat,
+  /**
+   * Compact and conservative formatting to maximize compatibility and
+   * embeddability of the resulting JSON.
+   *
+   * Should be safe to copy and paste directly into HTML and to transported in
+   * plain ASCII.
+   *
+   * Roughly Equivalent to:
+   * ```
+   * Custom{
+   *  indentation: NoIndentation,
+   *  arrayFormat: CompactArrayEntries,
+   *  objectFormat: CompactObjectEntries,
+   *  lineEnding: NoLineEnding,
+   *  finishWithNewLine: false,
+   *  escapeAllControlPoints: true,
+   *  escapeHTMLUnsafeSequences: true,
+   *  escapeNonASCII: true,
+   * }
+   * ```
+   *
+   * The following example have whitespaces, line breaks and control points
+   * replaced with visible characters.
+   * ```
+   * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+   * ```
+   *
+   * @since v0.6.0
+   */
   CompactAndSafeFormat,
+  /**
+   * Allows for fined grained control of the formatting output.
+   *
+   * @since v0.6.0
+   */
   Custom{
     indentation: IndentationFormat,
     arrayFormat: ArrayFormat,
@@ -284,112 +416,6 @@ provide enum FormattingChoices {
     escapeNonASCII: Bool,
   },
 }
-/*
- * Compact formatting that minimizes the size of resulting JSON at cost of not
- * being easily human readable.
- *
- * Only performs minimal string escaping as required by the ECMA-404 standard,
- * so the result needs to be treated as proper unicode and is not safe to be
- * transported in ASCII encoding.
- *
- * The following example have whitespaces, line breaks and control points
- * replaced with visible characters.
- * ```
- * {"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
- * ```
- */
-let defaultCompactFormat = {
-  indentation: NoIndentation,
-  arrayFormat: CompactArrayEntries,
-  objectFormat: CompactObjectEntries,
-  lineEnding: NoLineEnding,
-  finishWithNewLine: false,
-  escapeAllControlPoints: false,
-  escapeHTMLUnsafeSequences: false,
-  escapeNonASCII: false,
-}: FormattingSettings
-
-/*
- * Recommended human readable formatting.
- *
- * Escapes all control points for the sake of clarity, but prints unicode
- * codepoints directly so the result needs to be treated as proper unicode and
- * is not safe to be transported in ASCII encoding.
- *
- * The following example have whitespaces, line breaks and control points
- * replaced with visible characters.
- * ```
- * {↵
- * ··"currency":·"€",↵
- * ··"price":·99.9,↵
- * ··"currencyDescription":·"EURO\u007f",↵
- * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
- * }
- * ```
- */
-let defaultPrettyFormat = {
-  indentation: IndentWithSpaces(2),
-  arrayFormat: OneArrayEntryPerLine,
-  objectFormat: OneObjectEntryPerLine,
-  lineEnding: LineFeed,
-  finishWithNewLine: true,
-  escapeAllControlPoints: true,
-  escapeHTMLUnsafeSequences: false,
-  escapeNonASCII: false,
-}: FormattingSettings
-
-/**
- * Compact and conservative formatting to maximize compatibility and
- * embeddability of the resulting JSON.
- *
- * Should be safe to copy and paste directly into HTML and to transported in
- * plain ASCII.
- *
- * The following example have whitespaces, line breaks and control points
- * replaced with visible characters.
- * ```
- * {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
- * ```
- */
-let defaultCompactAndSafeFormat = {
-  indentation: NoIndentation,
-  arrayFormat: CompactArrayEntries,
-  objectFormat: CompactObjectEntries,
-  lineEnding: NoLineEnding,
-  finishWithNewLine: false,
-  escapeAllControlPoints: true,
-  escapeHTMLUnsafeSequences: true,
-  escapeNonASCII: true,
-}: FormattingSettings
-
-/**
- * Pretty and conservative formatting to maximize compatibility and
- * embeddability of the resulting JSON.
- *
- * Should be safe to copy and paste directly into HTML and to transported in
- * plain ASCII.
- *
- * The following example have whitespaces, line breaks and control points
- * replaced with visible characters.
- * ```
- * {↵
- * ··"currency":·"\u20ac",↵
- * ··"price":·99.9,↵
- * ··"currencyDescription":·"EURO\u007f",↵
- * ··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
- * }
- * ```
- */
-let defaultPrettyAndSafeFormat = {
-  indentation: IndentWithSpaces(2),
-  arrayFormat: OneArrayEntryPerLine,
-  objectFormat: OneObjectEntryPerLine,
-  lineEnding: LineFeed,
-  finishWithNewLine: true,
-  escapeAllControlPoints: true,
-  escapeHTMLUnsafeSequences: true,
-  escapeNonASCII: true,
-}: FormattingSettings
 
 record JsonWriterCompactImplHelper {
   buffer: Buffer.Buffer,
@@ -1302,12 +1328,49 @@ let makePrettyPrintJsonWriter =
 provide let toString = (format=Compact, json: Json) => {
   let buf = Buffer.make(16)
   let writer = match (format) {
-    Pretty => makePrettyPrintJsonWriter(defaultPrettyFormat, buf),
+    Pretty =>
+      makePrettyPrintJsonWriter(
+        {
+          indentation: IndentWithSpaces(2),
+          arrayFormat: OneArrayEntryPerLine,
+          objectFormat: OneObjectEntryPerLine,
+          lineEnding: LineFeed,
+          finishWithNewLine: true,
+          escapeAllControlPoints: true,
+          escapeHTMLUnsafeSequences: false,
+          escapeNonASCII: false,
+        },
+        buf
+      ),
     Compact => makeCompactJsonWriter(buf),
     PrettyAndSafeFormat =>
-      makePrettyPrintJsonWriter(defaultPrettyAndSafeFormat, buf),
+      makePrettyPrintJsonWriter(
+        {
+          indentation: IndentWithSpaces(2),
+          arrayFormat: OneArrayEntryPerLine,
+          objectFormat: OneObjectEntryPerLine,
+          lineEnding: LineFeed,
+          finishWithNewLine: true,
+          escapeAllControlPoints: true,
+          escapeHTMLUnsafeSequences: true,
+          escapeNonASCII: true,
+        },
+        buf
+      ),
     CompactAndSafeFormat =>
-      makePrettyPrintJsonWriter(defaultCompactAndSafeFormat, buf),
+      makePrettyPrintJsonWriter(
+        {
+          indentation: NoIndentation,
+          arrayFormat: CompactArrayEntries,
+          objectFormat: CompactObjectEntries,
+          lineEnding: NoLineEnding,
+          finishWithNewLine: false,
+          escapeAllControlPoints: true,
+          escapeHTMLUnsafeSequences: true,
+          escapeNonASCII: true,
+        },
+        buf
+      ),
     Custom{
       indentation,
       arrayFormat,
@@ -1328,7 +1391,7 @@ provide let toString = (format=Compact, json: Json) => {
           escapeAllControlPoints,
           escapeHTMLUnsafeSequences,
           escapeNonASCII,
-        }: FormattingSettings,
+        },
         buf
       ),
   }

--- a/stdlib/json.gr
+++ b/stdlib/json.gr
@@ -24,7 +24,7 @@ include "runtime/numbers"
 include "runtime/unsafe/memory"
 include "runtime/dataStructures"
 include "runtime/bigint" as BI
-from RunTimeString use { toString as runtimeToString }
+from RunTimeString use { toString as runtimeToString, getCodePoint }
 from Numbers use { coerceNumberToWasmI32 }
 from DataStructures use { tagSimpleNumber, newFloat64, untagSimpleNumber }
 
@@ -524,13 +524,13 @@ let printNumberWasmI64 = (value: WasmI64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let isFinite = (value: WasmF64) => {
-  from WasmF64 use { eq as (==), sub as (-) }
+  from WasmF64 use { (==), (-) }
   value - value == 0.0W
 }
 
 @unsafe
 let isNaN = (value: WasmF64) => {
-  from WasmF64 use { ne as (!=) }
+  from WasmF64 use { (!=) }
   value != value
 }
 
@@ -541,7 +541,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
     Buffer.addString(s, buffer)
     None
   } else {
-    from WasmF64 use { lt as (<) }
+    from WasmF64 use { (<) }
     // JSON standard doesn't allow NaN or infinite values in numbers,
     // but WASM f64 (IEEE 754-2008), as well as Grain's number types do
     // (Float64 as well as Number). This is the only reason that the
@@ -561,13 +561,7 @@ let printNumberWasmF64 = (value: WasmF64, buffer: Buffer.Buffer) => {
 
 @unsafe
 let printNumber = (value: Number, buffer: Buffer.Buffer) => {
-  from WasmI32 use {
-    and as (&),
-    eq as (==),
-    ne as (!=),
-    shl as (<<),
-    shrS as (>>),
-  }
+  from WasmI32 use { (&), (==), (!=), (<<), (>>) }
 
   let ptr = WasmI32.fromGrain(value)
   if ((ptr & 1n) != 0n) {
@@ -589,7 +583,7 @@ let printNumber = (value: Number, buffer: Buffer.Buffer) => {
             None
           },
           t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
-            from WasmF64 use { div as (/) }
+            from WasmF64 use { (/) }
             // As a compromnise, convert the rational into a float
             // and then print that. This means there can be
             // precision loss even for values that could be printed
@@ -1328,73 +1322,9 @@ let isInterTokenWhiteSpace = (codePoint: Number) => {
 
 let _END_OF_INPUT = -1
 
-exception MalformedUnicode
-
-// This function has been copied from the String module as a temporary
-// solution. This will likely be replaced by a more robust solution for
-// iterating over strings in the near future.
-@unsafe
-let getCodePoint = (ptr: WasmI32) => {
-  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
-  from WasmI32 use {
-    add as (+),
-    and as (&),
-    or as (|),
-    shl as (<<),
-    leU as (<=),
-    geU as (>=),
-    eq as (==),
-  }
-
-  let mut codePoint = 0n
-  let mut bytesSeen = 0n
-  let mut bytesNeeded = 0n
-  let mut lowerBoundary = 0x80n
-  let mut upperBoundary = 0xBFn
-
-  let mut offset = 0n
-
-  while (true) {
-    let byte = WasmI32.load8U(ptr + offset, 0n)
-    offset += 1n
-    if (bytesNeeded == 0n) {
-      if (byte >= 0x00n && byte <= 0x7Fn) {
-        return byte
-      } else if (byte >= 0xC2n && byte <= 0xDFn) {
-        bytesNeeded = 1n
-        codePoint = byte & 0x1Fn
-      } else if (byte >= 0xE0n && byte <= 0xEFn) {
-        if (byte == 0xE0n) lowerBoundary = 0xA0n
-        if (byte == 0xEDn) upperBoundary = 0x9Fn
-        bytesNeeded = 2n
-        codePoint = byte & 0xFn
-      } else if (byte >= 0xF0n && byte <= 0xF4n) {
-        if (byte == 0xF0n) lowerBoundary = 0x90n
-        if (byte == 0xF4n) upperBoundary = 0x8Fn
-        bytesNeeded = 3n
-        codePoint = byte & 0x7n
-      } else {
-        throw MalformedUnicode
-      }
-      continue
-    }
-    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
-      throw MalformedUnicode
-    }
-    lowerBoundary = 0x80n
-    upperBoundary = 0xBFn
-    codePoint = codePoint << 6n | byte & 0x3Fn
-    bytesSeen += 1n
-    if (bytesSeen == bytesNeeded) {
-      return codePoint
-    }
-  }
-  return 0n
-}
-
 @unsafe
 let rec readCodePoint = (bytePosition: Number, string: String) => {
-  from WasmI32 use { add as (+), ltU as (<) }
+  from WasmI32 use { (+), (<) }
 
   let strPtr = WasmI32.fromGrain(string)
 
@@ -1419,11 +1349,11 @@ let codePointUTF8ByteCount = (usv: Number) => {
     throw InvalidArgument("Invalid unicode scalar value")
   }
 
-  if (usv <= 127) {
+  if (usv <= 0x7f) {
     1
-  } else if (usv <= 2047) {
+  } else if (usv <= 0x7ff) {
     2
-  } else if (usv <= 65535) {
+  } else if (usv <= 0xffff) {
     3
   } else {
     4

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -231,6 +231,18 @@ record FormattingSettings {
 
 Allows fine grained control of formatting in JSON printing.
 
+### Json.**FormattingChoices**
+
+```grain
+enum FormattingChoices {
+  Pretty,
+  Compact,
+  Custom(FormattingSettings),
+}
+```
+
+Allows control of formatting in JSON printing.
+
 ### Json.**JSONParseError**
 
 ```grain
@@ -249,8 +261,13 @@ Functions and constants included in the Json module.
 
 ### Json.**defaultCompactFormat**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
-defaultCompactFormat : () -> FormattingSettings
+defaultCompactFormat : FormattingSettings
 ```
 
 Compact formatting that minimizes the size of resulting JSON at cost of not
@@ -268,8 +285,13 @@ replaced with visible characters.
 
 ### Json.**defaultPrettyFormat**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
-defaultPrettyFormat : () -> FormattingSettings
+defaultPrettyFormat : FormattingSettings
 ```
 
 Recommended human readable formatting.
@@ -291,8 +313,13 @@ replaced with visible characters.
 
 ### Json.**defaultCompactAndSafeFormat**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
-defaultCompactAndSafeFormat : () -> FormattingSettings
+defaultCompactAndSafeFormat : FormattingSettings
 ```
 
 Compact and conservative formatting to maximize compatibility and
@@ -309,8 +336,13 @@ replaced with visible characters.
 
 ### Json.**defaultPrettyAndSafeFormat**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
-defaultPrettyAndSafeFormat : () -> FormattingSettings
+defaultPrettyAndSafeFormat : FormattingSettings
 ```
 
 Pretty and conservative formatting to maximize compatibility and
@@ -332,9 +364,14 @@ replaced with visible characters.
 
 ### Json.**toString**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 toString :
-  (json: JSON, format: FormattingSettings) ->
+  (json: JSON, ?format: FormattingChoices) ->
    Result<String, JSONToStringError>
 ```
 
@@ -345,7 +382,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`json`|`JSON`|The JSON object to print|
-|`format`|`FormattingSettings`|Custom formatting setttings|
+|`format`|`Option<FormattingChoices>`|formatting option|
 
 Returns:
 
@@ -356,88 +393,62 @@ Returns:
 Examples:
 
 ```grain
-print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
-
-Example output:
-```json
-{"currency":"\u20ac","price":99.9}
+print(
+  Result.unwrap(
+    toString(
+      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+      format=Custom(defaultCompactAndSafeFormat)
+    )
+  )
+)
+// Output: {"currency":"\u20ac","price":99.9}"
 ```
-```
-
-### Json.**toStringCompact**
 
 ```grain
-toStringCompact : (json: JSON) -> Result<String, JSONToStringError>
+print(
+  Result.unwrap(
+    toString(
+      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]
+    )
+  )
+)
+// Output: {"currency":"€","price":99.9}
 ```
-
-Prints the JSON object into a string with compact formatting optimized for
-small size. Recommended for all uses where the intended consumer is a
-machine program. For example in REST APIs.
-
-Using this function can be preferred over `toString` with compact formatting
-settings since it can be slightly faster.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`json`|`JSON`|The JSON object to print|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
-
-Examples:
 
 ```grain
-print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
-
-Example output:
-```json
-{"currency":"€","price":99.9}
+print(
+  Result.unwrap(
+    toString(
+      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+      format=Compact
+     )
+  )
+)
+// Output: {"currency":"€","price":99.9}
 ```
-```
-
-### Json.**toStringPretty**
 
 ```grain
-toStringPretty : (json: JSON) -> Result<String, JSONToStringError>
-```
-
-Prints the JSON object into a string with default pretty formatting
-settings. Recommended for uses where the intended consumer is a person or
-the text should be easily inspectable. For example configuration files or
-document file formats.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`json`|`JSON`|The JSON object to print|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
-
-Example output:
-```json
-{
-  "currency": "€",
-  "price": 99.9
-}
-```|
-
-Examples:
-
-```grain
-print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+print(
+  Result.unwrap(
+    toString(
+      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
+      format=Pretty
+    )
+  )
+)
+// Output:
+// {
+// "currency": "€",
+// "price": 99.9
+//}
 ```
 
 ### Json.**parse**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 parse : String -> Result<JSON, JSONParseError>
@@ -455,16 +466,16 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.
-
-Example output:
-```
-Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
-```|
+|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
 
 Examples:
 
 ```grain
 print(parse("{\"currency\":\"$\",\"price\":119}"))
+
+Example output:
+```
+Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+```
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -5,7 +5,7 @@ title: Json
 JSON (JavaScript Object Notation) parsing, printing, and access utilities.
 
 ```grain
-include "json"
+from "json" include Json
 ```
 
 ```grain
@@ -38,7 +38,7 @@ enum Json {
 }
 ```
 
-Data structure representing the result of parsing and the input of printing JSON.
+Data structure representing JSON in Grain.
 
 Examples:
 
@@ -64,8 +64,8 @@ enum JsonToStringError {
 }
 ```
 
-Represents errors for cases where a `JSON` object cannot be represented in the
-JSON format along with a human readable text message.
+Represents errors for cases where a `Json` data structure cannot be represented as a
+JSON string.
 
 Variants:
 
@@ -73,7 +73,7 @@ Variants:
 InvalidNumber(String)
 ```
 
-The JSON object contains a number value of `NaN`, `Infinity` or `-Infinity`.
+The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`
 
 ### Json.**IndentationFormat**
 
@@ -85,10 +85,7 @@ enum IndentationFormat {
 }
 ```
 
-Controls how indentation is performed in custom formatting.
-
-The following examples have whitespaces and line breaks replaced with visible
-characters for illustrative purposes.
+Controls how indentation is outputted in custom formatting.
 
 Variants:
 
@@ -99,9 +96,9 @@ NoIndentation
 No indentation is emitted.
 
 ```json
-{↵
-"currency":·"€",↵
-"price":·99.9↵
+{
+"currency":·"€",
+"price":·99.9
 }
 ```
 
@@ -112,9 +109,9 @@ IndentWithTab
 Tabs are emitted.
 
 ```json
-{↵
-→"currency":·"€",↵
-→"price":·99.9↵
+{
+  "currency":·"€",
+  "price":·99.9
 }
 ```
 
@@ -126,17 +123,17 @@ The desired number of spaces are emitted.
 
 `IndentWithSpaces(2)`
 ```json
-{↵
-··"currency":·"€",↵
-··"price":·99.9↵
+{
+··"currency":·"€",
+··"price":·99.9
 }
 ```
 
 `IndentWithSpaces(4)`
 ```json
-{↵
-····"currency":·"€",↵
-····"price":·99.9↵
+{
+····"currency":·"€",
+····"price":·99.9
 }
 ```
 
@@ -150,10 +147,7 @@ enum ArrayFormat {
 }
 ```
 
-Controls how arrays are printed in custom formatting.
-
-The following examples have whitespaces and line breaks replaced with visible
-characters for illustrative purposes.
+Controls how arrays are outputted in custom formatting.
 
 Variants:
 
@@ -204,16 +198,16 @@ Arrays are emitted with newlines and indentation between each element.
 ```
 
 ```json
-[↵
-··1↵
+[
+··1
 ]
 ```
 
 ```json
-[↵
-··1,↵
-··2,↵
-··3↵
+[
+··1,
+··2,
+··3
 ]
 ```
 
@@ -227,10 +221,7 @@ enum ObjectFormat {
 }
 ```
 
-Controls how objects are printed in custom formatting.
-
-The following examples have whitespaces and line breaks replaced with visible
-characters for illustrative purposes.
+Controls how objects are outputted in custom formatting.
 
 Variants:
 
@@ -281,16 +272,16 @@ Objects are emitted with each entry on a new line.
 ```
 
 ```
-{↵
-··"a":·1↵
+{
+··"a":·1
 }
 ```
 
 ```
-{↵
-··"a":·1,↵
-··"b":·2,↵
-··"c":·3↵
+{
+··"a":·1,
+··"b":·2,
+··"c":·3
 }
 ```
 
@@ -305,7 +296,7 @@ enum LineEnding {
 }
 ```
 
-Controls line ending type in custom formatting.
+Controls how line endings are outputted in custom formatting.
 
 Variants:
 
@@ -354,7 +345,7 @@ enum FormattingChoices {
 }
 ```
 
-Allows control of formatting in JSON printing.
+Allows control of formatting in JSON output.
 
 Variants:
 
@@ -364,7 +355,7 @@ Pretty
 
 Recommended human readable formatting.
 
-Escapes all control points for the sake of clarity, but prints unicode
+Escapes all control points for the sake of clarity, but outputs unicode
 codepoints directly so the result needs to be treated as proper unicode and
 is not safe to be transported in ASCII encoding.
 
@@ -382,13 +373,11 @@ Custom{
 }
 ```
 
-The following example have whitespaces, line breaks and control points
-replaced with visible characters.
 ```json
-{↵
-··"currency":·"€",↵
-··"price":·99.9,↵
-··"currencyDescription":·"EURO\u007f",↵
+{
+··"currency":·"€",
+··"price":·99.9,
+··"currencyDescription":·"EURO\u007f",
 }
 ```
 
@@ -417,8 +406,6 @@ Custom{
 }
 ```
 
-The following example have whitespaces, line breaks and control points
-replaced with visible characters.
 ```json
 {"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
 ```
@@ -447,13 +434,11 @@ Custom{
 }
 ```
 
-The following example have whitespaces, line breaks and control points
-replaced with visible characters.
 ```json
-{↵
-··"currency":·"\u20ac",↵
-··"price":·99.9,↵
-··"currencyDescription":·"EURO\u007f",↵
+{
+··"currency":·"\u20ac",
+··"price":·99.9,
+··"currencyDescription":·"EURO\u007f",
 }
 ```
 
@@ -481,8 +466,6 @@ Custom{
 }
 ```
 
-The following example have whitespaces, line breaks and control points
-replaced with visible characters.
 ```json
 {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
 ```
@@ -512,7 +495,7 @@ enum JsonParseError {
 }
 ```
 
-Represents errors for JSON parsing along with a human readable text message.
+Represents errors for JSON parsing along with a human readable message.
 
 ## Values
 
@@ -531,20 +514,20 @@ toString :
    Result<String, JsonToStringError>
 ```
 
-Prints the JSON object into a string with specific formatting settings.
+Converts the `Json` data structure into a JSON string with specific formatting settings.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
 |`?format`|`FormattingChoices`|Formatting options|
-|`json`|`Json`|The JSON object to print|
+|`json`|`Json`|The `Json` data structure to convert|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<String, JsonToStringError>`|`Ok(str)` containing the printed JSON or `Err(err)` if the inputted object cannot be represented in the JSON format.,|
+|`Result<String, JsonToStringError>`|`Ok(str)` containing the JSON string or `Err(err)` if the provided `Json` data structure cannot be converted to a string|
 
 Examples:
 
@@ -604,13 +587,13 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`str`|`String`|The JSON text string|
+|`str`|`String`|The JSON string to parse|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Json, JsonParseError>`|`Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise.|
+|`Result<Json, JsonParseError>`|`Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise|
 
 Examples:
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -40,9 +40,6 @@ enum Json {
 
 Data structure representing the result of parsing and the input of printing JSON.
 
-This data structure is semantically equivalent to the JSON format allowing
-mostly lossless round trips of printing and parsing.
-
 Examples:
 
 ```grain

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -110,8 +110,8 @@ Tabs are emitted.
 
 ```json
 {
-  "currency": "€",
-  "price": 99.9
+	"currency": "€",
+	"price": 99.9
 }
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -21,33 +21,27 @@ enum Json {
 }
 ```
 
-Data structure representing the result of parsing and the input of printing
-JSON.
+Data structure representing the result of parsing and the input of printing JSON.
 
-For example this object
+Examples:
+
 ```grain
-JsonObject([
+Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
   ("currency", JsonString("€")),
   ("price", JsonNumber(99.99)),
 ])
 ```
-is equivalent to the following JSON:
-```json
-{"currency":"€","price":99.99}
-```
+
+```grain
+Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
+  ("currency", JsonString("€")),
+  ("price", JsonNumber(99.99)),
+])
 
 This data structure is semantically equivalent to the JSON format allowing
 mostly lossless round trips of printing and parsing. Exceptions to this are
 whitespace, multiple ways JSON allows escaping characters in strings, and
 some edge cases related to Grain's `Number` type.
-
-For example parsing the following JSON text will also result in the same
-`JSON` object as above.
-```json
-{
-  "currency": "\u20ac",
-  "price": 99.99
-}
 ```
 
 ### Json.**JsonToStringError**
@@ -58,7 +52,7 @@ enum JsonToStringError {
 }
 ```
 
-Represents errors for cases when a `JSON` object cannot be represente in the
+Represents errors for cases where a `JSON` object cannot be represented in the
 JSON format along with a human readable text message. This can happen when
 it contains number values `NaN`, `Infinity` or `-Infinity`.
 
@@ -114,6 +108,7 @@ charactes for illustrative purposes.
 ```grain
 enum ArrayFormat {
   CompactArrayEntries,
+  SpacedArrayEntries,
   OneArrayEntryPerLine,
 }
 ```
@@ -121,11 +116,24 @@ enum ArrayFormat {
 Controls how arrays are printed in custom formatting.
 
 Following examples have whitespaces and line breaks replaced with visible
-charactes for illustrative purposes.
+characters for illustrative purposes.
 
 `CompactArrayEntries`
 ```
 []
+```
+
+```
+[1]
+```
+
+```
+[1,2,3]
+```
+
+`SpacedArrayEntries`
+```
+[ ]
 ```
 
 ```
@@ -160,6 +168,7 @@ charactes for illustrative purposes.
 ```grain
 enum ObjectFormat {
   CompactObjectEntries,
+  SpacedObjectEntries,
   OneObjectEntryPerLine,
 }
 ```
@@ -167,7 +176,7 @@ enum ObjectFormat {
 Controls how objects are printed in custom formatting.
 
 Following examples have whitespaces and line breaks replaced with visible
-charactes for illustrative purposes.
+characters for illustrative purposes.
 
 `CompactObjectEntries`
 ```
@@ -180,6 +189,19 @@ charactes for illustrative purposes.
 
 ```
 {"a":1,"b":2,"c":3}
+```
+
+`SpacedObjectEntries`
+```
+{ }
+```
+
+```
+{"a": 1}
+```
+
+```
+{"a": 1, "b": 2, "c": 3}
 ```
 
 `OneObjectEntryPerLine`
@@ -371,7 +393,7 @@ No other changes yet.
 
 ```grain
 toString :
-  (?format: FormattingChoices, json: Json) ->
+  (?format: FormattingChoices, json: Json) =>
    Result<String, JsonToStringError>
 ```
 
@@ -394,53 +416,44 @@ Examples:
 
 ```grain
 print(
-  Result.unwrap(
-    toString(
-      format=Custom(defaultCompactAndSafeFormat),
-      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-    )
+  toString(
+    format=Custom(defaultCompactAndSafeFormat),
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
   )
 )
-// Output: {"currency":"\u20ac","price":99.9}"
+// Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
 ```
 
 ```grain
 print(
-  Result.unwrap(
-    toString(
-      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
-    )
+  toString(
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
   )
 )
-// Output: {"currency":"€","price":99.9}
+// Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
 ```
 
 ```grain
 print(
-  Result.unwrap(
-    toString(
-      format=Compact
-      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-     )
+  toString(
+    format=Compact
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
   )
 )
-// Output: {"currency":"€","price":99.9}
+// Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
 ```
 
 ```grain
 print(
-  Result.unwrap(
-    toString(
-      format=Pretty,
-      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-    )
+  toString(
+    format=Pretty,
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
   )
 )
-// Output:
-// {
-// "currency": "€",
-// "price": 99.9
-//}
+// Output: Ok("{
+// \"currency\": \"€\",
+// \"price\": 99.9
+//}")
 ```
 
 ### Json.**parse**
@@ -451,10 +464,10 @@ No other changes yet.
 </details>
 
 ```grain
-parse : String -> Result<Json, JsonParseError>
+parse : String => Result<Json, JsonParseError>
 ```
 
-Parses JSON input from a string into a `JSON` object.
+Parses JSON string into a `Json` data structure.
 
 Parameters:
 
@@ -471,11 +484,11 @@ Returns:
 Examples:
 
 ```grain
-print(parse("{\"currency\":\"$\",\"price\":119}"))
-
-Example output:
-```
-Ok(JsonObject([("currency", JsonString("$")), ("price", JsonNumber(119))]))
-```
+assert parse("{\"currency\":\"$\",\"price\":119}") == Ok(
+ JsonObject([
+   ("currency", JsonString("$")),
+   ("price", JsonNumber(119))
+ ])
+)
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -41,9 +41,7 @@ enum Json {
 Data structure representing the result of parsing and the input of printing JSON.
 
 This data structure is semantically equivalent to the JSON format allowing
-mostly lossless round trips of printing and parsing. Exceptions to this are
-whitespace, multiple ways JSON allows escaping characters in strings, and
-some edge cases related to Grain's `Number` type.
+mostly lossless round trips of printing and parsing.
 
 Examples:
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -70,8 +70,15 @@ enum JsonToStringError {
 ```
 
 Represents errors for cases where a `JSON` object cannot be represented in the
-JSON format along with a human readable text message. This can happen when
-it contains number values `NaN`, `Infinity` or `-Infinity`.
+JSON format along with a human readable text message.
+
+Variants:
+
+```grain
+InvalidNumber(String)
+```
+
+The JSON object contains a number value of `NaN`, `Infinity` or `-Infinity`.
 
 ### Json.**IndentationFormat**
 
@@ -275,6 +282,152 @@ enum FormattingChoices {
 ```
 
 Allows control of formatting in JSON printing.
+
+Variants:
+
+```grain
+Pretty
+```
+
+Recommended human readable formatting.
+
+Escapes all control points for the sake of clarity, but prints unicode
+codepoints directly so the result needs to be treated as proper unicode and
+is not safe to be transported in ASCII encoding.
+
+Roughly Equivalent to:
+```
+Custom{
+ indentation: IndentWithSpaces(2),
+ arrayFormat: OneArrayEntryPerLine,
+ objectFormat: OneObjectEntryPerLine,
+ lineEnding: LineFeed,
+ finishWithNewLine: true,
+ escapeAllControlPoints: true,
+ escapeHTMLUnsafeSequences: false,
+ escapeNonASCII: false,
+}
+```
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{↵
+··"currency":·"€",↵
+··"price":·99.9,↵
+··"currencyDescription":·"EURO\u007f",↵
+}
+```
+
+```grain
+Compact
+```
+
+Compact formatting that minimizes the size of resulting JSON at cost of not
+being easily human readable.
+
+Only performs minimal string escaping as required by the ECMA-404 standard,
+so the result needs to be treated as proper unicode and is not safe to be
+transported in ASCII encoding.
+
+Roughly Equivalent to:
+```
+Custom{
+ indentation: NoIndentation,
+ arrayFormat: CompactArrayEntries,
+ objectFormat: CompactObjectEntries,
+ lineEnding: NoLineEnding,
+ finishWithNewLine: false,
+ escapeAllControlPoints: false,
+ escapeHTMLUnsafeSequences: false,
+ escapeNonASCII: false,
+}
+```
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
+```
+
+```grain
+PrettyAndSafe
+```
+
+Pretty and conservative formatting to maximize compatibility and
+embeddability of the resulting JSON.
+
+Should be safe to copy and paste directly into HTML and to be transported in
+plain ASCII.
+
+Roughly Equivalent to:
+```
+Custom{
+ indentation: IndentWithSpaces(2),
+ arrayFormat: OneArrayEntryPerLine,
+ objectFormat: OneObjectEntryPerLine,
+ lineEnding: LineFeed,
+ finishWithNewLine: true,
+ escapeAllControlPoints: true,
+ escapeHTMLUnsafeSequences: true,
+ escapeNonASCII: true,
+}
+```
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{↵
+··"currency":·"\u20ac",↵
+··"price":·99.9,↵
+··"currencyDescription":·"EURO\u007f",↵
+}
+```
+
+```grain
+CompactAndSafe
+```
+
+Compact and conservative formatting to maximize compatibility and
+embeddability of the resulting JSON.
+
+Should be safe to copy and paste directly into HTML and to transported in
+plain ASCII.
+
+Roughly Equivalent to:
+```
+Custom{
+ indentation: NoIndentation,
+ arrayFormat: CompactArrayEntries,
+ objectFormat: CompactObjectEntries,
+ lineEnding: NoLineEnding,
+ finishWithNewLine: false,
+ escapeAllControlPoints: true,
+ escapeHTMLUnsafeSequences: true,
+ escapeNonASCII: true,
+}
+```
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
+```
+
+```grain
+Custom{
+  indentation: IndentationFormat,
+  arrayFormat: ArrayFormat,
+  objectFormat: ObjectFormat,
+  lineEnding: LineEnding,
+  finishWithNewLine: Bool,
+  escapeAllControlPoints: Bool,
+  escapeHTMLUnsafeSequences: Bool,
+  escapeNonASCII: Bool,
+}
+```
+
+Allows for fined grained control of the formatting output.
 
 ### Json.**JsonParseError**
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -294,8 +294,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`json`|`Option<FormattingChoices>`|The JSON object to print|
-|`format`|`Json`|formatting option|
+|`?format`|`FormattingChoices`|formatting option|
+|`json`|`Json`|The JSON object to print|
 
 Returns:
 
@@ -364,7 +364,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : String => Result<Json, JsonParseError>
+parse : (str: String) => Result<Json, JsonParseError>
 ```
 
 Parses JSON string into a `Json` data structure.

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -92,27 +92,45 @@ enum IndentationFormat {
 
 Controls how indentation is performed in custom formatting.
 
-Following examples have whitespaces and line breaks replaced with visible
+The following examples have whitespaces and line breaks replaced with visible
 characters for illustrative purposes.
 
-`NoIndentation`
+Variants:
+
+```grain
+NoIndentation
 ```
+
+No indentation is emitted.
+
+```json
 {↵
 "currency":·"€",↵
 "price":·99.9↵
 }
 ```
 
-`IndentWithTab`
+```grain
+IndentWithTab
 ```
+
+Tabs are emitted.
+
+```json
 {↵
 →"currency":·"€",↵
 →"price":·99.9↵
 }
 ```
 
-`IndentWithSpaces(2)`
+```grain
+IndentWithSpaces(Number)
 ```
+
+The desired number of spaces are emitted.
+
+`IndentWithSpaces(2)`
+```json
 {↵
 ··"currency":·"€",↵
 ··"price":·99.9↵
@@ -120,7 +138,7 @@ characters for illustrative purposes.
 ```
 
 `IndentWithSpaces(4)`
-```
+```json
 {↵
 ····"currency":·"€",↵
 ····"price":·99.9↵
@@ -139,47 +157,64 @@ enum ArrayFormat {
 
 Controls how arrays are printed in custom formatting.
 
-Following examples have whitespaces and line breaks replaced with visible
+The following examples have whitespaces and line breaks replaced with visible
 characters for illustrative purposes.
 
-`CompactArrayEntries`
+Variants:
+
+```grain
+CompactArrayEntries
 ```
+
+Arrays are emitted in a compact manner.
+
+```json
 []
 ```
 
-```
+```json
 [1]
 ```
 
-```
+```json
 [1,2,3]
 ```
 
-`SpacedArrayEntries`
+```grain
+SpacedArrayEntries
 ```
+
+Arrays are emitted with spaces between elements.
+
+```json
 [ ]
 ```
 
-```
+```json
 [1]
 ```
 
-```
-[1,2,3]
+```json
+[1, 2, 3]
 ```
 
-`OneArrayEntryPerLine`
+```grain
+OneArrayEntryPerLine
 ```
+
+Arrays are emitted with newlines and indentation between each element.
+
+```json
 []
 ```
 
-```
+```json
 [↵
 ··1↵
 ]
 ```
 
-```
+```json
 [↵
 ··1,↵
 ··2,↵
@@ -199,36 +234,53 @@ enum ObjectFormat {
 
 Controls how objects are printed in custom formatting.
 
-Following examples have whitespaces and line breaks replaced with visible
+The following examples have whitespaces and line breaks replaced with visible
 characters for illustrative purposes.
 
-`CompactObjectEntries`
+Variants:
+
+```grain
+CompactObjectEntries
 ```
+
+Objects are emitted in a compact manner.
+
+```json
 {}
 ```
 
-```
+```json
 {"a":1}
 ```
 
-```
+```json
 {"a":1,"b":2,"c":3}
 ```
 
-`SpacedObjectEntries`
+```grain
+SpacedObjectEntries
 ```
+
+Objects are emitted with spaces between entries.
+
+```json
 { }
 ```
 
-```
+```json
 {"a": 1}
 ```
 
-```
+```json
 {"a": 1, "b": 2, "c": 3}
 ```
 
-`OneObjectEntryPerLine`
+```grain
+OneObjectEntryPerLine
+```
+
+Objects are emitted with each entry on a new line.
+
 ```
 {}
 ```
@@ -259,6 +311,32 @@ enum LineEnding {
 ```
 
 Controls line ending type in custom formatting.
+
+Variants:
+
+```grain
+NoLineEnding
+```
+
+No line endings will be emitted.
+
+```grain
+LineFeed
+```
+
+A `\n` will be emitted at the end of each line.
+
+```grain
+CarriageReturnLineFeed
+```
+
+A `\r\n` will be emitted at the end of each line
+
+```grain
+CarriageReturn
+```
+
+A `\r` will be emitted at the end of each line
 
 ### Json.**FormattingChoices**
 
@@ -296,7 +374,7 @@ codepoints directly so the result needs to be treated as proper unicode and
 is not safe to be transported in ASCII encoding.
 
 Roughly Equivalent to:
-```
+```grain
 Custom{
  indentation: IndentWithSpaces(2),
  arrayFormat: OneArrayEntryPerLine,
@@ -311,7 +389,7 @@ Custom{
 
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
-```
+```json
 {↵
 ··"currency":·"€",↵
 ··"price":·99.9,↵
@@ -331,7 +409,7 @@ so the result needs to be treated as proper unicode and is not safe to be
 transported in ASCII encoding.
 
 Roughly Equivalent to:
-```
+```grain
 Custom{
  indentation: NoIndentation,
  arrayFormat: CompactArrayEntries,
@@ -346,7 +424,7 @@ Custom{
 
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
-```
+```json
 {"currency":"€","price":99.9,"currencyDescription":"EURO␡"}
 ```
 
@@ -361,7 +439,7 @@ Should be safe to copy and paste directly into HTML and to be transported in
 plain ASCII.
 
 Roughly Equivalent to:
-```
+```grain
 Custom{
  indentation: IndentWithSpaces(2),
  arrayFormat: OneArrayEntryPerLine,
@@ -376,7 +454,7 @@ Custom{
 
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
-```
+```json
 {↵
 ··"currency":·"\u20ac",↵
 ··"price":·99.9,↵
@@ -395,7 +473,7 @@ Should be safe to copy and paste directly into HTML and to transported in
 plain ASCII.
 
 Roughly Equivalent to:
-```
+```grain
 Custom{
  indentation: NoIndentation,
  arrayFormat: CompactArrayEntries,
@@ -410,7 +488,7 @@ Custom{
 
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
-```
+```json
 {"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f"}
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -2,22 +2,22 @@
 title: Json
 ---
 
-JSON (JavaScript Object Notation) parsing and printing.
+JSON (JavaScript Object Notation) parsing, printing, and access utilities.
 
 ## Types
 
 Type declarations included in the Json module.
 
-### Json.**JSON**
+### Json.**Json**
 
 ```grain
-enum JSON {
-  JSONNull,
-  JSONBoolean(Bool),
-  JSONNumber(Number),
-  JSONString(String),
-  JSONArray(List<JSON>),
-  JSONObject(List<(String, JSON)>),
+enum Json {
+  JsonNull,
+  JsonBoolean(Bool),
+  JsonNumber(Number),
+  JsonString(String),
+  JsonArray(List<Json>),
+  JsonObject(List<(String, Json)>),
 }
 ```
 
@@ -26,9 +26,9 @@ JSON.
 
 For example this object
 ```grain
-JSONObject([
-  ("currency", JSONString("€")),
-  ("price", JSONNumber(99.99)),
+JsonObject([
+  ("currency", JsonString("€")),
+  ("price", JsonNumber(99.99)),
 ])
 ```
 is equivalent to the following JSON:
@@ -38,8 +38,8 @@ is equivalent to the following JSON:
 
 This data structure is semantically equivalent to the JSON format allowing
 mostly lossless round trips of printing and parsing. Exceptions to this are
-white spaces, multiple ways JSON allows escaping characters in strings and
-some edge-cases related to Grain's `Number` type.
+whitespace, multiple ways JSON allows escaping characters in strings, and
+some edge cases related to Grain's `Number` type.
 
 For example parsing the following JSON text will also result in the same
 `JSON` object as above.
@@ -50,10 +50,10 @@ For example parsing the following JSON text will also result in the same
 }
 ```
 
-### Json.**JSONToStringError**
+### Json.**JsonToStringError**
 
 ```grain
-enum JSONToStringError {
+enum JsonToStringError {
   InvalidNumber(String),
 }
 ```
@@ -229,7 +229,7 @@ record FormattingSettings {
 }
 ```
 
-Allows fine grained control of formatting in JSON printing.
+Allows fine-grained control of formatting in JSON printing.
 
 ### Json.**FormattingChoices**
 
@@ -243,10 +243,10 @@ enum FormattingChoices {
 
 Allows control of formatting in JSON printing.
 
-### Json.**JSONParseError**
+### Json.**JsonParseError**
 
 ```grain
-enum JSONParseError {
+enum JsonParseError {
   UnexpectedEndOfInput(String),
   UnexpectedToken(String),
   InvalidUTF16SurrogatePair(String),
@@ -371,8 +371,8 @@ No other changes yet.
 
 ```grain
 toString :
-  (json: JSON, ?format: FormattingChoices) ->
-   Result<String, JSONToStringError>
+  (?format: FormattingChoices, json: Json) ->
+   Result<String, JsonToStringError>
 ```
 
 Prints the JSON object into a string with specific formatting settings.
@@ -381,14 +381,14 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`json`|`JSON`|The JSON object to print|
-|`format`|`Option<FormattingChoices>`|formatting option|
+|`json`|`Option<FormattingChoices>`|The JSON object to print|
+|`format`|`Json`|formatting option|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+|`Result<String, JsonToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
 
 Examples:
 
@@ -396,8 +396,8 @@ Examples:
 print(
   Result.unwrap(
     toString(
-      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
-      format=Custom(defaultCompactAndSafeFormat)
+      format=Custom(defaultCompactAndSafeFormat),
+      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
     )
   )
 )
@@ -408,7 +408,7 @@ print(
 print(
   Result.unwrap(
     toString(
-      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]
+      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
     )
   )
 )
@@ -419,8 +419,8 @@ print(
 print(
   Result.unwrap(
     toString(
-      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
       format=Compact
+      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
      )
   )
 )
@@ -431,8 +431,8 @@ print(
 print(
   Result.unwrap(
     toString(
-      JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]),
-      format=Pretty
+      format=Pretty,
+      JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
     )
   )
 )
@@ -451,7 +451,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : String -> Result<JSON, JSONParseError>
+parse : String -> Result<Json, JsonParseError>
 ```
 
 Parses JSON input from a string into a `JSON` object.
@@ -466,7 +466,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
+|`Result<Json, JsonParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
 
 Examples:
 
@@ -475,7 +475,7 @@ print(parse("{\"currency\":\"$\",\"price\":119}"))
 
 Example output:
 ```
-Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+Ok(JsonObject([("currency", JsonString("$")), ("price", JsonNumber(119))]))
 ```
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -69,7 +69,7 @@ enum IndentationFormat {
 Controls how indentation is performed in custom formatting.
 
 Following examples have whitespaces and line breaks replaced with visible
-charactes for illustrative purposes.
+characters for illustrative purposes.
 
 `NoIndentation`
 ```

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -4,6 +4,26 @@ title: Json
 
 JSON (JavaScript Object Notation) parsing, printing, and access utilities.
 
+```grain
+include "json"
+```
+
+```grain
+Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
+  ("currency", JsonString("€")),
+  ("price", JsonNumber(99.99)),
+])
+```
+
+```grain
+print(
+  toString(
+    format=Pretty,
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+  )
+)
+```
+
 ## Types
 
 Type declarations included in the Json module.
@@ -242,8 +262,8 @@ Controls line ending type in custom formatting.
 enum FormattingChoices {
   Pretty,
   Compact,
-  PrettyAndSafeFormat,
-  CompactAndSafeFormat,
+  PrettyAndSafe,
+  CompactAndSafe,
   Custom{
     indentation: IndentationFormat,
     arrayFormat: ArrayFormat,
@@ -294,35 +314,16 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`?format`|`FormattingChoices`|formatting option|
+|`?format`|`FormattingChoices`|Formatting options|
 |`json`|`Json`|The JSON object to print|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Result<String, JsonToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+|`Result<String, JsonToStringError>`|`Ok(str)` containing the printed JSON or `Err(err)` if the inputted object cannot be represented in the JSON format.,|
 
 Examples:
-
-```grain
-print(
-  toString(
-    format=Custom{
-     indentation: NoIndentation,
-     arrayFormat: CompactArrayEntries,
-     objectFormat: CompactObjectEntries,
-     lineEnding: NoLineEnding,
-     finishWithNewLine: false,
-     escapeAllControlPoints: true,
-     escapeHTMLUnsafeSequences: true,
-     escapeNonASCII: true,
-    },
-    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-  )
-)
-// Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
-```
 
 ```grain
 print(
@@ -356,6 +357,25 @@ print(
 //}")
 ```
 
+```grain
+print(
+  toString(
+    format=Custom{
+     indentation: NoIndentation,
+     arrayFormat: CompactArrayEntries,
+     objectFormat: CompactObjectEntries,
+     lineEnding: NoLineEnding,
+     finishWithNewLine: false,
+     escapeAllControlPoints: true,
+     escapeHTMLUnsafeSequences: true,
+     escapeNonASCII: true,
+    },
+    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+  )
+)
+// Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
+```
+
 ### Json.**parse**
 
 <details disabled>
@@ -379,7 +399,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Json, JsonParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
+|`Result<Json, JsonParseError>`|`Ok(json)` containing the parsed data structure on a successful parse or `Err(err)` containing a parse error otherwise.|
 
 Examples:
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -73,7 +73,7 @@ Variants:
 InvalidNumber(String)
 ```
 
-The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`
+The `Json` data structure contains a number value of `NaN`, `Infinity`, or `-Infinity`.
 
 ### Json.**IndentationFormat**
 
@@ -85,7 +85,7 @@ enum IndentationFormat {
 }
 ```
 
-Controls how indentation is outputted in custom formatting.
+Controls how indentation is output in custom formatting.
 
 Variants:
 
@@ -97,8 +97,8 @@ No indentation is emitted.
 
 ```json
 {
-"currency":·"€",
-"price":·99.9
+"currency": "€",
+"price": 99.9
 }
 ```
 
@@ -110,8 +110,8 @@ Tabs are emitted.
 
 ```json
 {
-  "currency":·"€",
-  "price":·99.9
+  "currency": "€",
+  "price": 99.9
 }
 ```
 
@@ -124,16 +124,16 @@ The desired number of spaces are emitted.
 `IndentWithSpaces(2)`
 ```json
 {
-··"currency":·"€",
-··"price":·99.9
+  "currency": "€",
+  "price": 99.9
 }
 ```
 
 `IndentWithSpaces(4)`
 ```json
 {
-····"currency":·"€",
-····"price":·99.9
+    "currency": "€",
+    "price": 99.9
 }
 ```
 
@@ -147,7 +147,7 @@ enum ArrayFormat {
 }
 ```
 
-Controls how arrays are outputted in custom formatting.
+Controls how arrays are output in custom formatting.
 
 Variants:
 
@@ -199,15 +199,15 @@ Arrays are emitted with newlines and indentation between each element.
 
 ```json
 [
-··1
+  1
 ]
 ```
 
 ```json
 [
-··1,
-··2,
-··3
+  1,
+  2,
+  3
 ]
 ```
 
@@ -221,7 +221,7 @@ enum ObjectFormat {
 }
 ```
 
-Controls how objects are outputted in custom formatting.
+Controls how objects are output in custom formatting.
 
 Variants:
 
@@ -273,15 +273,15 @@ Objects are emitted with each entry on a new line.
 
 ```
 {
-··"a":·1
+  "a": 1
 }
 ```
 
 ```
 {
-··"a":·1,
-··"b":·2,
-··"c":·3
+  "a": 1,
+  "b": 2,
+  "c": 3
 }
 ```
 
@@ -296,7 +296,7 @@ enum LineEnding {
 }
 ```
 
-Controls how line endings are outputted in custom formatting.
+Controls how line endings are output in custom formatting.
 
 Variants:
 
@@ -316,13 +316,13 @@ A `\n` will be emitted at the end of each line.
 CarriageReturnLineFeed
 ```
 
-A `\r\n` will be emitted at the end of each line
+A `\r\n` will be emitted at the end of each line.
 
 ```grain
 CarriageReturn
 ```
 
-A `\r` will be emitted at the end of each line
+A `\r` will be emitted at the end of each line.
 
 ### Json.**FormattingChoices**
 
@@ -375,9 +375,9 @@ Custom{
 
 ```json
 {
-··"currency":·"€",
-··"price":·99.9,
-··"currencyDescription":·"EURO\u007f",
+  "currency": "€",
+  "price": 99.9,
+  "currencyDescription": "EURO\u007f",
 }
 ```
 
@@ -436,9 +436,9 @@ Custom{
 
 ```json
 {
-··"currency":·"\u20ac",
-··"price":·99.9,
-··"currencyDescription":·"EURO\u007f",
+  "currency": "\u20ac",
+  "price": 99.9,
+  "currencyDescription": "EURO\u007f",
 }
 ```
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -2,7 +2,11 @@
 title: Json
 ---
 
-JSON (JavaScript Object Notation) parsing and printing.
+@module Json: JSON (JavaScript Object Notation) parsing and printing.
+
+## Types
+
+Type declarations included in the Json module.
 
 ### Json.**JSON**
 
@@ -23,8 +27,8 @@ JSON.
 For example this object
 ```grain
 JSONObject([
-("currency", JSONString("€")),
-("price", JSONNumber(99.99)),
+  ("currency", JSONString("€")),
+  ("price", JSONNumber(99.99)),
 ])
 ```
 is equivalent to the following JSON:
@@ -41,8 +45,8 @@ For example parsing the following JSON text will also result in the same
 `JSON` object as above.
 ```json
 {
-"currency": "\u20ac",
-"price": 99.99
+  "currency": "\u20ac",
+  "price": 99.99
 }
 ```
 
@@ -227,6 +231,22 @@ record FormattingSettings {
 
 Allows fine grained control of formatting in JSON printing.
 
+### Json.**JSONParseError**
+
+```grain
+enum JSONParseError {
+  UnexpectedEndOfInput(String),
+  UnexpectedToken(String),
+  InvalidUTF16SurrogatePair(String),
+}
+```
+
+Represents errors for JSON parsing along with a human readable text message.
+
+## Values
+
+Functions and constants included in the Json module.
+
 ### Json.**defaultCompactFormat**
 
 ```grain
@@ -310,53 +330,15 @@ replaced with visible characters.
 }
 ```
 
-### Json.**JSONWriterCompactImplHelper**
-
-```grain
-record JSONWriterCompactImplHelper {
-  buffer: Buffer.Buffer,
-  emitEscapedQuotedString: String -> Void,
-}
-```
-
-### Json.**JSONWriterPrettyImplHelper**
-
-```grain
-record JSONWriterPrettyImplHelper {
-  format: FormattingSettings,
-  bufferPretty: Buffer.Buffer,
-  emitEscapedQuotedStringPretty: String -> Void,
-  printNewLine: () -> Void,
-  printIndentation: Number -> Void,
-}
-```
-
-### Json.**JSONWriter**
-
-```grain
-record JSONWriter {
-  emit: JSON -> Option<JSONToStringError>,
-}
-```
-
 ### Json.**toString**
 
 ```grain
-toString : (JSON, FormattingSettings) -> Result<String, JSONToStringError>
+toString :
+  (json: JSON, format: FormattingSettings) ->
+   Result<String, JSONToStringError>
 ```
 
 Prints the JSON object into a string with specific formatting settings.
-
-
-
-
-
-
-
-Example output:
-```json
-{"currency":"\u20ac","price":99.9}
-```
 
 Parameters:
 
@@ -375,12 +357,17 @@ Examples:
 
 ```grain
 print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
+
+Example output:
+```json
+{"currency":"\u20ac","price":99.9}
+```
 ```
 
 ### Json.**toStringCompact**
 
 ```grain
-toStringCompact : JSON -> Result<String, JSONToStringError>
+toStringCompact : (json: JSON) -> Result<String, JSONToStringError>
 ```
 
 Prints the JSON object into a string with compact formatting optimized for
@@ -389,16 +376,6 @@ machine program. For example in REST APIs.
 
 Using this function can be preferred over `toString` with compact formatting
 settings since it can be slightly faster.
-
-
-
-
-
-
-Example output:
-```json
-{"currency":"€","price":99.9}
-```
 
 Parameters:
 
@@ -416,29 +393,23 @@ Examples:
 
 ```grain
 print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+
+Example output:
+```json
+{"currency":"€","price":99.9}
+```
 ```
 
 ### Json.**toStringPretty**
 
 ```grain
-toStringPretty : JSON -> Result<String, JSONToStringError>
+toStringPretty : (json: JSON) -> Result<String, JSONToStringError>
 ```
 
 Prints the JSON object into a string with default pretty formatting
 settings. Recommended for uses where the intended consumer is a person or
 the text should be easily inspectable. For example configuration files or
 document file formats.
-
-
-
-
-Example output:
-```json
-{
-"currency": "€",
-"price": 99.9
-}
-```
 
 Parameters:
 
@@ -450,35 +421,20 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.
+
+Example output:
+```json
+{
+  "currency": "€",
+  "price": 99.9
+}
+```|
 
 Examples:
 
 ```grain
 print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
-```
-
-### Json.**JSONParseError**
-
-```grain
-enum JSONParseError {
-  UnexpectedEndOfInput(String),
-  UnexpectedToken(String),
-  InvalidUTF16SurrogatePair(String),
-}
-```
-
-Represents errors for JSON parsing along with a human readable text message.
-
-### Json.**JSONParserImplHelper**
-
-```grain
-record JSONParserImplHelper {
-  reader: StringReader.StringReader,
-  bufferParse: Buffer.Buffer,
-  currentCodePoint: Number,
-  pos: Number,
-}
 ```
 
 ### Json.**parse**
@@ -488,14 +444,6 @@ parse : String -> Result<JSON, JSONParseError>
 ```
 
 Parses JSON input from a string into a `JSON` object.
-
-
-
-
-Example output:
-```
-Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
-```
 
 Parameters:
 
@@ -507,7 +455,12 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
+|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.
+
+Example output:
+```
+Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+```|
 
 Examples:
 

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -9,10 +9,7 @@ include "json"
 ```
 
 ```grain
-Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
-  ("currency", JsonString("€")),
-  ("price", JsonNumber(99.99)),
-])
+Json.parse("{\"currency\":\"€\",\"price\":99.99}")
 ```
 
 ```grain
@@ -51,14 +48,14 @@ some edge cases related to Grain's `Number` type.
 Examples:
 
 ```grain
-Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
+assert Json.parse("{\"currency\":\"€\",\"price\":99.99}") == JsonObject([
   ("currency", JsonString("€")),
   ("price", JsonNumber(99.99)),
 ])
 ```
 
 ```grain
-Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
+assert Json.parse("{\n\"currency\":\"€\",\n\"price\":99.99\n}") == JsonObject([
   ("currency", JsonString("€")),
   ("price", JsonNumber(99.99)),
 ])
@@ -326,54 +323,42 @@ Returns:
 Examples:
 
 ```grain
-print(
-  toString(
-    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
-  )
-)
-// Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
+assert toString(
+  JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))]
+) == Ok("{\"currency\":\"€\",\"price\":99.9}")
 ```
 
 ```grain
-print(
-  toString(
-    format=Compact
-    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-  )
-)
-// Output: Ok("{\"currency\":\"€\",\"price\":99.9}")
+assert toString(
+  format=Compact
+  JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+) == Ok("{\"currency\":\"€\",\"price\":99.9}")
 ```
 
 ```grain
-print(
-  toString(
-    format=Pretty,
-    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-  )
-)
-// Output: Ok("{
-// \"currency\": \"€\",
-// \"price\": 99.9
-//}")
+assert toString(
+  format=Pretty,
+  JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+) == Ok("{
+  \"currency\": \"€\",
+  \"price\": 99.9
+}")
 ```
 
 ```grain
-print(
-  toString(
-    format=Custom{
-     indentation: NoIndentation,
-     arrayFormat: CompactArrayEntries,
-     objectFormat: CompactObjectEntries,
-     lineEnding: NoLineEnding,
-     finishWithNewLine: false,
-     escapeAllControlPoints: true,
-     escapeHTMLUnsafeSequences: true,
-     escapeNonASCII: true,
-    },
-    JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
-  )
-)
-// Output: Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
+assert toString(
+  format=Custom{
+    indentation: NoIndentation,
+    arrayFormat: CompactArrayEntries,
+    objectFormat: CompactObjectEntries,
+    lineEnding: NoLineEnding,
+    finishWithNewLine: false,
+    escapeAllControlPoints: true,
+    escapeHTMLUnsafeSequences: true,
+    escapeNonASCII: true,
+  },
+  JsonObject([("currency", JsonString("€")), ("price", JsonNumber(99.9))])
+) == Ok("{\"currency\":\"\\u20ac\",\"price\":99.9}")
 ```
 
 ### Json.**parse**

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -1,0 +1,517 @@
+---
+title: Json
+---
+
+JSON (JavaScript Object Notation) parsing and printing.
+
+### Json.**JSON**
+
+```grain
+enum JSON {
+  JSONNull,
+  JSONBoolean(Bool),
+  JSONNumber(Number),
+  JSONString(String),
+  JSONArray(List<JSON>),
+  JSONObject(List<(String, JSON)>),
+}
+```
+
+Data structure representing the result of parsing and the input of printing
+JSON.
+
+For example this object
+```grain
+JSONObject([
+("currency", JSONString("€")),
+("price", JSONNumber(99.99)),
+])
+```
+is equivalent to the following JSON:
+```json
+{"currency":"€","price":99.99}
+```
+
+This data structure is semantically equivalent to the JSON format allowing
+mostly lossless round trips of printing and parsing. Exceptions to this are
+white spaces, multiple ways JSON allows escaping characters in strings and
+some edge-cases related to Grain's `Number` type.
+
+For example parsing the following JSON text will also result in the same
+`JSON` object as above.
+```json
+{
+"currency": "\u20ac",
+"price": 99.99
+}
+```
+
+### Json.**JSONToStringError**
+
+```grain
+enum JSONToStringError {
+  InvalidNumber(String),
+}
+```
+
+Represents errors for cases when a `JSON` object cannot be represente in the
+JSON format along with a human readable text message. This can happen when
+it contains number values `NaN`, `Infinity` or `-Infinity`.
+
+### Json.**IndentationFormat**
+
+```grain
+enum IndentationFormat {
+  NoIndentation,
+  IndentWithTab,
+  IndentWithSpaces(Number),
+}
+```
+
+Controls how indentation is performed in custom formatting.
+
+Following examples have whitespaces and line breaks replaced with visible
+charactes for illustrative purposes.
+
+`NoIndentation`
+```
+{↵
+"currency":·"€",↵
+"price":·99.9↵
+}
+```
+
+`IndentWithTab`
+```
+{↵
+→"currency":·"€",↵
+→"price":·99.9↵
+}
+```
+
+`IndentWithSpaces(2)`
+```
+{↵
+··"currency":·"€",↵
+··"price":·99.9↵
+}
+```
+
+`IndentWithSpaces(4)`
+```
+{↵
+····"currency":·"€",↵
+····"price":·99.9↵
+}
+```
+
+### Json.**ArrayFormat**
+
+```grain
+enum ArrayFormat {
+  CompactArrayEntries,
+  OneArrayEntryPerLine,
+}
+```
+
+Controls how arrays are printed in custom formatting.
+
+Following examples have whitespaces and line breaks replaced with visible
+charactes for illustrative purposes.
+
+`CompactArrayEntries`
+```
+[]
+```
+
+```
+[1]
+```
+
+```
+[1,2,3]
+```
+
+`OneArrayEntryPerLine`
+```
+[]
+```
+
+```
+[↵
+··1↵
+]
+```
+
+```
+[↵
+··1,↵
+··2,↵
+··3↵
+]
+```
+
+### Json.**ObjectFormat**
+
+```grain
+enum ObjectFormat {
+  CompactObjectEntries,
+  OneObjectEntryPerLine,
+}
+```
+
+Controls how objects are printed in custom formatting.
+
+Following examples have whitespaces and line breaks replaced with visible
+charactes for illustrative purposes.
+
+`CompactObjectEntries`
+```
+{}
+```
+
+```
+{"a":1}
+```
+
+```
+{"a":1,"b":2,"c":3}
+```
+
+`OneObjectEntryPerLine`
+```
+{}
+```
+
+```
+{↵
+··"a":·1↵
+}
+```
+
+```
+{↵
+··"a":·1,↵
+··"b":·2,↵
+··"c":·3↵
+}
+```
+
+### Json.**LineEnding**
+
+```grain
+enum LineEnding {
+  NoLineEnding,
+  LineFeed,
+  CarriageReturnLineFeed,
+  CarriageReturn,
+}
+```
+
+Controls line ending type in custom formatting.
+
+### Json.**FormattingSettings**
+
+```grain
+record FormattingSettings {
+  indentation: IndentationFormat,
+  arrayFormat: ArrayFormat,
+  objectFormat: ObjectFormat,
+  lineEnding: LineEnding,
+  finishWithNewLine: Bool,
+  escapeAllControlPoints: Bool,
+  escapeHTMLUnsafeSequences: Bool,
+  escapeNonASCII: Bool,
+}
+```
+
+Allows fine grained control of formatting in JSON printing.
+
+### Json.**defaultCompactFormat**
+
+```grain
+defaultCompactFormat : () -> FormattingSettings
+```
+
+Compact formatting that minimizes the size of resulting JSON at cost of not
+being easily human readable.
+
+Only performs minimal string escaping as required by the ECMA-404 standard,
+so the result needs to be treated as proper unicode and is not safe to be
+transported in ASCII encoding.
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+```
+
+### Json.**defaultPrettyFormat**
+
+```grain
+defaultPrettyFormat : () -> FormattingSettings
+```
+
+Recommended human readable formatting.
+
+Escapes all control points for the sake of clarity, but prints unicode
+codepoints directly so the result needs to be treated as proper unicode and
+is not safe to be transported in ASCII encoding.
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{↵
+··"currency":·"€",↵
+··"price":·99.9,↵
+··"currencyDescription":·"EURO\u007f",↵
+··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
+}
+```
+
+### Json.**defaultCompactAndSafeFormat**
+
+```grain
+defaultCompactAndSafeFormat : () -> FormattingSettings
+```
+
+Compact and conservative formatting to maximize compatibility and
+embeddability of the resulting JSON.
+
+Should be safe to copy and paste directly into HTML and to transported in
+plain ASCII.
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+```
+
+### Json.**defaultPrettyAndSafeFormat**
+
+```grain
+defaultPrettyAndSafeFormat : () -> FormattingSettings
+```
+
+Pretty and conservative formatting to maximize compatibility and
+embeddability of the resulting JSON.
+
+Should be safe to copy and paste directly into HTML and to transported in
+plain ASCII.
+
+The following example have whitespaces, line breaks and control points
+replaced with visible characters.
+```
+{↵
+··"currency":·"\u20ac",↵
+··"price":·99.9,↵
+··"currencyDescription":·"EURO\u007f",↵
+··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
+}
+```
+
+### Json.**JSONWriterCompactImplHelper**
+
+```grain
+record JSONWriterCompactImplHelper {
+  buffer: Buffer.Buffer,
+  emitEscapedQuotedString: String -> Void,
+}
+```
+
+### Json.**JSONWriterPrettyImplHelper**
+
+```grain
+record JSONWriterPrettyImplHelper {
+  format: FormattingSettings,
+  bufferPretty: Buffer.Buffer,
+  emitEscapedQuotedStringPretty: String -> Void,
+  printNewLine: () -> Void,
+  printIndentation: Number -> Void,
+}
+```
+
+### Json.**JSONWriter**
+
+```grain
+record JSONWriter {
+  emit: JSON -> Option<JSONToStringError>,
+}
+```
+
+### Json.**toString**
+
+```grain
+toString : (JSON, FormattingSettings) -> Result<String, JSONToStringError>
+```
+
+Prints the JSON object into a string with specific formatting settings.
+
+
+
+
+
+
+
+Example output:
+```json
+{"currency":"\u20ac","price":99.9}
+```
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`json`|`JSON`|The JSON object to print|
+|`format`|`FormattingSettings`|Custom formatting setttings|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+
+Examples:
+
+```grain
+print(Result.unwrap(toString(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]), defaultCompactAndSafeFormat())))
+```
+
+### Json.**toStringCompact**
+
+```grain
+toStringCompact : JSON -> Result<String, JSONToStringError>
+```
+
+Prints the JSON object into a string with compact formatting optimized for
+small size. Recommended for all uses where the intended consumer is a
+machine program. For example in REST APIs.
+
+Using this function can be preferred over `toString` with compact formatting
+settings since it can be slightly faster.
+
+
+
+
+
+
+Example output:
+```json
+{"currency":"€","price":99.9}
+```
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`json`|`JSON`|The JSON object to print|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+
+Examples:
+
+```grain
+print(Result.unwrap(toStringCompact(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+```
+
+### Json.**toStringPretty**
+
+```grain
+toStringPretty : JSON -> Result<String, JSONToStringError>
+```
+
+Prints the JSON object into a string with default pretty formatting
+settings. Recommended for uses where the intended consumer is a person or
+the text should be easily inspectable. For example configuration files or
+document file formats.
+
+
+
+
+Example output:
+```json
+{
+"currency": "€",
+"price": 99.9
+}
+```
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`json`|`JSON`|The JSON object to print|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<String, JSONToStringError>`|A `Result` object with either the string containing the printed JSON or an error if the input object cannot be represented in the JSON format.|
+
+Examples:
+
+```grain
+print(Result.unwrap(toStringPretty(JSONObject([("currency", JSONString("€")), ("price", JSONNumber(99.9))]))))
+```
+
+### Json.**JSONParseError**
+
+```grain
+enum JSONParseError {
+  UnexpectedEndOfInput(String),
+  UnexpectedToken(String),
+  InvalidUTF16SurrogatePair(String),
+}
+```
+
+Represents errors for JSON parsing along with a human readable text message.
+
+### Json.**JSONParserImplHelper**
+
+```grain
+record JSONParserImplHelper {
+  reader: StringReader.StringReader,
+  bufferParse: Buffer.Buffer,
+  currentCodePoint: Number,
+  pos: Number,
+}
+```
+
+### Json.**parse**
+
+```grain
+parse : String -> Result<JSON, JSONParseError>
+```
+
+Parses JSON input from a string into a `JSON` object.
+
+
+
+
+Example output:
+```
+Ok(JSONObject([("currency", JSONString("$")), ("price", JSONNumber(119))]))
+```
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`str`|`String`|The JSON text string|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<JSON, JSONParseError>`|A `Result` object with either the parsed `JSON` object or an error.|
+
+Examples:
+
+```grain
+print(parse("{\"currency\":\"$\",\"price\":119}"))
+```
+

--- a/stdlib/json.md
+++ b/stdlib/json.md
@@ -2,7 +2,7 @@
 title: Json
 ---
 
-@module Json: JSON (JavaScript Object Notation) parsing and printing.
+JSON (JavaScript Object Notation) parsing and printing.
 
 ## Types
 
@@ -280,7 +280,7 @@ transported in ASCII encoding.
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
 ```
-{"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
+{"currency":"€","price":99.9,"currencyDescription":"EURO␡","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"}
 ```
 
 ### Json.**defaultPrettyFormat**
@@ -307,7 +307,7 @@ replaced with visible characters.
 ··"currency":·"€",↵
 ··"price":·99.9,↵
 ··"currencyDescription":·"EURO\u007f",↵
-··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
+··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·</·with·unescaped·forward·slash"↵
 }
 ```
 
@@ -331,7 +331,7 @@ plain ASCII.
 The following example have whitespaces, line breaks and control points
 replaced with visible characters.
 ```
-{"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
+{"currency":"\u20ac","price":99.9,"currencyDescription":"EURO\u007f","script·unembeddable":"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"}
 ```
 
 ### Json.**defaultPrettyAndSafeFormat**
@@ -358,7 +358,7 @@ replaced with visible characters.
 ··"currency":·"\u20ac",↵
 ··"price":·99.9,↵
 ··"currencyDescription":·"EURO\u007f",↵
-··"script·unembeddable":·"You·cannot·pase·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
+··"script·unembeddable":·"You·cannot·paste·a·JSON·object·directly·into·a·<script>·tag·in·HTML·if·it·contains·<\/·with·unescaped·forward·slash"↵
 }
 ```
 

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -881,7 +881,7 @@ provide let print = (value, suffix="\n") => {
 @unsafe
 provide let getCodePoint = (ptr: WasmI32) => {
   // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
-  from WasmI32 use { (+), (&), (|), (<<), leU as (<=), geU as (>=), (==) }
+  use WasmI32.{ (+), (&), (|), (<<), leU as (<=), geU as (>=), (==) }
 
   let mut codePoint = 0n
   let mut bytesSeen = 0n

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -39,6 +39,9 @@ primitive (&&) = "@and"
 primitive (||) = "@or"
 primitive builtinId = "@builtin.id"
 primitive ignore = "@ignore"
+primitive throw = "@throw"
+
+exception MalformedUnicode
 
 @unsafe
 primitive typeMetadata = "@heap.type_metadata"
@@ -873,4 +876,55 @@ provide let print = (value, suffix="\n") => {
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
   void
+}
+
+@unsafe
+provide let getCodePoint = (ptr: WasmI32) => {
+  // Algorithm from https://encoding.spec.whatwg.org/#utf-8-decoder
+  from WasmI32 use { (+), (&), (|), (<<), leU as (<=), geU as (>=), (==) }
+
+  let mut codePoint = 0n
+  let mut bytesSeen = 0n
+  let mut bytesNeeded = 0n
+  let mut lowerBoundary = 0x80n
+  let mut upperBoundary = 0xBFn
+
+  let mut offset = 0n
+
+  while (true) {
+    let byte = WasmI32.load8U(ptr + offset, 0n)
+    offset += 1n
+    if (bytesNeeded == 0n) {
+      if (byte >= 0x00n && byte <= 0x7Fn) {
+        return byte
+      } else if (byte >= 0xC2n && byte <= 0xDFn) {
+        bytesNeeded = 1n
+        codePoint = byte & 0x1Fn
+      } else if (byte >= 0xE0n && byte <= 0xEFn) {
+        if (byte == 0xE0n) lowerBoundary = 0xA0n
+        if (byte == 0xEDn) upperBoundary = 0x9Fn
+        bytesNeeded = 2n
+        codePoint = byte & 0xFn
+      } else if (byte >= 0xF0n && byte <= 0xF4n) {
+        if (byte == 0xF0n) lowerBoundary = 0x90n
+        if (byte == 0xF4n) upperBoundary = 0x8Fn
+        bytesNeeded = 3n
+        codePoint = byte & 0x7n
+      } else {
+        throw MalformedUnicode
+      }
+      continue
+    }
+    if (!(lowerBoundary <= byte && byte <= upperBoundary)) {
+      throw MalformedUnicode
+    }
+    lowerBoundary = 0x80n
+    upperBoundary = 0xBFn
+    codePoint = codePoint << 6n | byte & 0x3Fn
+    bytesSeen += 1n
+    if (bytesSeen == bytesNeeded) {
+      return codePoint
+    }
+  }
+  return 0n
 }

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -89,6 +89,6 @@ Parameters:
 ### String.**getCodePoint**
 
 ```grain
-getCodePoint : (ptr: WasmI32) -> WasmI32
+getCodePoint : (ptr: WasmI32) => WasmI32
 ```
 

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -86,3 +86,9 @@ Parameters:
 |`value`|`a`|The operand|
 |`?suffix`|`String`|The string to print after the argument|
 
+### String.**getCodePoint**
+
+```grain
+getCodePoint : (ptr: WasmI32) -> WasmI32
+```
+


### PR DESCRIPTION
This PR aims to include my JSON parser/printer (https://github.com/cician/grain-json) into stdlib. Hopefully for 0.5 release.

I'm opening this PR as a draft for now since I expect to still make some important changes once stack allocated chars and thick numbers are in. Strictly speaking no changes are really required after stack chars PR is merged, but code can be improved for clarity by using chars instead of code points as raw numbers. Thick numbers on the other hand are going to affect the behavior of number parsing.