### PR TITLE
feat(compiler): Don't close over global values

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -261,7 +261,7 @@ type constant =
 type binding =
   | MArgBind(int32, Types.allocation_type)
   | MLocalBind(int32, Types.allocation_type)
-  | MGlobalBind(string, Types.allocation_type, bool)
+  | MGlobalBind(string, Types.allocation_type)
   | MClosureBind(int32)
   | MSwapBind(int32, Types.allocation_type) /* Used like a register would be */
   | MImport(int32); /* Index into list of imports */

--- a/compiler/src/middle_end/analyze_closure_scoped_vars.re
+++ b/compiler/src/middle_end/analyze_closure_scoped_vars.re
@@ -21,8 +21,8 @@ module CSVArg: Anf_iterator.IterArgument = {
 
   let leave_anf_expression = ({anf_desc: desc}) => {
     switch (desc) {
-    | AELet(Global, _, _, binds, _) =>
-      /* Assume that all globals are closure scope, since globals could
+    | AELet(Global({exported: true}), _, _, binds, _) =>
+      /* Assume that all exported globals are closure scope, since globals could
          appear in a closure scope in another module */
       let ids = List.map(fst, binds);
       closure_scoped_vars :=

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -185,7 +185,8 @@ let rec anf_count_vars = a =>
       List.map(((_, c)) => comp_count_vars(c), binds);
     let rec count_binds = (ptr, i32, i64, f32, f64, binds) => {
       switch (global, binds) {
-      | (Global, [_, ...rest]) => count_binds(ptr, i32, i64, f32, f64, rest)
+      | (Global(_), [_, ...rest]) =>
+        count_binds(ptr, i32, i64, f32, f64, rest)
       | (_, [(_, {comp_allocation_type: HeapAllocated}), ...rest]) =>
         count_binds(ptr + 1, i32, i64, f32, f64, rest)
       | (

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -8,7 +8,7 @@ open Types;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 [@deriving sexp]
 type global_flag =
-  | Global
+  | Global({exported: bool})
   | Nonglobal;
 
 type loc('a) = Location.loc('a);
@@ -387,6 +387,7 @@ type anf_program = {
 
 type anf_bind =
   | BSeq(comp_expression)
-  | BLet(Ident.t, comp_expression)
-  | BLetRec(list((Ident.t, comp_expression)))
-  | BLetExport(rec_flag, list((Ident.t, comp_expression)));
+  | BLet(Ident.t, comp_expression, global_flag)
+  | BLetMut(Ident.t, comp_expression, global_flag)
+  | BLetRec(list((Ident.t, comp_expression)), global_flag)
+  | BLetRecMut(list((Ident.t, comp_expression)), global_flag);

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -9,7 +9,7 @@ open Types;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 [@deriving sexp]
 type global_flag =
-  | Global
+  | Global({exported: bool})
   | Nonglobal;
 
 type loc('a) = Location.loc('a);
@@ -371,6 +371,7 @@ type anf_program = {
 
 type anf_bind =
   | BSeq(comp_expression)
-  | BLet(Ident.t, comp_expression)
-  | BLetRec(list((Ident.t, comp_expression)))
-  | BLetExport(rec_flag, list((Ident.t, comp_expression)));
+  | BLet(Ident.t, comp_expression, global_flag)
+  | BLetMut(Ident.t, comp_expression, global_flag)
+  | BLetRec(list((Ident.t, comp_expression)), global_flag)
+  | BLetRecMut(list((Ident.t, comp_expression)), global_flag);

--- a/compiler/src/middle_end/optimize_dead_assignments.re
+++ b/compiler/src/middle_end/optimize_dead_assignments.re
@@ -39,7 +39,7 @@ module DAEArg: Anf_mapper.MapArgument = {
 
   let leave_anf_expression = ({anf_desc: desc} as a) =>
     switch (desc) {
-    | AELet(Global, _, _, _, _)
+    | AELet(Global({exported: true}), _, _, _, _)
     | AELet(_, _, Mutable, _, _)
     | AESeq(_)
     | AEComp(_) => a

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1647,6 +1647,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                 val_kind: TValConstructor(desc),
                 val_loc: desc.cstr_loc,
                 val_mutable: false,
+                val_global: true,
               };
               c.comp_values =
                 Tbl.add(Ident.name(id), (val_desc, nopos), c.comp_values);
@@ -1705,6 +1706,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
             val_kind: TValConstructor(desc),
             val_loc: desc.cstr_loc,
             val_mutable: false,
+            val_global: true,
           };
           c.comp_values =
             Tbl.add(Ident.name(id), (val_desc, nopos), c.comp_values);
@@ -1776,6 +1778,7 @@ and store_type = (~check, id, info, env) => {
           val_kind: TValConstructor(desc),
           val_loc: desc.cstr_loc,
           val_mutable: false,
+          val_global: true,
         };
         (id, val_desc);
       },
@@ -1868,6 +1871,7 @@ and store_extension = (~check, id, ext, env) => {
       val_fullpath: PIdent(Ident.create(cstr.cstr_name)),
       val_kind: TValConstructor(cstr),
       val_mutable: false,
+      val_global: true,
       val_loc: cstr.cstr_loc,
     };
   };

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -268,6 +268,7 @@ let value_description = (s, descr) => {
   val_kind: descr.val_kind,
   val_fullpath: Path.PIdent(Ident.create("<unknown>")),
   val_mutable: descr.val_mutable,
+  val_global: descr.val_global,
   val_loc: loc(s, descr.val_loc),
 };
 

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -247,6 +247,7 @@ let maybe_add_pattern_variables_ghost = (loc_let, env, pv) =>
             val_kind: TValUnbound(ValUnboundGhostRecursive),
             val_loc: loc_let,
             val_mutable: false,
+            val_global: false,
           },
           env,
         )
@@ -834,7 +835,7 @@ and type_expect_ =
   | PExpLet(rec_flag, mut_flag, pats) =>
     let scp = None;
     let (pat_exp_list, new_env, unpacks) =
-      type_let(env, rec_flag, mut_flag, pats, scp, true);
+      type_let(env, rec_flag, mut_flag, false, pats, scp, true);
     /*let () =
       if rec_flag = Recursive then
         check_recursive_bindings env pat_exp_list
@@ -1710,6 +1711,7 @@ and type_let =
       env,
       rec_flag,
       mut_flag,
+      global_flag,
       spat_sexp_list,
       scope,
       allow,
@@ -1750,7 +1752,15 @@ and type_let =
   let nvs = List.map(_ => newvar(), spatl);
   let mut = mut_flag == Mutable;
   let (pat_list, new_env, force, unpacks, pv) =
-    type_pattern_list(~mut, env, spatl, scope, nvs, allow);
+    type_pattern_list(
+      ~mut,
+      ~global=global_flag,
+      env,
+      spatl,
+      scope,
+      nvs,
+      allow,
+    );
   let attrs_list = List.map(fst, spatl);
   let is_recursive = rec_flag == Recursive;
   /* If recursive, first unify with an approximation of the expression */
@@ -2089,6 +2099,7 @@ let type_binding = (env, rec_flag, mut_flag, spat_sexp_list, scope) => {
       env,
       rec_flag,
       mut_flag,
+      true,
       spat_sexp_list,
       scope,
       false,
@@ -2096,9 +2107,17 @@ let type_binding = (env, rec_flag, mut_flag, spat_sexp_list, scope) => {
 
   (pat_exp_list, new_env);
 };
-let type_let = (env, rec_flag, mut_flag, spat_sexp_list, scope) => {
+let type_let = (env, rec_flag, mut_flag, global_flag, spat_sexp_list, scope) => {
   let (pat_exp_list, new_env, _unpacks) =
-    type_let(env, rec_flag, mut_flag, spat_sexp_list, scope, false);
+    type_let(
+      env,
+      rec_flag,
+      mut_flag,
+      global_flag,
+      spat_sexp_list,
+      scope,
+      false,
+    );
   (pat_exp_list, new_env);
 };
 

--- a/compiler/src/typed/typecore.rei
+++ b/compiler/src/typed/typecore.rei
@@ -26,7 +26,14 @@ let type_binding:
   (Env.t, rec_flag, mut_flag, list(Parsetree.value_binding), option('a)) =>
   (list(Typedtree.value_binding), Env.t);
 let type_let:
-  (Env.t, rec_flag, mut_flag, list(Parsetree.value_binding), option('a)) =>
+  (
+    Env.t,
+    rec_flag,
+    mut_flag,
+    bool,
+    list(Parsetree.value_binding),
+    option('a)
+  ) =>
   (list(Typedtree.value_binding), Env.t);
 let type_expression: (Env.t, Parsetree.expression) => Typedtree.expression;
 let type_statement_expr:

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -939,6 +939,7 @@ let transl_value_decl = (env, loc, valdecl) => {
         Types.val_loc: loc,
         val_fullpath: Path.PIdent(Ident.create("<bogus>")) /*val_attributes = valdecl.pval_attributes*/,
         val_mutable: false,
+        val_global: true,
       }
     | _ => {
         val_type: ty,
@@ -947,6 +948,7 @@ let transl_value_decl = (env, loc, valdecl) => {
         Types.val_loc: loc,
         val_fullpath: Path.PIdent(Ident.create("<bogus>")) /*val_attributes = valdecl.pval_attributes*/,
         val_mutable: false,
+        val_global: true,
       }
     };
 

--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -1054,7 +1054,8 @@ let check_unused = (~lev=get_current_level(), env, expected_ty, cases) =>
     cases,
   );
 
-let add_pattern_variables = (~check=?, ~check_as=?, ~mut=false, env) => {
+let add_pattern_variables =
+    (~check=?, ~check_as=?, ~mut=false, ~global=false, env) => {
   let pv = get_ref(pattern_variables);
   (
     List.fold_right(
@@ -1070,6 +1071,7 @@ let add_pattern_variables = (~check=?, ~check_as=?, ~mut=false, env) => {
             Types.val_loc: loc,
             val_fullpath: Path.PIdent(id),
             val_mutable: mut,
+            val_global: global,
           },
           env,
         );
@@ -1092,7 +1094,8 @@ let type_pattern = (~lev, env, spat, scope, expected_ty) => {
   (pat, new_env, get_ref(pattern_force), unpacks);
 };
 
-let type_pattern_list = (~mut=false, env, spatl, scope, expected_tys, allow) => {
+let type_pattern_list =
+    (~mut=false, ~global=false, env, spatl, scope, expected_tys, allow) => {
   reset_pattern(/*scope*/ None, allow);
   let new_env = ref(env);
   let type_pat = ((attrs, pat), ty) => {
@@ -1110,7 +1113,8 @@ let type_pattern_list = (~mut=false, env, spatl, scope, expected_tys, allow) => 
   };
 
   let patl = List.map2(type_pat, spatl, expected_tys);
-  let (new_env, unpacks, pv) = add_pattern_variables(~mut, new_env^);
+  let (new_env, unpacks, pv) =
+    add_pattern_variables(~mut, ~global, new_env^);
   (patl, new_env, get_ref(pattern_force), unpacks, pv);
 };
 

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -137,6 +137,7 @@ type value_description = {
   val_kind: value_kind,
   val_fullpath: Path.t,
   val_mutable: bool,
+  val_global: bool,
   [@sexp_drop_if sexp_locs_disabled] [@default Location.dummy_loc]
   val_loc: Location.t,
 };

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -14,142 +14,134 @@ arrays › array_access
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $wimport_GRAIN$MODULE$runtime/exception_printException (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (if
-       (i32.lt_s
-        (i32.const 0)
-        (i32.sub
-         (i32.const 0)
-         (i32.load offset=4
-          (local.tee $2
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (local.tee $3
-              (tuple.extract 0
-               (tuple.make
-                (block (result i32)
-                 (i32.store
-                  (local.tee $0
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                      (i32.const 20)
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                  )
-                  (i32.const 5)
-                 )
-                 (i32.store offset=4
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=8
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=12
-                  (local.get $0)
-                  (i32.const 5)
-                 )
-                 (i32.store offset=16
-                  (local.get $0)
-                  (i32.const 7)
-                 )
-                 (local.get $0)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (i32.const 0)
-                )
-               )
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 20)
              )
              (i32.const 0)
             )
            )
           )
+          (i32.const 5)
          )
-        )
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (if
-       (i32.le_s
-        (i32.load offset=4
-         (local.get $2)
-        )
-        (local.get $1)
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (i32.add
-         (i32.shl
-          (if (result i32)
-           (i32.lt_u
-            (local.get $1)
-            (i32.const 0)
-           )
-           (i32.add
-            (local.get $1)
-            (i32.load offset=4
-             (local.get $2)
-            )
-           )
-           (local.get $1)
-          )
-          (i32.const 2)
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
          )
-         (local.get $2)
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
      )
-     (local.get $0)
+     (if
+      (i32.lt_s
+       (i32.const 0)
+       (i32.sub
+        (i32.const 0)
+        (i32.load offset=4
+         (local.tee $2
+          (tuple.extract 0
+           (tuple.make
+            (global.get $global_0)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (if
+      (i32.le_s
+       (i32.load offset=4
+        (local.get $2)
+       )
+       (local.get $1)
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (i32.add
+        (i32.shl
+         (if (result i32)
+          (i32.lt_u
+           (local.get $1)
+           (i32.const 0)
+          )
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+          (local.get $1)
+         )
+         (i32.const 2)
+        )
+        (local.get $2)
+       )
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -14,144 +14,136 @@ arrays › array_access4
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $wimport_GRAIN$MODULE$runtime/exception_printException (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (if
-       (i32.lt_s
-        (local.tee $1
-         (i32.const -2)
-        )
-        (i32.sub
-         (i32.const 0)
-         (i32.load offset=4
-          (local.tee $2
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (local.tee $3
-              (tuple.extract 0
-               (tuple.make
-                (block (result i32)
-                 (i32.store
-                  (local.tee $0
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                      (i32.const 20)
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                  )
-                  (i32.const 5)
-                 )
-                 (i32.store offset=4
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=8
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=12
-                  (local.get $0)
-                  (i32.const 5)
-                 )
-                 (i32.store offset=16
-                  (local.get $0)
-                  (i32.const 7)
-                 )
-                 (local.get $0)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (i32.const 0)
-                )
-               )
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 20)
              )
              (i32.const 0)
             )
            )
           )
+          (i32.const 5)
          )
-        )
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (if
-       (i32.le_s
-        (i32.load offset=4
-         (local.get $2)
-        )
-        (local.get $1)
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (i32.add
-         (i32.shl
-          (if (result i32)
-           (i32.lt_s
-            (local.get $1)
-            (i32.const 0)
-           )
-           (i32.add
-            (local.get $1)
-            (i32.load offset=4
-             (local.get $2)
-            )
-           )
-           (local.get $1)
-          )
-          (i32.const 2)
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
          )
-         (local.get $2)
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
      )
-     (local.get $0)
+     (if
+      (i32.lt_s
+       (local.tee $1
+        (i32.const -2)
+       )
+       (i32.sub
+        (i32.const 0)
+        (i32.load offset=4
+         (local.tee $2
+          (tuple.extract 0
+           (tuple.make
+            (global.get $global_0)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (if
+      (i32.le_s
+       (i32.load offset=4
+        (local.get $2)
+       )
+       (local.get $1)
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (i32.add
+        (i32.shl
+         (if (result i32)
+          (i32.lt_s
+           (local.get $1)
+           (i32.const 0)
+          )
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+          (local.get $1)
+         )
+         (i32.const 2)
+        )
+        (local.get $2)
+       )
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -14,144 +14,136 @@ arrays › array_access2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $wimport_GRAIN$MODULE$runtime/exception_printException (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (if
-       (i32.lt_s
-        (local.tee $1
-         (i32.const 1)
-        )
-        (i32.sub
-         (i32.const 0)
-         (i32.load offset=4
-          (local.tee $2
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (local.tee $3
-              (tuple.extract 0
-               (tuple.make
-                (block (result i32)
-                 (i32.store
-                  (local.tee $0
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                      (i32.const 20)
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                  )
-                  (i32.const 5)
-                 )
-                 (i32.store offset=4
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=8
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=12
-                  (local.get $0)
-                  (i32.const 5)
-                 )
-                 (i32.store offset=16
-                  (local.get $0)
-                  (i32.const 7)
-                 )
-                 (local.get $0)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (i32.const 0)
-                )
-               )
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 20)
              )
              (i32.const 0)
             )
            )
           )
+          (i32.const 5)
          )
-        )
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (if
-       (i32.le_s
-        (i32.load offset=4
-         (local.get $2)
-        )
-        (local.get $1)
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (i32.add
-         (i32.shl
-          (if (result i32)
-           (i32.lt_u
-            (local.get $1)
-            (i32.const 0)
-           )
-           (i32.add
-            (local.get $1)
-            (i32.load offset=4
-             (local.get $2)
-            )
-           )
-           (local.get $1)
-          )
-          (i32.const 2)
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
          )
-         (local.get $2)
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
      )
-     (local.get $0)
+     (if
+      (i32.lt_s
+       (local.tee $1
+        (i32.const 1)
+       )
+       (i32.sub
+        (i32.const 0)
+        (i32.load offset=4
+         (local.tee $2
+          (tuple.extract 0
+           (tuple.make
+            (global.get $global_0)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (if
+      (i32.le_s
+       (i32.load offset=4
+        (local.get $2)
+       )
+       (local.get $1)
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (i32.add
+        (i32.shl
+         (if (result i32)
+          (i32.lt_u
+           (local.get $1)
+           (i32.const 0)
+          )
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+          (local.get $1)
+         )
+         (i32.const 2)
+        )
+        (local.get $2)
+       )
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -14,144 +14,136 @@ arrays › array_access3
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $wimport_GRAIN$MODULE$runtime/exception_printException (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (if
-       (i32.lt_s
-        (local.tee $1
-         (i32.const 2)
-        )
-        (i32.sub
-         (i32.const 0)
-         (i32.load offset=4
-          (local.tee $2
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (local.tee $3
-              (tuple.extract 0
-               (tuple.make
-                (block (result i32)
-                 (i32.store
-                  (local.tee $0
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                      (i32.const 20)
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                  )
-                  (i32.const 5)
-                 )
-                 (i32.store offset=4
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=8
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=12
-                  (local.get $0)
-                  (i32.const 5)
-                 )
-                 (i32.store offset=16
-                  (local.get $0)
-                  (i32.const 7)
-                 )
-                 (local.get $0)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (i32.const 0)
-                )
-               )
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 20)
              )
              (i32.const 0)
             )
            )
           )
+          (i32.const 5)
          )
-        )
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (if
-       (i32.le_s
-        (i32.load offset=4
-         (local.get $2)
-        )
-        (local.get $1)
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (i32.add
-         (i32.shl
-          (if (result i32)
-           (i32.lt_u
-            (local.get $1)
-            (i32.const 0)
-           )
-           (i32.add
-            (local.get $1)
-            (i32.load offset=4
-             (local.get $2)
-            )
-           )
-           (local.get $1)
-          )
-          (i32.const 2)
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
          )
-         (local.get $2)
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
      )
-     (local.get $0)
+     (if
+      (i32.lt_s
+       (local.tee $1
+        (i32.const 2)
+       )
+       (i32.sub
+        (i32.const 0)
+        (i32.load offset=4
+         (local.tee $2
+          (tuple.extract 0
+           (tuple.make
+            (global.get $global_0)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (if
+      (i32.le_s
+       (i32.load offset=4
+        (local.get $2)
+       )
+       (local.get $1)
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (i32.add
+        (i32.shl
+         (if (result i32)
+          (i32.lt_u
+           (local.get $1)
+           (i32.const 0)
+          )
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+          (local.get $1)
+         )
+         (i32.const 2)
+        )
+        (local.get $2)
+       )
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -14,144 +14,136 @@ arrays › array_access5
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $wimport_GRAIN$MODULE$runtime/exception_printException (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (if
-       (i32.lt_s
-        (local.tee $1
-         (i32.const -3)
-        )
-        (i32.sub
-         (i32.const 0)
-         (i32.load offset=4
-          (local.tee $2
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (local.tee $3
-              (tuple.extract 0
-               (tuple.make
-                (block (result i32)
-                 (i32.store
-                  (local.tee $0
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                      (i32.const 20)
-                     )
-                     (i32.const 0)
-                    )
-                   )
-                  )
-                  (i32.const 5)
-                 )
-                 (i32.store offset=4
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=8
-                  (local.get $0)
-                  (i32.const 3)
-                 )
-                 (i32.store offset=12
-                  (local.get $0)
-                  (i32.const 5)
-                 )
-                 (i32.store offset=16
-                  (local.get $0)
-                  (i32.const 7)
-                 )
-                 (local.get $0)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (i32.const 0)
-                )
-               )
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 20)
              )
              (i32.const 0)
             )
            )
           )
+          (i32.const 5)
          )
-        )
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (if
-       (i32.le_s
-        (i32.load offset=4
-         (local.get $2)
-        )
-        (local.get $1)
-       )
-       (block
-        (drop
-         (call $wimport_GRAIN$MODULE$runtime/exception_printException
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
-          (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
-        )
-        (unreachable)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (i32.add
-         (i32.shl
-          (if (result i32)
-           (i32.lt_s
-            (local.get $1)
-            (i32.const 0)
-           )
-           (i32.add
-            (local.get $1)
-            (i32.load offset=4
-             (local.get $2)
-            )
-           )
-           (local.get $1)
-          )
-          (i32.const 2)
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
          )
-         (local.get $2)
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
      )
-     (local.get $0)
+     (if
+      (i32.lt_s
+       (local.tee $1
+        (i32.const -3)
+       )
+       (i32.sub
+        (i32.const 0)
+        (i32.load offset=4
+         (local.tee $2
+          (tuple.extract 0
+           (tuple.make
+            (global.get $global_0)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+       )
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (if
+      (i32.le_s
+       (i32.load offset=4
+        (local.get $2)
+       )
+       (local.get $1)
+      )
+      (block
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/exception_printException
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$printException)
+         (global.get $wimport_GRAIN$MODULE$runtime/exception_GRAIN$EXPORT$IndexOutOfBounds)
+        )
+       )
+       (unreachable)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (i32.add
+        (i32.shl
+         (if (result i32)
+          (i32.lt_s
+           (local.get $1)
+           (i32.const 0)
+          )
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+          (local.get $1)
+         )
+         (i32.const 2)
+        )
+        (local.get $2)
+       )
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › func_shadow
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153 $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155 $foo_1157)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,14 @@ basic functionality › func_shadow
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 2))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 2))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -62,7 +64,7 @@ basic functionality › func_shadow
   )
   (local.get $1)
  )
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -108,13 +110,11 @@ basic functionality › func_shadow
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -148,18 +148,26 @@ basic functionality › func_shadow
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $foo_1153
+         (global.get $global_0)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1155
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -180,18 +188,13 @@ basic functionality › func_shadow
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (global.get $gimport_pervasives_print)
             )
-            (tuple.extract 0
-             (tuple.make
-              (local.get $1)
-              (local.get $0)
-             )
-            )
+            (local.get $0)
            )
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (i32.load offset=8
           (local.get $0)
@@ -199,7 +202,7 @@ basic functionality › func_shadow
         )
        )
       )
-      (local.set $2
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -236,18 +239,26 @@ basic functionality › func_shadow
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
       )
-      (local.set $4
+      (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call $foo_1155
+         (global.get $global_1)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1157
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -258,45 +269,28 @@ basic functionality › func_shadow
        )
       )
       (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $0
+       (local.tee $1
         (tuple.extract 0
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $gimport_pervasives_print)
           )
-          (tuple.extract 0
-           (tuple.make
-            (local.get $2)
-            (local.get $0)
-           )
-          )
+          (local.get $1)
          )
         )
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
+        (local.get $0)
        )
        (i32.load offset=8
-        (local.get $0)
+        (local.get $1)
        )
       )
      )
-     (local.get $0)
+     (local.get $1)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (drop
@@ -308,10 +302,10 @@ basic functionality › func_shadow
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -9,64 +9,54 @@ basic functionality › if_one_sided6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 3)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 3)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (drop
-       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-        (block (result i32)
-         (local.set $0
-          (tuple.extract 0
-           (tuple.make
-            (i32.const 11)
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $0)
-            )
+     )
+     (drop
+      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+       (block (result i32)
+        (global.set $global_0
+         (tuple.extract 0
+          (tuple.make
+           (i32.const 11)
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (global.get $global_0)
            )
           )
          )
-         (i32.const 1879048190)
         )
+        (i32.const 1879048190)
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
-      )
      )
-     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_0)
+     )
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › block_no_expression
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $f_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $f_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -14,12 +14,13 @@ basic functionality › block_no_expression
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $f_1153 (; has Stack IR ;) (param $0 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $f_1155 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -30,73 +31,66 @@ basic functionality › block_no_expression
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 16)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 7)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 1)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $wimport__grainEnv_relocBase)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 0)
-          )
-          (local.get $0)
+          (i32.const 7)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 1)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $f_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
        )
       )
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
+     (call $f_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
       )
      )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -7,53 +7,43 @@ basic functionality › if_one_sided5
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 3)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 3)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 11)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
-         )
-        )
-       )
-      )
-      (i32.const 1879048190)
      )
-     (i32.const 0)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 11)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › pattern_match_unsafe_wasm
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $test_1153 $foo_1154)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $test_1155 $foo_1156)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,93 +15,81 @@ basic functionality › pattern_match_unsafe_wasm
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 2))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 2))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $test_1153 (; has Stack IR ;) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (i32.store offset=16
-   (tuple.extract 0
-    (tuple.make
-     (local.tee $2
-      (tuple.extract 0
-       (tuple.make
-        (block (result i32)
-         (i32.store
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-              (i32.const 20)
-             )
-             (i32.const 0)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $test_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+  (drop
+   (call $foo_1156
+    (local.tee $0
+     (tuple.extract 0
+      (tuple.make
+       (block (result i32)
+        (i32.store
+         (local.tee $0
+          (tuple.extract 0
+           (tuple.make
+            (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+             (i32.const 16)
             )
+            (i32.const 0)
            )
           )
-          (i32.const 7)
          )
-         (i32.store offset=4
-          (local.get $1)
-          (i32.const 2)
-         )
-         (i32.store offset=8
-          (local.get $1)
-          (i32.add
-           (global.get $wimport__grainEnv_relocBase)
-           (i32.const 1)
-          )
-         )
-         (i32.store offset=12
-          (local.get $1)
+         (i32.const 7)
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.const 2)
+        )
+        (i32.store offset=8
+         (local.get $0)
+         (i32.add
+          (global.get $wimport__grainEnv_relocBase)
           (i32.const 1)
          )
-         (local.get $1)
         )
-        (i32.const 0)
+        (i32.store offset=12
+         (local.get $0)
+         (i32.const 0)
+        )
+        (local.get $0)
        )
+       (i32.const 0)
       )
      )
-     (local.get $1)
     )
-   )
-   (i32.load offset=16
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $foo_1154
-    (local.get $2)
     (i32.const 0)
    )
   )
   (drop
-   (call $foo_1154
-    (local.get $2)
+   (call $foo_1156
+    (local.get $0)
     (i32.const 1)
    )
   )
   (drop
-   (call $foo_1154
-    (local.get $2)
+   (call $foo_1156
+    (local.get $0)
     (i32.const 5)
    )
   )
   (drop
-   (call $foo_1154
-    (local.get $2)
+   (call $foo_1156
+    (local.get $0)
     (i32.const 8)
    )
   )
-  (call $foo_1154
-   (local.get $2)
+  (call $foo_1156
+   (local.get $0)
    (i32.const 42)
   )
  )
- (func $foo_1154 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (block $switch.31_outer (result i32)
    (drop
@@ -265,12 +253,12 @@ basic functionality › pattern_match_unsafe_wasm
                  (unreachable)
                 )
                )
-               (local.set $2
+               (local.set $1
                 (tuple.extract 0
                  (tuple.make
                   (block (result i32)
                    (i32.store
-                    (local.tee $1
+                    (local.tee $0
                      (tuple.extract 0
                       (tuple.make
                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -284,14 +272,14 @@ basic functionality › pattern_match_unsafe_wasm
                     (i32.const 1)
                    )
                    (i32.store offset=4
-                    (local.get $1)
+                    (local.get $0)
                     (i32.const 5)
                    )
                    (i64.store offset=8
-                    (local.get $1)
+                    (local.get $0)
                     (i64.const 491327616111)
                    )
-                   (local.get $1)
+                   (local.get $0)
                   )
                   (i32.const 0)
                  )
@@ -302,14 +290,12 @@ basic functionality › pattern_match_unsafe_wasm
                  (local.tee $0
                   (tuple.extract 0
                    (tuple.make
-                    (i32.load offset=16
-                     (local.get $0)
-                    )
-                    (local.get $1)
+                    (global.get $gimport_pervasives_print)
+                    (local.get $0)
                    )
                   )
                  )
-                 (local.get $2)
+                 (local.get $1)
                  (i32.load offset=8
                   (local.get $0)
                  )
@@ -322,9 +308,7 @@ basic functionality › pattern_match_unsafe_wasm
                (local.tee $0
                 (tuple.extract 0
                  (tuple.make
-                  (i32.load offset=16
-                   (local.get $0)
-                  )
+                  (global.get $gimport_pervasives_print)
                   (i32.const 0)
                  )
                 )
@@ -342,9 +326,7 @@ basic functionality › pattern_match_unsafe_wasm
              (local.tee $0
               (tuple.extract 0
                (tuple.make
-                (i32.load offset=16
-                 (local.get $0)
-                )
+                (global.get $gimport_pervasives_print)
                 (i32.const 0)
                )
               )
@@ -362,9 +344,7 @@ basic functionality › pattern_match_unsafe_wasm
            (local.tee $0
             (tuple.extract 0
              (tuple.make
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_print)
               (i32.const 0)
              )
             )
@@ -382,9 +362,7 @@ basic functionality › pattern_match_unsafe_wasm
          (local.tee $0
           (tuple.extract 0
            (tuple.make
-            (i32.load offset=16
-             (local.get $0)
-            )
+            (global.get $gimport_pervasives_print)
             (i32.const 0)
            )
           )
@@ -402,9 +380,7 @@ basic functionality › pattern_match_unsafe_wasm
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (i32.load offset=16
-           (local.get $0)
-          )
+          (global.get $gimport_pervasives_print)
           (i32.const 0)
          )
         )
@@ -421,9 +397,7 @@ basic functionality › pattern_match_unsafe_wasm
     (local.tee $0
      (tuple.extract 0
       (tuple.make
-       (i32.load offset=16
-        (local.get $0)
-       )
+       (global.get $gimport_pervasives_print)
        (i32.const 0)
       )
      )
@@ -437,81 +411,66 @@ basic functionality › pattern_match_unsafe_wasm
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 1)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
+             (i32.const 0)
             )
            )
           )
-          (local.get $0)
+          (i32.const 7)
          )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 1)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
         )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-      )
-      (call $test_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
        )
       )
      )
-     (local.get $0)
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (call $test_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -7,53 +7,43 @@ basic functionality › if_one_sided3
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 3)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 3)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 5)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
-         )
-        )
-       )
-      )
-      (i32.const 1879048190)
      )
-     (i32.const 0)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 5)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -9,64 +9,54 @@ basic functionality › if_one_sided4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 3)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 3)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (drop
-       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-        (block (result i32)
-         (local.set $0
-          (tuple.extract 0
-           (tuple.make
-            (i32.const 5)
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $0)
-            )
+     )
+     (drop
+      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+       (block (result i32)
+        (global.set $global_0
+         (tuple.extract 0
+          (tuple.make
+           (i32.const 5)
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (global.get $global_0)
            )
           )
          )
-         (i32.const 1879048190)
         )
+        (i32.const 1879048190)
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
-      )
      )
-     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_0)
+     )
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › func_shadow_and_indirect_call
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153 $foo_1155 $foo_1157 $func_1170)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155 $foo_1157 $foo_1159 $func_1172)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,16 @@ basic functionality › func_shadow_and_indirect_call
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 4))
+ (global $global_3 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_5 i32 (i32.const 4))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_5))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -62,7 +66,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -104,7 +108,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1159 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -153,7 +157,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $func_1170 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $func_1172 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -200,15 +204,11 @@ basic functionality › func_shadow_and_indirect_call
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -242,18 +242,26 @@ basic functionality › func_shadow_and_indirect_call
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $4
+      (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $foo_1153
+         (global.get $global_0)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1155
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -274,18 +282,13 @@ basic functionality › func_shadow_and_indirect_call
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (global.get $gimport_pervasives_print)
             )
-            (tuple.extract 0
-             (tuple.make
-              (local.get $1)
-              (local.get $0)
-             )
-            )
+            (local.get $0)
            )
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $4)
+          (local.get $1)
          )
          (i32.load offset=8
           (local.get $0)
@@ -293,7 +296,7 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $2
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -330,18 +333,26 @@ basic functionality › func_shadow_and_indirect_call
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
       )
-      (local.set $5
+      (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $foo_1155
+         (global.get $global_1)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1157
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -362,18 +373,13 @@ basic functionality › func_shadow_and_indirect_call
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (global.get $gimport_pervasives_print)
             )
-            (tuple.extract 0
-             (tuple.make
-              (local.get $2)
-              (local.get $0)
-             )
-            )
+            (local.get $0)
            )
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $5)
+          (local.get $2)
          )
          (i32.load offset=8
           (local.get $0)
@@ -381,7 +387,7 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (local.set $3
+      (global.set $global_2
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -418,28 +424,36 @@ basic functionality › func_shadow_and_indirect_call
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_2)
          )
         )
        )
       )
-      (local.set $6
+      (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $foo_1157
+         (global.get $global_2)
+         (local.get $0)
+        )
+       )
+      )
+      (global.set $global_3
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1159
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (global.get $global_2)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_3)
          )
         )
        )
       )
-      (local.set $7
+      (local.set $3
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_=>_i32)
@@ -448,14 +462,9 @@ basic functionality › func_shadow_and_indirect_call
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $6)
+              (global.get $global_3)
              )
-             (tuple.extract 0
-              (tuple.make
-               (local.get $3)
-               (local.get $0)
-              )
-             )
+             (local.get $0)
             )
            )
           )
@@ -484,7 +493,7 @@ basic functionality › func_shadow_and_indirect_call
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $7)
+        (local.get $3)
        )
        (i32.load offset=8
         (local.get $0)
@@ -504,37 +513,13 @@ basic functionality › func_shadow_and_indirect_call
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_subtraction1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_subtraction1
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_subtraction1
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_subtraction1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_subtraction1
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -143,12 +143,6 @@ boxes › box_subtraction1
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_multiplication2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_multiplication2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_multiplication2
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_multiplication2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_multiplication2
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -130,7 +130,7 @@ boxes › box_multiplication2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $1)
+        (global.get $global_0)
        )
       )
      )
@@ -148,12 +148,6 @@ boxes › box_multiplication2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_division2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_division2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_division2
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_division2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_division2
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -130,7 +130,7 @@ boxes › box_division2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $1)
+        (global.get $global_0)
        )
       )
      )
@@ -148,12 +148,6 @@ boxes › box_division2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_addition2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_addition2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_addition2
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_addition2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_addition2
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -130,7 +130,7 @@ boxes › box_addition2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $1)
+        (global.get $global_0)
        )
       )
      )
@@ -148,12 +148,6 @@ boxes › box_addition2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_division1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_division1
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_division1
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_division1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_division1
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -143,12 +143,6 @@ boxes › box_division1
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_subtraction2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_subtraction2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_subtraction2
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_subtraction2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_subtraction2
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -130,7 +130,7 @@ boxes › box_subtraction2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $1)
+        (global.get $global_0)
        )
       )
      )
@@ -148,12 +148,6 @@ boxes › box_subtraction2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_addition1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_addition1
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_addition1
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_addition1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_addition1
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -143,12 +143,6 @@ boxes › box_addition1
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -14,21 +14,21 @@ boxes › box_multiplication1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -58,18 +58,18 @@ boxes › box_multiplication1
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -79,7 +79,7 @@ boxes › box_multiplication1
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -96,7 +96,7 @@ boxes › box_multiplication1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $1)
           )
           (i32.const 39)
           (i32.load offset=8
@@ -111,17 +111,17 @@ boxes › box_multiplication1
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $2)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
@@ -143,12 +143,6 @@ boxes › box_multiplication1
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -5,7 +5,7 @@ enums › adt_trailing
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Cheese_1154)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Cheese_1156)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -23,7 +23,7 @@ enums › adt_trailing
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
- (func $Cheese_1154 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $Cheese_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $1
    (tuple.extract 0
@@ -52,7 +52,7 @@ enums › adt_trailing
       )
       (i32.store offset=8
        (local.get $2)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=12
        (local.get $2)
@@ -118,7 +118,7 @@ enums › adt_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 85899347073)
+           (i64.const 85899347075)
           )
           (i64.store offset=32
            (local.get $0)
@@ -239,7 +239,7 @@ enums › adt_trailing
          )
          (i32.store offset=8
           (local.get $0)
-          (i32.const 2307)
+          (i32.const 2311)
          )
          (i32.store offset=12
           (local.get $0)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -6,7 +6,7 @@ enums › enum_recursive_data_definition
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Node_1156 $Cons_1158)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Node_1158 $Cons_1160)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -18,9 +18,10 @@ enums › enum_recursive_data_definition
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (global $global_3 (mut i32) (i32.const 0))
  (global $global_0 (mut i32) (i32.const 0))
+ (global $global_4 (mut i32) (i32.const 0))
  (global $global_1 (mut i32) (i32.const 0))
  (global $global_2 (mut i32) (i32.const 0))
- (global $global_5 i32 (i32.const 2))
+ (global $global_6 i32 (i32.const 2))
  (export \"memory\" (memory $0))
  (export \"GRAIN$EXPORT$Cons\" (global $global_3))
  (export \"GRAIN$EXPORT$Empty\" (global $global_0))
@@ -28,8 +29,8 @@ enums › enum_recursive_data_definition
  (export \"GRAIN$EXPORT$Nil\" (global $global_2))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_5))
- (func $Node_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_6))
+ (func $Node_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -58,7 +59,7 @@ enums › enum_recursive_data_definition
       )
       (i32.store offset=8
        (local.get $3)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=12
        (local.get $3)
@@ -108,7 +109,7 @@ enums › enum_recursive_data_definition
   )
   (local.get $3)
  )
- (func $Cons_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Cons_1160 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -137,7 +138,7 @@ enums › enum_recursive_data_definition
       )
       (i32.store offset=8
        (local.get $3)
-       (i32.const 2309)
+       (i32.const 2313)
       )
       (i32.store offset=12
        (local.get $3)
@@ -194,7 +195,6 @@ enums › enum_recursive_data_definition
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -232,7 +232,7 @@ enums › enum_recursive_data_definition
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 85899347074)
+            (i64.const 85899347076)
            )
            (i64.store offset=32
             (local.get $0)
@@ -256,7 +256,7 @@ enums › enum_recursive_data_definition
            )
            (i64.store offset=72
             (local.get $0)
-            (i64.const 85899347073)
+            (i64.const 85899347075)
            )
            (i64.store offset=80
             (local.get $0)
@@ -326,7 +326,7 @@ enums › enum_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -419,7 +419,7 @@ enums › enum_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)
@@ -561,7 +561,7 @@ enums › enum_recursive_data_definition
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call $Node_1156
+         (call $Node_1158
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)
@@ -585,7 +585,7 @@ enums › enum_recursive_data_definition
       (local.set $4
        (tuple.extract 0
         (tuple.make
-         (call $Cons_1158
+         (call $Cons_1160
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_3)
@@ -609,7 +609,7 @@ enums › enum_recursive_data_definition
       (local.set $5
        (tuple.extract 0
         (tuple.make
-         (call $Node_1156
+         (call $Node_1158
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)
@@ -630,10 +630,10 @@ enums › enum_recursive_data_definition
         )
        )
       )
-      (local.set $6
+      (global.set $global_4
        (tuple.extract 0
         (tuple.make
-         (call $Cons_1158
+         (call $Cons_1160
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_3)
@@ -649,7 +649,7 @@ enums › enum_recursive_data_definition
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_4)
          )
         )
        )
@@ -668,7 +668,7 @@ enums › enum_recursive_data_definition
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $6)
+        (global.get $global_4)
        )
        (i32.load offset=8
         (local.get $0)
@@ -707,12 +707,6 @@ enums › enum_recursive_data_definition
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -6,7 +6,7 @@ exceptions › exception_4
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -24,7 +24,7 @@ exceptions › exception_4
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
- (func $Foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $1
    (tuple.extract 0
@@ -57,7 +57,7 @@ exceptions › exception_4
       )
       (i32.store offset=12
        (local.get $3)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=16
        (local.get $3)
@@ -136,7 +136,7 @@ exceptions › exception_4
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903041)
+           (i64.const 12884903043)
           )
           (i64.store offset=40
            (local.get $0)
@@ -144,7 +144,7 @@ exceptions › exception_4
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 4960687226900)
+           (i64.const 4969277161492)
           )
           (i64.store offset=56
            (local.get $0)
@@ -253,7 +253,7 @@ exceptions › exception_4
          )
          (i32.store offset=12
           (local.get $0)
-          (i32.const 2311)
+          (i32.const 2315)
          )
          (i32.store offset=16
           (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -61,7 +61,7 @@ exceptions › exception_2
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903041)
+           (i64.const 12884903043)
           )
           (i64.store offset=40
            (local.get $0)
@@ -119,7 +119,7 @@ exceptions › exception_2
          )
          (i32.store offset=12
           (local.get $0)
-          (i32.const 2307)
+          (i32.const 2311)
          )
          (i32.store offset=16
           (local.get $0)

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -6,7 +6,7 @@ exports › let_rec_export
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
@@ -16,11 +16,11 @@ exports › let_rec_export
  (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"GRAIN$EXPORT$foo\" (global $global_0))
- (export \"foo\" (func $foo_1153))
+ (export \"foo\" (func $foo_1155))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -89,5 +89,5 @@ exports › let_rec_export
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 607
+ ;; custom section \"cmi\", size 625
 )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -6,7 +6,7 @@ functions › dup_func
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1157)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1159)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -14,12 +14,13 @@ functions › dup_func
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1159 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -30,73 +31,66 @@ functions › dup_func
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 16)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 7)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 1)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $wimport__grainEnv_relocBase)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 0)
-          )
-          (local.get $0)
+          (i32.const 7)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 1)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $foo_1157
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
        )
       )
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
+     (call $foo_1159
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
       )
      )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -6,7 +6,7 @@ functions › shorthand_4
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › shorthand_4
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -31,9 +32,7 @@ functions › shorthand_4
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=16
-           (local.get $0)
-          )
+          (global.get $gimport_pervasives_+)
          )
          (i32.const 0)
         )
@@ -68,82 +67,67 @@ functions › shorthand_4
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
+             (i32.const 0)
             )
            )
           )
-          (local.get $0)
+          (i32.const 7)
          )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $foo_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
-       (i32.const 3)
       )
      )
-     (local.get $0)
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (call $foo_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
+      )
+      (i32.const 3)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -5,7 +5,7 @@ functions › shorthand_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -13,12 +13,13 @@ functions › shorthand_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -47,74 +48,67 @@ functions › shorthand_1
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 16)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 7)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $wimport__grainEnv_relocBase)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 0)
-          )
-          (local.get $0)
+          (i32.const 7)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $foo_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
        )
-       (i32.const 3)
       )
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
+     (call $foo_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
       )
+      (i32.const 3)
      )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_5
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1158)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1160)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_5
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $lam_lambda_1160 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -123,9 +123,7 @@ functions › lam_destructure_5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -159,9 +157,7 @@ functions › lam_destructure_5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $3)
             )
@@ -195,9 +191,7 @@ functions › lam_destructure_5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $3)
             )
@@ -228,9 +222,7 @@ functions › lam_destructure_5
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $3)
          )
@@ -330,56 +322,43 @@ functions › lam_destructure_5
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 3)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
         )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
        )
       )
       (local.set $2
@@ -394,7 +373,12 @@ functions › lam_destructure_5
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
                (i32.const 20)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )
@@ -464,7 +448,7 @@ functions › lam_destructure_5
         )
        )
       )
-      (call $lam_lambda_1158
+      (call $lam_lambda_1160
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -5,7 +5,7 @@ functions › lambda_pat_any
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $x_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $x_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -13,12 +13,13 @@ functions › lambda_pat_any
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $x_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $x_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -36,12 +37,11 @@ functions › lambda_pat_any
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -75,12 +75,20 @@ functions › lambda_pat_any
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -92,12 +100,7 @@ functions › lambda_pat_any
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
                (i32.const 16)
               )
-              (tuple.extract 0
-               (tuple.make
-                (local.get $1)
-                (local.get $0)
-               )
-              )
+              (local.get $0)
              )
             )
            )
@@ -120,14 +123,14 @@ functions › lambda_pat_any
         )
        )
       )
-      (call $x_1153
+      (call $x_1155
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (global.get $global_0)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -139,12 +142,6 @@ functions › lambda_pat_any
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -6,7 +6,7 @@ functions › curried_func
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $add_1153 $func_1163)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $add_1155 $func_1165)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › curried_func
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 2))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 2))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $add_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $add_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -32,7 +33,7 @@ functions › curried_func
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_malloc
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-           (i32.const 24)
+           (i32.const 20)
           )
           (i32.const 0)
          )
@@ -53,18 +54,9 @@ functions › curried_func
       )
       (i32.store offset=12
        (local.get $2)
-       (i32.const 2)
+       (i32.const 1)
       )
       (i32.store offset=16
-       (local.get $2)
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=16
-         (local.get $0)
-        )
-       )
-      )
-      (i32.store offset=20
        (local.get $2)
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -91,7 +83,7 @@ functions › curried_func
   )
   (local.get $2)
  )
- (func $func_1163 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1165 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -102,9 +94,7 @@ functions › curried_func
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=16
-           (local.get $0)
-          )
+          (global.get $gimport_pervasives_+)
          )
          (i32.const 0)
         )
@@ -112,7 +102,7 @@ functions › curried_func
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=20
+       (i32.load offset=16
         (local.get $0)
        )
       )
@@ -145,70 +135,64 @@ functions › curried_func
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (local.set $1
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $1
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $2
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (global.set $global_0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (global.get $global_0)
+         )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+      )
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
        )
       )
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $add_1153
+         (call $add_1155
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 5)
          )
@@ -239,12 +223,6 @@ functions › curried_func
      )
      (local.get $1)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -5,7 +5,7 @@ functions › app_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1156)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1158)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -18,7 +18,7 @@ functions › app_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -91,7 +91,7 @@ functions › app_1
         )
        )
       )
-      (call $lam_lambda_1156
+      (call $lam_lambda_1158
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -5,7 +5,7 @@ functions › shorthand_3
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -13,12 +13,13 @@ functions › shorthand_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -47,74 +48,67 @@ functions › shorthand_3
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 16)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 7)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 2)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $wimport__grainEnv_relocBase)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 0)
-          )
-          (local.get $0)
+          (i32.const 7)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $foo_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
        )
-       (i32.const 3)
       )
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
+     (call $foo_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
       )
+      (i32.const 3)
      )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_3
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1156)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1158)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_3
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -87,9 +87,7 @@ functions › lam_destructure_3
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -120,9 +118,7 @@ functions › lam_destructure_3
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $2)
          )
@@ -191,56 +187,43 @@ functions › lam_destructure_3
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
         )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
        )
       )
       (local.set $2
@@ -255,7 +238,12 @@ functions › lam_destructure_3
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
                (i32.const 20)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )
@@ -286,7 +274,7 @@ functions › lam_destructure_3
         )
        )
       )
-      (call $lam_lambda_1156
+      (call $lam_lambda_1158
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_7
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1157)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1159)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_7
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1157 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1159 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -122,9 +122,7 @@ functions › lam_destructure_7
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -158,9 +156,7 @@ functions › lam_destructure_7
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $2)
             )
@@ -191,9 +187,7 @@ functions › lam_destructure_7
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $2)
          )
@@ -281,56 +275,43 @@ functions › lam_destructure_7
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (local.set $1
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
         )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
        )
       )
       (local.set $2
@@ -345,7 +326,12 @@ functions › lam_destructure_7
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
                (i32.const 16)
               )
-              (local.get $0)
+              (tuple.extract 0
+               (tuple.make
+                (local.get $1)
+                (local.get $0)
+               )
+              )
              )
             )
            )
@@ -418,7 +404,7 @@ functions › lam_destructure_7
         )
        )
       )
-      (call $lam_lambda_1157
+      (call $lam_lambda_1159
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -6,7 +6,7 @@ functions › shorthand_2
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › shorthand_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -31,9 +32,7 @@ functions › shorthand_2
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=16
-           (local.get $0)
-          )
+          (global.get $gimport_pervasives_+)
          )
          (i32.const 0)
         )
@@ -68,82 +67,67 @@ functions › shorthand_2
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
+             (i32.const 0)
             )
            )
           )
-          (local.get $0)
+          (i32.const 7)
          )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $foo_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
-       (i32.const 3)
       )
      )
-     (local.get $0)
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (call $foo_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
+      )
+      (i32.const 3)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_4
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › lam_destructure_4
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -87,9 +88,7 @@ functions › lam_destructure_4
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -120,9 +119,7 @@ functions › lam_destructure_4
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $2)
          )
@@ -186,64 +183,58 @@ functions › lam_destructure_4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (global.set $global_0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (global.get $global_0)
+         )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -286,14 +277,14 @@ functions › lam_destructure_4
         )
        )
       )
-      (call $foo_1153
+      (call $foo_1155
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (global.get $global_0)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -305,12 +296,6 @@ functions › lam_destructure_4
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_8
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › lam_destructure_8
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -122,9 +123,7 @@ functions › lam_destructure_8
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -158,9 +157,7 @@ functions › lam_destructure_8
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $2)
             )
@@ -191,9 +188,7 @@ functions › lam_destructure_8
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $2)
          )
@@ -276,64 +271,58 @@ functions › lam_destructure_8
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (global.set $global_0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (global.get $global_0)
+         )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -372,7 +361,7 @@ functions › lam_destructure_8
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -406,7 +395,7 @@ functions › lam_destructure_8
            (local.get $0)
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (local.get $2)
+            (local.get $1)
            )
           )
           (local.get $0)
@@ -418,14 +407,14 @@ functions › lam_destructure_8
         )
        )
       )
-      (call $foo_1153
+      (call $foo_1155
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (global.get $global_0)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
+        (local.get $2)
        )
       )
      )
@@ -443,12 +432,6 @@ functions › lam_destructure_8
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -5,7 +5,7 @@ functions › lam_destructure_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1183)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1185)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -18,7 +18,7 @@ functions › lam_destructure_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1183 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1185 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -120,7 +120,7 @@ functions › lam_destructure_1
         )
        )
       )
-      (call $lam_lambda_1183
+      (call $lam_lambda_1185
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -5,7 +5,7 @@ functions › lam_destructure_2
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -13,12 +13,13 @@ functions › lam_destructure_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -36,12 +37,11 @@ functions › lam_destructure_2
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -75,12 +75,20 @@ functions › lam_destructure_2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -92,12 +100,7 @@ functions › lam_destructure_2
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
                (i32.const 16)
               )
-              (tuple.extract 0
-               (tuple.make
-                (local.get $1)
-                (local.get $0)
-               )
-              )
+              (local.get $0)
              )
             )
            )
@@ -120,14 +123,14 @@ functions › lam_destructure_2
         )
        )
       )
-      (call $foo_1153
+      (call $foo_1155
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (global.get $global_0)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -139,12 +142,6 @@ functions › lam_destructure_2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -6,7 +6,7 @@ functions › func_record_associativity2
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1163)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1165)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -20,7 +20,7 @@ functions › func_record_associativity2
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1163 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $lam_lambda_1165 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -73,7 +73,7 @@ functions › func_record_associativity2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -85,7 +85,7 @@ functions › func_record_associativity2
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477890)
+            (i64.const 68719477892)
            )
            (i64.store offset=56
             (local.get $0)
@@ -187,7 +187,7 @@ functions › func_record_associativity2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -236,7 +236,7 @@ functions › func_record_associativity2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -6,7 +6,7 @@ functions › fn_trailing_comma
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $testFn_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $testFn_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › fn_trailing_comma
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $testFn_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $testFn_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -31,9 +32,7 @@ functions › fn_trailing_comma
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=16
-           (local.get $0)
-          )
+          (global.get $gimport_pervasives_+)
          )
          (i32.const 0)
         )
@@ -77,83 +76,68 @@ functions › fn_trailing_comma
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
-              )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 3)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
+             (i32.const 0)
             )
            )
           )
-          (local.get $0)
+          (i32.const 7)
          )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $testFn_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
-       )
-       (i32.const 5)
-       (i32.const 7)
       )
      )
-     (local.get $0)
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
+     )
+     (call $testFn_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
+      )
+      (i32.const 5)
+      (i32.const 7)
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_6
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -15,12 +15,13 @@ functions › lam_destructure_6
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $foo_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -123,9 +124,7 @@ functions › lam_destructure_6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (i32.const 0)
             )
@@ -159,9 +158,7 @@ functions › lam_destructure_6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $3)
             )
@@ -195,9 +192,7 @@ functions › lam_destructure_6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=16
-               (local.get $0)
-              )
+              (global.get $gimport_pervasives_+)
              )
              (local.get $3)
             )
@@ -228,9 +223,7 @@ functions › lam_destructure_6
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (global.get $gimport_pervasives_+)
           )
           (local.get $3)
          )
@@ -325,64 +318,58 @@ functions › lam_destructure_6
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (global.set $global_0
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 3)
-              )
-              (i32.store offset=8
-               (local.get $0)
-               (global.get $wimport__grainEnv_relocBase)
-              )
-              (i32.store offset=12
-               (local.get $0)
-               (i32.const 1)
-              )
-              (local.get $0)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 3)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (global.get $wimport__grainEnv_relocBase)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 0)
           )
           (local.get $0)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (global.get $global_0)
+         )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+      )
+      (local.set $0
+       (tuple.extract 0
+        (tuple.make
+         (global.get $global_0)
+         (local.get $0)
+        )
        )
       )
-      (local.set $2
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -425,7 +412,7 @@ functions › lam_destructure_6
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -464,7 +451,11 @@ functions › lam_destructure_6
         )
        )
       )
-      (call $foo_1153
+      (call $foo_1155
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $global_0)
+       )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)
@@ -472,10 +463,6 @@ functions › lam_destructure_6
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $2)
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
        )
       )
      )
@@ -493,12 +480,6 @@ functions › lam_destructure_6
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -6,7 +6,7 @@ functions › func_record_associativity1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1159)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1161)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -20,7 +20,7 @@ functions › func_record_associativity1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1159 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $lam_lambda_1161 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -71,7 +71,7 @@ functions › func_record_associativity1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -173,7 +173,7 @@ functions › func_record_associativity1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_division1
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $gimport_pervasives_/ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 153)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_division1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,45 +67,33 @@ let mut › let-mut_division1
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (i32.const 1879048190)
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_multiplication2
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $gimport_pervasives_* (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_multiplication2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_multiplication2
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -11,113 +11,62 @@ let mut › let-mut3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 12)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 12)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 8)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 1)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 9)
-          )
+          (i32.const 8)
+         )
+         (i32.store offset=4
           (local.get $0)
+          (i32.const 1)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 9)
          )
+         (local.get $0)
         )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $1)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $2)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $3)
        )
       )
      )
-     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (global.get $global_0)
+      )
+     )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_division3
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $gimport_pervasives_/ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 153)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_division3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_division3
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut5
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut5
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 3)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut5
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -11,16 +11,15 @@ let mut › let-mut2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -64,7 +63,7 @@ let mut › let-mut2
         )
        )
       )
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -101,28 +100,14 @@ let mut › let-mut2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $2)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (global.get $global_0)
       )
      )
      (local.get $0)
@@ -133,18 +118,6 @@ let mut › let-mut2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_multiplication1
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $gimport_pervasives_* (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_multiplication1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,45 +67,33 @@ let mut › let-mut_multiplication1
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (i32.const 1879048190)
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_multiplication3
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $gimport_pervasives_* (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_multiplication3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_multiplication3
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -9,56 +9,46 @@ let mut › let-mut4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 9)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 9)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
-      )
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 7)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
-         )
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
       )
      )
-     (i32.const 0)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 7)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_0)
+     )
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_subtraction1
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_subtraction1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,45 +67,33 @@ let mut › let-mut_subtraction1
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (i32.const 1879048190)
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_subtraction2
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_subtraction2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_subtraction2
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_addition2
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_addition2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_addition2
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_addition1
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_addition1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,45 +67,33 @@ let mut › let-mut_addition1
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (i32.const 1879048190)
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_subtraction3
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_subtraction3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_subtraction3
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_addition3
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_addition3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_addition3
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -12,50 +12,35 @@ let mut › let-mut_division2
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $gimport_pervasives_/ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 153)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,11 +53,11 @@ let mut › let-mut_division2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.const 39)
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,48 +67,36 @@ let mut › let-mut_division2
         )
        )
       )
-      (local.set $0
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $3)
+          (local.get $1)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $0)
+          (global.get $global_0)
          )
         )
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
+       (global.get $global_0)
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -9,45 +9,35 @@ let mut › let-mut1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $0
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 9)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (i32.const 9)
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
-      )
      )
-     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_0)
+     )
     )
+    (i32.const 0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -13,16 +13,16 @@ lists › list_spread
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $gimport_pervasives_[...] (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -58,7 +58,7 @@ lists › list_spread
         )
        )
       )
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -84,12 +84,12 @@ lists › list_spread
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -107,7 +107,7 @@ lists › list_spread
           (i32.const 5)
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (i32.load offset=8
            (local.get $0)
@@ -135,7 +135,7 @@ lists › list_spread
        (i32.const 3)
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
+        (local.get $2)
        )
        (i32.load offset=8
         (local.get $0)
@@ -156,12 +156,6 @@ lists › list_spread
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -16,11 +16,13 @@ loops › loop2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
@@ -28,13 +30,11 @@ loops › loop2
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -64,12 +64,12 @@ loops › loop2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -99,7 +99,7 @@ loops › loop2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -113,7 +113,7 @@ loops › loop2
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (i32.load offset=8
-              (local.get $2)
+              (global.get $global_0)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -160,7 +160,7 @@ loops › loop2
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (i32.load offset=8
-              (local.get $2)
+              (global.get $global_0)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -170,7 +170,7 @@ loops › loop2
            )
           )
          )
-         (local.set $4
+         (local.set $2
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -196,27 +196,27 @@ loops › loop2
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $4)
+             (local.get $2)
             )
            )
           )
          )
-         (local.set $7
+         (local.set $5
           (tuple.extract 0
            (tuple.make
             (block (result i32)
              (i32.store offset=8
-              (local.get $2)
+              (global.get $global_0)
               (tuple.extract 0
                (tuple.make
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $4)
+                 (local.get $2)
                 )
                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
                  (i32.load offset=8
-                  (local.get $2)
+                  (global.get $global_0)
                  )
                 )
                )
@@ -224,27 +224,27 @@ loops › loop2
              )
              (i32.const 1879048190)
             )
-            (local.get $7)
+            (local.get $5)
            )
           )
          )
-         (local.set $5
+         (local.set $3
           (tuple.extract 0
            (tuple.make
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (i32.load offset=8
-              (local.get $3)
+              (global.get $global_1)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $5)
+             (local.get $3)
             )
            )
           )
          )
-         (local.set $6
+         (local.set $4
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -261,7 +261,7 @@ loops › loop2
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $5)
+              (local.get $3)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -270,23 +270,23 @@ loops › loop2
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $6)
+             (local.get $4)
             )
            )
           )
          )
          (i32.store offset=8
-          (local.get $3)
+          (global.get $global_1)
           (tuple.extract 0
            (tuple.make
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $4)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
              (i32.load offset=8
-              (local.get $3)
+              (global.get $global_1)
              )
             )
            )
@@ -299,12 +299,18 @@ loops › loop2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $3)
+        (global.get $global_1)
        )
       )
      )
      (local.get $0)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
    )
   )
   (drop
@@ -322,25 +328,7 @@ loops › loop2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -14,41 +14,39 @@ loops › loop5
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $3
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 25)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $4
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (i32.const 1)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -57,20 +55,6 @@ loops › loop5
        (loop $MFor_loop.6 (result i32)
         (block $MFor.5 (result i32)
          (local.set $1
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $1)
-            )
-           )
-          )
-         )
-         (local.set $2
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -87,7 +71,7 @@ loops › loop5
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $1)
+              (global.get $global_0)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -96,46 +80,32 @@ loops › loop5
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $2)
+             (local.get $1)
             )
            )
           )
          )
-         (local.set $6
+         (local.set $2
           (tuple.extract 0
            (tuple.make
             (block (result i32)
-             (local.set $3
+             (global.set $global_0
               (tuple.extract 0
                (tuple.make
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $2)
+                 (local.get $1)
                 )
                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (local.get $3)
+                 (global.get $global_0)
                 )
                )
               )
              )
              (i32.const 1879048190)
             )
-            (local.get $6)
-           )
-          )
-         )
-         (local.set $5
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $5)
-            )
+            (local.get $2)
            )
           )
          )
@@ -158,7 +128,7 @@ loops › loop5
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
+               (global.get $global_0)
               )
               (i32.const 1)
               (i32.load offset=8
@@ -171,20 +141,6 @@ loops › loop5
           )
          )
          (local.set $1
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $1)
-            )
-           )
-          )
-         )
-         (local.set $2
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -201,7 +157,7 @@ loops › loop5
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $1)
+              (global.get $global_1)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -210,21 +166,21 @@ loops › loop5
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $2)
+             (local.get $1)
             )
            )
           )
          )
-         (local.set $4
+         (global.set $global_1
           (tuple.extract 0
            (tuple.make
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
+             (local.get $1)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $4)
+             (global.get $global_1)
             )
            )
           )
@@ -235,7 +191,7 @@ loops › loop5
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (global.get $global_1)
       )
      )
      (local.get $0)
@@ -245,37 +201,7 @@ loops › loop5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (i32.const 0)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -13,27 +13,26 @@ loops › loop3
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 7)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
@@ -41,20 +40,6 @@ loops › loop3
       (drop
        (loop $MFor_loop.4 (result i32)
         (block $MFor.3 (result i32)
-         (local.set $2
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $1)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $2)
-            )
-           )
-          )
-         )
          (drop
           (br_if $MFor.3
            (i32.const 1879048190)
@@ -74,7 +59,7 @@ loops › loop3
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $2)
+               (global.get $global_0)
               )
               (i32.const 1)
               (i32.load offset=8
@@ -86,21 +71,7 @@ loops › loop3
            )
           )
          )
-         (local.set $2
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $1)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $2)
-            )
-           )
-          )
-         )
-         (local.set $3
+         (local.set $1
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -117,7 +88,7 @@ loops › loop3
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $2)
+              (global.get $global_0)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -126,21 +97,21 @@ loops › loop3
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $3)
+             (local.get $1)
             )
            )
           )
          )
-         (local.set $1
+         (global.set $global_0
           (tuple.extract 0
            (tuple.make
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $1)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $1)
+             (global.get $global_0)
             )
            )
           )
@@ -151,7 +122,7 @@ loops › loop3
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (global.get $global_0)
       )
      )
      (local.get $0)
@@ -162,24 +133,6 @@ loops › loop3
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (i32.const 0)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -14,42 +14,40 @@ loops › loop4
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (i32.const 25)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (i32.const 1)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -57,20 +55,6 @@ loops › loop4
       (drop
        (loop $MFor_loop.6 (result i32)
         (block $MFor.5 (result i32)
-         (local.set $1
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $1)
-            )
-           )
-          )
-         )
          (drop
           (br_if $MFor.5
            (i32.const 1879048190)
@@ -90,7 +74,7 @@ loops › loop4
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $1)
+               (global.get $global_0)
               )
               (i32.const 1)
               (i32.load offset=8
@@ -103,20 +87,6 @@ loops › loop4
           )
          )
          (local.set $1
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $1)
-            )
-           )
-          )
-         )
-         (local.set $4
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -133,7 +103,7 @@ loops › loop4
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $1)
+              (global.get $global_0)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -142,50 +112,36 @@ loops › loop4
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $4)
+             (local.get $1)
             )
            )
           )
          )
-         (local.set $7
+         (local.set $3
           (tuple.extract 0
            (tuple.make
             (block (result i32)
-             (local.set $2
+             (global.set $global_0
               (tuple.extract 0
                (tuple.make
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $4)
+                 (local.get $1)
                 )
                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                 (local.get $2)
+                 (global.get $global_0)
                 )
                )
               )
              )
              (i32.const 1879048190)
             )
-            (local.get $7)
+            (local.get $3)
            )
           )
          )
-         (local.set $5
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
-            )
-            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $5)
-            )
-           )
-          )
-         )
-         (local.set $6
+         (local.set $2
           (tuple.extract 0
            (tuple.make
             (call_indirect (type $i32_i32_i32_=>_i32)
@@ -202,7 +158,7 @@ loops › loop4
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (local.get $5)
+              (global.get $global_1)
              )
              (i32.const 3)
              (i32.load offset=8
@@ -211,21 +167,21 @@ loops › loop4
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $6)
+             (local.get $2)
             )
            )
           )
          )
-         (local.set $3
+         (global.set $global_1
           (tuple.extract 0
            (tuple.make
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $2)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-             (local.get $3)
+             (global.get $global_1)
             )
            )
           )
@@ -236,23 +192,11 @@ loops › loop4
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (global.get $global_1)
       )
      )
      (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (drop
@@ -264,25 +208,7 @@ loops › loop4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (i32.const 0)
+    (local.get $2)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -6,7 +6,7 @@ optimizations › trs1
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $f1_1153)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $f1_1155)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -14,12 +14,13 @@ optimizations › trs1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 1))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $f1_1153 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (func $f1_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -54,75 +55,68 @@ optimizations › trs1
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 16)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 7)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (global.get $wimport__grainEnv_relocBase)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 0)
-          )
-          (local.get $0)
+          (i32.const 7)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 3)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $f1_1153
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
        )
-       (i32.const 3)
-       (i32.const 5)
       )
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
+     (call $f1_1155
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_0)
       )
+      (i32.const 3)
+      (i32.const 5)
      )
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -14,22 +14,22 @@ optimizations › test_dead_branch_elimination_5
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $1
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -59,12 +59,12 @@ optimizations › test_dead_branch_elimination_5
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $2
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -94,46 +94,46 @@ optimizations › test_dead_branch_elimination_5
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
       )
       (i32.store offset=8
-       (local.get $1)
+       (global.get $global_0)
        (tuple.extract 0
         (tuple.make
          (i32.const 7)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
         )
        )
       )
       (i32.store offset=8
-       (local.get $2)
+       (global.get $global_1)
        (tuple.extract 0
         (tuple.make
          (i32.const 9)
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
           (i32.load offset=8
-           (local.get $2)
+           (global.get $global_1)
           )
          )
         )
        )
       )
-      (local.set $3
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $1)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -143,13 +143,13 @@ optimizations › test_dead_branch_elimination_5
         )
        )
       )
-      (local.set $4
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
-           (local.get $2)
+           (global.get $global_1)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -173,11 +173,11 @@ optimizations › test_dead_branch_elimination_5
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
+        (local.get $1)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
+        (local.get $2)
        )
        (i32.load offset=8
         (local.get $0)
@@ -198,18 +198,6 @@ optimizations › test_dead_branch_elimination_5
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -62,7 +62,7 @@ pattern matching › record_match_3
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -136,7 +136,7 @@ pattern matching › record_match_3
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -65,7 +65,7 @@ pattern matching › adt_match_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -123,7 +123,7 @@ pattern matching › adt_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -58,7 +58,7 @@ pattern matching › record_match_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ pattern matching › record_match_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -58,7 +58,7 @@ pattern matching › record_match_1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ pattern matching › record_match_1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -64,7 +64,7 @@ pattern matching › record_match_4
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ pattern matching › record_match_4
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -59,7 +59,7 @@ pattern matching › record_match_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -71,7 +71,7 @@ pattern matching › record_match_deep
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477890)
+            (i64.const 68719477892)
            )
            (i64.store offset=56
             (local.get $0)
@@ -129,7 +129,7 @@ pattern matching › record_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -175,7 +175,7 @@ pattern matching › record_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -62,7 +62,7 @@ records › record_get_multiple
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -128,7 +128,7 @@ records › record_get_multiple
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -51,7 +51,7 @@ records › record_definition_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_definition_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_pun
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -58,7 +58,7 @@ records › record_destruct_1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ records › record_destruct_1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -15,18 +15,18 @@ records › record_destruct_4
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_4 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_4))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -64,7 +64,7 @@ records › record_destruct_4
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_4
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -165,7 +165,7 @@ records › record_destruct_4
         )
        )
       )
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -176,12 +176,12 @@ records › record_destruct_4
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -192,12 +192,12 @@ records › record_destruct_4
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
       )
-      (local.set $4
+      (global.set $global_2
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -208,12 +208,12 @@ records › record_destruct_4
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_2)
          )
         )
        )
       )
-      (local.set $5
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -230,11 +230,11 @@ records › record_destruct_4
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (global.get $global_1)
           )
           (i32.load offset=8
            (local.get $0)
@@ -261,11 +261,11 @@ records › record_destruct_4
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $5)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
+        (global.get $global_2)
        )
        (i32.load offset=8
         (local.get $0)
@@ -286,24 +286,6 @@ records › record_destruct_4
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -51,7 +51,7 @@ records › record_value_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_value_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -63,7 +63,7 @@ records › record_recursive_data_definition
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477890)
+            (i64.const 68719477892)
            )
            (i64.store offset=32
             (local.get $0)
@@ -75,7 +75,7 @@ records › record_recursive_data_definition
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=56
             (local.get $0)
@@ -133,7 +133,7 @@ records › record_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)
@@ -182,7 +182,7 @@ records › record_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -58,7 +58,7 @@ records › record_destruct_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ records › record_destruct_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_pun_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -12,16 +12,16 @@ records › record_destruct_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -59,7 +59,7 @@ records › record_destruct_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -71,7 +71,7 @@ records › record_destruct_deep
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477890)
+            (i64.const 68719477892)
            )
            (i64.store offset=56
             (local.get $0)
@@ -129,7 +129,7 @@ records › record_destruct_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -175,7 +175,7 @@ records › record_destruct_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)
@@ -197,7 +197,7 @@ records › record_destruct_deep
         )
        )
       )
-      (local.set $3
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -208,7 +208,7 @@ records › record_destruct_deep
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
@@ -216,7 +216,7 @@ records › record_destruct_deep
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=16
-        (local.get $3)
+        (global.get $global_0)
        )
       )
      )
@@ -234,12 +234,6 @@ records › record_destruct_deep
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -15,16 +15,16 @@ records › record_destruct_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -62,7 +62,7 @@ records › record_destruct_3
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -136,7 +136,7 @@ records › record_destruct_3
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -163,7 +163,7 @@ records › record_destruct_3
         )
        )
       )
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -174,12 +174,12 @@ records › record_destruct_3
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -190,7 +190,7 @@ records › record_destruct_3
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -209,11 +209,11 @@ records › record_destruct_3
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (global.get $global_0)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $3)
+        (global.get $global_1)
        )
        (i32.load offset=8
         (local.get $0)
@@ -228,18 +228,6 @@ records › record_destruct_3
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -59,7 +59,7 @@ records › record_get_multilevel
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -79,7 +79,7 @@ records › record_get_multilevel
            )
            (i64.store offset=64
             (local.get $0)
-            (i64.const 68719477890)
+            (i64.const 68719477892)
            )
            (i64.store offset=72
             (local.get $0)
@@ -137,7 +137,7 @@ records › record_get_multilevel
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -187,7 +187,7 @@ records › record_get_multilevel
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2309)
+           (i32.const 2313)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_definition_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_definition_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -57,7 +57,7 @@ records › record_get_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -115,7 +115,7 @@ records › record_get_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -15,18 +15,18 @@ records › record_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_4 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_4))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -64,7 +64,7 @@ records › record_destruct_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_trailing
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -165,7 +165,7 @@ records › record_destruct_trailing
         )
        )
       )
-      (local.set $2
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -176,12 +176,12 @@ records › record_destruct_trailing
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $3
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -192,12 +192,12 @@ records › record_destruct_trailing
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
       )
-      (local.set $4
+      (global.set $global_2
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -208,12 +208,12 @@ records › record_destruct_trailing
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_2)
          )
         )
        )
       )
-      (local.set $5
+      (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
@@ -230,11 +230,11 @@ records › record_destruct_trailing
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (global.get $global_0)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (global.get $global_1)
           )
           (i32.load offset=8
            (local.get $0)
@@ -261,11 +261,11 @@ records › record_destruct_trailing
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $5)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $4)
+        (global.get $global_2)
        )
        (i32.load offset=8
         (local.get $0)
@@ -286,24 +286,6 @@ records › record_destruct_trailing
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_2
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_both_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_both_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -51,7 +51,7 @@ records › record_both_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_both_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_multiple
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_multiple
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_multiple_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_multiple_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_value_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_value_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2307)
+       (i32.const 2311)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_2_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477889)
+           (i64.const 68719477891)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_2_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2307)
+      (i32.const 2311)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_20
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_20
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_20
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_19
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_19
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_19
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_21
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_21
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_21
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_22
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477889)
+            (i64.const 68719477891)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_22
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_22
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2307)
+           (i32.const 2311)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -11,17 +11,17 @@ tuples › nested_tup_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -104,7 +104,7 @@ tuples › nested_tup_3
         )
        )
       )
-      (local.set $3
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -144,23 +144,23 @@ tuples › nested_tup_3
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $4
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=12
-           (local.get $3)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -168,7 +168,7 @@ tuples › nested_tup_3
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $4)
+        (global.get $global_1)
        )
       )
      )
@@ -186,18 +186,6 @@ tuples › nested_tup_3
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -11,16 +11,16 @@ tuples › nested_tup_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -103,7 +103,7 @@ tuples › nested_tup_1
         )
        )
       )
-      (local.set $3
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -143,7 +143,7 @@ tuples › nested_tup_1
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
@@ -151,7 +151,7 @@ tuples › nested_tup_1
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=8
-        (local.get $3)
+        (global.get $global_0)
        )
       )
      )
@@ -169,12 +169,6 @@ tuples › nested_tup_1
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -11,83 +11,74 @@ tuples › big_tup_access
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (local.set $1
-       (tuple.extract 0
-        (tuple.make
-         (block (result i32)
-          (i32.store
-           (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-               (i32.const 24)
-              )
-              (i32.const 0)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 24)
              )
+             (i32.const 0)
             )
            )
-           (i32.const 8)
           )
-          (i32.store offset=4
-           (local.get $0)
-           (i32.const 4)
-          )
-          (i32.store offset=8
-           (local.get $0)
-           (i32.const 3)
-          )
-          (i32.store offset=12
-           (local.get $0)
-           (i32.const 5)
-          )
-          (i32.store offset=16
-           (local.get $0)
-           (i32.const 7)
-          )
-          (i32.store offset=20
-           (local.get $0)
-           (i32.const 9)
-          )
+          (i32.const 8)
+         )
+         (i32.store offset=4
           (local.get $0)
+          (i32.const 4)
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+         (i32.store offset=8
+          (local.get $0)
+          (i32.const 3)
          )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 5)
+         )
+         (i32.store offset=16
+          (local.get $0)
+          (i32.const 7)
+         )
+         (i32.store offset=20
+          (local.get $0)
+          (i32.const 9)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=16
-        (local.get $1)
-       )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (global.get $global_0)
       )
      )
-     (local.get $0)
     )
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -11,17 +11,17 @@ tuples › nested_tup_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -104,7 +104,7 @@ tuples › nested_tup_2
         )
        )
       )
-      (local.set $3
+      (global.set $global_0
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -144,23 +144,23 @@ tuples › nested_tup_2
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_0)
          )
         )
        )
       )
-      (local.set $4
+      (global.set $global_1
        (tuple.extract 0
         (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=12
-           (local.get $3)
+           (global.get $global_0)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
+          (global.get $global_1)
          )
         )
        )
@@ -168,7 +168,7 @@ tuples › nested_tup_2
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (i32.load offset=12
-        (local.get $4)
+        (global.get $global_1)
        )
       )
      )
@@ -186,18 +186,6 @@ tuples › nested_tup_2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (local.get $0)

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -280,6 +280,8 @@ let setInArray = array => {
     array[i] = (key, value)
     // no decRef on key and value, since they are stored in array
     Memory.decRef(WasmI32.fromGrain(iter))
+    Memory.incRef(WasmI32.fromGrain((+)))
+    Memory.incRef(WasmI32.fromGrain(i))
     i + 1
   }
   iter


### PR DESCRIPTION
This PR prevents global values from appearing in closures (in memory).