### PR TITLE
feat(stdlib): Convert runtime printing utils to @unsafe

### DIFF
--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -100,22 +100,6 @@ export let allocateString = size => {
 }
 
 /**
- * Creates a new Grain string containing the given character
- *
- * @param {WasmI32} c The character for which to allocate a string
- * @returns {WasmI32} The pointer to the string
- */
-export let singleByteString = c => {
-  let str = Memory.malloc(9n)
-
-  WasmI32.store(str, Tags._GRAIN_STRING_HEAP_TAG, 0n)
-  WasmI32.store(str, 1n, 4n)
-  WasmI32.store8(str, c, 8n)
-
-  str
-}
-
-/**
  * Allocates a new Grain char.
  *
  * @returns {WasmI32} The pointer to the char

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -45,8 +45,18 @@ primitive unbox: Box<a> -> a = "@unbox"
 
 exception DecRefError
 
-export let decimalCount32 = box((n: WasmI32) => 0n)
-export let utoa32Buffered = box((a: WasmI32, b: WasmI32, c: WasmI32) => void)
+let decimalCount32Dummy = (n: WasmI32) => 0n
+let utoa32BufferedDummy = (a: WasmI32, b: WasmI32, c: WasmI32) => void
+
+// When these boxes are backpatched, the reference count of each function will
+// fall to zero which would cause them to be freed. We can't free anything that
+// got allocated in runtime mode (since that memory space is not managed by the
+// GC, so here we prevent that by manually setting a higher refcount.
+WasmI32.store(WasmI32.fromGrain(decimalCount32Dummy) - 8n, 2n, 0n)
+WasmI32.store(WasmI32.fromGrain(utoa32BufferedDummy) - 8n, 2n, 0n)
+
+export let decimalCount32 = box(decimalCount32Dummy)
+export let utoa32Buffered = box(utoa32BufferedDummy)
 
 let mut _DEBUG = false
 

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -1,4 +1,4 @@
-/* grainc-flags --compilation-mode=runtime */
+/* grainc-flags --no-pervasives */
 
 /*
  * This file was inspired by AssemblyScript's std/assembly/util/number.ts
@@ -18,25 +18,34 @@ import WasmI32, {
 import WasmI64 from "runtime/unsafe/wasmi64"
 import WasmF64 from "runtime/unsafe/wasmf64"
 import Exception from "runtime/exception"
-import { allocateString, singleByteString } from "runtime/dataStructures"
+import { allocateString } from "runtime/dataStructures"
 
 primitive (!): Bool -> Bool = "@not"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 primitive throw: Exception -> a = "@throw"
 
+@unsafe
 export let _MAX_DOUBLE_LENGTH = 28n
 
+@unsafe
 let _CHAR_CODE_0 = 0x30n
+@unsafe
 let _CHAR_CODE_e = 0x65n
+@unsafe
 let _CHAR_CODE_PLUS = 0x2Bn
+@unsafe
 let _CHAR_CODE_MINUS = 0x2Dn
+@unsafe
 let _CHAR_CODE_DOT = 0x2En
 
+@unsafe
 let _I32_MAX = 0xffffffffN
 
+@unsafe
 let mut _POWERS10 = -1n
 
+@unsafe
 let get_POWERS10 = () => {
   if (_POWERS10 == -1n) {
     _POWERS10 = Memory.malloc(40n)
@@ -67,8 +76,10 @@ let get_POWERS10 = () => {
   "80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
   "90", "91", "92", "93", "94", "95", "96", "97", "98", "99"
 */
+@unsafe
 let mut _DIGITS = -1n
 
+@unsafe
 let get_DIGITS = () => {
   if (_DIGITS == -1n) {
     _DIGITS = Memory.malloc(200n)
@@ -177,8 +188,10 @@ let get_DIGITS = () => {
 }
 
 // Lookup table for pairwise char codes in range [0x00-0xFF]
+@unsafe
 let mut _HEX_DIGITS = -1n
 
+@unsafe
 export let get_HEX_DIGITS = () => {
   if (_HEX_DIGITS == -1n) {
     _HEX_DIGITS = Memory.malloc(512n)
@@ -457,8 +470,10 @@ export let get_HEX_DIGITS = () => {
   _HEX_DIGITS
 }
 
+@unsafe
 let mut _ANY_DIGITS = -1n
 
+@unsafe
 let get_ANY_DIGITS = () => {
   if (_ANY_DIGITS == -1n) {
     _ANY_DIGITS = Memory.malloc(36n)
@@ -502,8 +517,10 @@ let get_ANY_DIGITS = () => {
   _ANY_DIGITS
 }
 
+@unsafe
 let mut _EXP_POWERS = -1n
 
+@unsafe
 let get_EXP_POWERS = () => {
   if (_EXP_POWERS == -1n) {
     _EXP_POWERS = Memory.malloc(174n)
@@ -599,8 +616,10 @@ let get_EXP_POWERS = () => {
 }
 
 // 1e-348, 1e-340, ..., 1e340
+@unsafe
 let mut _FRC_POWERS = -1n
 
+@unsafe
 let get_FRC_POWERS = () => {
   if (_FRC_POWERS == -1n) {
     _FRC_POWERS = Memory.malloc(696n)
@@ -695,12 +714,14 @@ let get_FRC_POWERS = () => {
   _FRC_POWERS
 }
 
+@unsafe
 let isPowerOf2 = value => {
   WasmI32.popcnt(value) == 1n
 }
 
 // Count number of decimals for u32 values
 // In our case input value always non-zero so we can simplify some parts
+@unsafe
 export let decimalCount32 = value => {
   if (WasmI32.ltU(value, 100000n)) {
     if (WasmI32.ltU(value, 100n)) {
@@ -723,6 +744,7 @@ export let decimalCount32 = value => {
 
 // Count number of decimals for u64 values
 // In our case input value always greater than 2^32-1 so we can skip some parts
+@unsafe
 let decimalCount64High = value => {
   if (WasmI64.ltU(value, 1000000000000000N)) {
     if (WasmI64.ltU(value, 1000000000000N)) {
@@ -745,6 +767,7 @@ let decimalCount64High = value => {
   }
 }
 
+@unsafe
 let ulog_base = (num, base) => {
   if (isPowerOf2(base)) {
     WasmI32.divU(
@@ -770,6 +793,7 @@ let ulog_base = (num, base) => {
   }
 }
 
+@unsafe
 let utoa32_dec_lut = (buffer, num, offset) => {
   let mut num = num
   let mut offset = offset
@@ -809,6 +833,7 @@ let utoa32_dec_lut = (buffer, num, offset) => {
   }
 }
 
+@unsafe
 let utoa64_dec_lut = (buffer, num, offset) => {
   let mut num = num
   let mut offset = offset
@@ -841,6 +866,7 @@ let utoa64_dec_lut = (buffer, num, offset) => {
   utoa32_dec_lut(buffer, WasmI32.wrapI64(num), offset)
 }
 
+@unsafe
 let utoa_hex_lut = (buffer, num, offset) => {
   let lut = get_HEX_DIGITS()
   let mut num = num
@@ -863,22 +889,27 @@ let utoa_hex_lut = (buffer, num, offset) => {
   }
 }
 
+@unsafe
 let utoa32_dec_core = (buffer, num, offset) => {
   utoa32_dec_lut(buffer, num, offset)
 }
 
+@unsafe
 let utoa32_hex_core = (buffer, num, offset) => {
   utoa_hex_lut(buffer, WasmI64.extendI32U(num), offset)
 }
 
+@unsafe
 let utoa64_dec_core = (buffer, num, offset) => {
   utoa64_dec_lut(buffer, num, offset)
 }
 
+@unsafe
 let utoa64_hex_core = (buffer, num, offset) => {
   utoa_hex_lut(buffer, num, offset)
 }
 
+@unsafe
 let utoa64_any_core = (buffer, num, offset, radix) => {
   let lut = get_ANY_DIGITS()
   let base = WasmI64.extendI32U(radix)
@@ -915,13 +946,14 @@ let utoa64_any_core = (buffer, num, offset, radix) => {
   }
 }
 
+@unsafe
 export let utoa32Buffered = (buf, value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
       "toString() radix argument must be between 2 and 36"
     )
   }
-  let str = if (WasmI32.eqz(value)) {
+  if (WasmI32.eqz(value)) {
     WasmI32.store8(buf, _CHAR_CODE_0, 0n)
   } else if (radix == 10n) {
     let decimals = decimalCount32(value)
@@ -936,33 +968,34 @@ export let utoa32Buffered = (buf, value, radix) => {
   }
 }
 
+@unsafe
 export let utoa32 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
       "toString() radix argument must be between 2 and 36"
     )
   }
-  let str = if (WasmI32.eqz(value)) {
-    singleByteString(_CHAR_CODE_0)
+  if (WasmI32.eqz(value)) {
+    "0"
   } else if (radix == 10n) {
     let decimals = decimalCount32(value)
     let out = allocateString(decimals)
     utoa32_dec_core(out, value, decimals)
-    out
+    WasmI32.toGrain(out): String
   } else if (radix == 16n) {
     let decimals = WasmI32.shrU(31n - WasmI32.clz(value), 2n) + 1n
     let out = allocateString(decimals)
     utoa32_hex_core(out, value, decimals)
-    out
+    WasmI32.toGrain(out): String
   } else {
     let decimals = ulog_base(WasmI64.extendI32U(value), radix)
     let out = allocateString(decimals)
     utoa64_any_core(out, WasmI64.extendI32U(value), decimals, radix)
-    out
+    WasmI32.toGrain(out): String
   }
-  WasmI32.toGrain(str): String
 }
 
+@unsafe
 export let itoa32 = (value, radix) => {
   let mut value = value
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
@@ -970,67 +1003,71 @@ export let itoa32 = (value, radix) => {
       "toString() radix argument must be between 2 and 36"
     )
   }
-  let mut out = 0n
   let sign = WasmI32.shrU(value, 31n)
 
   if (WasmI32.ne(sign, 0n)) value = 0n - value
 
-  if (WasmI32.eqz(value)) {
-    out = singleByteString(_CHAR_CODE_0)
+  let out = if (WasmI32.eqz(value)) {
+    "0"
   } else if (radix == 10n) {
     let decimals = decimalCount32(value) + sign
-    out = allocateString(decimals)
+    let out = allocateString(decimals)
     utoa32_dec_core(out + 8n, value, decimals)
+    WasmI32.toGrain(out): String
   } else if (radix == 16n) {
     let decimals = WasmI32.shrU(31n - WasmI32.clz(value), 2n) + 1n + sign
-    out = allocateString(decimals)
+    let out = allocateString(decimals)
     utoa32_hex_core(out + 8n, value, decimals)
+    WasmI32.toGrain(out): String
   } else {
     let val64 = WasmI64.extendI32U(value)
     let decimals = ulog_base(val64, radix) + sign
-    out = allocateString(decimals)
+    let out = allocateString(decimals)
     utoa64_any_core(out + 8n, val64, decimals, radix)
+    WasmI32.toGrain(out): String
   }
-  if (WasmI32.ne(sign, 0n)) WasmI32.store8(out, _CHAR_CODE_MINUS, 8n)
-  WasmI32.toGrain(out): String
+  if (WasmI32.ne(sign, 0n))
+    WasmI32.store8(WasmI32.fromGrain(out), _CHAR_CODE_MINUS, 8n)
+  out
 }
 
+@unsafe
 export let utoa64 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
       "toString() radix argument must be between 2 and 36"
     )
   }
-  let str = if (WasmI64.eqz(value)) {
-    singleByteString(_CHAR_CODE_0)
+  if (WasmI64.eqz(value)) {
+    "0"
   } else if (radix == 10n) {
     if (WasmI64.leU(value, _I32_MAX)) {
       let val32 = WasmI32.wrapI64(value)
       let decimals = decimalCount32(val32)
       let out = allocateString(decimals)
       utoa32_dec_core(out + 8n, val32, decimals)
-      out
+      WasmI32.toGrain(out): String
     } else {
       let decimals = decimalCount64High(value)
       let out = allocateString(decimals)
       utoa64_dec_core(out + 8n, value, decimals)
-      out
+      WasmI32.toGrain(out): String
     }
   } else if (radix == 16n) {
     let decimals = WasmI32.shrU(63n - WasmI32.wrapI64(WasmI64.clz(value)), 2n) +
       1n
     let out = allocateString(decimals)
     utoa64_hex_core(out + 8n, value, decimals)
-    out
+    WasmI32.toGrain(out): String
   } else {
     let decimals = ulog_base(value, radix)
     let out = allocateString(decimals)
     utoa64_any_core(out + 8n, value, decimals, radix)
-    out
+    WasmI32.toGrain(out): String
   }
-  WasmI32.toGrain(str): String
 }
 
+@unsafe
 export let itoa64 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
@@ -1039,41 +1076,46 @@ export let itoa64 = (value, radix) => {
   }
 
   let mut value = value
-  let mut out = 0n
 
   let sign = WasmI32.wrapI64(WasmI64.shrU(value, 63N))
   if (sign != 0n) value = WasmI64.sub(0N, value)
 
-  if (WasmI64.eqz(value)) {
-    out = singleByteString(_CHAR_CODE_0)
+  let out = if (WasmI64.eqz(value)) {
+    "0"
   } else if (radix == 10n) {
     if (WasmI64.leU(value, _I32_MAX)) {
       let val32 = WasmI32.wrapI64(value)
       let decimals = decimalCount32(val32) + sign
-      out = allocateString(decimals)
+      let out = allocateString(decimals)
       utoa32_dec_core(out + 8n, val32, decimals)
+      WasmI32.toGrain(out): String
     } else {
       let decimals = decimalCount64High(value) + sign
-      out = allocateString(decimals)
+      let out = allocateString(decimals)
       utoa64_dec_core(out + 8n, value, decimals)
+      WasmI32.toGrain(out): String
     }
   } else if (radix == 16n) {
     let decimals = WasmI32.shrU(63n - WasmI32.wrapI64(WasmI64.clz(value)), 2n) +
       1n +
       sign
-    out = allocateString(decimals)
+    let out = allocateString(decimals)
     utoa64_hex_core(out + 8n, value, decimals)
+    WasmI32.toGrain(out): String
   } else {
     let decimals = ulog_base(value, radix) + sign
-    out = allocateString(decimals)
+    let out = allocateString(decimals)
     utoa64_any_core(out + 8n, value, decimals, radix)
+    WasmI32.toGrain(out): String
   }
-  if (sign != 0n) WasmI32.store8(out, _CHAR_CODE_MINUS, 8n)
-  WasmI32.toGrain(out): String
+  if (sign != 0n) WasmI32.store8(WasmI32.fromGrain(out), _CHAR_CODE_MINUS, 8n)
+  out
 }
 
+@unsafe
 let mut _K = 0n
 
+@unsafe
 let umul64f = (u, v) => {
   let u0 = WasmI64.and(u, 0xFFFFFFFFN)
   let v0 = WasmI64.and(v, 0xFFFFFFFFN)
@@ -1093,10 +1135,12 @@ let umul64f = (u, v) => {
   WasmI64.add(WasmI64.add(WasmI64.mul(u1, v1), t), w)
 }
 
+@unsafe
 let umul64e = (e1, e2) => {
   e1 + e2 + 64n // where 64 is significand size
 }
 
+@unsafe
 let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
   let mut lastp = buffer + len - 1n
   let mut digit = WasmI32.load8U(lastp, 0n)
@@ -1116,6 +1160,7 @@ let grisuRound = (buffer, len, delta, rest, ten_kappa, wp_w) => {
   WasmI32.store8(lastp, digit, 0n)
 }
 
+@unsafe
 let genDigits = (buffer, w_frc, w_exp, mp_frc, mp_exp, delta, sign) => {
   let mut delta = delta
   let one_exp = 0n - mp_exp
@@ -1243,6 +1288,7 @@ let genDigits = (buffer, w_frc, w_exp, mp_frc, mp_exp, delta, sign) => {
   len
 }
 
+@unsafe
 let genExponent = (buffer, k) => {
   let mut k = k
   let sign = WasmI32.ltS(k, 0n)
@@ -1253,6 +1299,7 @@ let genExponent = (buffer, k) => {
   decimals
 }
 
+@unsafe
 let grisu2 = (value, buffer, sign) => {
   // frexp routine
   let uv = WasmI64.reinterpretF64(value)
@@ -1319,6 +1366,7 @@ let grisu2 = (value, buffer, sign) => {
   genDigits(buffer, w_frc, w_exp, wp_frc, wp_exp, delta, sign)
 }
 
+@unsafe
 let prettify = (buffer, length, k) => {
   let mut length = length
   let kk = length + k
@@ -1362,6 +1410,7 @@ let prettify = (buffer, length, k) => {
   }
 }
 
+@unsafe
 let dtoa_core = (buffer, value) => {
   let mut value = value
   let hasSign = WasmF64.lt(value, 0.W)
@@ -1375,8 +1424,10 @@ let dtoa_core = (buffer, value) => {
   len + sign
 }
 
+@unsafe
 let mut _dtoa_buf = -1n
 
+@unsafe
 let get_dtoa_buf = () => {
   if (_dtoa_buf == -1n) {
     _dtoa_buf = Memory.malloc(_MAX_DOUBLE_LENGTH)
@@ -1384,14 +1435,17 @@ let get_dtoa_buf = () => {
   _dtoa_buf
 }
 
+@unsafe
 let isFinite = value => {
   WasmF64.eq(WasmF64.sub(value, value), 0.W)
 }
 
+@unsafe
 let isNaN = value => {
   WasmF64.ne(value, value)
 }
 
+@unsafe
 export let dtoa = value => {
   let str = if (WasmF64.eq(value, 0.W)) {
     let ret = allocateString(3n)

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -37,21 +37,13 @@ primitive (&&): (Bool, Bool) -> Bool = "@and"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 
 enum StringList {
-  SLEmpty,
-  SLCons(String, StringList),
-}
-
-@disableGC
-let slConsDisableGc = (a, b) => {
-  Memory.incRef(WasmI32.fromGrain(SLCons))
-  Memory.incRef(WasmI32.fromGrain(a))
-  // for easier chaining, we don't incRef `b`
-  SLCons(a, b)
+  [],
+  [...](String, StringList),
 }
 
 primitive _RUNTIME_TYPE_METADATA_PTR: WasmI32 = "@heap.type_metadata"
 
-@disableGC
+@unsafe
 let findTypeMetadata = (moduleId, typeId) => {
   let mut metadataPtr = WasmI32.load(_RUNTIME_TYPE_METADATA_PTR, 0n)
   let mut modData = -1n
@@ -81,7 +73,7 @@ let findTypeMetadata = (moduleId, typeId) => {
   }
 }
 
-@disableGC
+@unsafe
 let getVariantName = variant => {
   let moduleId = WasmI32.load(variant, 4n) >> 1n
   let typeId = WasmI32.load(variant, 8n) >> 1n
@@ -112,7 +104,7 @@ let getVariantName = variant => {
   }
 }
 
-@disableGC
+@unsafe
 let getRecordFieldNames = record_ => {
   let moduleId = WasmI32.load(record_, 4n) >> 1n
   let typeId = WasmI32.load(record_, 8n) >> 1n
@@ -131,6 +123,7 @@ let getRecordFieldNames = record_ => {
     for (let mut i = 0n; i < arity; i += 1n) {
       let fieldLength = WasmI32.load(fields + fieldOffset, 4n)
       let fieldName = allocateString(fieldLength)
+      Memory.incRef(fieldName)
       Memory.copy(fieldName + 8n, fields + fieldOffset + 8n, fieldLength)
       WasmI32.store(fieldArray + i * 4n, fieldName, 8n)
 
@@ -141,29 +134,29 @@ let getRecordFieldNames = record_ => {
   }
 }
 
-@disableGC
+@unsafe
 let rec totalBytes = (acc, list) => {
   match (list) {
-    SLCons(hd, tl) =>
+    [hd, ...tl] =>
       totalBytes(acc + WasmI32.load(WasmI32.fromGrain(hd), 4n), tl),
-    SLEmpty => acc,
+    [] => acc,
   }
 }
 
-@disableGC
+@unsafe
 let rec writeStrings = (buf, list) => {
   match (list) {
-    SLCons(hd, tl) => {
+    [hd, ...tl] => {
       let hd = WasmI32.fromGrain(hd)
       let hdSize = WasmI32.load(hd, 4n)
       Memory.copy(buf, hd + 8n, hdSize)
       writeStrings(buf + hdSize, tl)
     },
-    SLEmpty => void,
+    [] => void,
   }
 }
 
-@disableGC
+@unsafe
 let join = list => {
   let len = totalBytes(0n, list)
   let str = allocateString(len)
@@ -171,21 +164,20 @@ let join = list => {
   WasmI32.toGrain(str): String
 }
 
-@disableGC
+@unsafe
 let reverse = list => {
-  @disableGC
+  @unsafe
   let rec iter = (list, acc) => {
     match (list) {
-      SLEmpty => acc,
-      SLCons(first, rest) => iter(rest, slConsDisableGc(first, acc)),
+      [] => acc,
+      [first, ...rest] => iter(rest, [first, ...acc]),
     }
   }
-  Memory.incRef(WasmI32.fromGrain(SLEmpty))
-  iter(list, SLEmpty)
+  iter(list, [])
 }
 
-@disableGC
-export let rec concat = (s1: String, s2: String) => {
+@unsafe
+export let concat = (s1: String, s2: String) => {
   let ptr1 = WasmI32.fromGrain(s1)
   let ptr2 = WasmI32.fromGrain(s2)
 
@@ -197,14 +189,10 @@ export let rec concat = (s1: String, s2: String) => {
   Memory.copy(newString + 8n, ptr1 + 8n, size1)
   Memory.copy(newString + 8n + size1, ptr2 + 8n, size2)
 
-  let ret = WasmI32.toGrain(newString): String
-  Memory.decRef(ptr1)
-  Memory.decRef(ptr2)
-  Memory.decRef(WasmI32.fromGrain(concat))
-  ret
+  WasmI32.toGrain(newString): String
 }
 
-@disableGC
+@unsafe
 let escape = (ptr, isString) => {
   let _SEQ_B = 0x08n
   let _SEQ_F = 0x0Cn
@@ -291,33 +279,31 @@ let escape = (ptr, isString) => {
   WasmI32.toGrain(escapedString): String
 }
 
-@disableGC
+@unsafe
 let escapeString = (s: String) => {
   escape(WasmI32.fromGrain(s), true)
 }
 
-@disableGC
+@unsafe
 let escapeChar = (c: Char) => {
   escape(WasmI32.fromGrain(c), false)
 }
 
-@disableGC
+@unsafe
 let isListVariant = (variant: String) => {
   // Only lists can start with `[`, so only need to check for that
   // Sort of a hack until we have a better solution
   WasmI32.load8U(WasmI32.fromGrain(variant), 8n) == 0x5Bn
 }
 
-@disableGC
+@unsafe
 let rec heapValueToString = (ptr, extraIndents, toplevel) => {
   let tag = WasmI32.load(ptr, 0n)
   match (tag) {
     t when t == Tags._GRAIN_STRING_HEAP_TAG => {
+      // In both cases, we incRef ptr so we can use it again via WasmI32.toGrain
+      Memory.incRef(ptr)
       if (toplevel) {
-        // We can just return the pointer since its already a string and
-        // doesn't need escaping in this case, but by convention its reference
-        // count needs to be incremented.
-        Memory.incRef(ptr)
         WasmI32.toGrain(ptr): String
       } else {
         escapeString(WasmI32.toGrain(ptr))
@@ -377,6 +363,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         Memory.copy(str + 8n, ptr + 4n, numBytes)
         WasmI32.toGrain(str): String
       } else {
+        // We incRef ptr so we can reuse it via WasmI32.toGrain
+        Memory.incRef(ptr)
         escapeChar(WasmI32.toGrain(ptr))
       }
     },
@@ -398,33 +386,22 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
           } else {
             let comspace = ", "
             let rparen = ")"
-            Memory.incRef(WasmI32.fromGrain(SLEmpty))
-            let mut strings = slConsDisableGc(rparen, SLEmpty)
+            let mut strings = [rparen]
             for (let mut i = variantArity * 4n - 4n; i >= 0n; i -= 4n) {
               let tmp = toStringHelp(
                 WasmI32.load(ptr + i, 20n),
                 extraIndents,
                 false
               )
-              strings = slConsDisableGc(tmp, strings)
-              Memory.decRef(WasmI32.fromGrain(tmp))
+              strings = [tmp, ...strings]
               if (i > 0n) {
-                strings = slConsDisableGc(comspace, strings)
+                strings = [comspace, ...strings]
               }
             }
-            Memory.incRef(WasmI32.fromGrain(variantName))
             let lparen = "("
-            strings = slConsDisableGc(
-              variantName,
-              slConsDisableGc(lparen, strings)
-            )
-            let string = join(strings)
-            Memory.decRef(WasmI32.fromGrain(variantName))
-            Memory.decRef(WasmI32.fromGrain(lparen))
-            Memory.decRef(WasmI32.fromGrain(rparen))
-            Memory.decRef(WasmI32.fromGrain(strings))
-            Memory.decRef(WasmI32.fromGrain(comspace))
-            string
+            strings = [variantName, lparen, ...strings]
+
+            join(strings)
           }
         }
       }
@@ -451,13 +428,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         let spacePadding = allocateString(padAmount)
         Memory.fill(spacePadding + 8n, 0x20n, padAmount) // create indentation
         let spacePadding = WasmI32.toGrain(spacePadding): String
-        Memory.incRef(WasmI32.fromGrain(SLEmpty))
         let newline = "\n"
         let rbrace = "}"
-        let mut strings = slConsDisableGc(
-          newline,
-          slConsDisableGc(prevSpacePadding, slConsDisableGc(rbrace, SLEmpty))
-        )
+        let mut strings = [newline, prevSpacePadding, rbrace]
         let colspace = ": "
         let comlf = ",\n"
         for (let mut i = recordArity * 4n - 4n; i >= 0n; i -= 4n) {
@@ -467,58 +440,33 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
             extraIndents + 1n,
             false
           )
-          strings = slConsDisableGc(
-            spacePadding,
-            slConsDisableGc(
-              fieldName,
-              slConsDisableGc(colspace, slConsDisableGc(fieldValue, strings))
-            )
-          )
-          Memory.decRef(WasmI32.fromGrain(fieldValue))
+          strings = [spacePadding, fieldName, colspace, fieldValue, ...strings]
           if (i > 0n) {
-            strings = slConsDisableGc(comlf, strings)
+            strings = [comlf, ...strings]
           }
         }
         let lbrace = "{\n"
-        strings = slConsDisableGc(lbrace, strings)
-        let string = join(strings)
+        strings = [lbrace, ...strings]
 
-        Memory.decRef(WasmI32.fromGrain(strings))
-        Memory.decRef(WasmI32.fromGrain(spacePadding))
-        Memory.decRef(WasmI32.fromGrain(colspace))
-        Memory.decRef(WasmI32.fromGrain(comlf))
-        Memory.decRef(WasmI32.fromGrain(lbrace))
-        Memory.decRef(WasmI32.fromGrain(rbrace))
-        Memory.decRef(WasmI32.fromGrain(newline))
-
-        Memory.free(fields) // Avoid double-free of record field names
-
-        string
+        join(strings)
       }
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
       let arity = WasmI32.load(ptr, 4n)
-      Memory.incRef(WasmI32.fromGrain(SLEmpty))
       let rbrack = "]"
-      let mut strings = slConsDisableGc(rbrack, SLEmpty)
+      let mut strings = [rbrack]
       let comspace = ", "
       for (let mut i = arity * 4n - 4n; i >= 0n; i -= 4n) {
         let item = toStringHelp(WasmI32.load(ptr + i, 8n), extraIndents, false)
-        strings = slConsDisableGc(item, strings)
-        Memory.decRef(WasmI32.fromGrain(item))
+        strings = [item, ...strings]
         if (i > 0n) {
-          strings = slConsDisableGc(comspace, strings)
+          strings = [comspace, ...strings]
         }
       }
       let lbrack = "[> "
-      strings = slConsDisableGc(lbrack, strings)
-      let string = join(strings)
-      Memory.decRef(WasmI32.fromGrain(strings))
-      Memory.decRef(WasmI32.fromGrain(comspace))
-      Memory.decRef(WasmI32.fromGrain(lbrack))
-      Memory.decRef(WasmI32.fromGrain(rbrack))
+      strings = [lbrack, ...strings]
 
-      string
+      join(strings)
     },
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let numberTag = WasmI32.load(ptr, 4n)
@@ -532,18 +480,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         t when t == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG => {
           let numerator = NumberUtils.itoa32(WasmI32.load(ptr, 8n), 10n)
           let denominator = NumberUtils.itoa32(WasmI32.load(ptr, 12n), 10n)
-          Memory.incRef(WasmI32.fromGrain(SLEmpty))
           let slash = "/"
-          let strings = slConsDisableGc(
-            numerator,
-            slConsDisableGc(slash, slConsDisableGc(denominator, SLEmpty))
-          )
-          let string = join(strings)
-          Memory.decRef(WasmI32.fromGrain(strings))
-          Memory.decRef(WasmI32.fromGrain(numerator))
-          Memory.decRef(WasmI32.fromGrain(denominator))
-          Memory.decRef(WasmI32.fromGrain(slash))
-          string
+          let strings = [numerator, slash, denominator]
+          join(strings)
         },
         t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
           NumberUtils.dtoa(WasmF64.promoteF32(WasmF32.load(ptr, 8n)))
@@ -563,14 +502,12 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       } else {
         WasmI32.store(ptr, 0x80000000n | tupleLength, 4n)
         let comspace = ", "
-        Memory.incRef(WasmI32.fromGrain(SLEmpty))
         let rparen = ")"
-        let mut strings = slConsDisableGc(rparen, SLEmpty)
+        let mut strings = [rparen]
         if (tupleLength <= 1n) {
           // Special case: unary tuple
           let comma = ","
-          strings = slConsDisableGc(comma, strings)
-          Memory.decRef(WasmI32.fromGrain(comma))
+          strings = [comma, ...strings]
           void
         }
         for (let mut i = tupleLength * 4n - 4n; i >= 0n; i -= 4n) {
@@ -579,48 +516,32 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
             extraIndents,
             false
           )
-          strings = slConsDisableGc(item, strings)
-          Memory.decRef(WasmI32.fromGrain(item))
+          strings = [item, ...strings]
           if (i > 0n) {
-            strings = slConsDisableGc(comspace, strings)
+            strings = [comspace, ...strings]
           }
         }
         WasmI32.store(ptr, tupleLength, 4n)
 
         Memory.incRef(WasmI32.fromGrain(strings))
         let lparen = "("
-        strings = slConsDisableGc(lparen, strings)
+        strings = [lparen, ...strings]
 
-        let string = join(strings)
-        Memory.decRef(WasmI32.fromGrain(strings))
-        Memory.decRef(WasmI32.fromGrain(comspace))
-        Memory.decRef(WasmI32.fromGrain(rparen))
-        Memory.decRef(WasmI32.fromGrain(lparen))
-
-        string
+        join(strings)
       }
     },
     t when t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
       "<lambda>"
     },
     _ => {
-      Memory.incRef(WasmI32.fromGrain(SLEmpty))
-      let strings = slConsDisableGc(
+      let strings = [
         "<unknown heap tag type: 0x",
-        slConsDisableGc(
-          NumberUtils.itoa32(tag, 16n),
-          slConsDisableGc(
-            " | value: 0x",
-            slConsDisableGc(
-              NumberUtils.itoa32(ptr, 16n),
-              slConsDisableGc(">", SLEmpty)
-            )
-          )
-        )
-      )
-      let string = join(strings)
-      Memory.decRef(WasmI32.fromGrain(strings))
-      string
+        NumberUtils.itoa32(tag, 16n),
+        " | value: 0x",
+        NumberUtils.itoa32(ptr, 16n),
+        ">",
+      ]
+      join(strings)
     },
   }
 }, toStringHelp = (grainValue, extraIndents, toplevel) => {
@@ -642,10 +563,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
   let mut cur = ptr
   let mut isFirst = true
 
-  Memory.incRef(WasmI32.fromGrain(SLEmpty))
   let lbrack = "["
   let commaspace = ", "
-  let mut strings = slConsDisableGc(lbrack, SLEmpty)
+  let mut strings = [lbrack]
 
   while (true) {
     let variantId = WasmI32.load(cur, 12n) >> 1n // tagged number
@@ -653,46 +573,30 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       break
     } else {
       if (!isFirst) {
-        strings = slConsDisableGc(commaspace, strings)
+        strings = [commaspace, ...strings]
       }
       isFirst = false
       let item = toStringHelp(WasmI32.load(cur, 20n), extraIndents, false)
-      strings = slConsDisableGc(item, strings)
-      Memory.decRef(WasmI32.fromGrain(item))
+      strings = [item, ...strings]
       cur = WasmI32.load(cur, 24n)
     }
   }
   let rbrack = "]"
-  strings = slConsDisableGc(rbrack, strings)
+  strings = [rbrack, ...strings]
   let reversed = reverse(strings)
-  let string = join(reversed)
-  Memory.decRef(WasmI32.fromGrain(strings))
-  Memory.decRef(WasmI32.fromGrain(reversed))
-  Memory.decRef(WasmI32.fromGrain(lbrack))
-  Memory.decRef(WasmI32.fromGrain(rbrack))
-  Memory.decRef(WasmI32.fromGrain(commaspace))
-  string
+  join(reversed)
 }
 
-@disableGC
-export let rec toString = value => {
+@unsafe
+export let toString = value => {
   let value = WasmI32.fromGrain(value)
-  let ret = toStringHelp(value, 0n, true)
-  Memory.decRef(value)
-  Memory.decRef(WasmI32.fromGrain(toString))
-  ret
+  toStringHelp(value, 0n, true)
 }
 
-@disableGC
-export let rec print = value => {
-  // First convert the value to string, if it isn't one already. Calling
-  // toString will either return value instance itself if it's already a
-  // string, or a new string with the content of value object, which will need
-  // to be deallocated. In either case it's sufficient to force decrement its
-  // reference count.
+@unsafe
+export let print = value => {
+  // First convert the value to string, if it isn't one already.
   let valuePtr = WasmI32.fromGrain(value)
-  Memory.incRef(WasmI32.fromGrain(toString))
-  Memory.incRef(valuePtr) // for function call
   let s = toString(value)
   let ptr = WasmI32.fromGrain(s)
   // iov: [<ptr to string> <nbytes of string> <ptr to newline> <nbytes of newline>] (32 bytes)
@@ -709,8 +613,5 @@ export let rec print = value => {
   WasmI32.store(iov, 1n, 12n)
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
-  Memory.decRef(ptr)
-  Memory.decRef(WasmI32.fromGrain(print))
-  Memory.decRef(WasmI32.fromGrain(value))
   void
 }


### PR DESCRIPTION
The major thing to notice in this PR is that `runtime/numberUtils.gr` is no longer `--compilation-mode=runtime`. This means that it uses regular allocated Grain memory, which means that string literals, etc. are allowed to be used. Ideally, `malloc.gr`/`gc.gr`/`memory.gr` will be the only files in runtime mode.