### PR TITLE
fix(compiler): Apply correct allocation type to numbers

### DIFF
--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -47,7 +47,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=StackAllocated(WasmI32),
+      ~allocation_type=HeapAllocated,
       ~env?,
       CNumber(i),
     );


### PR DESCRIPTION
We can potentially be a little smarter here and only do this for numbers that get allocated on the heap; it'd save a few incref/decrefs.