### PR TITLE
feat(compiler): Convert `runtime/dataStructures.gr` to primitives

### DIFF
--- a/compiler/grainformat/debug.re
+++ b/compiler/grainformat/debug.re
@@ -63,6 +63,7 @@ let debug_expression = (expr: Parsetree.expression) => {
     print_loc("PExpRecordSet", expr.pexp_loc)
   | PExpMatch(expression, match_branches) =>
     print_loc("PExpMatch", expr.pexp_loc)
+  | PExpPrim0(prim0) => print_loc("PExpPrim0", expr.pexp_loc)
   | PExpPrim1(prim1, expression) => print_loc("PExpPrim1", expr.pexp_loc)
   | PExpPrim2(prim2, expression, expression1) =>
     print_loc("PExpPrim2", expr.pexp_loc)

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -2565,6 +2565,9 @@ and print_expression =
         ]),
       );
 
+    | PExpPrim0(prim0) =>
+      let original_code = get_original_code(expr.pexp_loc, original_source);
+      Doc.text(original_code);
     | PExpPrim1(prim1, expression) =>
       let original_code = get_original_code(expr.pexp_loc, original_source);
       Doc.text(original_code);

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -57,8 +57,6 @@ let grain_env_mod = Ident.create_persistent(grain_env_name);
 let malloc_mod = Ident.create_persistent("GRAIN$MODULE$runtime/malloc");
 let gc_mod = Ident.create_persistent("GRAIN$MODULE$runtime/gc");
 let exception_mod = Ident.create_persistent("GRAIN$MODULE$runtime/exception");
-let data_structures_mod =
-  Ident.create_persistent("GRAIN$MODULE$runtime/dataStructures");
 let console_mod = Ident.create_persistent("console");
 let print_exception_ident = Ident.create_persistent("printException");
 let print_exception_closure_ident =
@@ -73,21 +71,6 @@ let malloc_ident = Ident.create_persistent("malloc");
 let malloc_closure_ident = Ident.create_persistent("GRAIN$EXPORT$malloc");
 let incref_ident = Ident.create_persistent("incRef");
 let incref_closure_ident = Ident.create_persistent("GRAIN$EXPORT$incRef");
-let new_rational_ident = Ident.create_persistent("newRational");
-let new_rational_closure_ident =
-  Ident.create_persistent("GRAIN$EXPORT$newRational");
-let new_float32_ident = Ident.create_persistent("newFloat32");
-let new_float32_closure_ident =
-  Ident.create_persistent("GRAIN$EXPORT$newFloat32");
-let new_float64_ident = Ident.create_persistent("newFloat64");
-let new_float64_closure_ident =
-  Ident.create_persistent("GRAIN$EXPORT$newFloat64");
-let new_int32_ident = Ident.create_persistent("newInt32");
-let new_int32_closure_ident =
-  Ident.create_persistent("GRAIN$EXPORT$newInt32");
-let new_int64_ident = Ident.create_persistent("newInt64");
-let new_int64_closure_ident =
-  Ident.create_persistent("GRAIN$EXPORT$newInt64");
 let equal_mod = Ident.create_persistent("GRAIN$MODULE$runtime/equal");
 let equal_ident = Ident.create_persistent("equal");
 let equal_closure_ident = Ident.create_persistent("GRAIN$EXPORT$equal");
@@ -175,46 +158,6 @@ let grain_runtime_imports = [
     mimp_used: false,
   },
   {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_rational_closure_ident,
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_float32_closure_ident,
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_float64_closure_ident,
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_int32_closure_ident,
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_int64_closure_ident,
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
     mimp_mod: equal_mod,
     mimp_name: equal_closure_ident,
     mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
@@ -288,79 +231,11 @@ let grain_function_imports = [
     mimp_used: false,
   },
   {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_rational_ident,
-    mimp_type:
-      MFuncImport(
-        [
-          Types.StackAllocated(WasmI32),
-          Types.StackAllocated(WasmI32),
-          Types.StackAllocated(WasmI32),
-        ],
-        [Types.StackAllocated(WasmI32)],
-      ),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_float32_ident,
-    mimp_type:
-      MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmF32)],
-        [Types.StackAllocated(WasmI32)],
-      ),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_float64_ident,
-    mimp_type:
-      MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmF64)],
-        [Types.StackAllocated(WasmI32)],
-      ),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_int32_ident,
-    mimp_type:
-      MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
-      ),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
-    mimp_mod: data_structures_mod,
-    mimp_name: new_int64_ident,
-    mimp_type:
-      MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI64)],
-        [Types.StackAllocated(WasmI32)],
-      ),
-    mimp_kind: MImportWasm,
-    mimp_setup: MSetupNone,
-    mimp_used: false,
-  },
-  {
     mimp_mod: equal_mod,
     mimp_name: equal_ident,
     mimp_type:
       MFuncImport(
-        [
-          Types.StackAllocated(WasmI32),
-          Types.StackAllocated(WasmI32),
-          Types.StackAllocated(WasmI32),
-        ],
+        [Types.HeapAllocated, Types.HeapAllocated, Types.HeapAllocated],
         [Types.StackAllocated(WasmI32)],
       ),
     mimp_kind: MImportWasm,
@@ -517,85 +392,6 @@ let call_decref = (wasm_mod, env, arg) => {
     );
   };
 };
-let call_new_rational = (wasm_mod, env, args) =>
-  Expression.Call.make(
-    wasm_mod,
-    get_wasm_imported_name(data_structures_mod, new_rational_ident),
-    [
-      Expression.Global_get.make(
-        wasm_mod,
-        get_wasm_imported_name(
-          data_structures_mod,
-          new_rational_closure_ident,
-        ),
-        Type.int32,
-      ),
-      ...args,
-    ],
-    Type.int32,
-  );
-let call_new_float32 = (wasm_mod, env, args) =>
-  Expression.Call.make(
-    wasm_mod,
-    get_wasm_imported_name(data_structures_mod, new_float32_ident),
-    [
-      Expression.Global_get.make(
-        wasm_mod,
-        get_wasm_imported_name(
-          data_structures_mod,
-          new_float32_closure_ident,
-        ),
-        Type.int32,
-      ),
-      ...args,
-    ],
-    Type.int32,
-  );
-let call_new_float64 = (wasm_mod, env, args) =>
-  Expression.Call.make(
-    wasm_mod,
-    get_wasm_imported_name(data_structures_mod, new_float64_ident),
-    [
-      Expression.Global_get.make(
-        wasm_mod,
-        get_wasm_imported_name(
-          data_structures_mod,
-          new_float64_closure_ident,
-        ),
-        Type.int32,
-      ),
-      ...args,
-    ],
-    Type.int32,
-  );
-let call_new_int32 = (wasm_mod, env, args) =>
-  Expression.Call.make(
-    wasm_mod,
-    get_wasm_imported_name(data_structures_mod, new_int32_ident),
-    [
-      Expression.Global_get.make(
-        wasm_mod,
-        get_wasm_imported_name(data_structures_mod, new_int32_closure_ident),
-        Type.int32,
-      ),
-      ...args,
-    ],
-    Type.int32,
-  );
-let call_new_int64 = (wasm_mod, env, args) =>
-  Expression.Call.make(
-    wasm_mod,
-    get_wasm_imported_name(data_structures_mod, new_int64_ident),
-    [
-      Expression.Global_get.make(
-        wasm_mod,
-        get_wasm_imported_name(data_structures_mod, new_int64_closure_ident),
-        Type.int32,
-      ),
-      ...args,
-    ],
-    Type.int32,
-  );
 let call_equal = (wasm_mod, env, args) =>
   Expression.Call.make(
     wasm_mod,
@@ -1677,94 +1473,44 @@ let heap_allocate = (wasm_mod, env, num_words: int) =>
     );
   };
 
-let heap_runtime_allocate_imm =
-    (~additional_words=0, wasm_mod, env, num_words: immediate) => {
-  let num_words = () =>
-    untag_number(wasm_mod, compile_imm(wasm_mod, env, num_words));
-  let addition =
-    Expression.Binary.make(
-      wasm_mod,
-      Op.add_int32,
-      load(
-        wasm_mod,
-        Expression.Const.make(wasm_mod, const_int32(runtime_heap_ptr^)),
-      ),
+type heap_allocation_type =
+  | Words(immediate)
+  | Bytes(immediate);
+
+let heap_allocate_imm =
+    (~additional_words=0, wasm_mod, env, amount: heap_allocation_type) => {
+  let num_bytes =
+    switch (amount) {
+    | Words(num_words) when additional_words > 0 =>
       Expression.Binary.make(
         wasm_mod,
         Op.mul_int32,
         Expression.Binary.make(
           wasm_mod,
-          Op.and_int32,
-          Expression.Binary.make(
-            wasm_mod,
-            Op.add_int32,
-            num_words(),
-            // Add 3 extra and clear final bit to round up to an even number of words + 2
-            Expression.Const.make(
-              wasm_mod,
-              const_int32(3 + additional_words),
-            ),
-          ),
-          Expression.Const.make(wasm_mod, const_int32(0xfffffffe)),
+          Op.add_int32,
+          compile_imm(wasm_mod, env, num_words),
+          Expression.Const.make(wasm_mod, const_int32(additional_words)),
         ),
         Expression.Const.make(wasm_mod, const_int32(4)),
-      ),
-    );
-  Expression.Tuple_extract.make(
-    wasm_mod,
-    Expression.Tuple_make.make(
-      wasm_mod,
-      [
-        Expression.Block.make(
-          wasm_mod,
-          gensym_label("heap_allocate_runtime_imm"),
-          [
-            store(
-              wasm_mod,
-              load(
-                wasm_mod,
-                Expression.Const.make(
-                  wasm_mod,
-                  const_int32(runtime_heap_ptr^),
-                ),
-              ),
-              Expression.Const.make(wasm_mod, const_int32(1)),
-            ),
-            Expression.Binary.make(
-              wasm_mod,
-              Op.add_int32,
-              load(
-                wasm_mod,
-                Expression.Const.make(
-                  wasm_mod,
-                  const_int32(runtime_heap_ptr^),
-                ),
-              ),
-              Expression.Const.make(wasm_mod, const_int32(8)),
-            ),
-          ],
-        ),
-        Expression.Block.make(
-          wasm_mod,
-          gensym_label("store_runtime_heap_ptr"),
-          [
-            store(
-              wasm_mod,
-              Expression.Const.make(
-                wasm_mod,
-                const_int32(runtime_heap_ptr^),
-              ),
-              addition,
-            ),
-            // Binaryen tuples must include a concrete value (and tuples are
-            // the only way to use the stack)
-            Expression.Const.make(wasm_mod, const_int32(0)),
-          ],
-        ),
-      ],
-    ),
-    0,
-  );
+      )
+    | Words(num_words) =>
+      Expression.Binary.make(
+        wasm_mod,
+        Op.mul_int32,
+        compile_imm(wasm_mod, env, num_words),
+        Expression.Const.make(wasm_mod, const_int32(4)),
+      )
+    | Bytes(num_bytes) when additional_words > 0 =>
+      Expression.Binary.make(
+        wasm_mod,
+        Op.add_int32,
+        compile_imm(wasm_mod, env, num_bytes),
+        Expression.Const.make(wasm_mod, const_int32(additional_words * 4)),
+      )
+    | Bytes(num_bytes) => compile_imm(wasm_mod, env, num_bytes)
+    };
+
+  call_malloc(wasm_mod, env, [num_bytes]);
 };
 
 let buf_to_ints = (buf: Buffer.t): list(int64) => {
@@ -1865,6 +1611,30 @@ let allocate_byte_like_from_buffer = (wasm_mod, env, buf, tag, label) => {
   );
 };
 
+let allocate_byte_like_uninitialized = (wasm_mod, env, size, tag, label) => {
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+  let tee_swap = tee_swap(wasm_mod, env, 0);
+  let preamble = [
+    store(
+      ~offset=0,
+      wasm_mod,
+      tee_swap(
+        heap_allocate_imm(~additional_words=2, wasm_mod, env, Bytes(size)),
+      ),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_heap_tag_type(tag)),
+      ),
+    ),
+    store(~offset=4, wasm_mod, get_swap(), compile_imm(wasm_mod, env, size)),
+  ];
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label(label),
+    List.concat([preamble, [get_swap()]]),
+  );
+};
+
 let allocate_string = (wasm_mod, env, str) => {
   let buf = Buffer.create(80);
   Buffer.add_string(buf, str);
@@ -1877,6 +1647,16 @@ let allocate_string = (wasm_mod, env, str) => {
   );
 };
 
+let allocate_string_uninitialized = (wasm_mod, env, size) => {
+  allocate_byte_like_uninitialized(
+    wasm_mod,
+    env,
+    size,
+    StringType,
+    "allocate_string_uninitialized",
+  );
+};
+
 let allocate_bytes = (wasm_mod, env, bytes) => {
   let buf = Buffer.create(80);
   Buffer.add_bytes(buf, bytes);
@@ -1886,6 +1666,16 @@ let allocate_bytes = (wasm_mod, env, bytes) => {
     buf,
     BytesType,
     "allocate_bytes",
+  );
+};
+
+let allocate_bytes_uninitialized = (wasm_mod, env, size) => {
+  allocate_byte_like_uninitialized(
+    wasm_mod,
+    env,
+    size,
+    BytesType,
+    "allocate_bytes_uninitialized",
   );
 };
 
@@ -1923,24 +1713,25 @@ let allocate_char = (wasm_mod, env, char) => {
   );
 };
 
-let allocate_float32 = (wasm_mod, env, i) => {
-  call_new_float32(wasm_mod, env, [i]);
-};
-
-let allocate_float64 = (wasm_mod, env, i) => {
-  call_new_float64(wasm_mod, env, [i]);
-};
-
-let allocate_int32 = (wasm_mod, env, i) => {
-  call_new_int32(wasm_mod, env, [i]);
-};
-
-let allocate_int64 = (wasm_mod, env, i) => {
-  call_new_int64(wasm_mod, env, [i]);
-};
-
-let allocate_rational = (wasm_mod, env, n, d) => {
-  call_new_rational(wasm_mod, env, [n, d]);
+let allocate_char_uninitialized = (wasm_mod, env) => {
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+  let tee_swap = tee_swap(wasm_mod, env, 0);
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label("allocate_char_uninitialized"),
+    [
+      store(
+        ~offset=0,
+        wasm_mod,
+        tee_swap(heap_allocate(wasm_mod, env, 2)),
+        Expression.Const.make(
+          wasm_mod,
+          const_int32(tag_val_of_heap_tag_type(CharType)),
+        ),
+      ),
+      get_swap(),
+    ],
+  );
 };
 
 let allocate_closure =
@@ -2135,9 +1926,87 @@ let allocate_tuple = (~is_box=false, wasm_mod, env, elts) => {
   );
 };
 
+let allocate_uninitialized_tuple = (~is_box=false, wasm_mod, env, num_elts) => {
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+
+  let preamble = [
+    store(
+      ~offset=0,
+      wasm_mod,
+      tee_swap(
+        ~skip_incref=true,
+        wasm_mod,
+        env,
+        0,
+        heap_allocate_imm(
+          ~additional_words=2,
+          wasm_mod,
+          env,
+          Words(num_elts),
+        ),
+      ),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_heap_tag_type(TupleType)),
+      ),
+    ),
+    store(
+      ~offset=4,
+      wasm_mod,
+      get_swap(),
+      compile_imm(wasm_mod, env, num_elts),
+    ),
+  ];
+  let postamble = [get_swap()];
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label("allocate_tuple"),
+    List.concat([preamble, postamble]),
+  );
+};
+
 let allocate_box = (wasm_mod, env, elt) =>
   /* At the moment, we make no runtime distinction between boxes and tuples */
   allocate_tuple(~is_box=true, wasm_mod, env, [elt]);
+
+let allocate_uninitialized_array = (wasm_mod, env, num_elts) => {
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+
+  let preamble = [
+    store(
+      ~offset=0,
+      wasm_mod,
+      tee_swap(
+        ~skip_incref=true,
+        wasm_mod,
+        env,
+        0,
+        heap_allocate_imm(
+          ~additional_words=2,
+          wasm_mod,
+          env,
+          Words(num_elts),
+        ),
+      ),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_heap_tag_type(ArrayType)),
+      ),
+    ),
+    store(
+      ~offset=4,
+      wasm_mod,
+      get_swap(),
+      compile_imm(wasm_mod, env, num_elts),
+    ),
+  ];
+  let postamble = [get_swap()];
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label("allocate_uninitialized_array"),
+    List.concat([preamble, postamble]),
+  );
+};
 
 let allocate_array = (wasm_mod, env, elts) => {
   let num_elts = List.length(elts);
@@ -2246,10 +2115,198 @@ let allocate_record = (wasm_mod, env, ttag, elts) => {
   );
 };
 
+type alloc_number_type =
+  | Int32(Expression.t)
+  | Int64(Expression.t)
+  | Float32(Expression.t)
+  | Float64(Expression.t)
+  | Rational(Expression.t, Expression.t);
+
+let allocate_number = (wasm_mod, env, number) => {
+  /* Heap memory layout of numbers:
+     [ <value type tag>, <number_tag>, <payload>]
+     */
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+
+  let (number_tag, instrs) =
+    switch (number) {
+    | Int32(int32) => (
+        BoxedInt32,
+        [store(~offset=8, ~ty=Type.int32, wasm_mod, get_swap(), int32)],
+      )
+    | Int64(int64) => (
+        BoxedInt64,
+        [store(~offset=8, ~ty=Type.int64, wasm_mod, get_swap(), int64)],
+      )
+    | Float32(float32) => (
+        BoxedFloat32,
+        [store(~offset=8, ~ty=Type.float32, wasm_mod, get_swap(), float32)],
+      )
+    | Float64(float64) => (
+        BoxedFloat64,
+        [store(~offset=8, ~ty=Type.float64, wasm_mod, get_swap(), float64)],
+      )
+    | Rational(numerator, denominator) => (
+        BoxedRational,
+        [
+          store(~offset=8, ~ty=Type.int32, wasm_mod, get_swap(), numerator),
+          store(
+            ~offset=12,
+            ~ty=Type.int32,
+            wasm_mod,
+            get_swap(),
+            denominator,
+          ),
+        ],
+      )
+    };
+
+  let preamble = [
+    store(
+      ~offset=0,
+      wasm_mod,
+      tee_swap(
+        ~skip_incref=true,
+        wasm_mod,
+        env,
+        0,
+        // Grain allocations are 8-byte aligned, so no space is saved by
+        // allocating 3 words for 32-bit numbers
+        heap_allocate(wasm_mod, env, 4),
+      ),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_heap_tag_type(BoxedNumberType)),
+      ),
+    ),
+    store(
+      ~offset=4,
+      wasm_mod,
+      get_swap(),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_boxed_number_tag_type(number_tag)),
+      ),
+    ),
+  ];
+  let postamble = [get_swap()];
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label("allocate_number"),
+    List.concat([preamble, instrs, postamble]),
+  );
+};
+
+let allocate_number_uninitialized = (wasm_mod, env, number_tag) => {
+  /* Heap memory layout of numbers:
+     [ <value type tag>, <number_tag>, <payload>]
+     */
+  let get_swap = () => get_swap(wasm_mod, env, 0);
+
+  let preamble = [
+    store(
+      ~offset=0,
+      wasm_mod,
+      tee_swap(
+        ~skip_incref=true,
+        wasm_mod,
+        env,
+        0,
+        // Grain allocations are 8-byte aligned, so no space is saved by
+        // allocating 3 words for 32-bit numbers
+        heap_allocate(wasm_mod, env, 4),
+      ),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_heap_tag_type(BoxedNumberType)),
+      ),
+    ),
+    store(
+      ~offset=4,
+      wasm_mod,
+      get_swap(),
+      Expression.Const.make(
+        wasm_mod,
+        const_int32(tag_val_of_boxed_number_tag_type(number_tag)),
+      ),
+    ),
+  ];
+  let postamble = [get_swap()];
+  Expression.Block.make(
+    wasm_mod,
+    gensym_label("allocate_number"),
+    List.concat([preamble, postamble]),
+  );
+};
+
+let allocate_float32 = (wasm_mod, env, i) => {
+  allocate_number(wasm_mod, env, Float32(i));
+};
+
+let allocate_float64 = (wasm_mod, env, i) => {
+  allocate_number(wasm_mod, env, Float64(i));
+};
+
+let allocate_int32 = (wasm_mod, env, i) => {
+  allocate_number(wasm_mod, env, Int32(i));
+};
+
+let allocate_int64 = (wasm_mod, env, i) => {
+  allocate_number(wasm_mod, env, Int64(i));
+};
+
+let allocate_rational = (wasm_mod, env, n, d) => {
+  allocate_number(wasm_mod, env, Rational(n, d));
+};
+
+let compile_prim0 = (wasm_mod, env, p0): Expression.t => {
+  switch (p0) {
+  | AllocateChar => allocate_char_uninitialized(wasm_mod, env)
+  | AllocateInt32 => allocate_number_uninitialized(wasm_mod, env, BoxedInt32)
+  | AllocateInt64 => allocate_number_uninitialized(wasm_mod, env, BoxedInt64)
+  | AllocateFloat32 =>
+    allocate_number_uninitialized(wasm_mod, env, BoxedFloat32)
+  | AllocateFloat64 =>
+    allocate_number_uninitialized(wasm_mod, env, BoxedFloat64)
+  | AllocateRational =>
+    allocate_number_uninitialized(wasm_mod, env, BoxedRational)
+  };
+};
+
 let compile_prim1 = (wasm_mod, env, p1, arg, loc): Expression.t => {
   let compiled_arg = compile_imm(wasm_mod, env, arg);
   /* TODO: Overflow checks? */
   switch (p1) {
+  | AllocateArray => allocate_uninitialized_array(wasm_mod, env, arg)
+  | AllocateTuple => allocate_uninitialized_tuple(wasm_mod, env, arg)
+  | AllocateBytes => allocate_bytes_uninitialized(wasm_mod, env, arg)
+  | AllocateString => allocate_string_uninitialized(wasm_mod, env, arg)
+  | NewInt32 => allocate_number(wasm_mod, env, Int32(compiled_arg))
+  | NewInt64 => allocate_number(wasm_mod, env, Int64(compiled_arg))
+  | NewFloat32 => allocate_number(wasm_mod, env, Float32(compiled_arg))
+  | NewFloat64 => allocate_number(wasm_mod, env, Float64(compiled_arg))
+  | LoadAdtVariant => load(~offset=12, wasm_mod, compiled_arg)
+  | StringSize
+  | BytesSize => load(~offset=4, wasm_mod, compiled_arg)
+  | TagSimpleNumber =>
+    Expression.Binary.make(
+      wasm_mod,
+      Op.xor_int32,
+      Expression.Binary.make(
+        wasm_mod,
+        Op.shl_int32,
+        compiled_arg,
+        Expression.Const.make(wasm_mod, const_int32(0x1)),
+      ),
+      Expression.Const.make(wasm_mod, const_int32(0x1)),
+    )
+  | UntagSimpleNumber =>
+    Expression.Binary.make(
+      wasm_mod,
+      Op.shr_s_int32,
+      compiled_arg,
+      Expression.Const.make(wasm_mod, const_int32(0x1)),
+    )
   | Not =>
     /* Flip the first bit */
     Expression.Binary.make(
@@ -2431,6 +2488,12 @@ let compile_prim2 = (wasm_mod, env: codegen_env, p2, arg1, arg2): Expression.t =
         compiled_arg1(),
         compiled_arg2(),
       ),
+    )
+  | NewRational =>
+    allocate_number(
+      wasm_mod,
+      env,
+      Rational(compiled_arg1(), compiled_arg2()),
     )
   | WasmLoadI32({sz, signed}) =>
     compile_wasm_load(
@@ -2898,6 +2961,7 @@ and compile_instr = (wasm_mod, env, instr) =>
   | MAdtOp(adt_op, adt) => compile_adt_op(wasm_mod, env, adt, adt_op)
   | MRecordOp(record_op, record) =>
     compile_record_op(wasm_mod, env, record, record_op)
+  | MPrim0(p0) => compile_prim0(wasm_mod, env, p0)
   | MPrim1(p1, arg) => compile_prim1(wasm_mod, env, p1, arg, instr.instr_loc)
   | MPrim2(p2, arg1, arg2) => compile_prim2(wasm_mod, env, p2, arg1, arg2)
   | MPrimN(p, args) => compile_primn(wasm_mod, env, p, args)

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -18,6 +18,10 @@ type heap_tag_type = Value_tags.heap_tag_type;
 type attributes = Typedtree.attributes;
 
 type grain_error = Runtime_errors.grain_error;
+let (prim0_of_sexp, sexp_of_prim0) = (
+  Parsetree.prim0_of_sexp,
+  Parsetree.sexp_of_prim0,
+);
 let (prim1_of_sexp, sexp_of_prim1) = (
   Parsetree.prim1_of_sexp,
   Parsetree.sexp_of_prim1,
@@ -166,8 +170,30 @@ type wasm_op =
     | Op_gt_float64
     | Op_ge_float64;
 
+type prim0 =
+  Parsetree.prim0 =
+    | AllocateChar
+    | AllocateInt32
+    | AllocateInt64
+    | AllocateFloat32
+    | AllocateFloat64
+    | AllocateRational;
+
 type prim1 =
   Parsetree.prim1 =
+    | AllocateArray
+    | AllocateTuple
+    | AllocateBytes
+    | AllocateString
+    | NewInt32
+    | NewInt64
+    | NewFloat32
+    | NewFloat64
+    | LoadAdtVariant
+    | StringSize
+    | BytesSize
+    | TagSimpleNumber
+    | UntagSimpleNumber
     | Not
     | Box
     | Unbox
@@ -203,6 +229,7 @@ type prim1 =
 
 type prim2 =
   Parsetree.prim2 =
+    | NewRational
     | Is
     | Eq
     | And
@@ -383,6 +410,7 @@ and instr_desc =
   | MContinue
   | MBreak
   | MSwitch(immediate, list((int32, block)), block, Types.allocation_type) /* value, branches, default, return type */
+  | MPrim0(prim0)
   | MPrim1(prim1, immediate)
   | MPrim2(prim2, immediate, immediate)
   | MPrimN(primn, list(immediate))

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -178,6 +178,7 @@ module RegisterAllocation = {
       | MTagOp(top, tt, i) => MTagOp(top, tt, apply_allocation_to_imm(i))
       | MArityOp(aop, at, i) =>
         MArityOp(aop, at, apply_allocation_to_imm(i))
+      | MPrim0(pop) => MPrim0(pop)
       | MPrim1(pop, i) => MPrim1(pop, apply_allocation_to_imm(i))
       | MTupleOp(top, i) => MTupleOp(top, apply_allocation_to_imm(i))
       | MBoxOp(bop, i) => MBoxOp(bop, apply_allocation_to_imm(i))
@@ -316,6 +317,7 @@ let run_register_allocation = (instrs: list(Mashtree.instr)) => {
       Option.fold(~none=[], ~some=block_live_locals, b1)
       @ Option.fold(~none=[], ~some=block_live_locals, b2)
       @ block_live_locals(b3)
+    | MPrim0(_)
     | MContinue
     | MBreak => []
     | MSwitch(v, bs, d, ty) =>
@@ -754,6 +756,7 @@ let rec compile_comp = (~id=?, env, c) => {
       )
     | CContinue => MContinue
     | CBreak => MBreak
+    | CPrim0(p0) => MPrim0(p0)
     | CPrim1(Box, arg)
     | CPrim1(BoxBind, arg) => MAllocate(MBox(compile_imm(env, arg)))
     | CPrim1(Unbox, arg)

--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -43,8 +43,30 @@ let rec analyze_comp_expression =
     switch (desc) {
     | CImmExpr({imm_desc: ImmTrap}) => false
     | CImmExpr(_) => true
+    | CPrim0(
+        AllocateChar | AllocateInt32 | AllocateInt64 | AllocateFloat32 |
+        AllocateFloat64 |
+        AllocateRational,
+      ) =>
+      true
     | CPrim1(
-        Not | Box | Unbox | BoxBind | UnboxBind | Ignore | ArrayLength |
+        AllocateArray | AllocateTuple | AllocateBytes | AllocateString |
+        NewInt32 |
+        NewInt64 |
+        NewFloat32 |
+        NewFloat64 |
+        LoadAdtVariant |
+        StringSize |
+        BytesSize |
+        TagSimpleNumber |
+        UntagSimpleNumber |
+        Not |
+        Box |
+        Unbox |
+        BoxBind |
+        UnboxBind |
+        Ignore |
+        ArrayLength |
         WasmFromGrain |
         WasmToGrain |
         WasmUnaryI32(_) |
@@ -57,7 +79,8 @@ let rec analyze_comp_expression =
       true
     | CPrim1(Assert | Throw, _) => false
     | CPrim2(
-        Is | Eq | And | Or | WasmLoadI32(_) | WasmLoadI64(_) | WasmLoadF32 |
+        NewRational | Is | Eq | And | Or | WasmLoadI32(_) | WasmLoadI64(_) |
+        WasmLoadF32 |
         WasmLoadF64 |
         WasmBinaryI32(_) |
         WasmBinaryI64(_) |

--- a/compiler/src/middle_end/analyze_tail_calls.re
+++ b/compiler/src/middle_end/analyze_tail_calls.re
@@ -79,6 +79,7 @@ let rec analyze_comp_expression =
   | CInt64(_)
   | CFloat32(_)
   | CFloat64(_)
+  | CPrim0(_)
   | CPrim1(_)
   | CPrim2(_)
   | CPrimN(_)

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -83,6 +83,8 @@ module Comp = {
       ~env?,
       CFloat64(i),
     );
+  let prim0 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p0) =>
+    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim0(p0));
   let prim1 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p1, a) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim1(p1, a));
   let prim2 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p2, a1, a2) =>

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -55,6 +55,15 @@ module Comp: {
   let float64:
     (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, float) =>
     comp_expression;
+  let prim0:
+    (
+      ~loc: loc=?,
+      ~attributes: attributes=?,
+      ~allocation_type: allocation_type,
+      ~env: env=?,
+      prim0
+    ) =>
+    comp_expression;
   let prim1:
     (
       ~loc: loc=?,

--- a/compiler/src/middle_end/anf_iterator.re
+++ b/compiler/src/middle_end/anf_iterator.re
@@ -42,6 +42,7 @@ module MakeIter = (Iter: IterArgument) => {
     Iter.enter_comp_expression(c);
     switch (desc) {
     | CImmExpr(i) => iter_imm_expression(i)
+    | CPrim0(_) => ()
     | CPrim1(_, arg) => iter_imm_expression(arg)
     | CPrim2(_, arg1, arg2) =>
       iter_imm_expression(arg1);

--- a/compiler/src/middle_end/anf_mapper.re
+++ b/compiler/src/middle_end/anf_mapper.re
@@ -41,6 +41,7 @@ module MakeMap = (Iter: MapArgument) => {
     let d =
       switch (desc) {
       | CImmExpr(i) => CImmExpr(map_imm_expression(i))
+      | CPrim0(p0) => CPrim0(p0)
       | CPrim1(p1, arg) => CPrim1(p1, map_imm_expression(arg))
       | CPrim2(p2, arg1, arg2) =>
         let arg1 = map_imm_expression(arg1);

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -68,6 +68,7 @@ and comp_free_vars_help = (env, c: comp_expression) =>
       imm_free_vars_help(env, arg),
       branches,
     )
+  | CPrim0(_) => Ident.Set.empty
   | CPrim1(_, arg) => imm_free_vars_help(env, arg)
   | CPrim2(_, arg1, arg2) =>
     Ident.Set.union(

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -156,8 +156,30 @@ type wasm_op =
     | Op_gt_float64
     | Op_ge_float64;
 
+type prim0 =
+  Parsetree.prim0 =
+    | AllocateChar
+    | AllocateInt32
+    | AllocateInt64
+    | AllocateFloat32
+    | AllocateFloat64
+    | AllocateRational;
+
 type prim1 =
   Parsetree.prim1 =
+    | AllocateArray
+    | AllocateTuple
+    | AllocateBytes
+    | AllocateString
+    | NewInt32
+    | NewInt64
+    | NewFloat32
+    | NewFloat64
+    | LoadAdtVariant
+    | StringSize
+    | BytesSize
+    | TagSimpleNumber
+    | UntagSimpleNumber
     | Not
     | Box
     | Unbox
@@ -193,6 +215,7 @@ type prim1 =
 
 type prim2 =
   Parsetree.prim2 =
+    | NewRational
     | Is
     | Eq
     | And
@@ -238,6 +261,11 @@ type primn =
     | WasmMemoryFill
     | WasmMemorySize
     | WasmMemoryCompare;
+
+let (prim0_of_sexp, sexp_of_prim0) = (
+  Parsetree.prim0_of_sexp,
+  Parsetree.sexp_of_prim0,
+);
 
 let (prim1_of_sexp, sexp_of_prim1) = (
   Parsetree.prim1_of_sexp,
@@ -286,6 +314,7 @@ type comp_expression = {
 [@deriving sexp]
 and comp_expression_desc =
   | CImmExpr(imm_expression)
+  | CPrim0(prim0)
   | CPrim1(prim1, imm_expression)
   | CPrim2(prim2, imm_expression, imm_expression)
   | CPrimN(primn, list(imm_expression))

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -157,8 +157,30 @@ type wasm_op =
     | Op_gt_float64
     | Op_ge_float64;
 
+type prim0 =
+  Parsetree.prim0 =
+    | AllocateChar
+    | AllocateInt32
+    | AllocateInt64
+    | AllocateFloat32
+    | AllocateFloat64
+    | AllocateRational;
+
 type prim1 =
   Parsetree.prim1 =
+    | AllocateArray
+    | AllocateTuple
+    | AllocateBytes
+    | AllocateString
+    | NewInt32
+    | NewInt64
+    | NewFloat32
+    | NewFloat64
+    | LoadAdtVariant
+    | StringSize
+    | BytesSize
+    | TagSimpleNumber
+    | UntagSimpleNumber
     | Not
     | Box
     | Unbox
@@ -194,6 +216,7 @@ type prim1 =
 
 type prim2 =
   Parsetree.prim2 =
+    | NewRational
     | Is
     | Eq
     | And
@@ -271,6 +294,7 @@ type comp_expression = {
 [@deriving sexp]
 and comp_expression_desc =
   | CImmExpr(imm_expression)
+  | CPrim0(prim0)
   | CPrim1(prim1, imm_expression)
   | CPrim2(prim2, imm_expression, imm_expression)
   | CPrimN(primn, list(imm_expression))

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -284,6 +284,12 @@ let rec transl_imm =
       (Imm.id(~loc, ~env, tmp), [BLet(tmp, cexpr, Nonglobal)]);
     }
   | TExpNull => (Imm.const(~loc, ~env, Const_bool(false)), [])
+  | TExpPrim0(op) =>
+    let tmp = gensym("prim0");
+    (
+      Imm.id(~loc, ~env, tmp),
+      [BLet(tmp, Comp.prim0(~loc, ~env, ~allocation_type, op), Nonglobal)],
+    );
   | TExpPrim1(op, arg) =>
     let tmp = gensym("unary");
     let (arg_imm, arg_setup) = transl_imm(arg);
@@ -515,6 +521,8 @@ let rec transl_imm =
   | TExpApp({exp_desc: TExpIdent(_, _, {val_kind: TValPrim(prim)})}, args) =>
     Translprim.(
       switch (PrimMap.find_opt(prim_map, prim), args) {
+      | (Some(Primitive0(prim)), []) =>
+        transl_imm({...e, exp_desc: TExpPrim0(prim)})
       | (Some(Primitive1(prim)), [arg]) =>
         transl_imm({...e, exp_desc: TExpPrim1(prim, arg)})
       | (Some(Primitive2(prim)), [arg1, arg2]) =>
@@ -890,6 +898,10 @@ and transl_comp_expression =
     : (comp_expression, list(anf_bind)) => {
   let allocation_type = get_allocation_type(env, exp_type);
   switch (exp_desc) {
+  | TExpPrim0(op) => (
+      Comp.prim0(~loc, ~attributes, ~allocation_type, ~env, op),
+      [],
+    )
   | TExpPrim1(op, arg) =>
     let (arg_imm, arg_setup) = transl_imm(arg);
     (
@@ -1165,6 +1177,8 @@ and transl_comp_expression =
   | TExpApp({exp_desc: TExpIdent(_, _, {val_kind: TValPrim(prim)})}, args) =>
     Translprim.(
       switch (PrimMap.find_opt(prim_map, prim), args) {
+      | (Some(Primitive0(prim)), []) =>
+        transl_comp_expression({...e, exp_desc: TExpPrim0(prim)})
       | (Some(Primitive1(prim)), [arg]) =>
         transl_comp_expression({...e, exp_desc: TExpPrim1(prim, arg)})
       | (Some(Primitive2(prim)), [arg1, arg2]) =>

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -203,6 +203,8 @@ module Exp = {
     mk(~loc?, ~attributes?, PExpLet(a, b, c));
   let match = (~loc=?, ~attributes=?, a, b) =>
     mk(~loc?, ~attributes?, PExpMatch(a, b));
+  let prim0 = (~loc=?, ~attributes=?, a) =>
+    mk(~loc?, ~attributes?, PExpPrim0(a));
   let prim1 = (~loc=?, ~attributes=?, a, b) =>
     mk(~loc?, ~attributes?, PExpPrim1(a, b));
   let prim2 = (~loc=?, ~attributes=?, a, b, c) =>

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -152,6 +152,7 @@ module Exp: {
       list(match_branch)
     ) =>
     expression;
+  let prim0: (~loc: loc=?, ~attributes: attributes=?, prim0) => expression;
   let prim1:
     (~loc: loc=?, ~attributes: attributes=?, prim1, expression) => expression;
   let prim2:

--- a/compiler/src/parsing/ast_iterator.re
+++ b/compiler/src/parsing/ast_iterator.re
@@ -68,6 +68,7 @@ module E = {
     | PExpMatch(e, mbs) =>
       sub.expr(sub, e);
       List.iter(sub.match_branch(sub), mbs);
+    | PExpPrim0(p0) => ()
     | PExpPrim1(p1, e) => sub.expr(sub, e)
     | PExpPrim2(p2, e1, e2) =>
       sub.expr(sub, e1);

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -81,6 +81,7 @@ module E = {
         sub.expr(sub, e),
         List.map(sub.match_branch(sub), mbs),
       )
+    | PExpPrim0(p0) => prim0(~loc, ~attributes, p0)
     | PExpPrim1(p1, e) => prim1(~loc, ~attributes, p1, sub.expr(sub, e))
     | PExpPrim2(p2, e1, e2) =>
       prim2(~loc, ~attributes, p2, sub.expr(sub, e1), sub.expr(sub, e2))

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -300,9 +300,32 @@ type wasm_op =
   | Op_gt_float64
   | Op_ge_float64;
 
+/** Zero-argument operators */
+[@deriving (sexp, yojson)]
+type prim0 =
+  | AllocateChar
+  | AllocateInt32
+  | AllocateInt64
+  | AllocateFloat32
+  | AllocateFloat64
+  | AllocateRational;
+
 /** Single-argument operators */
 [@deriving (sexp, yojson)]
 type prim1 =
+  | AllocateArray
+  | AllocateTuple
+  | AllocateBytes
+  | AllocateString
+  | NewInt32
+  | NewInt64
+  | NewFloat32
+  | NewFloat64
+  | LoadAdtVariant
+  | StringSize
+  | BytesSize
+  | TagSimpleNumber
+  | UntagSimpleNumber
   | Not
   | Box
   | Unbox
@@ -340,6 +363,7 @@ type prim1 =
 
 [@deriving (sexp, yojson)]
 type prim2 =
+  | NewRational
   | Is
   | Eq
   | And
@@ -412,6 +436,7 @@ and expression_desc =
   | PExpRecordSet(expression, loc(Identifier.t), expression)
   | PExpLet(rec_flag, mut_flag, list(value_binding))
   | PExpMatch(expression, list(match_branch))
+  | PExpPrim0(prim0)
   | PExpPrim1(prim1, expression)
   | PExpPrim2(prim2, expression, expression)
   | PExpPrimN(primn, list(expression))

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -10,6 +10,7 @@ type primitive_constant =
 
 type primitive =
   | PrimitiveConstant(primitive_constant)
+  | Primitive0(prim0)
   | Primitive1(prim1)
   | Primitive2(prim2)
   | PrimitiveN(primn);
@@ -43,6 +44,25 @@ let prim_map =
       ("@heap.base", PrimitiveConstant(HeapBase)),
       ("@heap.start", PrimitiveConstant(HeapStart)),
       ("@heap.type_metadata", PrimitiveConstant(HeapTypeMetadata)),
+      ("@allocate.char", Primitive0(AllocateChar)),
+      ("@allocate.int32", Primitive0(AllocateInt32)),
+      ("@allocate.int64", Primitive0(AllocateInt64)),
+      ("@allocate.float32", Primitive0(AllocateFloat32)),
+      ("@allocate.float64", Primitive0(AllocateFloat64)),
+      ("@allocate.rational", Primitive0(AllocateRational)),
+      ("@allocate.array", Primitive1(AllocateArray)),
+      ("@allocate.tuple", Primitive1(AllocateTuple)),
+      ("@allocate.bytes", Primitive1(AllocateBytes)),
+      ("@allocate.string", Primitive1(AllocateString)),
+      ("@new.int32", Primitive1(NewInt32)),
+      ("@new.int64", Primitive1(NewInt64)),
+      ("@new.float32", Primitive1(NewFloat32)),
+      ("@new.float64", Primitive1(NewFloat64)),
+      ("@adt.load_variant", Primitive1(LoadAdtVariant)),
+      ("@string.size", Primitive1(StringSize)),
+      ("@bytes.size", Primitive1(BytesSize)),
+      ("@tag.simple_number", Primitive1(TagSimpleNumber)),
+      ("@untag.simple_number", Primitive1(UntagSimpleNumber)),
       ("@not", Primitive1(Not)),
       ("@box", Primitive1(Box)),
       ("@unbox", Primitive1(Unbox)),
@@ -54,6 +74,7 @@ let prim_map =
       ("@and", Primitive2(And)),
       ("@or", Primitive2(Or)),
       ("@array.length", Primitive1(ArrayLength)),
+      ("@new.rational", Primitive2(NewRational)),
       ("@wasm.load_int32", Primitive2(WasmLoadI32({sz: 4, signed: false}))),
       (
         "@wasm.load_8_s_int32",
@@ -1476,6 +1497,16 @@ let transl_prim = (env, desc) => {
           [];
         };
       (Exp.constant(~loc, ~attributes=disable_gc, value), attrs);
+    | Primitive0(
+        (
+          AllocateChar | AllocateInt32 | AllocateInt64 | AllocateFloat32 |
+          AllocateFloat64 |
+          AllocateRational
+        ) as p,
+      ) => (
+        Exp.lambda(~loc, ~attributes=disable_gc, [], Exp.prim0(~loc, p)),
+        [],
+      )
     | Primitive1(
         (
           WasmUnaryI32(_) | WasmUnaryI64(_) | WasmUnaryF32(_) | WasmUnaryF64(_) |

--- a/compiler/src/typed/translprim.rei
+++ b/compiler/src/typed/translprim.rei
@@ -7,6 +7,7 @@ type primitive_constant =
 
 type primitive =
   | PrimitiveConstant(primitive_constant)
+  | Primitive0(prim0)
   | Primitive1(prim1)
   | Primitive2(prim2)
   | PrimitiveN(primn);

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -98,8 +98,33 @@ let grain_type_of_wasm_prim_type =
   | Wasm_float64 => Builtin_types.type_wasmf64
   | Grain_bool => Builtin_types.type_bool;
 
+let prim0_type =
+  fun
+  | AllocateChar
+  | AllocateInt32
+  | AllocateInt64
+  | AllocateFloat32
+  | AllocateFloat64
+  | AllocateRational => Builtin_types.type_wasmi32;
+
 let prim1_type =
   fun
+  | AllocateArray
+  | AllocateTuple
+  | AllocateBytes
+  | AllocateString
+  | LoadAdtVariant
+  | StringSize
+  | BytesSize => (Builtin_types.type_wasmi32, Builtin_types.type_wasmi32)
+  | NewInt32 => (Builtin_types.type_wasmi32, Builtin_types.type_wasmi32)
+  | NewInt64 => (Builtin_types.type_wasmi64, Builtin_types.type_wasmi32)
+  | NewFloat32 => (Builtin_types.type_wasmf32, Builtin_types.type_wasmi32)
+  | NewFloat64 => (Builtin_types.type_wasmf64, Builtin_types.type_wasmi32)
+  | TagSimpleNumber => (Builtin_types.type_wasmi32, Builtin_types.type_number)
+  | UntagSimpleNumber => (
+      Builtin_types.type_number,
+      Builtin_types.type_wasmi32,
+    )
   | Not => (Builtin_types.type_bool, Builtin_types.type_bool)
   | Box
   | BoxBind => {
@@ -137,6 +162,11 @@ let prim1_type =
 
 let prim2_type =
   fun
+  | NewRational => (
+      Builtin_types.type_wasmi32,
+      Builtin_types.type_wasmi32,
+      Builtin_types.type_wasmi32,
+    )
   | And
   | Or => (
       Builtin_types.type_bool,
@@ -915,6 +945,16 @@ and type_expect_ =
       exp_extra: [],
       exp_attributes: attributes,
       exp_type: instance(env, ty_expected),
+      exp_env: env,
+    });
+  | PExpPrim0(p0) =>
+    let rettype = prim0_type(p0);
+    rue({
+      exp_desc: TExpPrim0(p0),
+      exp_loc: loc,
+      exp_extra: [],
+      exp_attributes: attributes,
+      exp_type: rettype,
       exp_env: env,
     });
   | PExpPrim1(p1, sarg) =>

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -175,8 +175,30 @@ type wasm_op =
     | Op_gt_float64
     | Op_ge_float64;
 
+type prim0 =
+  Parsetree.prim0 =
+    | AllocateChar
+    | AllocateInt32
+    | AllocateInt64
+    | AllocateFloat32
+    | AllocateFloat64
+    | AllocateRational;
+
 type prim1 =
   Parsetree.prim1 =
+    | AllocateArray
+    | AllocateTuple
+    | AllocateBytes
+    | AllocateString
+    | NewInt32
+    | NewInt64
+    | NewFloat32
+    | NewFloat64
+    | LoadAdtVariant
+    | StringSize
+    | BytesSize
+    | TagSimpleNumber
+    | UntagSimpleNumber
     | Not
     | Box
     | Unbox
@@ -212,6 +234,7 @@ type prim1 =
 
 type prim2 =
   Parsetree.prim2 =
+    | NewRational
     | Is
     | Eq
     | And
@@ -258,6 +281,10 @@ type primn =
     | WasmMemorySize
     | WasmMemoryCompare;
 
+let (prim0_of_sexp, sexp_of_prim0) = (
+  Parsetree.prim0_of_sexp,
+  Parsetree.sexp_of_prim0,
+);
 let (prim1_of_sexp, sexp_of_prim1) = (
   Parsetree.prim1_of_sexp,
   Parsetree.sexp_of_prim1,
@@ -425,6 +452,7 @@ and expression_desc =
     )
   | TExpLet(rec_flag, mut_flag, list(value_binding))
   | TExpMatch(expression, list(match_branch), partial)
+  | TExpPrim0(prim0)
   | TExpPrim1(prim1, expression)
   | TExpPrim2(prim2, expression, expression)
   | TExpPrimN(primn, list(expression))

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -174,8 +174,30 @@ type wasm_op =
     | Op_gt_float64
     | Op_ge_float64;
 
+type prim0 =
+  Parsetree.prim0 =
+    | AllocateChar
+    | AllocateInt32
+    | AllocateInt64
+    | AllocateFloat32
+    | AllocateFloat64
+    | AllocateRational;
+
 type prim1 =
   Parsetree.prim1 =
+    | AllocateArray
+    | AllocateTuple
+    | AllocateBytes
+    | AllocateString
+    | NewInt32
+    | NewInt64
+    | NewFloat32
+    | NewFloat64
+    | LoadAdtVariant
+    | StringSize
+    | BytesSize
+    | TagSimpleNumber
+    | UntagSimpleNumber
     | Not
     | Box
     | Unbox
@@ -211,6 +233,7 @@ type prim1 =
 
 type prim2 =
   Parsetree.prim2 =
+    | NewRational
     | Is
     | Eq
     | And
@@ -396,6 +419,7 @@ and expression_desc =
     )
   | TExpLet(rec_flag, mut_flag, list(value_binding))
   | TExpMatch(expression, list(match_branch), partial)
+  | TExpPrim0(prim0)
   | TExpPrim1(prim1, expression)
   | TExpPrim2(prim2, expression, expression)
   | TExpPrimN(primn, list(expression))

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -200,6 +200,7 @@ module MakeIterator =
     | TExpApp(exp, args) =>
       iter_expression(exp);
       List.iter(iter_expression, args);
+    | TExpPrim0(_) => ()
     | TExpPrim1(_, e) => iter_expression(e)
     | TExpPrim2(_, e1, e2) =>
       iter_expression(e1);

--- a/compiler/src/typed/typedtreeMap.re
+++ b/compiler/src/typed/typedtreeMap.re
@@ -197,6 +197,7 @@ module MakeMap =
         TExpLambda(map_match_branches(branches), p)
       | TExpApp(exp, args) =>
         TExpApp(map_expression(exp), List.map(map_expression, args))
+      | TExpPrim0(o) => TExpPrim0(o)
       | TExpPrim1(o, e) => TExpPrim1(o, map_expression(e))
       | TExpPrim2(o, e1, e2) =>
         TExpPrim2(o, map_expression(e1), map_expression(e2))

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -2,24 +2,46 @@ basic functionality › int64_1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt64\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt64 (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt64\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newInt64 (param i32 i64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newInt64
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt64)
-     (i64.const 99999999999999999)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 4)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 99999999999999999)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
@@ -2,24 +2,46 @@ basic functionality › heap_number_i64_wrapper
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt64\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt64 (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt64\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newInt64 (param i32 i64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newInt64
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt64)
-     (i64.const 2147483648)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 4)
+     )
+     (i64.store offset=8
+      (local.get $0)
+      (i64.const 2147483648)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -2,25 +2,50 @@ basic functionality › division1
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newRational\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newRational (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newRational\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newRational (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newRational
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newRational)
-     (i32.const 5)
-     (i32.const 2)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 5)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 5)
+     )
+     (i32.store offset=12
+      (local.get $0)
+      (i32.const 2)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -5,21 +5,43 @@ basic functionality › int32_1
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt32\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32 (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt32\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32)
-     (i32.const 42)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 42)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
@@ -5,21 +5,43 @@ basic functionality › heap_number_i32_wrapper_max
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt32\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32 (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt32\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32)
-     (i32.const 2147483647)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 2147483647)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
@@ -5,21 +5,43 @@ basic functionality › heap_number_i32_wrapper
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newInt32\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32 (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newInt32\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
   (tuple.extract 0
    (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/dataStructures_newInt32
-     (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newInt32)
-     (i32.const 1073741824)
+    (block (result i32)
+     (i32.store
+      (local.tee $0
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+          (i32.const 16)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (i32.const 6)
+     )
+     (i32.store offset=4
+      (local.get $0)
+      (i32.const 3)
+     )
+     (i32.store offset=8
+      (local.get $0)
+      (i32.const 1073741824)
+     )
+     (local.get $0)
     )
-    (i32.const 0)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -1,18 +1,18 @@
 pattern matching › constant_match_1
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"GRAIN$EXPORT$newRational\" (global $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newRational (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/dataStructures\" \"newRational\" (func $wimport_GRAIN$MODULE$runtime/dataStructures_newRational (param i32 i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $wimport_GRAIN$MODULE$runtime/equal_equal (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
@@ -23,17 +23,42 @@ pattern matching › constant_match_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local.set $1
+  (local $3 i32)
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (local.set $0
+      (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/dataStructures_newRational
-          (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newRational)
-          (i32.const 1)
-          (i32.const 3)
+         (block (result i32)
+          (i32.store
+           (local.tee $0
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (i32.const 6)
+          )
+          (i32.store offset=4
+           (local.get $0)
+           (i32.const 5)
+          )
+          (i32.store offset=8
+           (local.get $0)
+           (i32.const 1)
+          )
+          (i32.store offset=12
+           (local.get $0)
+           (i32.const 3)
+          )
+          (local.get $0)
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -42,16 +67,16 @@ pattern matching › constant_match_1
         )
        )
       )
-      (block $switch.15_outer (result i32)
+      (block $switch.17_outer (result i32)
        (drop
-        (block $switch.15_branch_1 (result i32)
+        (block $switch.17_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_2 (result i32)
+          (block $switch.17_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_3 (result i32)
+            (block $switch.17_branch_3 (result i32)
              (drop
-              (block $switch.15_default (result i32)
-               (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_default
+              (block $switch.17_default (result i32)
+               (br_table $switch.17_branch_1 $switch.17_branch_2 $switch.17_branch_3 $switch.17_default
                 (i32.const 0)
                 (i32.shr_s
                  (tuple.extract 0
@@ -67,7 +92,7 @@ pattern matching › constant_match_1
                         )
                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (local.get $0)
+                         (local.get $1)
                         )
                         (i32.const 11)
                        )
@@ -81,10 +106,34 @@ pattern matching › constant_match_1
                      (local.set $2
                       (tuple.extract 0
                        (tuple.make
-                        (call $wimport_GRAIN$MODULE$runtime/dataStructures_newRational
-                         (global.get $wimport_GRAIN$MODULE$runtime/dataStructures_GRAIN$EXPORT$newRational)
-                         (i32.const 1)
-                         (i32.const 3)
+                        (block (result i32)
+                         (i32.store
+                          (local.tee $0
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                              (i32.const 16)
+                             )
+                             (local.get $0)
+                            )
+                           )
+                          )
+                          (i32.const 6)
+                         )
+                         (i32.store offset=4
+                          (local.get $0)
+                          (i32.const 5)
+                         )
+                         (i32.store offset=8
+                          (local.get $0)
+                          (i32.const 1)
+                         )
+                         (i32.store offset=12
+                          (local.get $0)
+                          (i32.const 3)
+                         )
+                         (local.get $0)
                         )
                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -97,7 +146,7 @@ pattern matching › constant_match_1
                       (i32.const 3)
                       (i32.const 5)
                       (i32.shr_u
-                       (local.tee $1
+                       (local.tee $3
                         (tuple.extract 0
                          (tuple.make
                           (call $wimport_GRAIN$MODULE$runtime/equal_equal
@@ -107,7 +156,7 @@ pattern matching › constant_match_1
                            )
                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (local.get $0)
+                            (local.get $1)
                            )
                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -123,7 +172,7 @@ pattern matching › constant_match_1
                      )
                     )
                    )
-                   (local.get $1)
+                   (local.get $3)
                   )
                  )
                  (i32.const 1)
@@ -134,12 +183,12 @@ pattern matching › constant_match_1
              (unreachable)
             )
            )
-           (br $switch.15_outer
+           (br $switch.17_outer
             (i32.const 2147483646)
            )
           )
          )
-         (br $switch.15_outer
+         (br $switch.17_outer
           (i32.const -2)
          )
         )
@@ -147,14 +196,14 @@ pattern matching › constant_match_1
        (i32.const 2147483646)
       )
      )
-     (i32.const 0)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -163,7 +212,7 @@ pattern matching › constant_match_1
     (local.get $2)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -3,7 +3,7 @@
 /**
  * Allocates a new Grain array.
  *
- * @param numElts The number of elements to be contained in this array
+ * @param numElts: The number of elements to be contained in this array
  * @returns The pointer to the array
  */
 @unsafe
@@ -12,7 +12,7 @@ export primitive allocateArray: WasmI32 -> WasmI32 = "@allocate.array"
 /**
  * Allocates a new Grain tuple.
  *
- * @param numElts The number of elements to be contained in this tuple
+ * @param numElts: The number of elements to be contained in this tuple
  * @returns The pointer to the tuple
  */
 @unsafe
@@ -21,7 +21,7 @@ export primitive allocateTuple: WasmI32 -> WasmI32 = "@allocate.tuple"
 /**
  * Allocates a new Grain bytes.
  *
- * @param size The number of bytes to be contained in this buffer
+ * @param size: The number of bytes to be contained in this buffer
  * @returns The pointer to the bytes
  */
 @unsafe
@@ -30,7 +30,7 @@ export primitive allocateBytes: WasmI32 -> WasmI32 = "@allocate.bytes"
 /**
  * Allocates a new Grain string.
  *
- * @param size The size (in bytes) of the string to allocate
+ * @param size: The size (in bytes) of the string to allocate
  * @returns The pointer to the string
  */
 @unsafe
@@ -56,7 +56,7 @@ export primitive allocateInt32: () -> WasmI32 = "@allocate.int32"
 
 /**
  * Allocates a new Int32 with a prepopulated value
- * @param value The value to store
+ * @param value: The value to store
  * @returns The pointer to the Int32
  */
 @unsafe
@@ -72,7 +72,7 @@ export primitive allocateInt64: () -> WasmI32 = "@allocate.int64"
 
 /**
  * Allocates a new Int64 with a prepopulated value
- * @param value The value to store
+ * @param value: The value to store
  * @returns The pointer to the Int64
  */
 @unsafe
@@ -90,7 +90,7 @@ export primitive allocateFloat32: () -> WasmI32 = "@allocate.float32"
 
 /**
  * Allocates a new Float32 with a prepopulated value
- * @param value The value to store
+ * @param value: The value to store
  * @returns the pointer to the Float32
  */
 @unsafe
@@ -106,7 +106,7 @@ export primitive allocateFloat64: () -> WasmI32 = "@allocate.float64"
 
 /**
  * Allocates a new Float64 with a prepopulated value
- * @param value The value to store
+ * @param value: The value to store
  * @returns The pointer to the Float64
  */
 @unsafe
@@ -124,8 +124,8 @@ export primitive allocateRational: () -> WasmI32 = "@allocate.rational"
 
 /**
  * Allocates a new Rational with a prepopulated value
- * @param value The numerator value to store
- * @param value The denominator value to store
+ * @param value: The numerator value to store
+ * @param value: The denominator value to store
  * @returns The pointer to the Rational
  */
 @unsafe
@@ -134,7 +134,7 @@ export primitive newRational: (WasmI32, WasmI32) -> WasmI32 = "@new.rational"
 /**
  * Load the (tagged) variant of an ADT.
  *
- * @param ptr Untagged pointer to the ADT
+ * @param ptr: Untagged pointer to the ADT
  * @returns The (tagged) ADT variant id
  */
 @unsafe
@@ -143,7 +143,7 @@ export primitive loadAdtVariant: WasmI32 -> WasmI32 = "@adt.load_variant"
 /**
  * Load an untagged string's size.
  *
- * @param ptr Untagged pointer to the string
+ * @param ptr: Untagged pointer to the string
  * @returns The string size (in bytes)
  */
 @unsafe
@@ -152,7 +152,7 @@ export primitive stringSize: WasmI32 -> WasmI32 = "@string.size"
 /**
  * Load an untagged Bytes' size.
  *
- * @param ptr Untagged pointer to the Bytes
+ * @param ptr: Untagged pointer to the Bytes
  * @returns The Bytes size (in bytes)
  */
 @unsafe
@@ -161,7 +161,7 @@ export primitive bytesSize: WasmI32 -> WasmI32 = "@bytes.size"
 /**
  * Tag a simple number.
  *
- * @param num The number to tag
+ * @param num: The number to tag
  * @returns The tagged number
  */
 @unsafe
@@ -170,7 +170,7 @@ export primitive tagSimpleNumber: WasmI32 -> Number = "@tag.simple_number"
 /**
  * Untag a simple number.
  *
- * @param num The number to untag
+ * @param num: The number to untag
  * @returns The untagged number
  */
 @unsafe

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -1,350 +1,176 @@
-/* grainc-flags --compilation-mode=runtime */
-
-import Memory from "runtime/unsafe/memory"
-import Tags from "runtime/unsafe/tags"
-import WasmI32, {
-  add as (+),
-  mul as (*),
-  xor as (^),
-  shl as (<<),
-} from "runtime/unsafe/wasmi32"
-import WasmI64 from "runtime/unsafe/wasmi64"
-import WasmF32 from "runtime/unsafe/wasmf32"
-import WasmF64 from "runtime/unsafe/wasmf64"
-
-//
-// For performance reasons, all functions in this module do not
-// decRef their arguments. Consequently, callers should not incRef them before calling.
-//
+/* grainc-flags --no-pervasives */
 
 /**
  * Allocates a new Grain array.
  *
- * @param {WasmI32} numElts The number of elements to be contained in this array
- * @returns {WasmI32} The pointer to the array
+ * @param numElts The number of elements to be contained in this array
+ * @returns The pointer to the array
  */
-export let allocateArray = numElts => {
-  let arr = Memory.malloc((numElts + 2n) * 4n)
-
-  WasmI32.store(arr, Tags._GRAIN_ARRAY_HEAP_TAG, 0n)
-  WasmI32.store(arr, numElts, 4n)
-
-  arr
-}
-
-/**
- * Stores an item in a Grain array.
- *
- * @param {WasmI32} array The array to store the item in
- * @param {WasmI32} idx The index to store the item
- * @param {WasmI32} item The item to store
- */
-export let storeInArray = (arr, idx, item) => {
-  WasmI32.store(arr + idx * 4n, item, 8n)
-}
+@unsafe
+export primitive allocateArray: WasmI32 -> WasmI32 = "@allocate.array"
 
 /**
  * Allocates a new Grain tuple.
  *
- * @param {WasmI32} numElts The number of elements to be contained in this tuple
- * @returns {WasmI32} The pointer to the tuple
+ * @param numElts The number of elements to be contained in this tuple
+ * @returns The pointer to the tuple
  */
-export let allocateTuple = numElts => {
-  let tuple = Memory.malloc((numElts + 2n) * 4n)
-
-  WasmI32.store(tuple, Tags._GRAIN_TUPLE_HEAP_TAG, 0n)
-  WasmI32.store(tuple, numElts, 4n)
-
-  tuple
-}
-
-/**
- * Stores an item in a Grain tuple.
- *
- * @param {WasmI32} tuple The tuple to store the item in
- * @param {WasmI32} idx The index to store the item
- * @param {WasmI32} item The item to store
- */
-export let storeInTuple = (tuple, idx, item) => {
-  WasmI32.store(tuple + idx * 4n, item, 8n)
-}
+@unsafe
+export primitive allocateTuple: WasmI32 -> WasmI32 = "@allocate.tuple"
 
 /**
  * Allocates a new Grain bytes.
  *
- * @param {WasmI32} size The number of bytes to be contained in this buffer
- * @returns {WasmI32} The pointer to the bytes
+ * @param size The number of bytes to be contained in this buffer
+ * @returns The pointer to the bytes
  */
-export let allocateBytes = size => {
-  let len = size + 8n
-  let bytes = Memory.malloc(len)
-  Memory.fill(bytes, 0n, len)
-  WasmI32.store(bytes, Tags._GRAIN_BYTES_HEAP_TAG, 0n)
-  WasmI32.store(bytes, size, 4n)
-  bytes
-}
+@unsafe
+export primitive allocateBytes: WasmI32 -> WasmI32 = "@allocate.bytes"
 
 /**
  * Allocates a new Grain string.
  *
- * @param {WasmI32} size The size (in bytes) of the string to allocate
- * @returns {WasmI32} The pointer to the string
+ * @param size The size (in bytes) of the string to allocate
+ * @returns The pointer to the string
  */
-export let allocateString = size => {
-  let str = Memory.malloc(size + 8n)
-
-  WasmI32.store(str, Tags._GRAIN_STRING_HEAP_TAG, 0n)
-  WasmI32.store(str, size, 4n)
-
-  str
-}
+@unsafe
+export primitive allocateString: WasmI32 -> WasmI32 = "@allocate.string"
 
 /**
  * Allocates a new Grain char.
  *
- * @returns {WasmI32} The pointer to the char
+ * @returns The pointer to the char
  */
-export let allocateChar = () => {
-  let char = Memory.malloc(8n)
-
-  WasmI32.store(char, Tags._GRAIN_CHAR_HEAP_TAG, 0n)
-
-  char
-}
+@unsafe
+export primitive allocateChar: () -> WasmI32 = "@allocate.char"
 
 // INT32/INT64
 
 /**
- * Allocates a new Int64.
- *
- * @returns {WasmI32}
- */
-export let allocateInt64 = () => {
-  let ptr = Memory.malloc(16n)
-
-  WasmI32.store(ptr, Tags._GRAIN_BOXED_NUM_HEAP_TAG, 0n)
-  WasmI32.store(ptr, Tags._GRAIN_INT64_BOXED_NUM_TAG, 4n)
-
-  ptr
-}
-
-/**
- * Allocates a new Int64 with a prepopulated value
- * @param value The value to store
- */
-export let newInt64 = value => {
-  let ptr = allocateInt64()
-  WasmI64.store(ptr, value, 8n)
-  ptr
-}
-
-/**
- * Returns a pointer to the heap location containing this boxed number's Int64
- * @param wrappedInt64 The boxed int64 to return
- */
-export let rawInt64Ptr = wrappedInt64 => {
-  wrappedInt64 + 8n
-}
-
-export let loadInt64 = xptr => {
-  WasmI64.load(xptr, 8n)
-}
-
-/**
  * Allocates a new Int32.
  *
- * @returns {WasmI32}
+ * @returns
  */
-export let allocateInt32 = () => {
-  let ptr = Memory.malloc(12n)
-
-  WasmI32.store(ptr, Tags._GRAIN_BOXED_NUM_HEAP_TAG, 0n)
-  WasmI32.store(ptr, Tags._GRAIN_INT32_BOXED_NUM_TAG, 4n)
-
-  ptr
-}
+@unsafe
+export primitive allocateInt32: () -> WasmI32 = "@allocate.int32"
 
 /**
  * Allocates a new Int32 with a prepopulated value
  * @param value The value to store
  */
-export let newInt32 = value => {
-  let ptr = allocateInt32()
-  WasmI32.store(ptr, value, 8n)
-  ptr
-}
+@unsafe
+export primitive newInt32: WasmI32 -> WasmI32 = "@new.int32"
 
 /**
- * Returns a pointer to the heap location containing this boxed number's Int32
- * @param wrappedInt32 The boxed int32 to return
+ * Allocates a new Int64.
+ *
+ * @returns
  */
-export let rawInt32Ptr = wrappedInt32 => {
-  wrappedInt32 + 8n
-}
+@unsafe
+export primitive allocateInt64: () -> WasmI32 = "@allocate.int64"
 
-export let loadInt32 = xptr => {
-  WasmI32.load(xptr, 8n)
-}
+/**
+ * Allocates a new Int64 with a prepopulated value
+ * @param value The value to store
+ */
+@unsafe
+export primitive newInt64: WasmI64 -> WasmI32 = "@new.int64"
 
 // FLOATS
 
 /**
  * Allocates a new Float32.
  *
- * @returns {WasmI32}
+ * @returns
  */
-export let allocateFloat32 = () => {
-  let ptr = Memory.malloc(12n)
-
-  WasmI32.store(ptr, Tags._GRAIN_BOXED_NUM_HEAP_TAG, 0n)
-  WasmI32.store(ptr, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG, 4n)
-
-  ptr
-}
+@unsafe
+export primitive allocateFloat32: () -> WasmI32 = "@allocate.float32"
 
 /**
  * Allocates a new Float32 with a prepopulated value
  * @param value The value to store
  */
-export let newFloat32 = value => {
-  let ptr = allocateFloat32()
-  WasmF32.store(ptr, value, 8n)
-  ptr
-}
-
-/**
- * Returns a pointer to the heap location containing this boxed number's Float32
- * @param wrappedFloat32 The boxed float32 to return
- */
-export let rawFloat32Ptr = wrappedFloat32 => {
-  wrappedFloat32 + 8n
-}
-
-export let loadFloat32 = xptr => {
-  WasmF32.load(xptr, 8n)
-}
+@unsafe
+export primitive newFloat32: WasmF32 -> WasmI32 = "@new.float32"
 
 /**
  * Allocates a new Float64.
  *
- * @returns {WasmI32}
+ * @returns
  */
-export let allocateFloat64 = () => {
-  let ptr = Memory.malloc(16n)
-
-  WasmI32.store(ptr, Tags._GRAIN_BOXED_NUM_HEAP_TAG, 0n)
-  WasmI32.store(ptr, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG, 4n)
-
-  ptr
-}
+@unsafe
+export primitive allocateFloat64: () -> WasmI32 = "@allocate.float64"
 
 /**
  * Allocates a new Float64 with a prepopulated value
  * @param value The value to store
  */
-export let newFloat64 = value => {
-  let ptr = allocateFloat64()
-  WasmF64.store(ptr, value, 8n)
-  ptr
-}
-
-/**
- * Returns a pointer to the heap location containing this boxed number's Float64
- * @param wrappedFloat64 The boxed float64 to return
- */
-export let rawFloat64Ptr = wrappedFloat64 => {
-  wrappedFloat64 + 8n
-}
-
-export let loadFloat64 = xptr => {
-  WasmF64.load(xptr, 8n)
-}
+@unsafe
+export primitive newFloat64: WasmF64 -> WasmI32 = "@new.float64"
 
 // RATIONALS
 
 /**
  * Allocates a new Rational.
  *
- * @returns {WasmI32}
+ * @returns
  */
-export let allocateRational = () => {
-  let ptr = Memory.malloc(16n)
-
-  WasmI32.store(ptr, Tags._GRAIN_BOXED_NUM_HEAP_TAG, 0n)
-  WasmI32.store(ptr, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG, 4n)
-
-  ptr
-}
+@unsafe
+export primitive allocateRational: () -> WasmI32 = "@allocate.rational"
 
 /**
  * Allocates a new Rational with a prepopulated value
  * @param value The value to store
  */
-export let newRational = (numerator, denominator) => {
-  let ptr = allocateRational()
-  WasmI32.store(ptr, numerator, 8n)
-  WasmI32.store(ptr, denominator, 12n)
-  ptr
-}
-
-/**
- * Returns a pointer to the heap location containing this boxed number's Rational numerator
- * @param wrappedRational The boxed rational to return
- */
-export let rawRationalNumeratorPtr = wrappedRational => {
-  wrappedRational + 8n
-}
-
-/**
- * Returns a pointer to the heap location containing this boxed number's Rational numerator
- * @param wrappedRational The boxed rational to return
- */
-export let rawRationalDenominatorPtr = wrappedRational => {
-  wrappedRational + 12n
-}
-
-export let loadRationalNumerator = xptr => {
-  WasmI32.load(xptr, 8n)
-}
-
-export let loadRationalDenominator = xptr => {
-  WasmI32.load(xptr, 12n)
-}
-
-/**
- * Load a value from an ADT.
- *
- * @export
- * @param {WasmI32} ptr Untagged pointer to the ADT
- * @param {WasmI32} idx Index (from zero) of the item
- * @returns {WasmI32} The value located at the index
- */
-export let loadAdtVal = (ptr, idx) => {
-  WasmI32.load(ptr + idx * 4n, 20n)
-}
+@unsafe
+export primitive newRational: (WasmI32, WasmI32) -> WasmI32 = "@new.rational"
 
 /**
  * Load the (tagged) variant of an ADT.
  *
  * @export
- * @param {WasmI32} ptr Untagged pointer to the ADT
- * @returns {WasmI32} The (tagged) ADT variant id
+ * @param ptr Untagged pointer to the ADT
+ * @returns The (tagged) ADT variant id
  */
-export let loadAdtVariant = ptr => {
-  WasmI32.load(ptr, 12n)
-}
+@unsafe
+export primitive loadAdtVariant: WasmI32 -> WasmI32 = "@adt.load_variant"
 
 /**
  * Load an untagged string's size.
  *
  * @export
- * @param {WasmI32} ptr Untagged pointer to the string
- * @returns {WasmI32} The string size (in bytes)
+ * @param ptr Untagged pointer to the string
+ * @returns The string size (in bytes)
  */
-export let stringSize = ptr => {
-  WasmI32.load(ptr, 4n)
-}
+@unsafe
+export primitive stringSize: WasmI32 -> WasmI32 = "@string.size"
 
-export let tagSimpleNumber = x => {
-  WasmI32.toGrain(x << 1n ^ 1n): Number
-}
+/**
+ * Load an untagged Bytes' size.
+ *
+ * @export
+ * @param ptr Untagged pointer to the Bytes
+ * @returns The string size (in bytes)
+ */
+@unsafe
+export primitive bytesSize: WasmI32 -> WasmI32 = "@bytes.size"
+
+/**
+ * Tag a simple number.
+ *
+ * @export
+ * @param num The number to tag
+ * @returns The tagged number
+ */
+@unsafe
+export primitive tagSimpleNumber: WasmI32 -> Number = "@tag.simple_number"
+
+/**
+ * Untag a simple number.
+ *
+ * @export
+ * @param num The number to untag
+ * @returns The untagged number
+ */
+@unsafe
+export primitive untagSimpleNumber: Number -> WasmI32 = "@untag.simple_number"

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -49,7 +49,7 @@ export primitive allocateChar: () -> WasmI32 = "@allocate.char"
 /**
  * Allocates a new Int32.
  *
- * @returns
+ * @returns The pointer to the empty Int32
  */
 @unsafe
 export primitive allocateInt32: () -> WasmI32 = "@allocate.int32"
@@ -57,6 +57,7 @@ export primitive allocateInt32: () -> WasmI32 = "@allocate.int32"
 /**
  * Allocates a new Int32 with a prepopulated value
  * @param value The value to store
+ * @returns The pointer to the Int32
  */
 @unsafe
 export primitive newInt32: WasmI32 -> WasmI32 = "@new.int32"
@@ -64,7 +65,7 @@ export primitive newInt32: WasmI32 -> WasmI32 = "@new.int32"
 /**
  * Allocates a new Int64.
  *
- * @returns
+ * @returns The pointer to the empty Int64
  */
 @unsafe
 export primitive allocateInt64: () -> WasmI32 = "@allocate.int64"
@@ -72,6 +73,7 @@ export primitive allocateInt64: () -> WasmI32 = "@allocate.int64"
 /**
  * Allocates a new Int64 with a prepopulated value
  * @param value The value to store
+ * @returns The pointer to the Int64
  */
 @unsafe
 export primitive newInt64: WasmI64 -> WasmI32 = "@new.int64"
@@ -81,7 +83,7 @@ export primitive newInt64: WasmI64 -> WasmI32 = "@new.int64"
 /**
  * Allocates a new Float32.
  *
- * @returns
+ * @returns The pointer to the empty Float32
  */
 @unsafe
 export primitive allocateFloat32: () -> WasmI32 = "@allocate.float32"
@@ -89,6 +91,7 @@ export primitive allocateFloat32: () -> WasmI32 = "@allocate.float32"
 /**
  * Allocates a new Float32 with a prepopulated value
  * @param value The value to store
+ * @returns the pointer to the Float32
  */
 @unsafe
 export primitive newFloat32: WasmF32 -> WasmI32 = "@new.float32"
@@ -96,7 +99,7 @@ export primitive newFloat32: WasmF32 -> WasmI32 = "@new.float32"
 /**
  * Allocates a new Float64.
  *
- * @returns
+ * @returns The pointer to the empty Float64
  */
 @unsafe
 export primitive allocateFloat64: () -> WasmI32 = "@allocate.float64"
@@ -104,6 +107,7 @@ export primitive allocateFloat64: () -> WasmI32 = "@allocate.float64"
 /**
  * Allocates a new Float64 with a prepopulated value
  * @param value The value to store
+ * @returns The pointer to the Float64
  */
 @unsafe
 export primitive newFloat64: WasmF64 -> WasmI32 = "@new.float64"
@@ -113,14 +117,16 @@ export primitive newFloat64: WasmF64 -> WasmI32 = "@new.float64"
 /**
  * Allocates a new Rational.
  *
- * @returns
+ * @returns The pointer to the empty Rational
  */
 @unsafe
 export primitive allocateRational: () -> WasmI32 = "@allocate.rational"
 
 /**
  * Allocates a new Rational with a prepopulated value
- * @param value The value to store
+ * @param value The numerator value to store
+ * @param value The denominator value to store
+ * @returns The pointer to the Rational
  */
 @unsafe
 export primitive newRational: (WasmI32, WasmI32) -> WasmI32 = "@new.rational"
@@ -128,7 +134,6 @@ export primitive newRational: (WasmI32, WasmI32) -> WasmI32 = "@new.rational"
 /**
  * Load the (tagged) variant of an ADT.
  *
- * @export
  * @param ptr Untagged pointer to the ADT
  * @returns The (tagged) ADT variant id
  */
@@ -138,7 +143,6 @@ export primitive loadAdtVariant: WasmI32 -> WasmI32 = "@adt.load_variant"
 /**
  * Load an untagged string's size.
  *
- * @export
  * @param ptr Untagged pointer to the string
  * @returns The string size (in bytes)
  */
@@ -148,9 +152,8 @@ export primitive stringSize: WasmI32 -> WasmI32 = "@string.size"
 /**
  * Load an untagged Bytes' size.
  *
- * @export
  * @param ptr Untagged pointer to the Bytes
- * @returns The string size (in bytes)
+ * @returns The Bytes size (in bytes)
  */
 @unsafe
 export primitive bytesSize: WasmI32 -> WasmI32 = "@bytes.size"
@@ -158,7 +161,6 @@ export primitive bytesSize: WasmI32 -> WasmI32 = "@bytes.size"
 /**
  * Tag a simple number.
  *
- * @export
  * @param num The number to tag
  * @returns The tagged number
  */
@@ -168,7 +170,6 @@ export primitive tagSimpleNumber: WasmI32 -> Number = "@tag.simple_number"
 /**
  * Untag a simple number.
  *
- * @export
  * @param num The number to untag
  * @returns The untagged number
  */

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -1,0 +1,365 @@
+### DataStructures.**allocateArray**
+
+```grain
+allocateArray : WasmI32 -> WasmI32
+```
+
+Allocates a new Grain array.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`numElts`|`WasmI32`|The number of elements to be contained in this array|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the array|
+
+### DataStructures.**allocateTuple**
+
+```grain
+allocateTuple : WasmI32 -> WasmI32
+```
+
+Allocates a new Grain tuple.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`numElts`|`WasmI32`|The number of elements to be contained in this tuple|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the tuple|
+
+### DataStructures.**allocateBytes**
+
+```grain
+allocateBytes : WasmI32 -> WasmI32
+```
+
+Allocates a new Grain bytes.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`size`|`WasmI32`|The number of bytes to be contained in this buffer|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the bytes|
+
+### DataStructures.**allocateString**
+
+```grain
+allocateString : WasmI32 -> WasmI32
+```
+
+Allocates a new Grain string.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`size`|`WasmI32`|The size (in bytes) of the string to allocate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the string|
+
+### DataStructures.**allocateChar**
+
+```grain
+allocateChar : () -> WasmI32
+```
+
+Allocates a new Grain char.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the char|
+
+### DataStructures.**allocateInt32**
+
+```grain
+allocateInt32 : () -> WasmI32
+```
+
+Allocates a new Int32.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the empty Int32|
+
+### DataStructures.**newInt32**
+
+```grain
+newInt32 : WasmI32 -> WasmI32
+```
+
+Allocates a new Int32 with a prepopulated value
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`WasmI32`|The value to store|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the Int32|
+
+### DataStructures.**allocateInt64**
+
+```grain
+allocateInt64 : () -> WasmI32
+```
+
+Allocates a new Int64.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the empty Int64|
+
+### DataStructures.**newInt64**
+
+```grain
+newInt64 : WasmI64 -> WasmI32
+```
+
+Allocates a new Int64 with a prepopulated value
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`WasmI64`|The value to store|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the Int64|
+
+### DataStructures.**allocateFloat32**
+
+```grain
+allocateFloat32 : () -> WasmI32
+```
+
+Allocates a new Float32.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the empty Float32|
+
+### DataStructures.**newFloat32**
+
+```grain
+newFloat32 : WasmF32 -> WasmI32
+```
+
+Allocates a new Float32 with a prepopulated value
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`WasmF32`|The value to store|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|the pointer to the Float32|
+
+### DataStructures.**allocateFloat64**
+
+```grain
+allocateFloat64 : () -> WasmI32
+```
+
+Allocates a new Float64.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the empty Float64|
+
+### DataStructures.**newFloat64**
+
+```grain
+newFloat64 : WasmF64 -> WasmI32
+```
+
+Allocates a new Float64 with a prepopulated value
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`WasmF64`|The value to store|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the Float64|
+
+### DataStructures.**allocateRational**
+
+```grain
+allocateRational : () -> WasmI32
+```
+
+Allocates a new Rational.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the empty Rational|
+
+### DataStructures.**newRational**
+
+```grain
+newRational : (WasmI32, WasmI32) -> WasmI32
+```
+
+Allocates a new Rational with a prepopulated value
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`WasmI32`|The numerator value to store|
+|`value`|`WasmI32`|The denominator value to store|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the Rational|
+
+### DataStructures.**loadAdtVariant**
+
+```grain
+loadAdtVariant : WasmI32 -> WasmI32
+```
+
+Load the (tagged) variant of an ADT.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`ptr`|`WasmI32`|Untagged pointer to the ADT|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The (tagged) ADT variant id|
+
+### DataStructures.**stringSize**
+
+```grain
+stringSize : WasmI32 -> WasmI32
+```
+
+Load an untagged string's size.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`ptr`|`WasmI32`|Untagged pointer to the string|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The string size (in bytes)|
+
+### DataStructures.**bytesSize**
+
+```grain
+bytesSize : WasmI32 -> WasmI32
+```
+
+Load an untagged Bytes' size.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`ptr`|`WasmI32`|Untagged pointer to the Bytes|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The Bytes size (in bytes)|
+
+### DataStructures.**tagSimpleNumber**
+
+```grain
+tagSimpleNumber : WasmI32 -> Number
+```
+
+Tag a simple number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num`|`WasmI32`|The number to tag|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The tagged number|
+
+### DataStructures.**untagSimpleNumber**
+
+```grain
+untagSimpleNumber : Number -> WasmI32
+```
+
+Untag a simple number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num`|`Number`|The number to untag|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The untagged number|
+

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -24,12 +24,6 @@ import {
   newFloat64,
 } from "runtime/dataStructures"
 
-export newRational
-export newInt32
-export newInt64
-export newFloat32
-export newFloat64
-
 @unsafe
 let _I32_MAX = 0x7fffffffN
 @unsafe

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -30,7 +30,6 @@ import {
   tagSimpleNumber,
   allocateArray,
   allocateString,
-  loadAdtVal,
   newInt64,
   allocateInt64,
 } from "runtime/dataStructures"


### PR DESCRIPTION
This means that all of the data structures functions get inlined, so there's no performance cost to using something like `untagNumber`.