### PR TITLE
fix(compiler)!: Enable garbage collection of simply-recursive functions

### DIFF
--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -24,52 +24,61 @@ basic functionality › pattern_match_unsafe_wasm
   (local $1 i32)
   (local $2 i32)
   (i32.store offset=16
-   (tuple.extract 0
-    (tuple.make
-     (local.tee $2
-      (tuple.extract 0
-       (tuple.make
-        (block (result i32)
-         (i32.store
-          (local.tee $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-              (i32.const 20)
+   (local.tee $1
+    (tuple.extract 0
+     (tuple.make
+      (local.tee $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $1
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 20)
+              )
+              (i32.const 0)
              )
-             (i32.const 0)
             )
            )
+           (i32.const 7)
           )
-          (i32.const 7)
-         )
-         (i32.store offset=4
-          (local.get $1)
-          (i32.const 2)
-         )
-         (i32.store offset=8
-          (local.get $1)
-          (i32.add
-           (global.get $wimport__grainEnv_relocBase)
+          (i32.store offset=4
+           (local.get $1)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $1)
+           (i32.add
+            (global.get $wimport__grainEnv_relocBase)
+            (i32.const 1)
+           )
+          )
+          (i32.store offset=12
+           (local.get $1)
            (i32.const 1)
           )
-         )
-         (i32.store offset=12
           (local.get $1)
-          (i32.const 1)
          )
-         (local.get $1)
+         (i32.const 0)
         )
-        (i32.const 0)
        )
       )
+      (local.get $1)
      )
-     (local.get $1)
     )
    )
-   (i32.load offset=16
-    (local.get $0)
+   (local.tee $0
+    (tuple.extract 0
+     (tuple.make
+      (i32.load offset=16
+       (local.get $0)
+      )
+      (i32.const 0)
+     )
+    )
    )
   )
   (drop
@@ -104,24 +113,24 @@ basic functionality › pattern_match_unsafe_wasm
  (func $foo_1154 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (block $switch.31_outer (result i32)
+  (block $switch.32_outer (result i32)
    (drop
-    (block $switch.31_branch_1 (result i32)
+    (block $switch.32_branch_1 (result i32)
      (drop
-      (block $switch.31_branch_2 (result i32)
+      (block $switch.32_branch_2 (result i32)
        (drop
-        (block $switch.31_branch_3 (result i32)
+        (block $switch.32_branch_3 (result i32)
          (drop
-          (block $switch.31_branch_4 (result i32)
+          (block $switch.32_branch_4 (result i32)
            (drop
-            (block $switch.31_branch_5 (result i32)
+            (block $switch.32_branch_5 (result i32)
              (drop
-              (block $switch.31_branch_6 (result i32)
+              (block $switch.32_branch_6 (result i32)
                (drop
-                (block $switch.31_branch_7 (result i32)
+                (block $switch.32_branch_7 (result i32)
                  (drop
-                  (block $switch.31_default (result i32)
-                   (br_table $switch.31_branch_1 $switch.31_branch_2 $switch.31_branch_3 $switch.31_branch_4 $switch.31_branch_5 $switch.31_branch_6 $switch.31_branch_7 $switch.31_default
+                  (block $switch.32_default (result i32)
+                   (br_table $switch.32_branch_1 $switch.32_branch_2 $switch.32_branch_3 $switch.32_branch_4 $switch.32_branch_5 $switch.32_branch_6 $switch.32_branch_7 $switch.32_default
                     (i32.const 0)
                     (i32.shr_s
                      (tuple.extract 0
@@ -300,7 +309,7 @@ basic functionality › pattern_match_unsafe_wasm
                  )
                 )
                )
-               (br $switch.31_outer
+               (br $switch.32_outer
                 (call_indirect (type $i32_i32_=>_i32)
                  (local.tee $0
                   (tuple.extract 0
@@ -320,7 +329,7 @@ basic functionality › pattern_match_unsafe_wasm
                )
               )
              )
-             (br $switch.31_outer
+             (br $switch.32_outer
               (call_indirect (type $i32_i32_=>_i32)
                (local.tee $0
                 (tuple.extract 0
@@ -340,7 +349,7 @@ basic functionality › pattern_match_unsafe_wasm
              )
             )
            )
-           (br $switch.31_outer
+           (br $switch.32_outer
             (call_indirect (type $i32_i32_=>_i32)
              (local.tee $0
               (tuple.extract 0
@@ -360,7 +369,7 @@ basic functionality › pattern_match_unsafe_wasm
            )
           )
          )
-         (br $switch.31_outer
+         (br $switch.32_outer
           (call_indirect (type $i32_i32_=>_i32)
            (local.tee $0
             (tuple.extract 0
@@ -380,7 +389,7 @@ basic functionality › pattern_match_unsafe_wasm
          )
         )
        )
-       (br $switch.31_outer
+       (br $switch.32_outer
         (call_indirect (type $i32_i32_=>_i32)
          (local.tee $0
           (tuple.extract 0
@@ -400,7 +409,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
      )
-     (br $switch.31_outer
+     (br $switch.32_outer
       (call_indirect (type $i32_i32_=>_i32)
        (local.tee $0
         (tuple.extract 0
@@ -441,6 +450,7 @@ basic functionality › pattern_match_unsafe_wasm
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -492,9 +502,28 @@ basic functionality › pattern_match_unsafe_wasm
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_print)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $2)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
        )
       )
       (call $test_1153

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -69,6 +69,7 @@ functions › shorthand_4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -120,9 +121,28 @@ functions › shorthand_4
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $2)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
        )
       )
       (call $foo_1153

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -334,7 +334,7 @@ functions › lam_destructure_5
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -377,12 +377,31 @@ functions › lam_destructure_5
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -467,11 +486,11 @@ functions › lam_destructure_5
       (call $lam_lambda_1158
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -486,13 +505,13 @@ functions › lam_destructure_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -146,12 +146,12 @@ functions › curried_func
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (block (result i32)
       (i32.store offset=16
-       (local.tee $1
+       (local.tee $0
         (tuple.extract 0
          (tuple.make
           (local.tee $2
@@ -197,12 +197,31 @@ functions › curried_func
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $0
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (call $add_1153
@@ -220,24 +239,24 @@ functions › curried_func
        )
       )
       (call_indirect (type $i32_i32_=>_i32)
-       (local.tee $1
+       (local.tee $0
         (tuple.extract 0
          (tuple.make
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $0)
+           (local.get $1)
           )
-          (local.get $1)
+          (local.get $0)
          )
         )
        )
        (i32.const 7)
        (i32.load offset=8
-        (local.get $1)
+        (local.get $0)
        )
       )
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
@@ -250,10 +269,10 @@ functions › curried_func
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -195,7 +195,7 @@ functions › lam_destructure_3
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -238,12 +238,31 @@ functions › lam_destructure_3
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -289,11 +308,11 @@ functions › lam_destructure_3
       (call $lam_lambda_1156
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -304,13 +323,13 @@ functions › lam_destructure_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -285,7 +285,7 @@ functions › lam_destructure_7
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -328,12 +328,31 @@ functions › lam_destructure_7
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -406,7 +425,7 @@ functions › lam_destructure_7
            (local.get $0)
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (local.get $2)
+            (local.get $1)
            )
           )
           (local.get $0)
@@ -421,7 +440,7 @@ functions › lam_destructure_7
       (call $lam_lambda_1157
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -436,13 +455,13 @@ functions › lam_destructure_7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -69,6 +69,7 @@ functions › shorthand_2
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -120,9 +121,28 @@ functions › shorthand_2
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $2)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
        )
       )
       (call $foo_1153

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -195,7 +195,7 @@ functions › lam_destructure_4
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -238,12 +238,31 @@ functions › lam_destructure_4
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -289,11 +308,11 @@ functions › lam_destructure_4
       (call $foo_1153
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
       )
      )
@@ -304,13 +323,13 @@ functions › lam_destructure_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -285,7 +285,7 @@ functions › lam_destructure_8
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -328,12 +328,31 @@ functions › lam_destructure_8
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -406,7 +425,7 @@ functions › lam_destructure_8
            (local.get $0)
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (local.get $2)
+            (local.get $1)
            )
           )
           (local.get $0)
@@ -421,7 +440,7 @@ functions › lam_destructure_8
       (call $foo_1153
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -436,13 +455,13 @@ functions › lam_destructure_8
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -78,6 +78,7 @@ functions › fn_trailing_comma
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -129,9 +130,28 @@ functions › fn_trailing_comma
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $2)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
        )
       )
       (call $testFn_1153

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -334,7 +334,7 @@ functions › lam_destructure_6
        (local.tee $0
         (tuple.extract 0
          (tuple.make
-          (local.tee $1
+          (local.tee $2
            (tuple.extract 0
             (tuple.make
              (block (result i32)
@@ -377,12 +377,31 @@ functions › lam_destructure_6
          )
         )
        )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (i32.const 0)
+         )
+        )
        )
       )
-      (local.set $2
+      (if
+       (i32.eq
+        (local.get $0)
+        (local.get $1)
+       )
+       (drop
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+      (local.set $1
        (tuple.extract 0
         (tuple.make
          (block (result i32)
@@ -467,11 +486,11 @@ functions › lam_destructure_6
       (call $foo_1153
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $1)
+        (local.get $2)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
+        (local.get $1)
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -486,13 +505,13 @@ functions › lam_destructure_6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -26,6 +26,7 @@ import WasmI32, {
   mul as (*),
   and as (&),
   eq as (==),
+  ne as (!=),
 } from "runtime/unsafe/wasmi32"
 
 // Using foreigns directly here to avoid cyclic dependency
@@ -232,7 +233,12 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
       let arity = WasmI32.load(userPtr, 12n)
       let maxOffset = arity * 4n
       for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-        ignore(decRef(WasmI32.load(userPtr + i, 16n), false))
+        let val = WasmI32.load(userPtr + i, 16n)
+        // special case: we don't traverse into self-references on lambdas
+        // (this is a hack which allows us to garbage-collect simply-recursive functions)
+        if (val != userPtr) {
+          ignore(decRef(val, false))
+        }
       }
     },
     _ => {


### PR DESCRIPTION
Closes #1148. Marking as a draft because there are failing stdlib tests. It _looks_ like this is just because of a problem in random.gr (the other failing modules import it directly or indirectly), but I have not been able to figure out what it is. To reproduce the problem, one can run this program:
```grain
import Random from "sys/random"
Random.random()
```
(Note: This implementation can probably be optimized a bit, but I want to track down the test failure first)