### PR TITLE
feat(compiler): Reduce closure sizes by utilizing `$self` argument when possible

### DIFF
--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -1,0 +1,686 @@
+functions › func_recursive_closure
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $makeAdder_1155 $truc_1158 $func_1189 $foo_1159 $bar_1162)
+ (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $gimport_pervasives_- (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $gimport_pervasives_== (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_3 i32 (i32.const 5))
+ (export \"memory\" (memory $0))
+ (export \"GRAIN$EXPORT$truc\" (global $global_1))
+ (export \"truc\" (func $truc_1158))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
+ (func $makeAdder_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+           (i32.const 20)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.const 7)
+      )
+      (i32.store offset=4
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.store offset=8
+       (local.get $2)
+       (i32.add
+        (global.get $wimport__grainEnv_relocBase)
+        (i32.const 2)
+       )
+      )
+      (i32.store offset=12
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.store offset=16
+       (local.get $2)
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $1)
+       )
+      )
+      (local.get $2)
+     )
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $2)
+ )
+ (func $truc_1158 (; has Stack IR ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store offset=16
+       (local.tee $1
+        (tuple.extract 0
+         (tuple.make
+          (local.tee $2
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $1
+                (tuple.extract 0
+                 (tuple.make
+                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                   (i32.const 20)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $1)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $1)
+               (i32.add
+                (global.get $wimport__grainEnv_relocBase)
+                (i32.const 3)
+               )
+              )
+              (i32.store offset=12
+               (local.get $1)
+               (i32.const 1)
+              )
+              (local.get $1)
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.get $1)
+         )
+        )
+       )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $2)
+       )
+      )
+      (call $foo_1159
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $2)
+       )
+       (i32.const 11)
+      )
+     )
+     (local.get $1)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $1)
+ )
+ (func $func_1189 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+         (i32.const 0)
+        )
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (i32.load offset=16
+        (local.get $0)
+       )
+      )
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $2)
+ )
+ (func $foo_1159 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $makeAdder_1155
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $global_0)
+          )
+          (i32.const 3)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (i32.store offset=16
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (local.tee $4
+           (tuple.extract 0
+            (tuple.make
+             (block (result i32)
+              (i32.store
+               (local.tee $2
+                (tuple.extract 0
+                 (tuple.make
+                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                   (i32.const 24)
+                  )
+                  (i32.const 0)
+                 )
+                )
+               )
+               (i32.const 7)
+              )
+              (i32.store offset=4
+               (local.get $2)
+               (i32.const 2)
+              )
+              (i32.store offset=8
+               (local.get $2)
+               (i32.add
+                (global.get $wimport__grainEnv_relocBase)
+                (i32.const 4)
+               )
+              )
+              (i32.store offset=12
+               (local.get $2)
+               (i32.const 2)
+              )
+              (local.get $2)
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=16
+         (local.get $0)
+        )
+       )
+      )
+      (i32.store offset=20
+       (local.get $2)
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $3)
+       )
+      )
+      (if (result i32)
+       (i32.shr_u
+        (tuple.extract 0
+         (tuple.make
+          (call_indirect (type $i32_i32_i32_=>_i32)
+           (local.tee $2
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (global.get $gimport_pervasives_==)
+              )
+              (local.get $2)
+             )
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (local.get $1)
+           )
+           (i32.const 1)
+           (i32.load offset=8
+            (local.get $2)
+           )
+          )
+          (i32.const 0)
+         )
+        )
+        (i32.const 31)
+       )
+       (i32.const 1)
+       (if (result i32)
+        (i32.shr_u
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $2
+             (tuple.extract 0
+              (tuple.make
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_==)
+               )
+               (local.get $2)
+              )
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $1)
+            )
+            (i32.const 3)
+            (i32.load offset=8
+             (local.get $2)
+            )
+           )
+           (i32.const 0)
+          )
+         )
+         (i32.const 31)
+        )
+        (call $bar_1162
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $4)
+         )
+         (i32.const 3)
+        )
+        (block (result i32)
+         (local.set $5
+          (tuple.extract 0
+           (tuple.make
+            (call_indirect (type $i32_i32_i32_=>_i32)
+             (local.tee $2
+              (tuple.extract 0
+               (tuple.make
+                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                 (global.get $gimport_pervasives_-)
+                )
+                (local.get $2)
+               )
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (local.get $1)
+             )
+             (i32.const 3)
+             (i32.load offset=8
+              (local.get $2)
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+             (i32.const 0)
+            )
+           )
+          )
+         )
+         (call $foo_1159
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (i32.load offset=16
+            (local.get $0)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $5)
+          )
+         )
+        )
+       )
+      )
+     )
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (local.get $2)
+ )
+ (func $bar_1162 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $foo_1159
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (i32.load offset=16
+            (local.get $0)
+           )
+          )
+          (i32.const 1)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call_indirect (type $i32_i32_=>_i32)
+          (local.tee $2
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $0)
+              )
+             )
+             (i32.const 0)
+            )
+           )
+          )
+          (i32.const 3)
+          (i32.load offset=8
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
+        )
+       )
+      )
+      (call_indirect (type $i32_i32_i32_=>_i32)
+       (local.tee $2
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
+          )
+          (local.get $2)
+         )
+        )
+       )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $3)
+       )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (local.get $4)
+       )
+       (i32.load offset=8
+        (local.get $2)
+       )
+      )
+     )
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (local.get $2)
+ )
+ (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+           (i32.const 16)
+          )
+          (i32.const 0)
+         )
+        )
+       )
+       (i32.const 7)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 2)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (global.get $wimport__grainEnv_relocBase)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (global.get $global_0)
+     (local.get $0)
+    )
+   )
+  )
+  (global.set $global_1
+   (tuple.extract 0
+    (tuple.make
+     (block (result i32)
+      (i32.store
+       (local.tee $0
+        (tuple.extract 0
+         (tuple.make
+          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+           (i32.const 16)
+          )
+          (local.get $0)
+         )
+        )
+       )
+       (i32.const 7)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 1)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.add
+        (global.get $wimport__grainEnv_relocBase)
+        (i32.const 1)
+       )
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_1)
+     )
+    )
+   )
+  )
+  (call $truc_1158
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_1)
+   )
+  )
+ )
+ (func $_start (; has Stack IR ;)
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 635
+)

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -96,59 +96,46 @@ functions › func_recursive_closure
    (tuple.extract 0
     (tuple.make
      (block (result i32)
-      (i32.store offset=16
-       (local.tee $1
-        (tuple.extract 0
-         (tuple.make
-          (local.tee $2
-           (tuple.extract 0
-            (tuple.make
-             (block (result i32)
-              (i32.store
-               (local.tee $1
-                (tuple.extract 0
-                 (tuple.make
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 20)
-                  )
-                  (i32.const 0)
-                 )
-                )
-               )
-               (i32.const 7)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (block (result i32)
+          (i32.store
+           (local.tee $1
+            (tuple.extract 0
+             (tuple.make
+              (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+               (i32.const 16)
               )
-              (i32.store offset=4
-               (local.get $1)
-               (i32.const 2)
-              )
-              (i32.store offset=8
-               (local.get $1)
-               (i32.add
-                (global.get $wimport__grainEnv_relocBase)
-                (i32.const 3)
-               )
-              )
-              (i32.store offset=12
-               (local.get $1)
-               (i32.const 1)
-              )
-              (local.get $1)
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (i32.const 0)
              )
             )
            )
+           (i32.const 7)
+          )
+          (i32.store offset=4
+           (local.get $1)
+           (i32.const 2)
+          )
+          (i32.store offset=8
+           (local.get $1)
+           (i32.add
+            (global.get $wimport__grainEnv_relocBase)
+            (i32.const 3)
+           )
+          )
+          (i32.store offset=12
+           (local.get $1)
+           (i32.const 0)
           )
           (local.get $1)
          )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
+         )
         )
-       )
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (local.get $2)
        )
       )
       (call $foo_1159
@@ -159,7 +146,12 @@ functions › func_recursive_closure
        (i32.const 11)
       )
      )
-     (local.get $1)
+     (tuple.extract 0
+      (tuple.make
+       (local.get $2)
+       (local.get $1)
+      )
+     )
     )
    )
   )
@@ -304,9 +296,7 @@ functions › func_recursive_closure
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=16
-         (local.get $0)
-        )
+        (local.get $0)
        )
       )
       (i32.store offset=20
@@ -419,9 +409,7 @@ functions › func_recursive_closure
          (call $foo_1159
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (i32.load offset=16
-            (local.get $0)
-           )
+           (local.get $0)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -45,7 +45,7 @@ functions › func_recursive_closure
          )
         )
        )
-       (i32.const 7)
+       (i32.const 6)
       )
       (i32.store offset=4
        (local.get $2)
@@ -112,7 +112,7 @@ functions › func_recursive_closure
              )
             )
            )
-           (i32.const 7)
+           (i32.const 6)
           )
           (i32.store offset=4
            (local.get $1)
@@ -264,7 +264,7 @@ functions › func_recursive_closure
                  )
                 )
                )
-               (i32.const 7)
+               (i32.const 6)
               )
               (i32.store offset=4
                (local.get $2)
@@ -569,99 +569,114 @@ functions › func_recursive_closure
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (global.set $global_0
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-           (i32.const 16)
+  (tuple.extract 0
+   (tuple.make
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
+             )
+             (i32.const 0)
+            )
+           )
           )
+          (i32.const 6)
+         )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 2)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (global.get $wimport__grainEnv_relocBase)
+         )
+         (i32.store offset=12
+          (local.get $0)
           (i32.const 0)
          )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
         )
        )
-       (i32.const 7)
       )
-      (i32.store offset=4
-       (local.get $0)
-       (i32.const 2)
-      )
-      (i32.store offset=8
-       (local.get $0)
-       (global.get $wimport__grainEnv_relocBase)
-      )
-      (i32.store offset=12
-       (local.get $0)
-       (i32.const 0)
-      )
-      (local.get $0)
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (global.get $global_0)
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_0)
+        (local.get $0)
+       )
+      )
      )
-    )
-   )
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
-  (global.set $global_1
-   (tuple.extract 0
-    (tuple.make
-     (block (result i32)
-      (i32.store
-       (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-           (i32.const 16)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (block (result i32)
+         (i32.store
+          (local.tee $0
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+              (i32.const 16)
+             )
+             (local.get $0)
+            )
+           )
           )
-          (local.get $0)
+          (i32.const 6)
          )
+         (i32.store offset=4
+          (local.get $0)
+          (i32.const 1)
+         )
+         (i32.store offset=8
+          (local.get $0)
+          (i32.add
+           (global.get $wimport__grainEnv_relocBase)
+           (i32.const 1)
+          )
+         )
+         (i32.store offset=12
+          (local.get $0)
+          (i32.const 0)
+         )
+         (local.get $0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
         )
        )
-       (i32.const 7)
       )
-      (i32.store offset=4
-       (local.get $0)
-       (i32.const 1)
-      )
-      (i32.store offset=8
-       (local.get $0)
-       (i32.add
-        (global.get $wimport__grainEnv_relocBase)
-        (i32.const 1)
+     )
+     (local.set $0
+      (tuple.extract 0
+       (tuple.make
+        (global.get $global_1)
+        (local.get $0)
        )
       )
-      (i32.store offset=12
-       (local.get $0)
-       (i32.const 0)
-      )
-      (local.get $0)
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (global.get $global_1)
+     (call $truc_1158
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $global_1)
+      )
      )
     )
-   )
-  )
-  (call $truc_1158
-   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (global.get $global_1)
+    (local.get $0)
    )
   )
  )

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -165,4 +165,24 @@ describe("functions", ({test}) => {
     "func_record_associativity2",
     "record Foo { g: () -> Bool }; record Bar { f: Foo }; let foo = {f: {g: () => false}}; !foo.f.g()",
   );
+
+  assertSnapshot(
+    "func_recursive_closure",
+    {|let makeAdder = (n) => (x) => x + n
+export let truc = () => {
+  let rec foo = (x) => {
+    let baz = makeAdder(1);
+    let bar = y => foo(0) + baz(1);
+    if (x == 0) {
+      0
+    } else if (x == 1) {
+      bar(1)
+    } else {
+      foo(x - 1)
+    }
+  }
+  foo(5)
+}
+truc()|},
+  );
 });


### PR DESCRIPTION
Closes #1148 (though not in the way that the ticket describes). This PR changes the compilation of functions such that self-references are looked up at runtime via argument #0 (`$self`), rather than a closure variable. In addition to making the closures smaller, this should increase the scope of functions which are garbage-collectible (see #989).

I've implemented this patch in two commits, since the change did not modify any snapshots. The first commit introduces a test case, and the second commit shows the diff on that test case's snapshot to illustrate the change (and show that it actually works).