### PR TITLE
feat(compiler): Cleaner wasm output for low-level wasm types

### DIFF
--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -23,17 +23,11 @@ arrays › array_access
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -67,17 +61,14 @@ arrays › array_access
   )
   (if
    (i32.lt_s
-    (i32.const 0)
+    (local.tee $0
+     (i32.const 0)
+    )
     (i32.sub
      (i32.const 0)
      (i32.load offset=4
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (global.get $global_0)
-         (i32.const 0)
-        )
-       )
+      (local.tee $1
+       (global.get $global_0)
       )
      )
     )
@@ -95,9 +86,9 @@ arrays › array_access
   (if
    (i32.le_s
     (i32.load offset=4
-     (local.get $2)
+     (local.get $1)
     )
-    (local.get $1)
+    (local.get $0)
    )
    (block
     (drop
@@ -109,33 +100,16 @@ arrays › array_access
     (unreachable)
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (i32.add
-       (i32.shl
-        (if (result i32)
-         (i32.lt_u
-          (local.get $1)
-          (i32.const 0)
-         )
-         (i32.add
-          (local.get $1)
-          (i32.load offset=4
-           (local.get $2)
-          )
-         )
-         (local.get $1)
-        )
-        (i32.const 2)
-       )
-       (local.get $2)
-      )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (i32.add
+     (i32.shl
+      (local.get $0)
+      (i32.const 2)
      )
+     (local.get $1)
     )
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
@@ -16,14 +16,9 @@ arrays › array1_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -44,12 +39,7 @@ arrays › array1_trailing
    (local.get $0)
    (i32.const 7)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -23,17 +23,11 @@ arrays › array_access4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -67,19 +61,14 @@ arrays › array_access4
   )
   (if
    (i32.lt_s
-    (local.tee $1
+    (local.tee $0
      (i32.const -2)
     )
     (i32.sub
      (i32.const 0)
      (i32.load offset=4
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (global.get $global_0)
-         (i32.const 0)
-        )
-       )
+      (local.tee $1
+       (global.get $global_0)
       )
      )
     )
@@ -97,9 +86,9 @@ arrays › array_access4
   (if
    (i32.le_s
     (i32.load offset=4
-     (local.get $2)
+     (local.get $1)
     )
-    (local.get $1)
+    (local.get $0)
    )
    (block
     (drop
@@ -111,33 +100,28 @@ arrays › array_access4
     (unreachable)
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (i32.add
-       (i32.shl
-        (if (result i32)
-         (i32.lt_s
-          (local.get $1)
-          (i32.const 0)
-         )
-         (i32.add
-          (local.get $1)
-          (i32.load offset=4
-           (local.get $2)
-          )
-         )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (i32.add
+     (i32.shl
+      (if (result i32)
+       (i32.lt_s
+        (local.get $0)
+        (i32.const 0)
+       )
+       (i32.add
+        (local.get $0)
+        (i32.load offset=4
          (local.get $1)
         )
-        (i32.const 2)
        )
-       (local.get $2)
+       (local.get $0)
       )
+      (i32.const 2)
      )
+     (local.get $1)
     )
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -23,17 +23,11 @@ arrays › array_access2
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -67,19 +61,14 @@ arrays › array_access2
   )
   (if
    (i32.lt_s
-    (local.tee $1
+    (local.tee $0
      (i32.const 1)
     )
     (i32.sub
      (i32.const 0)
      (i32.load offset=4
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (global.get $global_0)
-         (i32.const 0)
-        )
-       )
+      (local.tee $1
+       (global.get $global_0)
       )
      )
     )
@@ -97,9 +86,9 @@ arrays › array_access2
   (if
    (i32.le_s
     (i32.load offset=4
-     (local.get $2)
+     (local.get $1)
     )
-    (local.get $1)
+    (local.get $0)
    )
    (block
     (drop
@@ -111,33 +100,16 @@ arrays › array_access2
     (unreachable)
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (i32.add
-       (i32.shl
-        (if (result i32)
-         (i32.lt_u
-          (local.get $1)
-          (i32.const 0)
-         )
-         (i32.add
-          (local.get $1)
-          (i32.load offset=4
-           (local.get $2)
-          )
-         )
-         (local.get $1)
-        )
-        (i32.const 2)
-       )
-       (local.get $2)
-      )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (i32.add
+     (i32.shl
+      (local.get $0)
+      (i32.const 2)
      )
+     (local.get $1)
     )
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -23,17 +23,11 @@ arrays › array_access3
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -67,19 +61,14 @@ arrays › array_access3
   )
   (if
    (i32.lt_s
-    (local.tee $1
+    (local.tee $0
      (i32.const 2)
     )
     (i32.sub
      (i32.const 0)
      (i32.load offset=4
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (global.get $global_0)
-         (i32.const 0)
-        )
-       )
+      (local.tee $1
+       (global.get $global_0)
       )
      )
     )
@@ -97,9 +86,9 @@ arrays › array_access3
   (if
    (i32.le_s
     (i32.load offset=4
-     (local.get $2)
+     (local.get $1)
     )
-    (local.get $1)
+    (local.get $0)
    )
    (block
     (drop
@@ -111,33 +100,16 @@ arrays › array_access3
     (unreachable)
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (i32.add
-       (i32.shl
-        (if (result i32)
-         (i32.lt_u
-          (local.get $1)
-          (i32.const 0)
-         )
-         (i32.add
-          (local.get $1)
-          (i32.load offset=4
-           (local.get $2)
-          )
-         )
-         (local.get $1)
-        )
-        (i32.const 2)
-       )
-       (local.get $2)
-      )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (i32.add
+     (i32.shl
+      (local.get $0)
+      (i32.const 2)
      )
+     (local.get $1)
     )
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -23,17 +23,11 @@ arrays › array_access5
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -67,19 +61,14 @@ arrays › array_access5
   )
   (if
    (i32.lt_s
-    (local.tee $1
+    (local.tee $0
      (i32.const -3)
     )
     (i32.sub
      (i32.const 0)
      (i32.load offset=4
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (global.get $global_0)
-         (i32.const 0)
-        )
-       )
+      (local.tee $1
+       (global.get $global_0)
       )
      )
     )
@@ -97,9 +86,9 @@ arrays › array_access5
   (if
    (i32.le_s
     (i32.load offset=4
-     (local.get $2)
+     (local.get $1)
     )
-    (local.get $1)
+    (local.get $0)
    )
    (block
     (drop
@@ -111,33 +100,28 @@ arrays › array_access5
     (unreachable)
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (i32.add
-       (i32.shl
-        (if (result i32)
-         (i32.lt_s
-          (local.get $1)
-          (i32.const 0)
-         )
-         (i32.add
-          (local.get $1)
-          (i32.load offset=4
-           (local.get $2)
-          )
-         )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (i32.add
+     (i32.shl
+      (if (result i32)
+       (i32.lt_s
+        (local.get $0)
+        (i32.const 0)
+       )
+       (i32.add
+        (local.get $0)
+        (i32.load offset=4
          (local.get $1)
         )
-        (i32.const 2)
        )
-       (local.get $2)
+       (local.get $0)
       )
+      (i32.const 2)
      )
+     (local.get $1)
     )
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
@@ -16,14 +16,9 @@ arrays › array3
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -44,12 +39,7 @@ arrays › array3
    (local.get $0)
    (i32.const 7)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
@@ -16,14 +16,9 @@ arrays › array1_trailing_space
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 4)
@@ -44,12 +39,7 @@ arrays › array1_trailing_space
    (local.get $0)
    (i32.const 7)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const -33)
-     (i32.const 35)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const -33)
+   (i32.const 35)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › land4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_&)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_&)
     )
+   )
+   (i32.const 1)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lxor1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_^)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_^)
     )
+   )
+   (i32.const 3)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lor1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_|)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_|)
     )
+   )
+   (i32.const 3)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo6
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 35)
-     (i32.const 35)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const 35)
+   (i32.const 35)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -21,19 +21,14 @@ basic functionality › precedence3
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_%)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_%)
        )
       )
       (i32.const 9)
@@ -49,41 +44,31 @@ basic functionality › precedence3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 7)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
+    )
+    (i32.const 7)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lsl1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_<<)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 15)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_<<)
     )
+   )
+   (i32.const 15)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -27,12 +27,7 @@ basic functionality › unsafe_wasm_globals
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $gimport_runtime/unsafe/printWasm_printI32)
-       (i32.const 0)
-      )
-     )
+     (global.get $gimport_runtime/unsafe/printWasm_printI32)
     )
     (global.get $gimport_unsafeWasmGlobalsExports__I32_VAL)
     (i32.load offset=8
@@ -43,12 +38,7 @@ basic functionality › unsafe_wasm_globals
   (drop
    (call_indirect (type $i32_i64_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $gimport_runtime/unsafe/printWasm_printI64)
-       (local.get $0)
-      )
-     )
+     (global.get $gimport_runtime/unsafe/printWasm_printI64)
     )
     (global.get $gimport_unsafeWasmGlobalsExports__I64_VAL)
     (i32.load offset=8
@@ -59,12 +49,7 @@ basic functionality › unsafe_wasm_globals
   (drop
    (call_indirect (type $i32_f32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $gimport_runtime/unsafe/printWasm_printF32)
-       (local.get $0)
-      )
-     )
+     (global.get $gimport_runtime/unsafe/printWasm_printF32)
     )
     (global.get $gimport_unsafeWasmGlobalsExports__F32_VAL)
     (i32.load offset=8
@@ -74,12 +59,7 @@ basic functionality › unsafe_wasm_globals
   )
   (call_indirect (type $i32_f64_=>_i32)
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (global.get $gimport_runtime/unsafe/printWasm_printF64)
-      (local.get $0)
-     )
-    )
+    (global.get $gimport_runtime/unsafe/printWasm_printF64)
    )
    (global.get $gimport_unsafeWasmGlobalsExports__F64_VAL)
    (i32.load offset=8

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -29,81 +29,9 @@ basic functionality › comp22
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 7)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 1)
-  )
-  (i32.store offset=8
-   (local.get $0)
-   (i32.const 3)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $2
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_pervasives_[])
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -132,14 +60,9 @@ basic functionality › comp22
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -161,47 +84,82 @@ basic functionality › comp22
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
+    )
+   )
+   (i32.const 7)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 1)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
+     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_isnt)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $0)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
-     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_isnt)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $4)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
    )
   )
   (drop
@@ -216,7 +174,19 @@ basic functionality › comp22
     (local.get $4)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › land1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_&)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_&)
     )
+   )
+   (i32.const 3)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -19,14 +19,9 @@ basic functionality › orshort2
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (i32.const 0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 3)
@@ -35,12 +30,7 @@ basic functionality › orshort2
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (i32.const 2147483646)
-    (local.get $0)
-   )
-  )
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -21,19 +21,14 @@ basic functionality › precedence4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_%)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_%)
        )
       )
       (i32.const 9)
@@ -49,41 +44,31 @@ basic functionality › precedence4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.const 7)
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.const 7)
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lsl2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_<<)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_<<)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › comp17
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_isnt)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 2147483646)
-     (i32.const -2)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_isnt)
     )
+   )
+   (i32.const 2147483646)
+   (i32.const -2)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › complex2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_print)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_print)
     )
+   )
+   (i32.const 11)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › int64_1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -36,12 +31,7 @@ basic functionality › int64_1
    (local.get $0)
    (i64.const 99999999999999999)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -25,19 +25,14 @@ basic functionality › comp20
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
@@ -47,6 +42,32 @@ basic functionality › comp20
       )
       (i32.load offset=8
        (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 3)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $0)
+      )
+      (i32.load offset=8
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -60,24 +81,19 @@ basic functionality › comp20
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 3)
+      (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $2)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -91,24 +107,19 @@ basic functionality › comp20
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 5)
+      (i32.const 3)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_pervasives_[])
+       (local.get $2)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -119,65 +130,30 @@ basic functionality › comp20
    )
   )
   (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $4
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_isnt)
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (i32.load offset=8
+     (local.get $4)
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_isnt)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
-     (local.get $0)
-    )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -198,13 +174,7 @@ basic functionality › comp20
     (local.get $3)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (local.get $0)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lor3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_|)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_|)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › decr_3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_decr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_decr)
     )
+   )
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › heap_number_i64_wrapper
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -36,12 +31,7 @@ basic functionality › heap_number_i64_wrapper
    (local.get $0)
    (i64.const 2147483648)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -26,14 +26,9 @@ basic functionality › func_shadow
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -66,14 +61,9 @@ basic functionality › func_shadow
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -108,14 +98,9 @@ basic functionality › func_shadow
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -143,14 +128,6 @@ basic functionality › func_shadow
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (local.set $2
    (tuple.extract 0
     (tuple.make
@@ -170,14 +147,9 @@ basic functionality › func_shadow
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -191,14 +163,9 @@ basic functionality › func_shadow
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -229,14 +196,6 @@ basic functionality › func_shadow
     )
    )
   )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_1)
-     (local.get $0)
-    )
-   )
-  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -254,28 +213,18 @@ basic functionality › func_shadow
    )
   )
   (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $1
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_print)
-         )
-         (local.get $1)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $0)
-      )
-      (i32.load offset=8
-       (local.get $1)
-      )
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
      (local.get $1)
     )
    )

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo5
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 35)
-     (i32.const -33)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const 35)
+   (i32.const -33)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -38,14 +38,9 @@ basic functionality › if_one_sided6
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_0)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_0)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › binop6
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 19)
-     (i32.const 11)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const 19)
+   (i32.const 11)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -33,14 +33,9 @@ basic functionality › block_no_expression
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -68,23 +63,10 @@ basic functionality › block_no_expression
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $f_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-    )
-    (local.get $0)
+  (call $f_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lor2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_|)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_|)
     )
+   )
+   (i32.const 3)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › land2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_&)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_&)
     )
+   )
+   (i32.const 3)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -24,14 +24,9 @@ basic functionality › pattern_match_unsafe_wasm
  (func $test_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -88,7 +83,6 @@ basic functionality › pattern_match_unsafe_wasm
   )
  )
  (func $foo_1132 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
   (block $switch.31_outer (result i32)
    (drop
     (block $switch.31_branch_1 (result i32)
@@ -109,138 +103,101 @@ basic functionality › pattern_match_unsafe_wasm
                    (br_table $switch.31_branch_1 $switch.31_branch_2 $switch.31_branch_3 $switch.31_branch_4 $switch.31_branch_5 $switch.31_branch_6 $switch.31_branch_7 $switch.31_default
                     (i32.const 0)
                     (i32.shr_s
-                     (tuple.extract 0
-                      (tuple.make
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.get $1)
-                              (i32.const 1)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
+                     (select
+                      (i32.const 1)
+                      (select
+                       (i32.const 3)
+                       (select
+                        (i32.const 5)
                         (select
-                         (i32.const 3)
+                         (i32.const 7)
                          (select
-                          (i32.const 5)
+                          (i32.const 9)
                           (select
-                           (i32.const 7)
-                           (select
-                            (i32.const 9)
-                            (select
-                             (i32.const 11)
-                             (i32.const 13)
-                             (i32.shr_u
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.or
-                                 (i32.shl
-                                  (i32.eq
-                                   (local.get $1)
-                                   (i32.const 6)
-                                  )
-                                  (i32.const 31)
-                                 )
-                                 (i32.const 2147483646)
-                                )
-                                (i32.const 0)
-                               )
+                           (i32.const 11)
+                           (i32.const 13)
+                           (i32.shr_u
+                            (i32.or
+                             (i32.shl
+                              (i32.eq
+                               (local.get $1)
+                               (i32.const 6)
                               )
                               (i32.const 31)
                              )
-                            )
-                            (i32.shr_u
-                             (tuple.extract 0
-                              (tuple.make
-                               (i32.or
-                                (i32.shl
-                                 (i32.eq
-                                  (local.get $1)
-                                  (i32.const 5)
-                                 )
-                                 (i32.const 31)
-                                )
-                                (i32.const 2147483646)
-                               )
-                               (i32.const 0)
-                              )
-                             )
-                             (i32.const 31)
-                            )
-                           )
-                           (i32.shr_u
-                            (tuple.extract 0
-                             (tuple.make
-                              (i32.or
-                               (i32.shl
-                                (i32.eq
-                                 (local.get $1)
-                                 (i32.const 4)
-                                )
-                                (i32.const 31)
-                               )
-                               (i32.const 2147483646)
-                              )
-                              (i32.const 0)
-                             )
+                             (i32.const 2147483646)
                             )
                             (i32.const 31)
                            )
                           )
                           (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $1)
-                                (i32.const 3)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
+                           (i32.or
+                            (i32.shl
+                             (i32.eq
+                              (local.get $1)
+                              (i32.const 5)
                              )
-                             (i32.const 0)
+                             (i32.const 31)
                             )
+                            (i32.const 2147483646)
                            )
                            (i32.const 31)
                           )
                          )
                          (i32.shr_u
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $1)
-                                (i32.const 2)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (local.get $1)
+                             (i32.const 4)
                             )
+                            (i32.const 31)
                            )
+                           (i32.const 2147483646)
                           )
                           (i32.const 31)
                          )
                         )
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $1)
+                            (i32.const 3)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
+                         )
+                         (i32.const 31)
+                        )
                        )
-                       (local.get $2)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.get $1)
+                           (i32.const 2)
+                          )
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                      )
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
                       )
                      )
                      (i32.const 1)
@@ -253,14 +210,9 @@ basic functionality › pattern_match_unsafe_wasm
                )
                (i32.store
                 (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                    (i32.const 16)
-                   )
-                   (i32.const 0)
-                  )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                  (i32.const 16)
                  )
                 )
                 (i32.const 1)
@@ -273,7 +225,7 @@ basic functionality › pattern_match_unsafe_wasm
                 (local.get $0)
                 (i64.const 491327616111)
                )
-               (local.set $1
+               (local.set $0
                 (tuple.extract 0
                  (tuple.make
                   (local.get $0)
@@ -283,17 +235,12 @@ basic functionality › pattern_match_unsafe_wasm
                )
                (br $switch.31_outer
                 (call_indirect (type $i32_i32_=>_i32)
-                 (local.tee $0
-                  (tuple.extract 0
-                   (tuple.make
-                    (global.get $gimport_pervasives_print)
-                    (local.get $0)
-                   )
-                  )
+                 (local.tee $1
+                  (global.get $gimport_pervasives_print)
                  )
-                 (local.get $1)
+                 (local.get $0)
                  (i32.load offset=8
-                  (local.get $0)
+                  (local.get $1)
                  )
                 )
                )
@@ -302,12 +249,7 @@ basic functionality › pattern_match_unsafe_wasm
              (br $switch.31_outer
               (call_indirect (type $i32_i32_=>_i32)
                (local.tee $0
-                (tuple.extract 0
-                 (tuple.make
-                  (global.get $gimport_pervasives_print)
-                  (i32.const 0)
-                 )
-                )
+                (global.get $gimport_pervasives_print)
                )
                (i32.const 13)
                (i32.load offset=8
@@ -320,12 +262,7 @@ basic functionality › pattern_match_unsafe_wasm
            (br $switch.31_outer
             (call_indirect (type $i32_i32_=>_i32)
              (local.tee $0
-              (tuple.extract 0
-               (tuple.make
-                (global.get $gimport_pervasives_print)
-                (i32.const 0)
-               )
-              )
+              (global.get $gimport_pervasives_print)
              )
              (i32.const 11)
              (i32.load offset=8
@@ -338,12 +275,7 @@ basic functionality › pattern_match_unsafe_wasm
          (br $switch.31_outer
           (call_indirect (type $i32_i32_=>_i32)
            (local.tee $0
-            (tuple.extract 0
-             (tuple.make
-              (global.get $gimport_pervasives_print)
-              (i32.const 0)
-             )
-            )
+            (global.get $gimport_pervasives_print)
            )
            (i32.const 9)
            (i32.load offset=8
@@ -356,12 +288,7 @@ basic functionality › pattern_match_unsafe_wasm
        (br $switch.31_outer
         (call_indirect (type $i32_i32_=>_i32)
          (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (global.get $gimport_pervasives_print)
-            (i32.const 0)
-           )
-          )
+          (global.get $gimport_pervasives_print)
          )
          (i32.const 7)
          (i32.load offset=8
@@ -374,12 +301,7 @@ basic functionality › pattern_match_unsafe_wasm
      (br $switch.31_outer
       (call_indirect (type $i32_i32_=>_i32)
        (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (global.get $gimport_pervasives_print)
-          (i32.const 0)
-         )
-        )
+        (global.get $gimport_pervasives_print)
        )
        (i32.const 5)
        (i32.load offset=8
@@ -391,12 +313,7 @@ basic functionality › pattern_match_unsafe_wasm
    )
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (global.get $gimport_pervasives_print)
-       (i32.const 0)
-      )
-     )
+     (global.get $gimport_pervasives_print)
     )
     (i32.const 3)
     (i32.load offset=8
@@ -409,14 +326,9 @@ basic functionality › pattern_match_unsafe_wasm
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -444,23 +356,10 @@ basic functionality › pattern_match_unsafe_wasm
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $test_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-    )
-    (local.get $0)
+  (call $test_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › asr1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_>>)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 359)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_>>)
     )
+   )
+   (i32.const 359)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › division1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -40,12 +35,7 @@ basic functionality › division1
    (local.get $0)
    (i32.const 2)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -28,14 +28,9 @@ basic functionality › comp21
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -48,7 +43,7 @@ basic functionality › comp21
    (local.get $0)
    (i32.const 3)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -59,24 +54,19 @@ basic functionality › comp21
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -95,14 +85,9 @@ basic functionality › comp21
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -115,10 +100,39 @@ basic functionality › comp21
    (local.get $0)
    (i32.const 3)
   )
-  (local.set $3
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $0)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_pervasives_[])
+      )
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -127,66 +141,21 @@ basic functionality › comp21
    )
   )
   (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
+   (i32.or
+    (i32.shl
+     (i32.eq
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_pervasives_[])
-      )
-      (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
+     (i32.const 31)
     )
-   )
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.or
-      (i32.shl
-       (i32.eq
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $2)
-        )
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
-        )
-       )
-       (i32.const 31)
-      )
-      (i32.const 2147483646)
-     )
-     (local.get $0)
-    )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.const 2147483646)
    )
   )
   (drop
@@ -204,10 +173,16 @@ basic functionality › comp21
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lxor3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_^)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_^)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › incr_3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_incr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const -1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_incr)
     )
+   )
+   (i32.const -1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › void
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -36,12 +31,7 @@ basic functionality › void
    (local.get $0)
    (i64.const 7303014)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lxor2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_^)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 3)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_^)
     )
+   )
+   (i32.const 3)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › if_one_sided
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_print)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_print)
     )
+   )
+   (i32.const 11)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lxor4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_^)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_^)
     )
+   )
+   (i32.const 1)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -19,14 +19,9 @@ basic functionality › complex1
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (i32.const 0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 7)
@@ -35,12 +30,7 @@ basic functionality › complex1
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (i32.const -5)
-    (local.get $0)
-   )
-  )
+  (i32.const -5)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lsr2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_>>>)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_>>>)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -21,14 +21,9 @@ basic functionality › toplevel_statements
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (i32.const 0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 3)
@@ -40,14 +35,9 @@ basic functionality › toplevel_statements
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 5)
@@ -59,14 +49,9 @@ basic functionality › toplevel_statements
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 7)
@@ -78,14 +63,9 @@ basic functionality › toplevel_statements
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 9)
@@ -97,14 +77,9 @@ basic functionality › toplevel_statements
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 11)
@@ -115,14 +90,9 @@ basic functionality › toplevel_statements
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -135,12 +105,7 @@ basic functionality › toplevel_statements
    (local.get $0)
    (i64.const 7303014)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lsr1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_>>>)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 15)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_>>>)
     )
+   )
+   (i32.const 15)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › incr_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_incr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 5)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_incr)
     )
+   )
+   (i32.const 5)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › incr_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_incr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_incr)
     )
+   )
+   (i32.const 11)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const -33)
-     (i32.const -7)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const -33)
+   (i32.const -7)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › lor4
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_|)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 1)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_|)
     )
+   )
+   (i32.const 1)
+   (i32.const 1)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › int64_pun_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_*)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 19999999)
-     (i32.const 199999999)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_*)
     )
+   )
+   (i32.const 19999999)
+   (i32.const 199999999)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › decr_1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_decr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 5)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_decr)
     )
+   )
+   (i32.const 5)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -19,14 +19,9 @@ basic functionality › andshort1
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (i32.const 0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (i32.const 3)
@@ -35,12 +30,7 @@ basic functionality › andshort1
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (i32.const 2147483646)
-    (local.get $0)
-   )
-  )
+  (i32.const 2147483646)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo1
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const -33)
-     (i32.const 9)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const -33)
+   (i32.const 9)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › land3
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_&)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_&)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › comp18
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_isnt)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 9)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_isnt)
     )
+   )
+   (i32.const 9)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -38,14 +38,9 @@ basic functionality › if_one_sided4
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_0)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_0)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › asr2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_>>)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 1)
-     (i32.const 3)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_>>)
     )
+   )
+   (i32.const 1)
+   (i32.const 3)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › int32_1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -36,12 +31,7 @@ basic functionality › int32_1
    (local.get $0)
    (i32.const 42)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › modulo2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_%)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 35)
-     (i32.const -7)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_%)
     )
+   )
+   (i32.const 35)
+   (i32.const -7)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -16,25 +16,15 @@ basic functionality › decr_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_decr)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_decr)
     )
+   )
+   (i32.const 11)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -24,19 +24,14 @@ basic functionality › comp19
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
@@ -46,6 +41,32 @@ basic functionality › comp19
       )
       (i32.load offset=8
        (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 3)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $0)
+      )
+      (i32.load offset=8
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -59,24 +80,19 @@ basic functionality › comp19
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 3)
+      (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $2)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -90,24 +106,19 @@ basic functionality › comp19
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 5)
+      (i32.const 3)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_pervasives_[])
+       (local.get $2)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -118,57 +129,27 @@ basic functionality › comp19
    )
   )
   (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
+   (i32.or
+    (i32.shl
+     (i32.eq
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
       )
-      (i32.const 3)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $3)
       )
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
+     (i32.const 31)
     )
+    (i32.const 2147483646)
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.or
-      (i32.shl
-       (i32.eq
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $2)
-        )
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
-        )
-       )
-       (i32.const 31)
-      )
-      (i32.const 2147483646)
-     )
-     (local.get $0)
-    )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -189,13 +170,7 @@ basic functionality › comp19
     (local.get $3)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (local.get $0)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › heap_number_i32_wrapper_max
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -36,12 +31,7 @@ basic functionality › heap_number_i32_wrapper_max
    (local.get $0)
    (i32.const 2147483647)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
@@ -16,14 +16,9 @@ basic functionality › heap_number_i32_wrapper
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -36,12 +31,7 @@ basic functionality › heap_number_i32_wrapper
    (local.get $0)
    (i32.const 1073741824)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -17,26 +17,16 @@ basic functionality › int64_pun_2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_pervasives_-)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const -199999997)
-     (i32.const 1999999999)
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_-)
     )
+   )
+   (i32.const -199999997)
+   (i32.const 1999999999)
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -28,14 +28,9 @@ basic functionality › func_shadow_and_indirect_call
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -68,14 +63,9 @@ basic functionality › func_shadow_and_indirect_call
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -108,14 +98,9 @@ basic functionality › func_shadow_and_indirect_call
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -155,14 +140,9 @@ basic functionality › func_shadow_and_indirect_call
   (local $1 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -198,14 +178,9 @@ basic functionality › func_shadow_and_indirect_call
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -233,15 +208,7 @@ basic functionality › func_shadow_and_indirect_call
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (call $foo_1131
@@ -260,19 +227,14 @@ basic functionality › func_shadow_and_indirect_call
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $1)
+     (local.get $2)
     )
     (i32.load offset=8
      (local.get $0)
@@ -281,14 +243,9 @@ basic functionality › func_shadow_and_indirect_call
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -319,15 +276,7 @@ basic functionality › func_shadow_and_indirect_call
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_1)
-     (local.get $0)
-    )
-   )
-  )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call $foo_1133
@@ -346,19 +295,14 @@ basic functionality › func_shadow_and_indirect_call
   (drop
    (call_indirect (type $i32_i32_=>_i32)
     (local.tee $0
-     (tuple.extract 0
-      (tuple.make
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_print)
-       )
-       (local.get $0)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $2)
+     (local.get $3)
     )
     (i32.load offset=8
      (local.get $0)
@@ -367,14 +311,9 @@ basic functionality › func_shadow_and_indirect_call
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -405,14 +344,6 @@ basic functionality › func_shadow_and_indirect_call
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_2)
-     (local.get $0)
-    )
-   )
-  )
   (global.set $global_3
    (tuple.extract 0
     (tuple.make
@@ -429,19 +360,14 @@ basic functionality › func_shadow_and_indirect_call
     )
    )
   )
-  (local.set $3
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $global_3)
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $global_3)
        )
       )
       (i32.load offset=8
@@ -455,37 +381,21 @@ basic functionality › func_shadow_and_indirect_call
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_print)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -500,7 +410,13 @@ basic functionality › func_shadow_and_indirect_call
     (local.get $3)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_subtraction1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_subtraction1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_subtraction1
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_subtraction1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,12 +111,13 @@ boxes › box_subtraction1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
+  (local.set $2
+   (i32.const 1879048190)
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -135,13 +126,7 @@ boxes › box_subtraction1
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_multiplication2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_multiplication2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_multiplication2
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_*)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_*)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_multiplication2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,17 +111,18 @@ boxes › box_multiplication2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_0)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -140,13 +131,7 @@ boxes › box_multiplication2
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_division2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_division2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_division2
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_/)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_/)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_division2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,17 +111,18 @@ boxes › box_division2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_0)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -140,13 +131,7 @@ boxes › box_division2
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_addition2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_addition2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_addition2
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_addition2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,17 +111,18 @@ boxes › box_addition2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_0)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -140,13 +131,7 @@ boxes › box_addition2
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_division1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_division1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_division1
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_/)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_/)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_division1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,12 +111,13 @@ boxes › box_division1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
+  (local.set $2
+   (i32.const 1879048190)
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -135,13 +126,7 @@ boxes › box_division1
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_subtraction2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_subtraction2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_subtraction2
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_subtraction2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,17 +111,18 @@ boxes › box_subtraction2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_0)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -140,13 +131,7 @@ boxes › box_subtraction2
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_addition1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_addition1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_addition1
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_addition1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,12 +111,13 @@ boxes › box_addition1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
+  (local.set $2
+   (i32.const 1879048190)
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -135,13 +126,7 @@ boxes › box_addition1
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -26,14 +26,9 @@ boxes › box_multiplication1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -57,7 +52,7 @@ boxes › box_multiplication1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -73,28 +68,23 @@ boxes › box_multiplication1
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_*)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_*)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.const 39)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,7 +100,7 @@ boxes › box_multiplication1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $2)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -121,12 +111,13 @@ boxes › box_multiplication1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
+  (local.set $2
+   (i32.const 1879048190)
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -135,13 +126,7 @@ boxes › box_multiplication1
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -19,14 +19,9 @@ boxes › test_set_extra1
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -40,7 +35,7 @@ boxes › test_set_extra1
    (i32.const 3)
   )
   (i32.store offset=8
-   (local.tee $1
+   (local.tee $0
     (tuple.extract 0
      (tuple.make
       (local.get $0)
@@ -57,27 +52,22 @@ boxes › test_set_extra1
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $1
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -27,14 +27,9 @@ enums › adt_trailing
   (local $2 i32)
   (i32.store
    (local.tee $2
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 2)
@@ -82,14 +77,9 @@ enums › adt_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -134,40 +124,28 @@ enums › adt_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -195,24 +173,11 @@ enums › adt_trailing
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 2)
@@ -247,14 +212,9 @@ enums › adt_trailing
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_1)
-    )
-    (local.get $0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_1)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -34,14 +34,9 @@ enums › enum_recursive_data_definition
   (local $3 i32)
   (i32.store
    (local.tee $3
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 2)
@@ -111,14 +106,9 @@ enums › enum_recursive_data_definition
   (local $3 i32)
   (i32.store
    (local.tee $3
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 2)
@@ -193,14 +183,9 @@ enums › enum_recursive_data_definition
   (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 120)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 120)
     )
    )
    (i32.const 1)
@@ -265,40 +250,28 @@ enums › enum_recursive_data_definition
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 2)
@@ -337,14 +310,9 @@ enums › enum_recursive_data_definition
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -372,24 +340,11 @@ enums › enum_recursive_data_definition
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_1)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 2)
@@ -423,14 +378,9 @@ enums › enum_recursive_data_definition
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -461,24 +411,11 @@ enums › enum_recursive_data_definition
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_3)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -491,7 +428,7 @@ enums › enum_recursive_data_definition
    (local.get $0)
    (i64.const 54015209861748)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -504,14 +441,9 @@ enums › enum_recursive_data_definition
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -524,7 +456,7 @@ enums › enum_recursive_data_definition
    (local.get $0)
    (i64.const 55114721489524)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -545,7 +477,7 @@ enums › enum_recursive_data_definition
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $0)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -593,7 +525,7 @@ enums › enum_recursive_data_definition
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -631,43 +563,33 @@ enums › enum_recursive_data_definition
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_print)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_4)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
-     (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_4)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
   (drop
@@ -688,7 +610,7 @@ enums › enum_recursive_data_definition
     (local.get $5)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -28,14 +28,9 @@ exceptions › exception_4
   (local $3 i32)
   (i32.store
    (local.tee $3
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 2)
@@ -96,14 +91,9 @@ exceptions › exception_4
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 72)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 72)
     )
    )
    (i32.const 1)
@@ -144,40 +134,28 @@ exceptions › exception_4
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -205,24 +183,11 @@ exceptions › exception_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 2)
@@ -257,14 +222,9 @@ exceptions › exception_4
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_1)
-    )
-    (local.get $0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_1)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -23,14 +23,9 @@ exceptions › exception_2
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -59,40 +54,28 @@ exceptions › exception_2
    (local.get $0)
    (i64.const 7302982)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 2)
@@ -127,14 +110,9 @@ exceptions › exception_2
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_0)
-    )
-    (local.get $0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_0)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
+++ b/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
@@ -14,14 +14,9 @@ exports › export7
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -33,14 +33,9 @@ exports › let_rec_export
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -68,17 +63,7 @@ exports › let_rec_export
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (i32.const 1879048190)
-    (tuple.extract 0
-     (tuple.make
-      (global.get $global_0)
-      (local.get $0)
-     )
-    )
-   )
-  )
+  (i32.const 1879048190)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
@@ -14,14 +14,9 @@ exports › export4
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_onlyXExported_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_onlyXExported_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -17,28 +17,18 @@ exports › export9
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_z)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_z)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -22,19 +22,14 @@ exports › export8
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_exportStar_y)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_exportStar_y)
        )
       )
       (i32.const 9)
@@ -49,44 +44,34 @@ exports › export8
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_exportStar_x)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_x)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -33,14 +33,9 @@ functions › dup_func
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -68,23 +63,10 @@ functions › dup_func
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $foo_1135
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-    )
-    (local.get $0)
+  (call $foo_1135
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -28,14 +28,9 @@ functions › shorthand_4
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -69,14 +64,9 @@ functions › shorthand_4
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -104,25 +94,12 @@ functions › shorthand_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $foo_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $foo_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 3)
-    )
-    (local.get $0)
-   )
+   (i32.const 3)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -50,14 +50,9 @@ functions › shorthand_1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -85,25 +80,12 @@ functions › shorthand_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $foo_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $foo_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 3)
-    )
-    (local.get $0)
-   )
+   (i32.const 3)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -30,7 +30,7 @@ functions › lam_destructure_5
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local.set $4
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -46,61 +46,13 @@ functions › lam_destructure_5
     )
    )
   )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $7
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $2)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $8
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $2)
+      (i32.load offset=12
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -113,28 +65,10 @@ functions › lam_destructure_5
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $3)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -147,28 +81,10 @@ functions › lam_destructure_5
   (local.set $10
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (i32.load offset=8
-       (local.get $3)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $2)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -181,21 +97,32 @@ functions › lam_destructure_5
   (local.set $11
    (tuple.extract 0
     (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $9)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -212,34 +139,87 @@ functions › lam_destructure_5
     )
    )
   )
-  (local.set $3
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $11)
+       (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $7)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $4)
       )
      )
-     (local.get $3)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $5
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $11)
+      )
+      (i32.load offset=8
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $6
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $10)
+      )
+      (i32.load offset=8
+       (local.get $6)
+      )
+     )
+     (local.get $6)
     )
    )
   )
@@ -259,24 +239,6 @@ functions › lam_destructure_5
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
    )
   )
   (drop
@@ -309,7 +271,25 @@ functions › lam_destructure_5
     (local.get $11)
    )
   )
-  (local.get $3)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (local.get $6)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
@@ -318,14 +298,9 @@ functions › lam_destructure_5
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -355,19 +330,9 @@ functions › lam_destructure_5
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $1)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -401,14 +366,9 @@ functions › lam_destructure_5
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -425,7 +385,7 @@ functions › lam_destructure_5
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $3
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -436,23 +396,18 @@ functions › lam_destructure_5
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $lam_lambda_1136
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-     )
+  (local.set $3
+   (call $lam_lambda_1136
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -472,10 +427,10 @@ functions › lam_destructure_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -39,14 +39,9 @@ functions › lambda_pat_any
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -74,24 +69,11 @@ functions › lambda_pat_any
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -104,7 +86,7 @@ functions › lambda_pat_any
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -115,19 +97,14 @@ functions › lambda_pat_any
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $x_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-     )
+  (local.set $1
+   (call $x_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -135,10 +112,10 @@ functions › lambda_pat_any
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -25,14 +25,9 @@ functions › curried_func
   (local $2 i32)
   (i32.store
    (local.tee $2
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 6)
@@ -88,14 +83,9 @@ functions › curried_func
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -135,14 +125,9 @@ functions › curried_func
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -170,14 +155,6 @@ functions › curried_func
     )
    )
   )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
@@ -196,25 +173,15 @@ functions › curried_func
    )
   )
   (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $1
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (local.get $0)
-         )
-         (local.get $1)
-        )
-       )
-      )
-      (i32.const 7)
-      (i32.load offset=8
-       (local.get $1)
-      )
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (local.get $0)
      )
+    )
+    (i32.const 7)
+    (i32.load offset=8
      (local.get $1)
     )
    )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -31,14 +31,9 @@ functions › func_recursive_closure
   (local $2 i32)
   (i32.store
    (local.tee $2
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 6)
@@ -92,14 +87,9 @@ functions › func_recursive_closure
   (local $2 i32)
   (i32.store
    (local.tee $1
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -119,7 +109,7 @@ functions › func_recursive_closure
    (local.get $1)
    (i32.const 0)
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (local.get $1)
@@ -130,22 +120,17 @@ functions › func_recursive_closure
     )
    )
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (call $foo_1135
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $1)
       )
       (i32.const 11)
      )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $2)
-       (local.get $1)
-      )
-     )
+     (local.get $1)
     )
    )
   )
@@ -158,10 +143,10 @@ functions › func_recursive_closure
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
-  (local.get $1)
+  (local.get $2)
  )
  (func $func_1165 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -170,14 +155,9 @@ functions › func_recursive_closure
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -236,14 +216,9 @@ functions › func_recursive_closure
   )
   (i32.store
    (local.tee $2
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 6)
@@ -265,20 +240,15 @@ functions › func_recursive_closure
   )
   (i32.store offset=16
    (local.tee $2
-    (tuple.extract 0
-     (tuple.make
-      (local.tee $4
-       (tuple.extract 0
-        (tuple.make
-         (local.get $2)
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
+    (local.tee $4
+     (tuple.extract 0
+      (tuple.make
+       (local.get $2)
+       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+        (i32.const 0)
        )
       )
-      (local.get $2)
      )
     )
    )
@@ -299,30 +269,20 @@ functions › func_recursive_closure
     (tuple.make
      (if (result i32)
       (i32.shr_u
-       (tuple.extract 0
-        (tuple.make
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $2
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_==)
-             )
-             (local.get $2)
-            )
-           )
-          )
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
-          )
-          (i32.const 1)
-          (i32.load offset=8
-           (local.get $2)
-          )
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $2
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_==)
          )
-         (i32.const 0)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $1)
+        )
+        (i32.const 1)
+        (i32.load offset=8
+         (local.get $2)
         )
        )
        (i32.const 31)
@@ -330,30 +290,20 @@ functions › func_recursive_closure
       (i32.const 1)
       (if (result i32)
        (i32.shr_u
-        (tuple.extract 0
-         (tuple.make
-          (call_indirect (type $i32_i32_i32_=>_i32)
-           (local.tee $2
-            (tuple.extract 0
-             (tuple.make
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (global.get $gimport_pervasives_==)
-              )
-              (local.get $2)
-             )
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (local.get $1)
-           )
-           (i32.const 3)
-           (i32.load offset=8
-            (local.get $2)
-           )
+        (call_indirect (type $i32_i32_i32_=>_i32)
+         (local.tee $2
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_==)
           )
-          (i32.const 0)
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (local.get $1)
+         )
+         (i32.const 3)
+         (i32.load offset=8
+          (local.get $2)
          )
         )
         (i32.const 31)
@@ -371,14 +321,9 @@ functions › func_recursive_closure
           (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
             (local.tee $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_-)
-               )
-               (local.get $2)
-              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_-)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -450,7 +395,7 @@ functions › func_recursive_closure
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local.set $3
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $foo_1135
@@ -469,20 +414,15 @@ functions › func_recursive_closure
     )
    )
   )
-  (local.set $4
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $0)
-          )
-         )
-         (i32.const 0)
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (local.get $0)
         )
        )
       )
@@ -498,34 +438,29 @@ functions › func_recursive_closure
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
-      (i32.load offset=8
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $2)
       )
+      (i32.load offset=8
+       (local.get $3)
+      )
      )
-     (local.get $2)
+     (local.get $3)
     )
    )
   )
@@ -544,29 +479,24 @@ functions › func_recursive_closure
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $4)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $2)
    )
   )
-  (local.get $2)
+  (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -594,24 +524,11 @@ functions › func_recursive_closure
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -642,23 +559,10 @@ functions › func_recursive_closure
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_1)
-     (local.get $0)
-    )
-   )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $truc_1134
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_1)
-     )
-    )
-    (local.get $0)
+  (call $truc_1134
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_1)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -50,14 +50,9 @@ functions › app_1
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -74,7 +69,7 @@ functions › app_1
    (local.get $0)
    (i32.const 0)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -85,32 +80,22 @@ functions › app_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $lam_lambda_1132
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.const 3)
-     )
-     (tuple.extract 0
-      (tuple.make
-       (local.get $1)
-       (local.get $0)
-      )
-     )
+  (local.set $1
+   (call $lam_lambda_1132
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
     )
+    (i32.const 3)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -50,14 +50,9 @@ functions › shorthand_3
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -85,25 +80,12 @@ functions › shorthand_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $foo_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $foo_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 3)
-    )
-    (local.get $0)
-   )
+   (i32.const 3)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -26,7 +26,7 @@ functions › lam_destructure_3
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local.set $3
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -42,7 +42,7 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $4
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -58,7 +58,7 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $5
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -74,28 +74,23 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $6
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
+       (local.get $6)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (local.get $5)
       )
       (i32.load offset=8
        (local.get $2)
@@ -108,34 +103,29 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (local.get $4)
       )
       (i32.load offset=8
-       (local.get $2)
+       (local.get $3)
       )
      )
-     (local.get $2)
+     (local.get $3)
     )
    )
   )
@@ -149,12 +139,6 @@ functions › lam_destructure_3
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (drop
@@ -175,7 +159,13 @@ functions › lam_destructure_3
     (local.get $6)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
@@ -183,14 +173,9 @@ functions › lam_destructure_3
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -220,19 +205,9 @@ functions › lam_destructure_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $1)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -253,7 +228,7 @@ functions › lam_destructure_3
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -264,19 +239,14 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $lam_lambda_1134
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $lam_lambda_1134
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -290,10 +260,10 @@ functions › lam_destructure_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -29,7 +29,7 @@ functions › lam_destructure_7
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local.set $3
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -45,45 +45,13 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $1)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -99,7 +67,7 @@ functions › lam_destructure_7
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -112,28 +80,10 @@ functions › lam_destructure_7
   (local.set $8
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (i32.load offset=8
-       (local.get $2)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -146,28 +96,10 @@ functions › lam_destructure_7
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $2)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -182,14 +114,9 @@ functions › lam_destructure_7
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -198,13 +125,71 @@ functions › lam_destructure_7
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (local.get $8)
       )
       (i32.load offset=8
        (local.get $2)
       )
      )
-     (local.get $2)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $2)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $7)
+      )
+      (i32.load offset=8
+       (local.get $3)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $6)
+      )
+      (i32.load offset=8
+       (local.get $4)
+      )
+     )
+     (local.get $4)
     )
    )
   )
@@ -218,18 +203,6 @@ functions › lam_destructure_7
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (drop
@@ -262,7 +235,19 @@ functions › lam_destructure_7
     (local.get $9)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (local.get $4)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
@@ -271,14 +256,9 @@ functions › lam_destructure_7
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -308,19 +288,9 @@ functions › lam_destructure_7
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $1)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -350,14 +320,9 @@ functions › lam_destructure_7
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -381,7 +346,7 @@ functions › lam_destructure_7
     (local.get $2)
    )
   )
-  (local.set $3
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -392,19 +357,14 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $lam_lambda_1135
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-     )
+  (local.set $3
+   (call $lam_lambda_1135
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -424,10 +384,10 @@ functions › lam_destructure_7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -28,14 +28,9 @@ functions › shorthand_2
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -69,14 +64,9 @@ functions › shorthand_2
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -104,25 +94,12 @@ functions › shorthand_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $foo_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $foo_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 3)
-    )
-    (local.get $0)
-   )
+   (i32.const 3)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -27,7 +27,7 @@ functions › lam_destructure_4
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local.set $3
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -43,7 +43,7 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $4
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -59,7 +59,7 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $5
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -75,28 +75,23 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $6
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
+       (local.get $6)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (local.get $5)
       )
       (i32.load offset=8
        (local.get $2)
@@ -109,34 +104,29 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (local.get $4)
       )
       (i32.load offset=8
-       (local.get $2)
+       (local.get $3)
       )
      )
-     (local.get $2)
+     (local.get $3)
     )
    )
   )
@@ -150,12 +140,6 @@ functions › lam_destructure_4
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
    )
   )
   (drop
@@ -176,21 +160,22 @@ functions › lam_destructure_4
     (local.get $6)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $3)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -218,24 +203,11 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -256,7 +228,7 @@ functions › lam_destructure_4
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -267,19 +239,14 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $foo_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-     )
+  (local.set $1
+   (call $foo_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -287,10 +254,10 @@ functions › lam_destructure_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -30,7 +30,7 @@ functions › lam_destructure_8
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local.set $3
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -46,45 +46,13 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $1)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -100,7 +68,7 @@ functions › lam_destructure_8
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -113,28 +81,10 @@ functions › lam_destructure_8
   (local.set $8
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (i32.load offset=8
-       (local.get $2)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -147,28 +97,10 @@ functions › lam_destructure_8
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $2)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -183,14 +115,9 @@ functions › lam_destructure_8
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $2)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -199,13 +126,71 @@ functions › lam_destructure_8
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
+       (local.get $8)
       )
       (i32.load offset=8
        (local.get $2)
       )
      )
-     (local.get $2)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $2)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $7)
+      )
+      (i32.load offset=8
+       (local.get $3)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $6)
+      )
+      (i32.load offset=8
+       (local.get $4)
+      )
+     )
+     (local.get $4)
     )
    )
   )
@@ -219,18 +204,6 @@ functions › lam_destructure_8
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (drop
@@ -263,7 +236,19 @@ functions › lam_destructure_8
     (local.get $9)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (local.get $4)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
@@ -271,14 +256,9 @@ functions › lam_destructure_8
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -306,24 +286,11 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -353,14 +320,9 @@ functions › lam_destructure_8
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -384,7 +346,7 @@ functions › lam_destructure_8
     (local.get $1)
    )
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -395,19 +357,14 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $foo_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $foo_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -421,10 +378,10 @@ functions › lam_destructure_8
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -39,14 +39,9 @@ functions › lam_destructure_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -76,19 +71,9 @@ functions › lam_destructure_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $1)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -101,7 +86,7 @@ functions › lam_destructure_1
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -112,19 +97,14 @@ functions › lam_destructure_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $lam_lambda_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $lam_lambda_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -138,10 +118,10 @@ functions › lam_destructure_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -39,14 +39,9 @@ functions › lam_destructure_2
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -74,24 +69,11 @@ functions › lam_destructure_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -104,7 +86,7 @@ functions › lam_destructure_2
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -115,19 +97,14 @@ functions › lam_destructure_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $foo_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-     )
+  (local.set $1
+   (call $foo_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -135,10 +112,10 @@ functions › lam_destructure_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -38,14 +38,9 @@ functions › func_record_associativity2
   (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 72)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 72)
     )
    )
    (i32.const 1)
@@ -86,40 +81,28 @@ functions › func_record_associativity2
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -149,19 +132,9 @@ functions › func_record_associativity2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $2)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -203,14 +176,9 @@ functions › func_record_associativity2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -234,7 +202,7 @@ functions › func_record_associativity2
     (local.get $3)
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -251,7 +219,7 @@ functions › func_record_associativity2
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -277,35 +245,20 @@ functions › func_record_associativity2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.xor
-      (tuple.extract 0
-       (tuple.make
-        (call_indirect (type $i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $5)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load offset=8
-          (local.get $0)
-         )
-        )
-        (i32.const 0)
-       )
+  (local.set $1
+   (i32.xor
+    (call_indirect (type $i32_=>_i32)
+     (local.tee $1
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
       )
-      (i32.const -2147483648)
      )
-     (local.get $0)
+     (i32.load offset=8
+      (local.get $1)
+     )
     )
+    (i32.const -2147483648)
    )
   )
   (drop
@@ -323,7 +276,7 @@ functions › func_record_associativity2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -338,7 +291,7 @@ functions › func_record_associativity2
     (local.get $5)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -28,14 +28,9 @@ functions › fn_trailing_comma
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -78,14 +73,9 @@ functions › fn_trailing_comma
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -113,26 +103,13 @@ functions › fn_trailing_comma
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $testFn_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $testFn_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 5)
-     (i32.const 7)
-    )
-    (local.get $0)
-   )
+   (i32.const 5)
+   (i32.const 7)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -31,7 +31,7 @@ functions › lam_destructure_6
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local.set $4
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -47,61 +47,13 @@ functions › lam_destructure_6
     )
    )
   )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $7
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $2)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $8
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $2)
+      (i32.load offset=12
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -114,28 +66,10 @@ functions › lam_destructure_6
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $3)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -148,28 +82,10 @@ functions › lam_destructure_6
   (local.set $10
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (i32.load offset=8
-       (local.get $3)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $2)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -182,21 +98,32 @@ functions › lam_destructure_6
   (local.set $11
    (tuple.extract 0
     (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $9)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -213,34 +140,87 @@ functions › lam_destructure_6
     )
    )
   )
-  (local.set $3
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $3)
-        )
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $11)
+       (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $7)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $4)
       )
      )
-     (local.get $3)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $5
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $11)
+      )
+      (i32.load offset=8
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $6
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $10)
+      )
+      (i32.load offset=8
+       (local.get $6)
+      )
+     )
+     (local.get $6)
     )
    )
   )
@@ -260,24 +240,6 @@ functions › lam_destructure_6
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
    )
   )
   (drop
@@ -310,7 +272,25 @@ functions › lam_destructure_6
     (local.get $11)
    )
   )
-  (local.get $3)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (local.get $6)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
@@ -318,14 +298,9 @@ functions › lam_destructure_6
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -353,24 +328,11 @@ functions › lam_destructure_6
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
-   )
-  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -404,14 +366,9 @@ functions › lam_destructure_6
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -428,7 +385,7 @@ functions › lam_destructure_6
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -439,23 +396,18 @@ functions › lam_destructure_6
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $foo_1131
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $foo_1131
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
    )
@@ -469,10 +421,10 @@ functions › lam_destructure_6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -36,14 +36,9 @@ functions › func_record_associativity1
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -72,40 +67,28 @@ functions › func_record_associativity1
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -122,7 +105,7 @@ functions › func_record_associativity1
    (local.get $0)
    (i32.const 0)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -135,19 +118,9 @@ functions › func_record_associativity1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (tuple.extract 0
-       (tuple.make
-        (local.get $1)
-        (local.get $0)
-       )
-      )
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -171,10 +144,10 @@ functions › func_record_associativity1
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -191,7 +164,7 @@ functions › func_record_associativity1
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $2)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -201,41 +174,20 @@ functions › func_record_associativity1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.xor
-      (tuple.extract 0
-       (tuple.make
-        (call_indirect (type $i32_=>_i32)
-         (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
-            )
-            (local.get $0)
-           )
-          )
-         )
-         (i32.load offset=8
-          (local.get $0)
-         )
-        )
-        (i32.const 0)
-       )
+  (local.set $1
+   (i32.xor
+    (call_indirect (type $i32_=>_i32)
+     (local.tee $1
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
       )
-      (i32.const -2147483648)
      )
-     (local.get $0)
+     (i32.load offset=8
+      (local.get $1)
+     )
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.const -2147483648)
    )
   )
   (drop
@@ -247,10 +199,16 @@ functions › func_record_associativity1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
@@ -18,29 +18,19 @@ imports › import_all_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_Cons)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 5)
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_Cons)
     )
+   )
+   (i32.const 5)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
@@ -14,14 +14,9 @@ imports › import_some
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
@@ -14,14 +14,9 @@ imports › import_all_except_multiple
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_z)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_exportStar_z)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.259f419e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.259f419e.0.snapshot
@@ -14,14 +14,9 @@ imports › import_relative_path1
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_../test-libs/exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_../test-libs/exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -22,19 +22,14 @@ imports › import_alias_multiple_constructor
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_tlists_Cons)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_tlists_Cons)
        )
       )
       (i32.const 3)
@@ -53,40 +48,30 @@ imports › import_alias_multiple_constructor
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_tlists_sum)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_tlists_sum)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.45beae05.0.snapshot
+++ b/compiler/test/__snapshots__/imports.45beae05.0.snapshot
@@ -14,14 +14,9 @@ imports › annotation_across_import
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_tlists_Empty)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_tlists_Empty)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -17,28 +17,18 @@ imports › import_alias_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
@@ -14,14 +14,9 @@ imports › import_alias
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
@@ -17,28 +17,18 @@ imports › import_some_multiple_trailing
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -17,28 +17,18 @@ imports › import_some_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -20,19 +20,14 @@ imports › import_relative_path4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_./bar/bar_bar)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_./bar/bar_bar)
        )
       )
       (i32.const 5)
@@ -47,40 +42,30 @@ imports › import_relative_path4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_print)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_print)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
@@ -14,14 +14,9 @@ imports › import_all_except_constructor
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_tlists_Empty)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_tlists_Empty)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
@@ -18,29 +18,19 @@ imports › import_some_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_Cons)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_Cons)
     )
+   )
+   (i32.const 11)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
@@ -14,14 +14,9 @@ imports › import_module
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -17,28 +17,18 @@ imports › import_module2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
@@ -18,29 +18,19 @@ imports › import_same_module_unify2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_Cons)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_Cons)
     )
+   )
+   (i32.const 11)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
@@ -17,24 +17,14 @@ imports › import_with_export_multiple
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_sameExport_foo)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_sameExport_foo)
     )
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
@@ -18,29 +18,19 @@ imports › import_same_module_unify
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_Cons)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (i32.const 11)
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_Cons)
     )
+   )
+   (i32.const 11)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -17,28 +17,18 @@ imports › import_all_except_multiple_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_sum)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_sum)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
+++ b/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
@@ -17,28 +17,18 @@ imports › import_some_multiple_trailing2
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_exportStar_y)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_exportStar_y)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -17,28 +17,18 @@ imports › import_alias_constructor
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_sum)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_sum)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.e295854d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e295854d.0.snapshot
@@ -14,14 +14,9 @@ imports › import_relative_path2
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_../../test/test-libs/exportStar_x)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_../../test/test-libs/exportStar_x)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
@@ -14,14 +14,9 @@ imports › import_relative_path3
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_nested/nested_j)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $gimport_nested/nested_j)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
@@ -19,32 +19,22 @@ imports › import_muliple_modules
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
-  (tuple.extract 0
-   (tuple.make
-    (call_indirect (type $i32_i32_i32_=>_i32)
-     (local.tee $0
-      (tuple.extract 0
-       (tuple.make
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (global.get $gimport_tlists_Cons)
-        )
-        (i32.const 0)
-       )
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_exportStar_x)
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_Empty)
-     )
-     (i32.load offset=8
-      (local.get $0)
-     )
+  (call_indirect (type $i32_i32_i32_=>_i32)
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_Cons)
     )
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_x)
+   )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_Empty)
+   )
+   (i32.load offset=8
     (local.get $0)
    )
   )

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -22,19 +22,14 @@ imports › import_some_mixed
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_tlists_Cons)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_tlists_Cons)
        )
       )
       (i32.const 11)
@@ -53,40 +48,30 @@ imports › import_some_mixed
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_tlists_sum)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_tlists_sum)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_division1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_/)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_/)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_division1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,21 +72,16 @@ let mut › let-mut_division1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $1
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_multiplication2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_*)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_*)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_multiplication2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_multiplication2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -21,14 +21,9 @@ let mut › let-mut3
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -52,15 +47,10 @@ let mut › let-mut3
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (global.get $global_0)
-     )
-    )
-    (local.get $0)
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=8
+    (global.get $global_0)
    )
   )
  )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_division3
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_/)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_/)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_division3
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_division3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut5
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut5
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut5
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -22,14 +22,9 @@ let mut › let-mut2
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -59,14 +54,9 @@ let mut › let-mut2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -98,14 +88,9 @@ let mut › let-mut2
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_multiplication1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_*)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_*)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_multiplication1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,21 +72,16 @@ let mut › let-mut_multiplication1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $1
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_multiplication3
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_*)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_*)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_multiplication3
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_multiplication3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -38,14 +38,9 @@ let mut › let-mut4
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_0)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_0)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_subtraction1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_subtraction1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,21 +72,16 @@ let mut › let-mut_subtraction1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $1
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_subtraction2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_subtraction2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_subtraction2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_addition2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_addition2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_addition2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_addition1
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_addition1
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,21 +72,16 @@ let mut › let-mut_addition1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $1
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_subtraction3
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_-)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_-)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_subtraction3
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_subtraction3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_addition3
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_addition3
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_addition3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -32,19 +32,14 @@ let mut › let-mut_division2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_/)
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_/)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -68,7 +63,7 @@ let mut › let-mut_division2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $1)
+      (local.get $0)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -77,24 +72,19 @@ let mut › let-mut_division2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -27,14 +27,9 @@ let mut › let-mut1
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $global_0)
-    )
-    (i32.const 0)
-   )
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (global.get $global_0)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -27,15 +27,10 @@ lists › list_spread
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 9)
@@ -44,7 +39,7 @@ lists › list_spread
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -59,14 +54,9 @@ lists › list_spread
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 7)
@@ -85,19 +75,14 @@ lists › list_spread
     )
    )
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
@@ -116,31 +101,21 @@ lists › list_spread
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_[...])
      )
+    )
+    (i32.const 3)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $2)
     )
    )
   )
@@ -153,10 +128,10 @@ lists › list_spread
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -22,19 +22,14 @@ lists › list1_trailing_space
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 7)
@@ -53,28 +48,23 @@ lists › list1_trailing_space
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -84,32 +74,28 @@ lists › list1_trailing_space
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_[...])
      )
-     (local.get $0)
     )
+    (i32.const 3)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -118,13 +104,7 @@ lists › list1_trailing_space
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -22,19 +22,14 @@ lists › list1_trailing
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 7)
@@ -53,28 +48,23 @@ lists › list1_trailing
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -84,32 +74,28 @@ lists › list1_trailing
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_[...])
      )
-     (local.get $0)
     )
+    (i32.const 3)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -118,13 +104,7 @@ lists › list1_trailing
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -29,17 +29,11 @@ loops › loop2
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -65,14 +59,9 @@ loops › loop2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -99,7 +88,7 @@ loops › loop2
   (drop
    (loop $MFor_loop.8 (result i32)
     (block $MFor.7 (result i32)
-     (local.set $1
+     (local.set $0
       (tuple.extract 0
        (tuple.make
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -121,24 +110,19 @@ loops › loop2
        (i32.eqz
         (i32.shr_u
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_>)
-             )
-             (local.get $0)
-            )
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_>)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $1)
+           (local.get $0)
           )
           (i32.const 1)
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
          (i32.const 31)
@@ -157,7 +141,7 @@ loops › loop2
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -167,14 +151,9 @@ loops › loop2
        (tuple.make
         (call_indirect (type $i32_i32_i32_=>_i32)
          (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (global.get $gimport_pervasives_-)
-            )
-            (local.get $0)
-           )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_-)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -210,14 +189,6 @@ loops › loop2
        )
       )
      )
-     (local.set $5
-      (tuple.extract 0
-       (tuple.make
-        (i32.const 1879048190)
-        (local.get $5)
-       )
-      )
-     )
      (local.set $3
       (tuple.extract 0
        (tuple.make
@@ -239,14 +210,9 @@ loops › loop2
        (tuple.make
         (call_indirect (type $i32_i32_i32_=>_i32)
          (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (global.get $gimport_pervasives_+)
-            )
-            (local.get $0)
-           )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -286,23 +252,18 @@ loops › loop2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_1)
-      )
-     )
-     (local.get $0)
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -329,7 +290,7 @@ loops › loop2
     (i32.const 0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -24,7 +24,6 @@ loops › loop5
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
@@ -55,14 +54,9 @@ loops › loop5
        (tuple.make
         (call_indirect (type $i32_i32_i32_=>_i32)
          (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (global.get $gimport_pervasives_-)
-            )
-            (local.get $0)
-           )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_-)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -95,14 +89,6 @@ loops › loop5
        )
       )
      )
-     (local.set $2
-      (tuple.extract 0
-       (tuple.make
-        (i32.const 1879048190)
-        (local.get $2)
-       )
-      )
-     )
      (drop
       (br_if $MFor.5
        (i32.const 1879048190)
@@ -110,14 +96,9 @@ loops › loop5
         (i32.shr_u
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_>=)
-             )
-             (local.get $0)
-            )
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_>=)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -139,14 +120,9 @@ loops › loop5
        (tuple.make
         (call_indirect (type $i32_i32_i32_=>_i32)
          (local.tee $0
-          (tuple.extract 0
-           (tuple.make
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (global.get $gimport_pervasives_+)
-            )
-            (local.get $0)
-           )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (global.get $gimport_pervasives_+)
           )
          )
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -184,14 +160,9 @@ loops › loop5
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_1)
-     )
-     (local.get $0)
-    )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_1)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -39,14 +39,9 @@ loops › loop3
      (i32.shr_u
       (call_indirect (type $i32_i32_i32_=>_i32)
        (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_>)
-          )
-          (local.get $0)
-         )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (global.get $gimport_pervasives_>)
         )
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -66,14 +61,9 @@ loops › loop3
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_-)
-             )
-             (local.get $0)
-            )
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_-)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -113,14 +103,9 @@ loops › loop3
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (local.get $0)
-    )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -25,7 +25,6 @@ loops › loop4
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
@@ -54,14 +53,9 @@ loops › loop4
      (i32.shr_u
       (call_indirect (type $i32_i32_i32_=>_i32)
        (local.tee $0
-        (tuple.extract 0
-         (tuple.make
-          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (global.get $gimport_pervasives_>)
-          )
-          (local.get $0)
-         )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (global.get $gimport_pervasives_>)
         )
        )
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -81,14 +75,9 @@ loops › loop4
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_-)
-             )
-             (local.get $0)
-            )
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_-)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -121,27 +110,14 @@ loops › loop4
         )
        )
       )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (i32.const 1879048190)
-         (local.get $3)
-        )
-       )
-      )
       (local.set $2
        (tuple.extract 0
         (tuple.make
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (global.get $gimport_pervasives_+)
-             )
-             (local.get $0)
-            )
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -181,14 +157,9 @@ loops › loop4
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_1)
-     )
-     (local.get $0)
-    )
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_1)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -57,14 +57,9 @@ optimizations › trs1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 6)
@@ -92,26 +87,13 @@ optimizations › trs1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (global.get $global_0)
-     (local.get $0)
-    )
+  (call $f1_1131
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_0)
    )
-  )
-  (tuple.extract 0
-   (tuple.make
-    (call $f1_1131
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $global_0)
-     )
-     (i32.const 3)
-     (i32.const 5)
-    )
-    (local.get $0)
-   )
+   (i32.const 3)
+   (i32.const 5)
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -27,14 +27,9 @@ optimizations › test_dead_branch_elimination_5
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -60,14 +55,9 @@ optimizations › test_dead_branch_elimination_5
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -119,7 +109,7 @@ optimizations › test_dead_branch_elimination_5
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -151,41 +141,31 @@ optimizations › test_dead_branch_elimination_5
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -194,7 +174,7 @@ optimizations › test_dead_branch_elimination_5
     (local.get $2)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -27,14 +27,9 @@ pattern matching › record_match_3
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -79,40 +74,28 @@ pattern matching › record_match_3
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -144,7 +127,7 @@ pattern matching › record_match_3
    (local.get $0)
    (i32.const 13)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -161,7 +144,7 @@ pattern matching › record_match_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -177,7 +160,7 @@ pattern matching › record_match_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -187,41 +170,31 @@ pattern matching › record_match_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
-     (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -236,7 +209,7 @@ pattern matching › record_match_3
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -26,18 +26,11 @@ pattern matching › adt_match_deep
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -66,40 +59,28 @@ pattern matching › adt_match_deep
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -123,7 +104,7 @@ pattern matching › adt_match_deep
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -134,149 +115,123 @@ pattern matching › adt_match_deep
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.21_outer (result i32)
+  (local.set $2
+   (block $switch.21_outer (result i32)
+    (drop
+     (block $switch.21_branch_1 (result i32)
       (drop
-       (block $switch.21_branch_1 (result i32)
+       (block $switch.21_branch_2 (result i32)
         (drop
-         (block $switch.21_branch_2 (result i32)
-          (drop
-           (block $switch.21_default (result i32)
-            (br_table $switch.21_branch_1 $switch.21_branch_2 $switch.21_default
-             (i32.const 0)
-             (i32.shr_s
-              (tuple.extract 0
-               (tuple.make
-                (if (result i32)
-                 (i32.shr_u
-                  (tuple.extract 0
-                   (tuple.make
-                    (i32.or
-                     (i32.shl
-                      (i32.eq
-                       (local.tee $4
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.load offset=12
-                           (local.tee $2
-                            (tuple.extract 0
-                             (tuple.make
-                              (call_indirect (type $i32_i32_i32_=>_i32)
-                               (local.tee $0
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                   (global.get $gimport_pervasives_[...])
-                                  )
-                                  (local.get $0)
-                                 )
-                                )
-                               )
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (local.get $1)
-                               )
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (global.get $gimport_pervasives_[])
-                               )
-                               (i32.load offset=8
-                                (local.get $0)
-                               )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                           )
-                          )
-                          (i32.const 0)
-                         )
-                        )
-                       )
-                       (i32.const 3)
-                      )
-                      (i32.const 31)
-                     )
-                     (i32.const 2147483646)
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                  (i32.const 31)
-                 )
-                 (i32.const 3)
-                 (if (result i32)
-                  (i32.shr_u
-                   (local.tee $5
+         (block $switch.21_default (result i32)
+          (br_table $switch.21_branch_1 $switch.21_branch_2 $switch.21_default
+           (i32.const 0)
+           (i32.shr_s
+            (if (result i32)
+             (i32.shr_u
+              (i32.or
+               (i32.shl
+                (i32.eq
+                 (local.tee $2
+                  (i32.load offset=12
+                   (local.tee $1
                     (tuple.extract 0
                      (tuple.make
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $4)
-                         (i32.const 1)
+                      (call_indirect (type $i32_i32_i32_=>_i32)
+                       (local.tee $1
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (global.get $gimport_pervasives_[...])
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $0)
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (global.get $gimport_pervasives_[])
+                       )
+                       (i32.load offset=8
+                        (local.get $1)
+                       )
                       )
-                      (i32.const 0)
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (i32.const 0)
+                      )
                      )
                     )
                    )
-                   (i32.const 31)
                   )
-                  (i32.const 1)
-                  (unreachable)
                  )
+                 (i32.const 3)
                 )
-                (local.get $5)
+                (i32.const 31)
                )
+               (i32.const 2147483646)
+              )
+              (i32.const 31)
+             )
+             (i32.const 3)
+             (if (result i32)
+              (i32.shr_u
+               (i32.or
+                (i32.shl
+                 (i32.eq
+                  (local.get $2)
+                  (i32.const 1)
+                 )
+                 (i32.const 31)
+                )
+                (i32.const 2147483646)
+               )
+               (i32.const 31)
               )
               (i32.const 1)
+              (unreachable)
              )
             )
-           )
-          )
-          (unreachable)
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (i32.const 1)
            )
           )
          )
         )
-        (br $switch.21_outer
+        (unreachable)
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=16
-           (local.get $3)
+          (i32.load offset=20
+           (local.get $1)
           )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (i32.const 0)
          )
         )
        )
       )
-      (i32.const 1999)
+      (br $switch.21_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=16
+         (local.get $3)
+        )
+       )
+      )
      )
-     (local.get $0)
     )
+    (i32.const 1999)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -288,16 +243,10 @@ pattern matching › adt_match_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -35,21 +35,14 @@ pattern matching › tuple_match_deep4
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local.set $9
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
@@ -70,14 +63,9 @@ pattern matching › tuple_match_deep4
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -94,10 +82,10 @@ pattern matching › tuple_match_deep4
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $9)
+    (local.get $10)
    )
   )
-  (local.set $4
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -108,508 +96,220 @@ pattern matching › tuple_match_deep4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.53_outer (result i32)
+  (local.set $1
+   (block $switch.53_outer (result i32)
+    (drop
+     (block $switch.53_branch_1 (result i32)
       (drop
-       (block $switch.53_branch_1 (result i32)
+       (block $switch.53_branch_2 (result i32)
         (drop
-         (block $switch.53_branch_2 (result i32)
+         (block $switch.53_branch_3 (result i32)
           (drop
-           (block $switch.53_branch_3 (result i32)
+           (block $switch.53_branch_4 (result i32)
             (drop
-             (block $switch.53_branch_4 (result i32)
+             (block $switch.53_branch_5 (result i32)
               (drop
-               (block $switch.53_branch_5 (result i32)
-                (drop
-                 (block $switch.53_default (result i32)
-                  (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_branch_3 $switch.53_branch_4 $switch.53_branch_5 $switch.53_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $10
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                     (i32.load offset=12
-                                      (local.get $4)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.53_default (result i32)
+                (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_branch_3 $switch.53_branch_4 $switch.53_branch_5 $switch.53_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $11
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                             (i32.load offset=12
+                              (local.get $0)
+                             )
+                            )
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $11)
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $10)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $14
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $14)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.53_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=12
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $11
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=8
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $12
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $11)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $13
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $12)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.53_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $13)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -618,8 +318,8 @@ pattern matching › tuple_match_deep4
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
+              (i32.load offset=12
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -634,7 +334,7 @@ pattern matching › tuple_match_deep4
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $2)
               )
              )
@@ -645,13 +345,29 @@ pattern matching › tuple_match_deep4
             )
            )
           )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $4)
+             )
+            )
+           )
+          )
           (local.set $6
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (local.get $1)
+               (local.get $4)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -666,8 +382,40 @@ pattern matching › tuple_match_deep4
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $12
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=8
-               (local.get $4)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -681,27 +429,51 @@ pattern matching › tuple_match_deep4
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
+              (local.tee $8
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
                )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $8)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $9
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $7)
               )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
               (i32.load offset=8
-               (local.get $0)
+               (local.get $9)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -713,44 +485,23 @@ pattern matching › tuple_match_deep4
           )
           (br $switch.53_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-               (local.get $0)
-              )
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $8)
+             (local.get $9)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $6)
             )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
            )
           )
          )
@@ -760,8 +511,8 @@ pattern matching › tuple_match_deep4
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
+            (i32.load offset=12
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -776,8 +527,8 @@ pattern matching › tuple_match_deep4
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $4)
+            (i32.load offset=24
+             (local.get $2)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -787,55 +538,183 @@ pattern matching › tuple_match_deep4
           )
          )
         )
-        (br $switch.53_outer
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $3)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (local.set $6
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $7
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $5
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $5
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
              )
-             (local.get $0)
             )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $7)
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $6)
+            )
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (br $switch.53_outer
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $4)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $2)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=20
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $3)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $4)
+         )
+        )
+       )
+      )
+      (br $switch.53_outer
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $1
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (i32.load offset=8
+         (local.get $1)
+        )
        )
       )
      )
-     (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (i32.load offset=8
+      (local.get $0)
+     )
+    )
    )
   )
   (drop
@@ -847,7 +726,13 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
    )
   )
   (drop
@@ -865,6 +750,12 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -877,13 +768,7 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
+    (local.get $5)
    )
   )
   (drop
@@ -895,10 +780,16 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $13)
+    (local.get $8)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -30,21 +30,14 @@ pattern matching › adt_match_4
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
   (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 13)
@@ -68,14 +61,9 @@ pattern matching › adt_match_4
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 11)
@@ -94,457 +82,230 @@ pattern matching › adt_match_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.54_outer (result i32)
+  (local.set $1
+   (block $switch.54_outer (result i32)
+    (drop
+     (block $switch.54_branch_1 (result i32)
       (drop
-       (block $switch.54_branch_1 (result i32)
+       (block $switch.54_branch_2 (result i32)
         (drop
-         (block $switch.54_branch_2 (result i32)
+         (block $switch.54_branch_3 (result i32)
           (drop
-           (block $switch.54_branch_3 (result i32)
+           (block $switch.54_branch_4 (result i32)
             (drop
-             (block $switch.54_branch_4 (result i32)
+             (block $switch.54_branch_5 (result i32)
               (drop
-               (block $switch.54_branch_5 (result i32)
-                (drop
-                 (block $switch.54_default (result i32)
-                  (br_table $switch.54_branch_1 $switch.54_branch_2 $switch.54_branch_3 $switch.54_branch_4 $switch.54_branch_5 $switch.54_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $3
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call_indirect (type $i32_i32_i32_=>_i32)
-                                     (local.tee $0
-                                      (tuple.extract 0
-                                       (tuple.make
-                                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                         (global.get $gimport_pervasives_[...])
-                                        )
-                                        (local.get $0)
-                                       )
-                                      )
-                                     )
-                                     (i32.const 9)
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (local.get $7)
-                                     )
-                                     (i32.load offset=8
-                                      (local.get $0)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.54_default (result i32)
+                (br_table $switch.54_branch_1 $switch.54_branch_2 $switch.54_branch_3 $switch.54_branch_4 $switch.54_branch_5 $switch.54_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $0
+                          (tuple.extract 0
+                           (tuple.make
+                            (call_indirect (type $i32_i32_i32_=>_i32)
+                             (local.tee $0
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (global.get $gimport_pervasives_[...])
                               )
                              )
-                             (i32.const 3)
+                             (i32.const 9)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $7)
+                             )
+                             (i32.load offset=8
+                              (local.get $0)
+                             )
                             )
-                            (i32.const 31)
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $0)
+                              )
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $3)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $11
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $4
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $11)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.54_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $4
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $4)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $9
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $10
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $9)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.54_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $10)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $4)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -553,13 +314,29 @@ pattern matching › adt_match_4
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $1)
+              (i32.load offset=24
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (local.get $2)
+             )
+            )
+           )
+          )
+          (local.set $3
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $3)
              )
             )
            )
@@ -580,48 +357,172 @@ pattern matching › adt_match_4
             )
            )
           )
-          (br $switch.54_outer
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
+          (local.set $8
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $0)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $5
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
                )
-               (local.get $0)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $9)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
+              )
+              (i32.load offset=8
+               (local.get $5)
               )
              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (br $switch.54_outer
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $5)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (local.get $4)
             )
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
            )
           )
          )
         )
+        (local.set $2
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=24
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (local.set $3
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $3)
+           )
+          )
+         )
+        )
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
         (br $switch.54_outer
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $4)
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (local.get $3)
+          )
+          (i32.load offset=8
+           (local.get $1)
           )
          )
         )
        )
       )
-      (i32.const 1)
+      (br $switch.54_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (local.get $0)
+        )
+       )
+      )
      )
-     (local.get $0)
     )
+    (i32.const 1)
    )
   )
   (drop
@@ -639,19 +540,19 @@ pattern matching › adt_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -675,10 +576,10 @@ pattern matching › adt_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
+    (local.get $5)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -23,14 +23,9 @@ pattern matching › record_match_2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -75,40 +70,28 @@ pattern matching › record_match_2
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -134,14 +117,9 @@ pattern matching › record_match_2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -176,7 +154,7 @@ pattern matching › record_match_2
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -187,15 +165,10 @@ pattern matching › record_match_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=20
      (local.get $0)
     )
    )
@@ -209,10 +182,10 @@ pattern matching › record_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -24,34 +24,27 @@ pattern matching › constant_match_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i64.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i64.const 7303014)
   )
   (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -61,14 +54,9 @@ pattern matching › constant_match_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -93,161 +81,126 @@ pattern matching › constant_match_3
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.28_outer (result i32)
+   (block $switch.28_outer (result i32)
+    (drop
+     (block $switch.28_branch_1 (result i32)
       (drop
-       (block $switch.28_branch_1 (result i32)
+       (block $switch.28_branch_2 (result i32)
         (drop
-         (block $switch.28_branch_2 (result i32)
+         (block $switch.28_branch_3 (result i32)
           (drop
-           (block $switch.28_branch_3 (result i32)
-            (drop
-             (block $switch.28_default (result i32)
-              (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_branch_3 $switch.28_default
-               (i32.const 0)
-               (i32.shr_s
-                (tuple.extract 0
-                 (tuple.make
-                  (if (result i32)
-                   (i32.shr_u
-                    (tuple.extract 0
-                     (tuple.make
-                      (select
-                       (i32.const 2147483646)
-                       (local.tee $5
-                        (tuple.extract 0
-                         (tuple.make
-                          (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (local.get $1)
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (local.get $2)
-                           )
-                          )
-                          (i32.const 0)
-                         )
-                        )
-                       )
-                       (i32.shr_u
-                        (local.get $5)
-                        (i32.const 31)
-                       )
-                      )
-                      (i32.const 0)
-                     )
-                    )
-                    (i32.const 31)
+           (block $switch.28_default (result i32)
+            (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_branch_3 $switch.28_default
+             (i32.const 0)
+             (i32.shr_s
+              (if (result i32)
+               (i32.shr_u
+                (select
+                 (i32.const 2147483646)
+                 (local.tee $0
+                  (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
                    )
-                   (i32.const 1)
-                   (block (result i32)
-                    (i32.store
-                     (local.tee $0
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                         (i32.const 16)
-                        )
-                        (local.get $0)
-                       )
-                      )
-                     )
-                     (i32.const 1)
-                    )
-                    (i32.store offset=4
-                     (local.get $0)
-                     (i32.const 3)
-                    )
-                    (i64.store offset=8
-                     (local.get $0)
-                     (i64.const 7303014)
-                    )
-                    (local.set $3
-                     (tuple.extract 0
-                      (tuple.make
-                       (local.get $0)
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (i32.const 0)
-                       )
-                      )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 5)
-                     (i32.shr_u
-                      (tuple.extract 0
-                       (tuple.make
-                        (select
-                         (i32.const -2)
-                         (local.tee $4
-                          (tuple.extract 0
-                           (tuple.make
-                            (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $1)
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $3)
-                             )
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.shr_u
-                          (local.get $4)
-                          (i32.const 31)
-                         )
-                        )
-                        (i32.const 0)
-                       )
-                      )
-                      (i32.const 31)
-                     )
-                    )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $1)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $2)
                    )
                   )
-                  (local.get $4)
+                 )
+                 (i32.shr_u
+                  (local.get $0)
+                  (i32.const 31)
                  )
                 )
-                (i32.const 1)
+                (i32.const 31)
+               )
+               (i32.const 1)
+               (block (result i32)
+                (i32.store
+                 (local.tee $0
+                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                   (i32.const 16)
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.store offset=4
+                 (local.get $0)
+                 (i32.const 3)
+                )
+                (i64.store offset=8
+                 (local.get $0)
+                 (i64.const 7303014)
+                )
+                (local.set $3
+                 (tuple.extract 0
+                  (tuple.make
+                   (local.get $0)
+                   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                    (i32.const 0)
+                   )
+                  )
+                 )
+                )
+                (select
+                 (i32.const 3)
+                 (i32.const 5)
+                 (i32.shr_u
+                  (select
+                   (i32.const -2)
+                   (local.tee $0
+                    (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $1)
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $3)
+                     )
+                    )
+                   )
+                   (i32.shr_u
+                    (local.get $0)
+                    (i32.const 31)
+                   )
+                  )
+                  (i32.const 31)
+                 )
+                )
                )
               )
+              (i32.const 1)
              )
             )
-            (unreachable)
            )
           )
-          (br $switch.28_outer
-           (i32.const 2147483646)
-          )
+          (unreachable)
          )
         )
         (br $switch.28_outer
-         (i32.const -2)
+         (i32.const 2147483646)
         )
        )
       )
-      (i32.const 2147483646)
+      (br $switch.28_outer
+       (i32.const -2)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 2147483646)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -25,14 +25,9 @@ pattern matching › guarded_match_2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -53,7 +48,7 @@ pattern matching › guarded_match_2
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -70,7 +65,7 @@ pattern matching › guarded_match_2
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -80,80 +75,60 @@ pattern matching › guarded_match_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.13_outer (result i32)
+  (local.set $1
+   (block $switch.13_outer (result i32)
+    (drop
+     (block $switch.13_branch_1 (result i32)
       (drop
-       (block $switch.13_branch_1 (result i32)
+       (block $switch.13_branch_2 (result i32)
         (drop
-         (block $switch.13_branch_2 (result i32)
-          (drop
-           (block $switch.13_default (result i32)
-            (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
-             (i32.const 0)
-             (i32.shr_s
-              (tuple.extract 0
-               (tuple.make
-                (select
-                 (i32.const 1)
-                 (i32.const 3)
-                 (i32.shr_u
-                  (tuple.extract 0
-                   (tuple.make
-                    (call_indirect (type $i32_i32_i32_=>_i32)
-                     (local.tee $0
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (global.get $gimport_pervasives_==)
-                        )
-                        (local.get $0)
-                       )
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (local.get $2)
-                     )
-                     (i32.const 3)
-                     (i32.load offset=8
-                      (local.get $0)
-                     )
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                  (i32.const 31)
-                 )
+         (block $switch.13_default (result i32)
+          (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
+           (i32.const 0)
+           (i32.shr_s
+            (select
+             (i32.const 1)
+             (i32.const 3)
+             (i32.shr_u
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (local.tee $1
+                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                 (global.get $gimport_pervasives_==)
                 )
-                (i32.const 0)
+               )
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (local.get $2)
+               )
+               (i32.const 3)
+               (i32.load offset=8
+                (local.get $1)
                )
               )
-              (i32.const 1)
+              (i32.const 31)
              )
             )
+            (i32.const 1)
            )
           )
-          (unreachable)
          )
         )
-        (br $switch.13_outer
-         (i32.const 199)
-        )
+        (unreachable)
        )
       )
-      (i32.const 85)
+      (br $switch.13_outer
+       (i32.const 199)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 85)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -162,7 +137,7 @@ pattern matching › guarded_match_2
     (local.get $2)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -32,14 +32,9 @@ pattern matching › tuple_match_deep
   (local $9 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -56,7 +51,7 @@ pattern matching › tuple_match_deep
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $3
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -69,14 +64,9 @@ pattern matching › tuple_match_deep
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -93,65 +83,17 @@ pattern matching › tuple_match_deep
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $3)
+    (local.get $5)
    )
   )
   (i32.store offset=16
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $2
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $2)
-      )
-     )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -164,8 +106,24 @@ pattern matching › tuple_match_deep
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $2)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -180,8 +138,8 @@ pattern matching › tuple_match_deep
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $1)
+      (i32.load offset=12
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -194,28 +152,10 @@ pattern matching › tuple_match_deep
   (local.set $8
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -228,26 +168,8 @@ pattern matching › tuple_match_deep
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
        (local.get $0)
       )
@@ -259,19 +181,14 @@ pattern matching › tuple_match_deep
     )
    )
   )
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -280,38 +197,67 @@ pattern matching › tuple_match_deep
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
+       (local.get $6)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
-     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $8)
+      )
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+  (local.set $4
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $4
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $7)
+    )
+    (i32.load offset=8
+     (local.get $4)
+    )
    )
   )
   (drop
@@ -323,7 +269,19 @@ pattern matching › tuple_match_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -344,7 +302,19 @@ pattern matching › tuple_match_deep
     (local.get $9)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -23,14 +23,9 @@ pattern matching › record_match_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -75,40 +70,28 @@ pattern matching › record_match_1
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -134,14 +117,9 @@ pattern matching › record_match_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -176,7 +154,7 @@ pattern matching › record_match_1
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -187,15 +165,10 @@ pattern matching › record_match_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
      (local.get $0)
     )
    )
@@ -209,10 +182,10 @@ pattern matching › record_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -28,19 +28,11 @@ pattern matching › constant_match_2
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -53,7 +45,7 @@ pattern matching › constant_match_2
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $6
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -66,14 +58,9 @@ pattern matching › constant_match_2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -86,7 +73,7 @@ pattern matching › constant_match_2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $6)
+    (local.get $5)
    )
   )
   (i32.store offset=12
@@ -97,7 +84,7 @@ pattern matching › constant_match_2
    (local.get $0)
    (i32.const 2147483646)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -108,16 +95,27 @@ pattern matching › constant_match_2
     )
    )
   )
-  (local.set $5
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
+     (local.get $0)
+    )
+   )
+  )
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
+      (i32.load offset=12
+       (local.get $0)
       )
      )
-     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
@@ -126,24 +124,8 @@ pattern matching › constant_match_2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $8
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -153,403 +135,339 @@ pattern matching › constant_match_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.60_outer (result i32)
+  (local.set $1
+   (block $switch.60_outer (result i32)
+    (drop
+     (block $switch.60_branch_1 (result i32)
       (drop
-       (block $switch.60_branch_1 (result i32)
+       (block $switch.60_branch_2 (result i32)
         (drop
-         (block $switch.60_branch_2 (result i32)
+         (block $switch.60_branch_3 (result i32)
           (drop
-           (block $switch.60_branch_3 (result i32)
+           (block $switch.60_branch_4 (result i32)
             (drop
-             (block $switch.60_branch_4 (result i32)
-              (drop
-               (block $switch.60_default (result i32)
-                (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
-                 (i32.const 0)
-                 (i32.shr_s
-                  (tuple.extract 0
-                   (tuple.make
-                    (if (result i32)
-                     (i32.shr_u
-                      (tuple.extract 0
-                       (tuple.make
-                        (if (result i32)
-                         (i32.shr_u
-                          (local.tee $5
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $5)
-                                (i32.const 2147483646)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (if (result i32)
-                          (i32.shr_u
-                           (local.tee $2
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                               )
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (local.get $7)
-                               )
-                               (i32.const 11)
-                              )
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                          (block (result i32)
-                           (i32.store
-                            (local.tee $0
-                             (tuple.extract 0
-                              (tuple.make
-                               (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                                (i32.const 16)
-                               )
-                               (local.get $0)
-                              )
-                             )
-                            )
-                            (i32.const 1)
-                           )
-                           (i32.store offset=4
-                            (local.get $0)
-                            (i32.const 3)
-                           )
-                           (i64.store offset=8
-                            (local.get $0)
-                            (i64.const 7496034)
-                           )
-                           (local.set $3
-                            (tuple.extract 0
-                             (tuple.make
-                              (local.get $0)
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                             (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                             (local.get $8)
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                             (local.get $3)
-                            )
-                           )
-                          )
-                          (local.get $2)
-                         )
-                         (local.get $5)
-                        )
-                        (local.get $2)
+             (block $switch.60_default (result i32)
+              (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
+               (i32.const 0)
+               (i32.shr_s
+                (if (result i32)
+                 (i32.shr_u
+                  (if (result i32)
+                   (i32.shr_u
+                    (local.tee $1
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (local.tee $1
+                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $6)
+                       )
+                       (i32.const 11)
+                      )
+                     )
+                     (i32.const 31)
+                    )
+                    (block (result i32)
+                     (i32.store
+                      (local.tee $2
+                       (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                        (i32.const 16)
                        )
                       )
-                      (i32.const 31)
+                      (i32.const 1)
                      )
-                     (i32.const 1)
-                     (block (result i32)
-                      (local.set $9
-                       (tuple.extract 0
-                        (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (i32.load offset=16
-                           (local.get $1)
-                          )
-                         )
+                     (i32.store offset=4
+                      (local.get $2)
+                      (i32.const 3)
+                     )
+                     (i64.store offset=8
+                      (local.get $2)
+                      (i64.const 7496034)
+                     )
+                     (local.set $2
+                      (tuple.extract 0
+                       (tuple.make
+                        (local.get $2)
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
                          (i32.const 0)
                         )
                        )
                       )
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                      )
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (local.get $7)
+                      )
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (local.get $2)
+                      )
+                     )
+                    )
+                    (local.get $1)
+                   )
+                   (local.get $1)
+                  )
+                  (i32.const 31)
+                 )
+                 (i32.const 1)
+                 (block (result i32)
+                  (local.set $1
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (i32.load offset=16
+                     (local.get $0)
+                    )
+                   )
+                  )
+                  (local.set $2
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (i32.load offset=8
+                       (local.get $0)
+                      )
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                      (local.get $2)
+                     )
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (i32.shr_u
+                    (if (result i32)
+                     (i32.shr_u
+                      (local.tee $1
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const -2)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                      )
+                      (i32.const 31)
+                     )
+                     (block (result i32)
+                      (i32.store
+                       (local.tee $3
+                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                         (i32.const 16)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.store offset=4
+                       (local.get $3)
+                       (i32.const 3)
+                      )
+                      (i64.store offset=8
+                       (local.get $3)
+                       (i64.const 7303014)
+                      )
                       (local.set $3
                        (tuple.extract 0
                         (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (i32.load offset=8
-                           (local.get $1)
-                          )
-                         )
+                         (local.get $3)
                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                          (local.get $3)
+                          (i32.const 0)
                          )
                         )
                        )
                       )
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (if (result i32)
-                           (i32.shr_u
-                            (local.tee $2
-                             (tuple.extract 0
-                              (tuple.make
-                               (i32.or
-                                (i32.shl
-                                 (i32.eq
-                                  (local.get $9)
-                                  (i32.const -2)
-                                 )
-                                 (i32.const 31)
-                                )
-                                (i32.const 2147483646)
-                               )
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                            (i32.const 31)
-                           )
-                           (block (result i32)
-                            (i32.store
-                             (local.tee $0
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                                 (i32.const 16)
-                                )
-                                (local.get $0)
-                               )
-                              )
-                             )
-                             (i32.const 1)
-                            )
-                            (i32.store offset=4
-                             (local.get $0)
-                             (i32.const 3)
-                            )
-                            (i64.store offset=8
-                             (local.get $0)
-                             (i64.const 7303014)
-                            )
-                            (local.set $4
-                             (tuple.extract 0
-                              (tuple.make
-                               (local.get $0)
-                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                (i32.const 0)
-                               )
-                              )
-                             )
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $3)
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $4)
-                             )
-                            )
-                           )
-                           (local.get $2)
-                          )
-                          (i32.const 0)
-                         )
-                        )
-                        (i32.const 31)
+                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
                        )
-                       (i32.const 3)
-                       (block (result i32)
-                        (local.set $2
-                         (tuple.extract 0
-                          (tuple.make
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (i32.load offset=16
-                             (local.get $1)
-                            )
-                           )
-                           (i32.const 0)
-                          )
-                         )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $2)
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $3)
+                       )
+                      )
+                     )
+                     (local.get $1)
+                    )
+                    (i32.const 31)
+                   )
+                   (i32.const 3)
+                   (block (result i32)
+                    (local.set $1
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (i32.load offset=16
+                       (local.get $0)
+                      )
+                     )
+                    )
+                    (local.set $3
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=8
+                         (local.get $0)
                         )
-                        (local.set $4
-                         (tuple.extract 0
-                          (tuple.make
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (i32.load offset=8
-                             (local.get $1)
-                            )
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                            (local.get $4)
-                           )
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 5)
-                         (i32.const 7)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (if (result i32)
-                             (i32.shr_u
-                              (local.tee $2
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.or
-                                  (i32.shl
-                                   (i32.eq
-                                    (local.get $2)
-                                    (i32.const 2147483646)
-                                   )
-                                   (i32.const 31)
-                                  )
-                                  (i32.const 2147483646)
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 31)
-                             )
-                             (block (result i32)
-                              (i32.store
-                               (local.tee $0
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                                   (i32.const 16)
-                                  )
-                                  (local.get $0)
-                                 )
-                                )
-                               )
-                               (i32.const 1)
-                              )
-                              (i32.store offset=4
-                               (local.get $0)
-                               (i32.const 3)
-                              )
-                              (i64.store offset=8
-                               (local.get $0)
-                               (i64.const 7303014)
-                              )
-                              (local.set $10
-                               (tuple.extract 0
-                                (tuple.make
-                                 (local.get $0)
-                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                               )
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (local.get $4)
-                               )
-                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                (local.get $10)
-                               )
-                              )
-                             )
-                             (local.get $2)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (local.get $3)
                        )
                       )
                      )
                     )
-                    (local.get $9)
+                    (select
+                     (i32.const 5)
+                     (i32.const 7)
+                     (i32.shr_u
+                      (if (result i32)
+                       (i32.shr_u
+                        (local.tee $1
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $1)
+                            (i32.const 2147483646)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
+                         )
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (i32.store
+                         (local.tee $4
+                          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                           (i32.const 16)
+                          )
+                         )
+                         (i32.const 1)
+                        )
+                        (i32.store offset=4
+                         (local.get $4)
+                         (i32.const 3)
+                        )
+                        (i64.store offset=8
+                         (local.get $4)
+                         (i64.const 7303014)
+                        )
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (local.get $4)
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $3)
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $4)
+                         )
+                        )
+                       )
+                       (local.get $1)
+                      )
+                      (i32.const 31)
+                     )
+                    )
                    )
                   )
-                  (i32.const 1)
                  )
                 )
+                (i32.const 1)
                )
               )
-              (unreachable)
              )
             )
-            (br $switch.60_outer
-             (i32.const 2147483646)
-            )
+            (unreachable)
            )
           )
           (br $switch.60_outer
-           (i32.const -2)
+           (i32.const 2147483646)
           )
          )
         )
         (br $switch.60_outer
-         (i32.const 2147483646)
+         (i32.const -2)
         )
        )
       )
-      (i32.const 2147483646)
+      (br $switch.60_outer
+       (i32.const 2147483646)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 2147483646)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
    )
   )
   (drop
@@ -561,7 +479,7 @@ pattern matching › constant_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $2)
    )
   )
   (drop
@@ -576,13 +494,7 @@ pattern matching › constant_match_2
     (local.get $4)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
-   )
-  )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -29,14 +29,9 @@ pattern matching › record_match_4
   (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -81,40 +76,28 @@ pattern matching › record_match_4
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -146,26 +129,10 @@ pattern matching › record_match_4
    (local.get $0)
    (i32.const 13)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $2
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=24
-       (local.get $1)
-      )
-     )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -178,8 +145,8 @@ pattern matching › record_match_4
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $1)
+      (i32.load offset=24
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -194,8 +161,8 @@ pattern matching › record_match_4
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
+      (i32.load offset=20
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -208,27 +175,9 @@ pattern matching › record_match_4
   (local.set $5
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (i32.load offset=8
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
        (local.get $0)
       )
      )
@@ -239,19 +188,14 @@ pattern matching › record_match_4
     )
    )
   )
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -260,26 +204,44 @@ pattern matching › record_match_4
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $4)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
-     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (i32.load offset=8
+     (local.get $2)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
   (drop
@@ -300,7 +262,13 @@ pattern matching › record_match_4
     (local.get $5)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -23,17 +23,11 @@ pattern matching › constant_match_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 5)
@@ -62,136 +56,109 @@ pattern matching › constant_match_1
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.17_outer (result i32)
+   (block $switch.17_outer (result i32)
+    (drop
+     (block $switch.17_branch_1 (result i32)
       (drop
-       (block $switch.17_branch_1 (result i32)
+       (block $switch.17_branch_2 (result i32)
         (drop
-         (block $switch.17_branch_2 (result i32)
+         (block $switch.17_branch_3 (result i32)
           (drop
-           (block $switch.17_branch_3 (result i32)
-            (drop
-             (block $switch.17_default (result i32)
-              (br_table $switch.17_branch_1 $switch.17_branch_2 $switch.17_branch_3 $switch.17_default
-               (i32.const 0)
-               (i32.shr_s
-                (tuple.extract 0
-                 (tuple.make
-                  (if (result i32)
-                   (i32.shr_u
-                    (tuple.extract 0
-                     (tuple.make
-                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (local.get $1)
-                       )
-                       (i32.const 11)
-                      )
-                      (i32.const 0)
-                     )
-                    )
-                    (i32.const 31)
-                   )
-                   (i32.const 1)
-                   (block (result i32)
-                    (i32.store
-                     (local.tee $0
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                         (i32.const 16)
-                        )
-                        (local.get $0)
-                       )
-                      )
-                     )
-                     (i32.const 5)
-                    )
-                    (i32.store offset=4
-                     (local.get $0)
-                     (i32.const 5)
-                    )
-                    (i32.store offset=8
-                     (local.get $0)
-                     (i32.const 1)
-                    )
-                    (i32.store offset=12
-                     (local.get $0)
-                     (i32.const 3)
-                    )
-                    (local.set $2
-                     (tuple.extract 0
-                      (tuple.make
-                       (local.get $0)
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (i32.const 0)
-                       )
-                      )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 5)
-                     (i32.shr_u
-                      (local.tee $3
-                       (tuple.extract 0
-                        (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $1)
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $2)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (i32.const 31)
-                     )
-                    )
+           (block $switch.17_default (result i32)
+            (br_table $switch.17_branch_1 $switch.17_branch_2 $switch.17_branch_3 $switch.17_default
+             (i32.const 0)
+             (i32.shr_s
+              (if (result i32)
+               (i32.shr_u
+                (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                 )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (local.get $1)
+                 )
+                 (i32.const 11)
+                )
+                (i32.const 31)
+               )
+               (i32.const 1)
+               (block (result i32)
+                (i32.store
+                 (local.tee $0
+                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                   (i32.const 16)
+                  )
+                 )
+                 (i32.const 5)
+                )
+                (i32.store offset=4
+                 (local.get $0)
+                 (i32.const 5)
+                )
+                (i32.store offset=8
+                 (local.get $0)
+                 (i32.const 1)
+                )
+                (i32.store offset=12
+                 (local.get $0)
+                 (i32.const 3)
+                )
+                (local.set $2
+                 (tuple.extract 0
+                  (tuple.make
+                   (local.get $0)
+                   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                    (i32.const 0)
                    )
                   )
-                  (local.get $3)
                  )
                 )
-                (i32.const 1)
+                (select
+                 (i32.const 3)
+                 (i32.const 5)
+                 (i32.shr_u
+                  (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $1)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $2)
+                   )
+                  )
+                  (i32.const 31)
+                 )
+                )
                )
               )
+              (i32.const 1)
              )
             )
-            (unreachable)
            )
           )
-          (br $switch.17_outer
-           (i32.const 2147483646)
-          )
+          (unreachable)
          )
         )
         (br $switch.17_outer
-         (i32.const -2)
+         (i32.const 2147483646)
         )
        )
       )
-      (i32.const 2147483646)
+      (br $switch.17_outer
+       (i32.const -2)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 2147483646)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -37,21 +37,14 @@ pattern matching › tuple_match_deep6
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local.set $9
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 13)
@@ -70,53 +63,17 @@ pattern matching › tuple_match_deep6
     )
    )
   )
-  (local.set $10
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 11)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $11
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 9)
+      (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $10)
@@ -132,16 +89,37 @@ pattern matching › tuple_match_deep6
     )
    )
   )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $0
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 9)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $11)
+      )
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -158,10 +136,10 @@ pattern matching › tuple_match_deep6
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $11)
+    (local.get $12)
    )
   )
-  (local.set $4
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -172,508 +150,220 @@ pattern matching › tuple_match_deep6
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.59_outer (result i32)
+  (local.set $1
+   (block $switch.59_outer (result i32)
+    (drop
+     (block $switch.59_branch_1 (result i32)
       (drop
-       (block $switch.59_branch_1 (result i32)
+       (block $switch.59_branch_2 (result i32)
         (drop
-         (block $switch.59_branch_2 (result i32)
+         (block $switch.59_branch_3 (result i32)
           (drop
-           (block $switch.59_branch_3 (result i32)
+           (block $switch.59_branch_4 (result i32)
             (drop
-             (block $switch.59_branch_4 (result i32)
+             (block $switch.59_branch_5 (result i32)
               (drop
-               (block $switch.59_branch_5 (result i32)
-                (drop
-                 (block $switch.59_default (result i32)
-                  (br_table $switch.59_branch_1 $switch.59_branch_2 $switch.59_branch_3 $switch.59_branch_4 $switch.59_branch_5 $switch.59_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $12
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                     (i32.load offset=12
-                                      (local.get $4)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.59_default (result i32)
+                (br_table $switch.59_branch_1 $switch.59_branch_2 $switch.59_branch_3 $switch.59_branch_4 $switch.59_branch_5 $switch.59_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $13
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                             (i32.load offset=12
+                              (local.get $0)
+                             )
+                            )
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $13)
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $12)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $16
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $16)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.59_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=12
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $13
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=8
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $14
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $13)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $15
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $14)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.59_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $15)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -682,8 +372,8 @@ pattern matching › tuple_match_deep6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
+              (i32.load offset=12
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -698,7 +388,7 @@ pattern matching › tuple_match_deep6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $2)
               )
              )
@@ -709,13 +399,29 @@ pattern matching › tuple_match_deep6
             )
            )
           )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $4)
+             )
+            )
+           )
+          )
           (local.set $6
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (local.get $1)
+               (local.get $4)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -730,8 +436,40 @@ pattern matching › tuple_match_deep6
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $14
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=8
-               (local.get $4)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -745,27 +483,51 @@ pattern matching › tuple_match_deep6
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
+              (local.tee $8
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
                )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $14)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $8)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $9
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $7)
               )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
               (i32.load offset=8
-               (local.get $0)
+               (local.get $9)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -777,44 +539,23 @@ pattern matching › tuple_match_deep6
           )
           (br $switch.59_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-               (local.get $0)
-              )
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $8)
+             (local.get $9)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $6)
             )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
            )
           )
          )
@@ -824,8 +565,8 @@ pattern matching › tuple_match_deep6
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
+            (i32.load offset=12
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -840,8 +581,8 @@ pattern matching › tuple_match_deep6
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $4)
+            (i32.load offset=24
+             (local.get $2)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -851,49 +592,183 @@ pattern matching › tuple_match_deep6
           )
          )
         )
-        (br $switch.59_outer
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $3)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (local.set $6
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $7
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $5
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $5
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
              )
-             (local.get $0)
             )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $7)
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $6)
+            )
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (br $switch.59_outer
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $4)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $2)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=20
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $3)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $4)
+         )
+        )
+       )
+      )
+      (br $switch.59_outer
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $1
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (i32.load offset=8
+         (local.get $1)
+        )
        )
       )
      )
-     (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (i32.load offset=8
+      (local.get $0)
+     )
+    )
    )
   )
   (drop
@@ -911,19 +786,19 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $12)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
    )
   )
   (drop
@@ -941,6 +816,12 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -953,13 +834,7 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $13)
+    (local.get $5)
    )
   )
   (drop
@@ -971,10 +846,16 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $15)
+    (local.get $8)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -25,14 +25,9 @@ pattern matching › tuple_match_3
   (local $5 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -58,14 +53,9 @@ pattern matching › tuple_match_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -101,15 +91,10 @@ pattern matching › tuple_match_3
    )
   )
   (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
-      )
-     )
-     (i32.const 0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
+     (local.get $1)
     )
    )
   )
@@ -147,14 +132,9 @@ pattern matching › tuple_match_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -180,14 +160,6 @@ pattern matching › tuple_match_3
   (i32.store offset=16
    (local.get $0)
    (local.get $5)
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (local.get $0)
-    )
-   )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -33,18 +33,11 @@ pattern matching › tuple_match_deep3
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -64,7 +57,7 @@ pattern matching › tuple_match_deep3
     (global.get $gimport_pervasives_[])
    )
   )
-  (local.set $4
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -75,508 +68,220 @@ pattern matching › tuple_match_deep3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.50_outer (result i32)
+  (local.set $1
+   (block $switch.50_outer (result i32)
+    (drop
+     (block $switch.50_branch_1 (result i32)
       (drop
-       (block $switch.50_branch_1 (result i32)
+       (block $switch.50_branch_2 (result i32)
         (drop
-         (block $switch.50_branch_2 (result i32)
+         (block $switch.50_branch_3 (result i32)
           (drop
-           (block $switch.50_branch_3 (result i32)
+           (block $switch.50_branch_4 (result i32)
             (drop
-             (block $switch.50_branch_4 (result i32)
+             (block $switch.50_branch_5 (result i32)
               (drop
-               (block $switch.50_branch_5 (result i32)
-                (drop
-                 (block $switch.50_default (result i32)
-                  (br_table $switch.50_branch_1 $switch.50_branch_2 $switch.50_branch_3 $switch.50_branch_4 $switch.50_branch_5 $switch.50_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $9
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                     (i32.load offset=12
-                                      (local.get $4)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.50_default (result i32)
+                (br_table $switch.50_branch_1 $switch.50_branch_2 $switch.50_branch_3 $switch.50_branch_4 $switch.50_branch_5 $switch.50_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $10
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                             (i32.load offset=12
+                              (local.get $0)
+                             )
+                            )
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $10)
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $9)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $13
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $13)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.50_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=12
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $10
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=8
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $11
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $10)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $12
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $11)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.50_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $12)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -585,8 +290,8 @@ pattern matching › tuple_match_deep3
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
+              (i32.load offset=12
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -601,7 +306,7 @@ pattern matching › tuple_match_deep3
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $2)
               )
              )
@@ -612,13 +317,29 @@ pattern matching › tuple_match_deep3
             )
            )
           )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $4)
+             )
+            )
+           )
+          )
           (local.set $6
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (local.get $1)
+               (local.get $4)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -633,8 +354,40 @@ pattern matching › tuple_match_deep3
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $11
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=8
-               (local.get $4)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -648,27 +401,51 @@ pattern matching › tuple_match_deep3
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
+              (local.tee $8
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
                )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $8)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $9
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $7)
               )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
               (i32.load offset=8
-               (local.get $0)
+               (local.get $9)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -680,44 +457,23 @@ pattern matching › tuple_match_deep3
           )
           (br $switch.50_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-               (local.get $0)
-              )
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $8)
+             (local.get $9)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $6)
             )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
            )
           )
          )
@@ -727,8 +483,8 @@ pattern matching › tuple_match_deep3
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
+            (i32.load offset=12
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -743,8 +499,8 @@ pattern matching › tuple_match_deep3
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $4)
+            (i32.load offset=24
+             (local.get $2)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -754,61 +510,195 @@ pattern matching › tuple_match_deep3
           )
          )
         )
-        (br $switch.50_outer
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $3)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (local.set $6
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $7
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $5
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $5
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
              )
-             (local.get $0)
             )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $7)
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $6)
+            )
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (br $switch.50_outer
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $4)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $2)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=20
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $3)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $4)
+         )
+        )
+       )
+      )
+      (br $switch.50_outer
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $1
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (i32.load offset=8
+         (local.get $1)
+        )
        )
       )
      )
-     (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (i32.load offset=8
+      (local.get $0)
+     )
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $10)
    )
   )
   (drop
@@ -826,6 +716,12 @@ pattern matching › tuple_match_deep3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -838,13 +734,7 @@ pattern matching › tuple_match_deep3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
+    (local.get $5)
    )
   )
   (drop
@@ -856,10 +746,16 @@ pattern matching › tuple_match_deep3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $12)
+    (local.get $8)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -26,417 +26,209 @@ pattern matching › adt_match_1
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.45_outer (result i32)
+  (local.set $0
+   (block $switch.45_outer (result i32)
+    (drop
+     (block $switch.45_branch_1 (result i32)
       (drop
-       (block $switch.45_branch_1 (result i32)
+       (block $switch.45_branch_2 (result i32)
         (drop
-         (block $switch.45_branch_2 (result i32)
+         (block $switch.45_branch_3 (result i32)
           (drop
-           (block $switch.45_branch_3 (result i32)
+           (block $switch.45_branch_4 (result i32)
             (drop
-             (block $switch.45_branch_4 (result i32)
+             (block $switch.45_branch_5 (result i32)
               (drop
-               (block $switch.45_branch_5 (result i32)
-                (drop
-                 (block $switch.45_default (result i32)
-                  (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_branch_5 $switch.45_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $4
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (global.get $gimport_pervasives_[])
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.45_default (result i32)
+                (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_branch_5 $switch.45_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $0
+                        (i32.load offset=12
+                         (global.get $gimport_pervasives_[])
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $0
+                         (i32.load offset=12
+                          (local.tee $1
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (global.get $gimport_pervasives_[])
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.tee $2
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $1)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $4
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $0
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (global.get $gimport_pervasives_[])
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $8
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $0)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $8)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $4)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $4
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $4)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $4)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $0)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $0)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.45_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (global.get $gimport_pervasives_[])
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $0)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $5
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (global.get $gimport_pervasives_[])
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $1
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (i32.const 0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $6)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $5)
-                )
-                (i32.load offset=8
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.45_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $1
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $1)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $3)
-              )
-              (i32.load offset=8
-               (local.get $1)
-              )
-             )
+             (i32.const 1999)
             )
            )
           )
-          (local.set $0
+          (local.set $1
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -447,7 +239,7 @@ pattern matching › adt_match_1
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $0)
+              (local.get $1)
              )
             )
            )
@@ -457,8 +249,8 @@ pattern matching › adt_match_1
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $0)
+              (i32.load offset=24
+               (local.get $1)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -474,7 +266,7 @@ pattern matching › adt_match_1
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (global.get $gimport_pervasives_[])
+               (local.get $2)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -484,54 +276,178 @@ pattern matching › adt_match_1
             )
            )
           )
-          (br $switch.45_outer
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
-             (tuple.extract 0
-              (tuple.make
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $1)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $6
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (global.get $gimport_pervasives_[])
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $4
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
                )
-               (i32.const 0)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $4)
               )
              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (br $switch.45_outer
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $0
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $4)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (local.get $3)
             )
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
          )
         )
+        (local.set $1
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=24
+             (global.get $gimport_pervasives_[])
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $1)
+           )
+          )
+         )
+        )
+        (local.set $2
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $1)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (local.set $3
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (global.get $gimport_pervasives_[])
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $3)
+           )
+          )
+         )
+        )
         (br $switch.45_outer
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (global.get $gimport_pervasives_[])
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $0
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $3)
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $2)
+          )
+          (i32.load offset=8
+           (local.get $0)
           )
          )
         )
        )
       )
-      (i32.const 1)
+      (br $switch.45_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (global.get $gimport_pervasives_[])
+        )
+       )
+      )
      )
-     (local.get $1)
     )
+    (i32.const 1)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -561,10 +477,10 @@ pattern matching › adt_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+    (local.get $4)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -44,14 +44,9 @@ pattern matching › tuple_match_deep2
   (local $21 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -68,7 +63,7 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (i32.const 15)
   )
-  (local.set $6
+  (local.set $11
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -81,14 +76,9 @@ pattern matching › tuple_match_deep2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -109,10 +99,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $6)
+    (local.get $11)
    )
   )
-  (local.set $7
+  (local.set $12
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -125,14 +115,9 @@ pattern matching › tuple_match_deep2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -149,10 +134,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $7)
+    (local.get $12)
    )
   )
-  (local.set $8
+  (local.set $13
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -165,14 +150,9 @@ pattern matching › tuple_match_deep2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -189,10 +169,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $8)
+    (local.get $13)
    )
   )
-  (local.set $9
+  (local.set $14
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -205,14 +185,9 @@ pattern matching › tuple_match_deep2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -229,10 +204,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $9)
+    (local.get $14)
    )
   )
-  (local.set $2
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -243,13 +218,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $3
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $2)
+       (local.get $6)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -259,13 +234,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $4
+  (local.set $8
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $3)
+       (local.get $7)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -275,13 +250,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $4)
+       (local.get $8)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -291,93 +266,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $5
+  (local.set $9
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $10
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $11
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $12
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $13
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $14
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $4)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -392,8 +287,8 @@ pattern matching › tuple_match_deep2
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $3)
+      (i32.load offset=12
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -409,7 +304,7 @@ pattern matching › tuple_match_deep2
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $2)
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -422,27 +317,9 @@ pattern matching › tuple_match_deep2
   (local.set $17
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $16)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $15)
-      )
-      (i32.load offset=8
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
        (local.get $0)
       )
      )
@@ -456,26 +333,8 @@ pattern matching › tuple_match_deep2
   (local.set $18
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $17)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $14)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
        (local.get $0)
       )
@@ -490,28 +349,10 @@ pattern matching › tuple_match_deep2
   (local.set $19
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $18)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $13)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $8)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -524,28 +365,10 @@ pattern matching › tuple_match_deep2
   (local.set $20
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $19)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $12)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $7)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -558,28 +381,10 @@ pattern matching › tuple_match_deep2
   (local.set $21
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $20)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $11)
-      )
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $0)
+       (local.get $6)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -589,19 +394,14 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -610,74 +410,154 @@ pattern matching › tuple_match_deep2
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $20)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
-     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $19)
+      )
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $2)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $18)
+      )
+      (i32.load offset=8
+       (local.get $3)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $17)
+      )
+      (i32.load offset=8
+       (local.get $4)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $5
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $16)
+      )
+      (i32.load offset=8
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
+  (local.set $10
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $10
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $5)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $15)
+    )
+    (i32.load offset=8
+     (local.get $10)
+    )
    )
   )
   (drop
@@ -702,6 +582,36 @@ pattern matching › tuple_match_deep2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
    )
   )
   (drop
@@ -746,7 +656,37 @@ pattern matching › tuple_match_deep2
     (local.get $21)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (local.get $10)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -24,14 +24,9 @@ pattern matching › record_match_deep
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 72)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 72)
     )
    )
    (i32.const 1)
@@ -72,40 +67,28 @@ pattern matching › record_match_deep
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -144,14 +127,9 @@ pattern matching › record_match_deep
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -175,10 +153,26 @@ pattern matching › record_match_deep
     (local.get $2)
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -187,31 +181,10 @@ pattern matching › record_match_deep
    )
   )
   (local.set $3
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $3)
-      )
-     )
-     (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
+     (local.get $1)
     )
    )
   )
@@ -224,16 +197,16 @@ pattern matching › record_match_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $1)
    )
   )
-  (local.get $0)
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -24,17 +24,11 @@ pattern matching › guarded_match_4
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -55,7 +49,7 @@ pattern matching › guarded_match_4
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -72,7 +66,7 @@ pattern matching › guarded_match_4
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -88,7 +82,7 @@ pattern matching › guarded_match_4
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -98,114 +92,84 @@ pattern matching › guarded_match_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.20_outer (result i32)
+  (local.set $1
+   (block $switch.20_outer (result i32)
+    (drop
+     (block $switch.20_branch_1 (result i32)
       (drop
-       (block $switch.20_branch_1 (result i32)
+       (block $switch.20_branch_2 (result i32)
         (drop
-         (block $switch.20_branch_2 (result i32)
-          (drop
-           (block $switch.20_default (result i32)
-            (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
-             (i32.const 0)
-             (i32.shr_s
-              (tuple.extract 0
-               (tuple.make
-                (select
-                 (i32.const 1)
-                 (i32.const 3)
-                 (i32.shr_u
-                  (tuple.extract 0
-                   (tuple.make
-                    (if (result i32)
-                     (i32.shr_u
-                      (local.tee $4
-                       (tuple.extract 0
-                        (tuple.make
-                         (call_indirect (type $i32_i32_i32_=>_i32)
-                          (local.tee $0
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $gimport_pervasives_==)
-                             )
-                             (local.get $0)
-                            )
-                           )
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $3)
-                          )
-                          (i32.const 5)
-                          (i32.load offset=8
-                           (local.get $0)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (i32.const 31)
-                     )
-                     (call_indirect (type $i32_i32_i32_=>_i32)
-                      (local.tee $0
-                       (tuple.extract 0
-                        (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (global.get $gimport_pervasives_==)
-                         )
-                         (local.get $0)
-                        )
-                       )
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $2)
-                      )
-                      (i32.const 7)
-                      (i32.load offset=8
-                       (local.get $0)
-                      )
-                     )
-                     (local.get $4)
-                    )
-                    (i32.const 0)
+         (block $switch.20_default (result i32)
+          (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
+           (i32.const 0)
+           (i32.shr_s
+            (select
+             (i32.const 1)
+             (i32.const 3)
+             (i32.shr_u
+              (if (result i32)
+               (i32.shr_u
+                (local.tee $1
+                 (call_indirect (type $i32_i32_i32_=>_i32)
+                  (local.tee $1
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $gimport_pervasives_==)
                    )
                   )
-                  (i32.const 31)
+                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                   (local.get $3)
+                  )
+                  (i32.const 5)
+                  (i32.load offset=8
+                   (local.get $1)
+                  )
                  )
                 )
-                (i32.const 0)
+                (i32.const 31)
                )
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (local.tee $1
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (global.get $gimport_pervasives_==)
+                 )
+                )
+                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                 (local.get $2)
+                )
+                (i32.const 7)
+                (i32.load offset=8
+                 (local.get $1)
+                )
+               )
+               (local.get $1)
               )
-              (i32.const 1)
+              (i32.const 31)
              )
             )
+            (i32.const 1)
            )
           )
-          (unreachable)
          )
         )
-        (br $switch.20_outer
-         (i32.const 199)
-        )
+        (unreachable)
        )
       )
-      (i32.const 85)
+      (br $switch.20_outer
+       (i32.const 199)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 85)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -220,7 +184,7 @@ pattern matching › guarded_match_4
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -25,14 +25,9 @@ pattern matching › guarded_match_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -53,7 +48,7 @@ pattern matching › guarded_match_1
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -70,7 +65,7 @@ pattern matching › guarded_match_1
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -80,80 +75,60 @@ pattern matching › guarded_match_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.13_outer (result i32)
+  (local.set $1
+   (block $switch.13_outer (result i32)
+    (drop
+     (block $switch.13_branch_1 (result i32)
       (drop
-       (block $switch.13_branch_1 (result i32)
+       (block $switch.13_branch_2 (result i32)
         (drop
-         (block $switch.13_branch_2 (result i32)
-          (drop
-           (block $switch.13_default (result i32)
-            (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
-             (i32.const 0)
-             (i32.shr_s
-              (tuple.extract 0
-               (tuple.make
-                (select
-                 (i32.const 1)
-                 (i32.const 3)
-                 (i32.shr_u
-                  (tuple.extract 0
-                   (tuple.make
-                    (call_indirect (type $i32_i32_i32_=>_i32)
-                     (local.tee $0
-                      (tuple.extract 0
-                       (tuple.make
-                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (global.get $gimport_pervasives_==)
-                        )
-                        (local.get $0)
-                       )
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (local.get $2)
-                     )
-                     (i32.const 3)
-                     (i32.load offset=8
-                      (local.get $0)
-                     )
-                    )
-                    (i32.const 0)
-                   )
-                  )
-                  (i32.const 31)
-                 )
+         (block $switch.13_default (result i32)
+          (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
+           (i32.const 0)
+           (i32.shr_s
+            (select
+             (i32.const 1)
+             (i32.const 3)
+             (i32.shr_u
+              (call_indirect (type $i32_i32_i32_=>_i32)
+               (local.tee $1
+                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                 (global.get $gimport_pervasives_==)
                 )
-                (i32.const 0)
+               )
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (local.get $2)
+               )
+               (i32.const 3)
+               (i32.load offset=8
+                (local.get $1)
                )
               )
-              (i32.const 1)
+              (i32.const 31)
              )
             )
+            (i32.const 1)
            )
           )
-          (unreachable)
          )
         )
-        (br $switch.13_outer
-         (i32.const 199)
-        )
+        (unreachable)
        )
       )
-      (i32.const 85)
+      (br $switch.13_outer
+       (i32.const 199)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 85)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -162,7 +137,7 @@ pattern matching › guarded_match_1
     (local.get $2)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -28,459 +28,230 @@ pattern matching › adt_match_2
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.48_outer (result i32)
+   (block $switch.48_outer (result i32)
+    (drop
+     (block $switch.48_branch_1 (result i32)
       (drop
-       (block $switch.48_branch_1 (result i32)
+       (block $switch.48_branch_2 (result i32)
         (drop
-         (block $switch.48_branch_2 (result i32)
+         (block $switch.48_branch_3 (result i32)
           (drop
-           (block $switch.48_branch_3 (result i32)
+           (block $switch.48_branch_4 (result i32)
             (drop
-             (block $switch.48_branch_4 (result i32)
+             (block $switch.48_branch_5 (result i32)
               (drop
-               (block $switch.48_branch_5 (result i32)
-                (drop
-                 (block $switch.48_default (result i32)
-                  (br_table $switch.48_branch_1 $switch.48_branch_2 $switch.48_branch_3 $switch.48_branch_4 $switch.48_branch_5 $switch.48_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $3
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call_indirect (type $i32_i32_i32_=>_i32)
-                                     (local.tee $0
-                                      (tuple.extract 0
-                                       (tuple.make
-                                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                         (global.get $gimport_pervasives_[...])
-                                        )
-                                        (i32.const 0)
-                                       )
-                                      )
-                                     )
-                                     (i32.const 5)
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (global.get $gimport_pervasives_[])
-                                     )
-                                     (i32.load offset=8
-                                      (local.get $0)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.48_default (result i32)
+                (br_table $switch.48_branch_1 $switch.48_branch_2 $switch.48_branch_3 $switch.48_branch_4 $switch.48_branch_5 $switch.48_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $0
+                        (i32.load offset=12
+                         (local.tee $1
+                          (tuple.extract 0
+                           (tuple.make
+                            (call_indirect (type $i32_i32_i32_=>_i32)
+                             (local.tee $1
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (global.get $gimport_pervasives_[...])
                               )
                              )
-                             (i32.const 3)
+                             (i32.const 5)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (global.get $gimport_pervasives_[])
+                             )
+                             (i32.load offset=8
+                              (local.get $1)
+                             )
                             )
-                            (i32.const 31)
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $0
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $1)
+                              )
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $0
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $3)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $9
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $4
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $9)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $0)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $0)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $0)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.48_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $4
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $4)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $6)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.48_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $4)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -489,13 +260,29 @@ pattern matching › adt_match_2
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $1)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (local.get $2)
+             )
+            )
+           )
+          )
+          (local.set $3
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $3)
              )
             )
            )
@@ -516,26 +303,82 @@ pattern matching › adt_match_2
             )
            )
           )
-          (br $switch.48_outer
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
+          (local.set $6
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $7
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $1)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $5
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
                )
-               (local.get $0)
               )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $7)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (i32.load offset=8
+               (local.get $5)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (br $switch.48_outer
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $0
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $5)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
+             (local.get $4)
             )
             (i32.load offset=8
              (local.get $0)
@@ -544,26 +387,88 @@ pattern matching › adt_match_2
           )
          )
         )
+        (local.set $2
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=24
+             (local.get $1)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (local.set $3
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $3)
+           )
+          )
+         )
+        )
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $1)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
         (br $switch.48_outer
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $0
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $4)
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (local.get $3)
+          )
+          (i32.load offset=8
+           (local.get $0)
           )
          )
         )
        )
       )
-      (i32.const 1)
+      (br $switch.48_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (local.get $1)
+        )
+       )
+      )
      )
-     (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (i32.const 1)
    )
   )
   (drop
@@ -576,6 +481,12 @@ pattern matching › adt_match_2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -599,7 +510,7 @@ pattern matching › adt_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $5)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -24,17 +24,11 @@ pattern matching › guarded_match_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -55,7 +49,7 @@ pattern matching › guarded_match_3
    (local.get $0)
    (i32.const 7)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -72,7 +66,7 @@ pattern matching › guarded_match_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -88,7 +82,7 @@ pattern matching › guarded_match_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -98,114 +92,84 @@ pattern matching › guarded_match_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.20_outer (result i32)
+  (local.set $1
+   (block $switch.20_outer (result i32)
+    (drop
+     (block $switch.20_branch_1 (result i32)
       (drop
-       (block $switch.20_branch_1 (result i32)
+       (block $switch.20_branch_2 (result i32)
         (drop
-         (block $switch.20_branch_2 (result i32)
-          (drop
-           (block $switch.20_default (result i32)
-            (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
-             (i32.const 0)
-             (i32.shr_s
-              (tuple.extract 0
-               (tuple.make
-                (select
-                 (i32.const 1)
-                 (i32.const 3)
-                 (i32.shr_u
-                  (tuple.extract 0
-                   (tuple.make
-                    (if (result i32)
-                     (i32.shr_u
-                      (local.tee $4
-                       (tuple.extract 0
-                        (tuple.make
-                         (call_indirect (type $i32_i32_i32_=>_i32)
-                          (local.tee $0
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $gimport_pervasives_==)
-                             )
-                             (local.get $0)
-                            )
-                           )
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $3)
-                          )
-                          (i32.const 5)
-                          (i32.load offset=8
-                           (local.get $0)
-                          )
-                         )
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                      (i32.const 31)
-                     )
-                     (call_indirect (type $i32_i32_i32_=>_i32)
-                      (local.tee $0
-                       (tuple.extract 0
-                        (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (global.get $gimport_pervasives_==)
-                         )
-                         (local.get $0)
-                        )
-                       )
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $2)
-                      )
-                      (i32.const 7)
-                      (i32.load offset=8
-                       (local.get $0)
-                      )
-                     )
-                     (local.get $4)
-                    )
-                    (i32.const 0)
+         (block $switch.20_default (result i32)
+          (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
+           (i32.const 0)
+           (i32.shr_s
+            (select
+             (i32.const 1)
+             (i32.const 3)
+             (i32.shr_u
+              (if (result i32)
+               (i32.shr_u
+                (local.tee $1
+                 (call_indirect (type $i32_i32_i32_=>_i32)
+                  (local.tee $1
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $gimport_pervasives_==)
                    )
                   )
-                  (i32.const 31)
+                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                   (local.get $3)
+                  )
+                  (i32.const 5)
+                  (i32.load offset=8
+                   (local.get $1)
+                  )
                  )
                 )
-                (i32.const 0)
+                (i32.const 31)
                )
+               (call_indirect (type $i32_i32_i32_=>_i32)
+                (local.tee $1
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (global.get $gimport_pervasives_==)
+                 )
+                )
+                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                 (local.get $2)
+                )
+                (i32.const 7)
+                (i32.load offset=8
+                 (local.get $1)
+                )
+               )
+               (local.get $1)
               )
-              (i32.const 1)
+              (i32.const 31)
              )
             )
+            (i32.const 1)
            )
           )
-          (unreachable)
          )
         )
-        (br $switch.20_outer
-         (i32.const 199)
-        )
+        (unreachable)
        )
       )
-      (i32.const 85)
+      (br $switch.20_outer
+       (i32.const 199)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 85)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -220,7 +184,7 @@ pattern matching › guarded_match_3
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -29,21 +29,14 @@ pattern matching › adt_match_3
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
   (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 11)
@@ -62,457 +55,230 @@ pattern matching › adt_match_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.51_outer (result i32)
+  (local.set $1
+   (block $switch.51_outer (result i32)
+    (drop
+     (block $switch.51_branch_1 (result i32)
       (drop
-       (block $switch.51_branch_1 (result i32)
+       (block $switch.51_branch_2 (result i32)
         (drop
-         (block $switch.51_branch_2 (result i32)
+         (block $switch.51_branch_3 (result i32)
           (drop
-           (block $switch.51_branch_3 (result i32)
+           (block $switch.51_branch_4 (result i32)
             (drop
-             (block $switch.51_branch_4 (result i32)
+             (block $switch.51_branch_5 (result i32)
               (drop
-               (block $switch.51_branch_5 (result i32)
-                (drop
-                 (block $switch.51_default (result i32)
-                  (br_table $switch.51_branch_1 $switch.51_branch_2 $switch.51_branch_3 $switch.51_branch_4 $switch.51_branch_5 $switch.51_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $3
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call_indirect (type $i32_i32_i32_=>_i32)
-                                     (local.tee $0
-                                      (tuple.extract 0
-                                       (tuple.make
-                                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                         (global.get $gimport_pervasives_[...])
-                                        )
-                                        (local.get $0)
-                                       )
-                                      )
-                                     )
-                                     (i32.const 9)
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (local.get $6)
-                                     )
-                                     (i32.load offset=8
-                                      (local.get $0)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.51_default (result i32)
+                (br_table $switch.51_branch_1 $switch.51_branch_2 $switch.51_branch_3 $switch.51_branch_4 $switch.51_branch_5 $switch.51_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $0
+                          (tuple.extract 0
+                           (tuple.make
+                            (call_indirect (type $i32_i32_i32_=>_i32)
+                             (local.tee $0
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (global.get $gimport_pervasives_[...])
                               )
                              )
-                             (i32.const 3)
+                             (i32.const 9)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $6)
+                             )
+                             (i32.load offset=8
+                              (local.get $0)
+                             )
                             )
-                            (i32.const 31)
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $0)
+                              )
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $3)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $10
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $4
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $10)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.51_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $4
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $4)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $9
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.51_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $9)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $4)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -521,13 +287,29 @@ pattern matching › adt_match_3
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $1)
+              (i32.load offset=24
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (local.get $2)
+             )
+            )
+           )
+          )
+          (local.set $3
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $3)
              )
             )
            )
@@ -548,48 +330,172 @@ pattern matching › adt_match_3
             )
            )
           )
-          (br $switch.51_outer
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
+          (local.set $7
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $8
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $0)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $5
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
                )
-               (local.get $0)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $7)
+              )
+              (i32.load offset=8
+               (local.get $5)
               )
              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (br $switch.51_outer
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $5)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (local.get $4)
             )
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
            )
           )
          )
         )
+        (local.set $2
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=24
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (local.set $3
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $3)
+           )
+          )
+         )
+        )
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
         (br $switch.51_outer
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $4)
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (local.get $3)
+          )
+          (i32.load offset=8
+           (local.get $1)
           )
          )
         )
        )
       )
-      (i32.const 1)
+      (br $switch.51_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (local.get $0)
+        )
+       )
+      )
      )
-     (local.get $0)
     )
+    (i32.const 1)
    )
   )
   (drop
@@ -601,19 +507,19 @@ pattern matching › adt_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -637,10 +543,10 @@ pattern matching › adt_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (local.get $5)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -31,21 +31,14 @@ pattern matching › adt_match_5
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
   (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 15)
@@ -69,14 +62,9 @@ pattern matching › adt_match_5
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 13)
@@ -100,14 +88,9 @@ pattern matching › adt_match_5
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 11)
@@ -126,457 +109,230 @@ pattern matching › adt_match_5
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.57_outer (result i32)
+  (local.set $1
+   (block $switch.57_outer (result i32)
+    (drop
+     (block $switch.57_branch_1 (result i32)
       (drop
-       (block $switch.57_branch_1 (result i32)
+       (block $switch.57_branch_2 (result i32)
         (drop
-         (block $switch.57_branch_2 (result i32)
+         (block $switch.57_branch_3 (result i32)
           (drop
-           (block $switch.57_branch_3 (result i32)
+           (block $switch.57_branch_4 (result i32)
             (drop
-             (block $switch.57_branch_4 (result i32)
+             (block $switch.57_branch_5 (result i32)
               (drop
-               (block $switch.57_branch_5 (result i32)
-                (drop
-                 (block $switch.57_default (result i32)
-                  (br_table $switch.57_branch_1 $switch.57_branch_2 $switch.57_branch_3 $switch.57_branch_4 $switch.57_branch_5 $switch.57_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $3
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call_indirect (type $i32_i32_i32_=>_i32)
-                                     (local.tee $0
-                                      (tuple.extract 0
-                                       (tuple.make
-                                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                         (global.get $gimport_pervasives_[...])
-                                        )
-                                        (local.get $0)
-                                       )
-                                      )
-                                     )
-                                     (i32.const 9)
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (local.get $8)
-                                     )
-                                     (i32.load offset=8
-                                      (local.get $0)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.57_default (result i32)
+                (br_table $switch.57_branch_1 $switch.57_branch_2 $switch.57_branch_3 $switch.57_branch_4 $switch.57_branch_5 $switch.57_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $0
+                          (tuple.extract 0
+                           (tuple.make
+                            (call_indirect (type $i32_i32_i32_=>_i32)
+                             (local.tee $0
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (global.get $gimport_pervasives_[...])
                               )
                              )
-                             (i32.const 3)
+                             (i32.const 9)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $8)
+                             )
+                             (i32.load offset=8
+                              (local.get $0)
+                             )
                             )
-                            (i32.const 31)
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $0)
+                              )
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
+                            )
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $3)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $12
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $4
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $12)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.57_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $4
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $4)
-               )
-              )
-             )
-            )
-            (local.set $9
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $10
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $11
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $10)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $9)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.57_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $11)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $4)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -585,13 +341,29 @@ pattern matching › adt_match_5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $1)
+              (i32.load offset=24
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
               (local.get $2)
+             )
+            )
+           )
+          )
+          (local.set $3
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $3)
              )
             )
            )
@@ -612,48 +384,172 @@ pattern matching › adt_match_5
             )
            )
           )
-          (br $switch.57_outer
-           (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $10
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $0)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $5
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
                )
-               (local.get $0)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $9)
+              )
+              (i32.load offset=8
+               (local.get $5)
               )
              )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (br $switch.57_outer
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
+             )
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $5)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
              (local.get $4)
             )
-            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $2)
-            )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
            )
           )
          )
         )
+        (local.set $2
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=24
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (local.set $3
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $3)
+           )
+          )
+         )
+        )
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
         (br $switch.57_outer
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
+           )
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+           (local.get $4)
+          )
+          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (local.get $3)
+          )
+          (i32.load offset=8
+           (local.get $1)
           )
          )
         )
        )
       )
-      (i32.const 1)
+      (br $switch.57_outer
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (i32.load offset=20
+         (local.get $0)
+        )
+       )
+      )
      )
-     (local.get $0)
     )
+    (i32.const 1)
    )
   )
   (drop
@@ -677,19 +573,19 @@ pattern matching › adt_match_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -713,10 +609,10 @@ pattern matching › adt_match_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
+    (local.get $5)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -36,21 +36,14 @@ pattern matching › tuple_match_deep5
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local.set $9
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 11)
@@ -69,25 +62,20 @@ pattern matching › tuple_match_deep5
     )
    )
   )
-  (local.set $10
+  (local.set $11
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 9)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
+       (local.get $10)
       )
       (i32.load offset=8
        (local.get $0)
@@ -102,14 +90,9 @@ pattern matching › tuple_match_deep5
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -126,10 +109,10 @@ pattern matching › tuple_match_deep5
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $10)
+    (local.get $11)
    )
   )
-  (local.set $4
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -140,508 +123,220 @@ pattern matching › tuple_match_deep5
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.56_outer (result i32)
+  (local.set $1
+   (block $switch.56_outer (result i32)
+    (drop
+     (block $switch.56_branch_1 (result i32)
       (drop
-       (block $switch.56_branch_1 (result i32)
+       (block $switch.56_branch_2 (result i32)
         (drop
-         (block $switch.56_branch_2 (result i32)
+         (block $switch.56_branch_3 (result i32)
           (drop
-           (block $switch.56_branch_3 (result i32)
+           (block $switch.56_branch_4 (result i32)
             (drop
-             (block $switch.56_branch_4 (result i32)
+             (block $switch.56_branch_5 (result i32)
               (drop
-               (block $switch.56_branch_5 (result i32)
-                (drop
-                 (block $switch.56_default (result i32)
-                  (br_table $switch.56_branch_1 $switch.56_branch_2 $switch.56_branch_3 $switch.56_branch_4 $switch.56_branch_5 $switch.56_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $11
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                     (i32.load offset=12
-                                      (local.get $4)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.56_default (result i32)
+                (br_table $switch.56_branch_1 $switch.56_branch_2 $switch.56_branch_3 $switch.56_branch_4 $switch.56_branch_5 $switch.56_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $12
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                             (i32.load offset=12
+                              (local.get $0)
+                             )
+                            )
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $12)
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $11)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $15
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $15)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.56_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=12
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $12
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=8
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $13
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $12)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $14
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $13)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.56_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $14)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -650,8 +345,8 @@ pattern matching › tuple_match_deep5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
+              (i32.load offset=12
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -666,7 +361,7 @@ pattern matching › tuple_match_deep5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $2)
               )
              )
@@ -677,13 +372,29 @@ pattern matching › tuple_match_deep5
             )
            )
           )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $4)
+             )
+            )
+           )
+          )
           (local.set $6
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (local.get $1)
+               (local.get $4)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -698,8 +409,40 @@ pattern matching › tuple_match_deep5
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $13
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=8
-               (local.get $4)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -713,27 +456,51 @@ pattern matching › tuple_match_deep5
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
+              (local.tee $8
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
                )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $13)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $8)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $9
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $7)
               )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
               (i32.load offset=8
-               (local.get $0)
+               (local.get $9)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -745,44 +512,23 @@ pattern matching › tuple_match_deep5
           )
           (br $switch.56_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-               (local.get $0)
-              )
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $8)
+             (local.get $9)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $6)
             )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
            )
           )
          )
@@ -792,8 +538,8 @@ pattern matching › tuple_match_deep5
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
+            (i32.load offset=12
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -808,8 +554,8 @@ pattern matching › tuple_match_deep5
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $4)
+            (i32.load offset=24
+             (local.get $2)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -819,49 +565,183 @@ pattern matching › tuple_match_deep5
           )
          )
         )
-        (br $switch.56_outer
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $3)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (local.set $6
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $7
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $5
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $5
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
              )
-             (local.get $0)
             )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $7)
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $6)
+            )
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (br $switch.56_outer
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $4)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $2)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=20
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $3)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $4)
+         )
+        )
+       )
+      )
+      (br $switch.56_outer
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $1
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (i32.load offset=8
+         (local.get $1)
+        )
        )
       )
      )
-     (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (i32.load offset=8
+      (local.get $0)
+     )
+    )
    )
   )
   (drop
@@ -873,19 +753,19 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $11)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
    )
   )
   (drop
@@ -903,6 +783,12 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -915,13 +801,7 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $12)
+    (local.get $5)
    )
   )
   (drop
@@ -933,10 +813,16 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $14)
+    (local.get $8)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -33,35 +33,27 @@ pattern matching › constant_match_4
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i64.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i64.const 7303014)
   )
-  (local.set $4
+  (local.set $3
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -70,38 +62,33 @@ pattern matching › constant_match_4
    )
   )
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $4)
+    (local.get $3)
    )
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (i32.const 11)
   )
   (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -109,7 +96,7 @@ pattern matching › constant_match_4
     )
    )
   )
-  (local.set $5
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -125,7 +112,7 @@ pattern matching › constant_match_4
     )
    )
   )
-  (local.set $6
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -143,14 +130,9 @@ pattern matching › constant_match_4
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -163,7 +145,7 @@ pattern matching › constant_match_4
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $7
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -175,92 +157,137 @@ pattern matching › constant_match_4
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.60_outer (result i32)
+   (block $switch.60_outer (result i32)
+    (drop
+     (block $switch.60_branch_1 (result i32)
       (drop
-       (block $switch.60_branch_1 (result i32)
+       (block $switch.60_branch_2 (result i32)
         (drop
-         (block $switch.60_branch_2 (result i32)
+         (block $switch.60_branch_3 (result i32)
           (drop
-           (block $switch.60_branch_3 (result i32)
+           (block $switch.60_branch_4 (result i32)
             (drop
-             (block $switch.60_branch_4 (result i32)
-              (drop
-               (block $switch.60_default (result i32)
-                (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
-                 (i32.const 0)
-                 (i32.shr_s
-                  (tuple.extract 0
-                   (tuple.make
+             (block $switch.60_default (result i32)
+              (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
+               (i32.const 0)
+               (i32.shr_s
+                (if (result i32)
+                 (i32.shr_u
+                  (if (result i32)
+                   (i32.shr_u
+                    (local.tee $0
+                     (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                      )
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (local.get $5)
+                      )
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (local.get $6)
+                      )
+                     )
+                    )
+                    (i32.const 31)
+                   )
+                   (call_indirect (type $i32_i32_i32_=>_i32)
+                    (local.tee $0
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (global.get $gimport_pervasives_==)
+                     )
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $4)
+                    )
+                    (i32.const 15)
+                    (i32.load offset=8
+                     (local.get $0)
+                    )
+                   )
+                   (local.get $0)
+                  )
+                  (i32.const 31)
+                 )
+                 (i32.const 1)
+                 (block (result i32)
+                  (local.set $7
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (i32.load offset=12
+                       (local.get $1)
+                      )
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                  )
+                  (local.set $8
+                   (tuple.extract 0
+                    (tuple.make
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (i32.load offset=8
+                       (local.get $1)
+                      )
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                  )
+                  (if (result i32)
+                   (i32.shr_u
                     (if (result i32)
                      (i32.shr_u
-                      (tuple.extract 0
-                       (tuple.make
-                        (if (result i32)
-                         (i32.shr_u
-                          (local.tee $13
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (local.get $6)
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (local.get $7)
-                              )
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (call_indirect (type $i32_i32_i32_=>_i32)
-                          (local.tee $0
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $gimport_pervasives_==)
-                             )
-                             (local.get $0)
-                            )
-                           )
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $5)
-                          )
-                          (i32.const 15)
-                          (i32.load offset=8
-                           (local.get $0)
-                          )
-                         )
-                         (local.get $13)
+                      (local.tee $0
+                       (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
                         )
-                        (i32.const 0)
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (local.get $7)
+                        )
+                        (i32.const 19)
                        )
                       )
                       (i32.const 31)
                      )
-                     (i32.const 1)
                      (block (result i32)
-                      (local.set $8
+                      (i32.store
+                       (local.tee $2
+                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                         (i32.const 16)
+                        )
+                       )
+                       (i32.const 1)
+                      )
+                      (i32.store offset=4
+                       (local.get $2)
+                       (i32.const 3)
+                      )
+                      (i64.store offset=8
+                       (local.get $2)
+                       (i64.const 7303014)
+                      )
+                      (local.set $2
                        (tuple.extract 0
                         (tuple.make
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (i32.load offset=12
-                           (local.get $1)
-                          )
-                         )
+                         (local.get $2)
                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
                           (i32.const 0)
@@ -268,291 +295,187 @@ pattern matching › constant_match_4
                         )
                        )
                       )
-                      (local.set $9
-                       (tuple.extract 0
-                        (tuple.make
+                      (select
+                       (i32.const -2)
+                       (local.tee $0
+                        (call $wimport_GRAIN$MODULE$runtime/equal_equal
                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (i32.load offset=8
-                           (local.get $1)
-                          )
+                          (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
                          )
-                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                          (i32.const 0)
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $8)
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $2)
                          )
                         )
                        )
-                      )
-                      (if (result i32)
                        (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (if (result i32)
-                           (i32.shr_u
-                            (local.tee $10
-                             (tuple.extract 0
-                              (tuple.make
-                               (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                 (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                                )
-                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                 (local.get $8)
-                                )
-                                (i32.const 19)
-                               )
-                               (i32.const 0)
-                              )
-                             )
-                            )
-                            (i32.const 31)
-                           )
-                           (block (result i32)
-                            (i32.store
-                             (local.tee $0
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                                 (i32.const 16)
-                                )
-                                (local.get $0)
-                               )
-                              )
-                             )
-                             (i32.const 1)
-                            )
-                            (i32.store offset=4
-                             (local.get $0)
-                             (i32.const 3)
-                            )
-                            (i64.store offset=8
-                             (local.get $0)
-                             (i64.const 7303014)
-                            )
-                            (local.set $2
-                             (tuple.extract 0
-                              (tuple.make
-                               (local.get $0)
-                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                (i32.const 0)
-                               )
-                              )
-                             )
-                            )
-                            (select
-                             (i32.const -2)
-                             (local.tee $3
-                              (tuple.extract 0
-                               (tuple.make
-                                (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                  (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                                 )
-                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                  (local.get $9)
-                                 )
-                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                  (local.get $2)
-                                 )
-                                )
-                                (i32.const 0)
-                               )
-                              )
-                             )
-                             (i32.shr_u
-                              (local.get $3)
-                              (i32.const 31)
-                             )
-                            )
-                           )
-                           (local.get $10)
-                          )
-                          (local.get $3)
-                         )
-                        )
+                        (local.get $0)
                         (i32.const 31)
                        )
-                       (i32.const 3)
-                       (block (result i32)
-                        (local.set $2
-                         (tuple.extract 0
-                          (tuple.make
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (i32.load offset=12
-                             (local.get $1)
-                            )
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                            (local.get $2)
-                           )
-                          )
-                         )
+                      )
+                     )
+                     (local.get $0)
+                    )
+                    (i32.const 31)
+                   )
+                   (i32.const 3)
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=12
+                         (local.get $1)
                         )
-                        (local.set $11
-                         (tuple.extract 0
-                          (tuple.make
-                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                            (i32.load offset=8
-                             (local.get $1)
-                            )
-                           )
-                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                        )
-                        (i32.store
-                         (local.tee $0
-                          (tuple.extract 0
-                           (tuple.make
-                            (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                             (i32.const 16)
-                            )
-                            (local.get $0)
-                           )
-                          )
-                         )
-                         (i32.const 1)
-                        )
-                        (i32.store offset=4
-                         (local.get $0)
-                         (i32.const 3)
-                        )
-                        (i64.store offset=8
-                         (local.get $0)
-                         (i64.const 7303014)
-                        )
-                        (local.set $12
-                         (tuple.extract 0
-                          (tuple.make
-                           (local.get $0)
-                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 5)
-                         (i32.const 7)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (if (result i32)
-                             (i32.shr_u
-                              (local.tee $3
-                               (tuple.extract 0
-                                (tuple.make
-                                 (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                   (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                                  )
-                                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                   (local.get $11)
-                                  )
-                                  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                   (local.get $12)
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 31)
-                             )
-                             (call_indirect (type $i32_i32_i32_=>_i32)
-                              (local.tee $0
-                               (tuple.extract 0
-                                (tuple.make
-                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                  (global.get $gimport_pervasives_==)
-                                 )
-                                 (local.get $0)
-                                )
-                               )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (local.get $2)
-                              )
-                              (i32.const 11)
-                              (i32.load offset=8
-                               (local.get $0)
-                              )
-                             )
-                             (local.get $3)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (local.get $2)
                        )
                       )
                      )
                     )
-                    (local.get $10)
+                    (local.set $9
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=8
+                         (local.get $1)
+                        )
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
+                      )
+                     )
+                    )
+                    (i32.store
+                     (local.tee $0
+                      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                       (i32.const 16)
+                      )
+                     )
+                     (i32.const 1)
+                    )
+                    (i32.store offset=4
+                     (local.get $0)
+                     (i32.const 3)
+                    )
+                    (i64.store offset=8
+                     (local.get $0)
+                     (i64.const 7303014)
+                    )
+                    (local.set $10
+                     (tuple.extract 0
+                      (tuple.make
+                       (local.get $0)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
+                      )
+                     )
+                    )
+                    (select
+                     (i32.const 5)
+                     (i32.const 7)
+                     (i32.shr_u
+                      (if (result i32)
+                       (i32.shr_u
+                        (local.tee $0
+                         (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                          )
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (local.get $9)
+                          )
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (local.get $10)
+                          )
+                         )
+                        )
+                        (i32.const 31)
+                       )
+                       (call_indirect (type $i32_i32_i32_=>_i32)
+                        (local.tee $0
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (global.get $gimport_pervasives_==)
+                         )
+                        )
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (local.get $2)
+                        )
+                        (i32.const 11)
+                        (i32.load offset=8
+                         (local.get $0)
+                        )
+                       )
+                       (local.get $0)
+                      )
+                      (i32.const 31)
+                     )
+                    )
                    )
                   )
-                  (i32.const 1)
                  )
                 )
+                (i32.const 1)
                )
               )
-              (unreachable)
              )
             )
-            (br $switch.60_outer
-             (i32.const 2147483646)
-            )
+            (unreachable)
            )
           )
           (br $switch.60_outer
-           (i32.const -2)
+           (i32.const 2147483646)
           )
          )
         )
         (br $switch.60_outer
-         (i32.const 2147483646)
+         (i32.const -2)
         )
        )
       )
-      (i32.const 2147483646)
+      (br $switch.60_outer
+       (i32.const 2147483646)
+      )
      )
-     (local.get $0)
     )
+    (i32.const 2147483646)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $3)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
    )
   )
   (drop
@@ -582,25 +505,19 @@ pattern matching › constant_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
+    (local.get $9)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $12)
+    (local.get $10)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -38,21 +38,14 @@ pattern matching › tuple_match_deep7
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local.set $9
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 15)
@@ -71,53 +64,17 @@ pattern matching › tuple_match_deep7
     )
    )
   )
-  (local.set $10
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 13)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (local.set $11
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 11)
+      (i32.const 13)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $10)
@@ -138,17 +95,12 @@ pattern matching › tuple_match_deep7
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 9)
+      (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $11)
@@ -164,16 +116,37 @@ pattern matching › tuple_match_deep7
     )
    )
   )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $0
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 9)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $12)
+      )
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -190,10 +163,10 @@ pattern matching › tuple_match_deep7
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $12)
+    (local.get $13)
    )
   )
-  (local.set $4
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -204,508 +177,220 @@ pattern matching › tuple_match_deep7
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (block $switch.62_outer (result i32)
+  (local.set $1
+   (block $switch.62_outer (result i32)
+    (drop
+     (block $switch.62_branch_1 (result i32)
       (drop
-       (block $switch.62_branch_1 (result i32)
+       (block $switch.62_branch_2 (result i32)
         (drop
-         (block $switch.62_branch_2 (result i32)
+         (block $switch.62_branch_3 (result i32)
           (drop
-           (block $switch.62_branch_3 (result i32)
+           (block $switch.62_branch_4 (result i32)
             (drop
-             (block $switch.62_branch_4 (result i32)
+             (block $switch.62_branch_5 (result i32)
               (drop
-               (block $switch.62_branch_5 (result i32)
-                (drop
-                 (block $switch.62_default (result i32)
-                  (br_table $switch.62_branch_1 $switch.62_branch_2 $switch.62_branch_3 $switch.62_branch_4 $switch.62_branch_5 $switch.62_default
-                   (i32.const 0)
-                   (i32.shr_s
-                    (tuple.extract 0
-                     (tuple.make
-                      (if (result i32)
-                       (i32.shr_u
-                        (tuple.extract 0
-                         (tuple.make
-                          (i32.or
-                           (i32.shl
-                            (i32.eq
-                             (local.tee $5
-                              (tuple.extract 0
-                               (tuple.make
-                                (i32.load offset=12
-                                 (local.tee $13
-                                  (tuple.extract 0
-                                   (tuple.make
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                     (i32.load offset=12
-                                      (local.get $4)
-                                     )
-                                    )
-                                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                     (i32.const 0)
-                                    )
-                                   )
-                                  )
-                                 )
-                                )
-                                (i32.const 0)
-                               )
+               (block $switch.62_default (result i32)
+                (br_table $switch.62_branch_1 $switch.62_branch_2 $switch.62_branch_3 $switch.62_branch_4 $switch.62_branch_5 $switch.62_default
+                 (i32.const 0)
+                 (i32.shr_s
+                  (if (result i32)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (local.tee $1
+                        (i32.load offset=12
+                         (local.tee $14
+                          (tuple.extract 0
+                           (tuple.make
+                            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                             (i32.load offset=12
+                              (local.get $0)
+                             )
+                            )
+                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                             (i32.const 0)
+                            )
+                           )
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 3)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.tee $1
+                         (i32.load offset=12
+                          (local.tee $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (i32.load offset=24
+                               (local.get $14)
                               )
                              )
-                             (i32.const 3)
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (i32.const 0)
+                             )
                             )
-                            (i32.const 31)
                            )
-                           (i32.const 2147483646)
                           )
-                          (i32.const 0)
                          )
+                        )
+                        (i32.const 3)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
+                    (if (result i32)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.tee $1
+                          (i32.load offset=12
+                           (local.tee $3
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $2)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                         )
+                         (i32.const 3)
                         )
                         (i32.const 31)
                        )
-                       (if (result i32)
-                        (i32.shr_u
-                         (tuple.extract 0
-                          (tuple.make
-                           (i32.or
-                            (i32.shl
-                             (i32.eq
-                              (local.tee $5
-                               (tuple.extract 0
-                                (tuple.make
-                                 (i32.load offset=12
-                                  (local.tee $1
-                                   (tuple.extract 0
-                                    (tuple.make
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                      (i32.load offset=24
-                                       (local.get $13)
-                                      )
-                                     )
-                                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                      (i32.const 0)
-                                     )
-                                    )
-                                   )
-                                  )
-                                 )
-                                 (i32.const 0)
-                                )
-                               )
-                              )
-                              (i32.const 3)
-                             )
-                             (i32.const 31)
-                            )
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 0)
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (if (result i32)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.tee $17
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $2
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $1)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                               )
-                               (i32.const 3)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                         (select
-                          (i32.const 7)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (tuple.extract 0
-                                 (tuple.make
-                                  (i32.load offset=12
-                                   (local.tee $3
-                                    (tuple.extract 0
-                                     (tuple.make
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                                       (i32.load offset=24
-                                        (local.get $2)
-                                       )
-                                      )
-                                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                                       (i32.const 0)
-                                      )
-                                     )
-                                    )
-                                   )
-                                  )
-                                  (i32.const 0)
-                                 )
-                                )
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                         (select
-                          (i32.const 5)
-                          (i32.const 9)
-                          (i32.shr_u
-                           (tuple.extract 0
-                            (tuple.make
-                             (i32.or
-                              (i32.shl
-                               (i32.eq
-                                (local.get $17)
-                                (i32.const 1)
-                               )
-                               (i32.const 31)
-                              )
-                              (i32.const 2147483646)
-                             )
-                             (i32.const 0)
-                            )
-                           )
-                           (i32.const 31)
-                          )
-                         )
-                        )
-                        (select
-                         (i32.const 3)
-                         (i32.const 9)
-                         (i32.shr_u
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                          (i32.const 31)
-                         )
-                        )
-                       )
-                       (if (result i32)
-                        (i32.shr_u
-                         (local.tee $5
-                          (tuple.extract 0
-                           (tuple.make
-                            (i32.or
-                             (i32.shl
-                              (i32.eq
-                               (local.get $5)
-                               (i32.const 1)
-                              )
-                              (i32.const 31)
-                             )
-                             (i32.const 2147483646)
-                            )
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                         (i32.const 31)
-                        )
-                        (i32.const 1)
-                        (unreachable)
-                       )
+                       (i32.const 2147483646)
                       )
-                      (local.get $5)
+                      (i32.const 31)
+                     )
+                     (select
+                      (i32.const 7)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (i32.load offset=12
+                           (local.tee $4
+                            (tuple.extract 0
+                             (tuple.make
+                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                               (i32.load offset=24
+                                (local.get $3)
+                               )
+                              )
+                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                               (i32.const 0)
+                              )
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
+                     )
+                     (select
+                      (i32.const 5)
+                      (i32.const 9)
+                      (i32.shr_u
+                       (i32.or
+                        (i32.shl
+                         (i32.eq
+                          (local.get $1)
+                          (i32.const 1)
+                         )
+                         (i32.const 31)
+                        )
+                        (i32.const 2147483646)
+                       )
+                       (i32.const 31)
+                      )
                      )
                     )
+                    (select
+                     (i32.const 3)
+                     (i32.const 9)
+                     (i32.shr_u
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (local.get $1)
+                         (i32.const 1)
+                        )
+                        (i32.const 31)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                    )
+                   )
+                   (if (result i32)
+                    (i32.shr_u
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (local.get $1)
+                        (i32.const 1)
+                       )
+                       (i32.const 31)
+                      )
+                      (i32.const 2147483646)
+                     )
+                     (i32.const 31)
+                    )
                     (i32.const 1)
+                    (unreachable)
                    )
                   )
+                  (i32.const 1)
                  )
                 )
-                (unreachable)
                )
               )
-              (br $switch.62_outer
-               (i32.const 1999)
-              )
-             )
-            )
-            (local.set $1
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=12
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $1)
-               )
-              )
-             )
-            )
-            (local.set $2
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $2)
-               )
-              )
-             )
-            )
-            (local.set $3
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=24
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (local.get $3)
-               )
-              )
-             )
-            )
-            (local.set $6
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $3)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $7
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $2)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $8
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=20
-                 (local.get $1)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $14
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (i32.load offset=8
-                 (local.get $4)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $15
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $14)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $8)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
-             )
-            )
-            (local.set $16
-             (tuple.extract 0
-              (tuple.make
-               (call_indirect (type $i32_i32_i32_=>_i32)
-                (local.tee $0
-                 (tuple.extract 0
-                  (tuple.make
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $gimport_pervasives_+)
-                   )
-                   (local.get $0)
-                  )
-                 )
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $15)
-                )
-                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $7)
-                )
-                (i32.load offset=8
-                 (local.get $0)
-                )
-               )
-               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                (i32.const 0)
-               )
-              )
+              (unreachable)
              )
             )
             (br $switch.62_outer
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $16)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-            )
-           )
-          )
-          (local.set $1
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $1)
-             )
+             (i32.const 1999)
             )
            )
           )
@@ -714,8 +399,8 @@ pattern matching › tuple_match_deep7
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
+              (i32.load offset=12
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -730,7 +415,7 @@ pattern matching › tuple_match_deep7
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
+              (i32.load offset=24
                (local.get $2)
               )
              )
@@ -741,13 +426,29 @@ pattern matching › tuple_match_deep7
             )
            )
           )
+          (local.set $4
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=24
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (local.get $4)
+             )
+            )
+           )
+          )
           (local.set $6
            (tuple.extract 0
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=20
-               (local.get $1)
+               (local.get $4)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -762,8 +463,40 @@ pattern matching › tuple_match_deep7
             (tuple.make
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $3)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $5
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (i32.load offset=20
+               (local.get $2)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $15
+           (tuple.extract 0
+            (tuple.make
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (i32.load offset=8
-               (local.get $4)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -777,27 +510,51 @@ pattern matching › tuple_match_deep7
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $0
-               (tuple.extract 0
-                (tuple.make
-                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                  (global.get $gimport_pervasives_+)
-                 )
-                 (local.get $0)
-                )
+              (local.tee $8
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
                )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $15)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (i32.load offset=8
+               (local.get $8)
+              )
+             )
+             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+              (i32.const 0)
+             )
+            )
+           )
+          )
+          (local.set $9
+           (tuple.extract 0
+            (tuple.make
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $9
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $8)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $7)
               )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
               (i32.load offset=8
-               (local.get $0)
+               (local.get $9)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -809,44 +566,23 @@ pattern matching › tuple_match_deep7
           )
           (br $switch.62_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $0
-             (tuple.extract 0
-              (tuple.make
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-               (local.get $0)
-              )
+            (local.tee $1
+             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+              (global.get $gimport_pervasives_+)
              )
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $8)
+             (local.get $9)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $6)
             )
             (i32.load offset=8
-             (local.get $0)
+             (local.get $1)
             )
-           )
-          )
-         )
-        )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $4)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
            )
           )
          )
@@ -856,8 +592,8 @@ pattern matching › tuple_match_deep7
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
+            (i32.load offset=12
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -872,8 +608,8 @@ pattern matching › tuple_match_deep7
           (tuple.make
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $4)
+            (i32.load offset=24
+             (local.get $2)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -883,49 +619,183 @@ pattern matching › tuple_match_deep7
           )
          )
         )
-        (br $switch.62_outer
-         (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $0
-           (tuple.extract 0
-            (tuple.make
+        (local.set $4
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $3)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (local.get $4)
+           )
+          )
+         )
+        )
+        (local.set $6
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=20
+             (local.get $2)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $7
+         (tuple.extract 0
+          (tuple.make
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (i32.load offset=8
+             (local.get $0)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (local.set $5
+         (tuple.extract 0
+          (tuple.make
+           (call_indirect (type $i32_i32_i32_=>_i32)
+            (local.tee $5
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
              )
-             (local.get $0)
             )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $7)
+            )
+            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+             (local.get $6)
+            )
+            (i32.load offset=8
+             (local.get $5)
+            )
+           )
+           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+            (i32.const 0)
+           )
+          )
+         )
+        )
+        (br $switch.62_outer
+         (call_indirect (type $i32_i32_i32_=>_i32)
+          (local.tee $1
+           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+            (global.get $gimport_pervasives_+)
            )
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
-           (local.get $0)
+           (local.get $1)
           )
          )
         )
        )
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (i32.load offset=8
-        (local.get $4)
+      (local.set $2
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=12
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $2)
+         )
+        )
+       )
+      )
+      (local.set $3
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=20
+           (local.get $2)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $3)
+         )
+        )
+       )
+      )
+      (local.set $4
+       (tuple.extract 0
+        (tuple.make
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (i32.load offset=8
+           (local.get $0)
+          )
+         )
+         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+          (local.get $4)
+         )
+        )
+       )
+      )
+      (br $switch.62_outer
+       (call_indirect (type $i32_i32_i32_=>_i32)
+        (local.tee $1
+         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+          (global.get $gimport_pervasives_+)
+         )
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (i32.load offset=8
+         (local.get $1)
+        )
        )
       )
      )
-     (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (i32.load offset=8
+      (local.get $0)
+     )
+    )
    )
   )
   (drop
@@ -949,19 +819,19 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $13)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
    )
   )
   (drop
@@ -979,6 +849,12 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -991,13 +867,7 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $14)
+    (local.get $5)
    )
   )
   (drop
@@ -1009,10 +879,16 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $16)
+    (local.get $8)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -27,14 +27,9 @@ records › record_get_multiple
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -71,40 +66,28 @@ records › record_get_multiple
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -132,7 +115,7 @@ records › record_get_multiple
    (local.get $0)
    (i32.const 19)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -149,7 +132,7 @@ records › record_get_multiple
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -165,7 +148,7 @@ records › record_get_multiple
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -175,41 +158,31 @@ records › record_get_multiple
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
-     (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -224,7 +197,7 @@ records › record_get_multiple
     (local.get $3)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -17,14 +17,9 @@ records › record_definition_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -53,40 +48,28 @@ records › record_definition_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -110,12 +93,7 @@ records › record_definition_trailing
    (local.get $0)
    (i32.const 9)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -53,40 +48,28 @@ records › record_pun
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -110,12 +93,7 @@ records › record_pun
    (local.get $0)
    (i32.const 9)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -23,14 +23,9 @@ records › record_destruct_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -75,40 +70,28 @@ records › record_destruct_1
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -134,14 +117,9 @@ records › record_destruct_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -176,7 +154,7 @@ records › record_destruct_1
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -187,15 +165,10 @@ records › record_destruct_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
      (local.get $0)
     )
    )
@@ -209,10 +182,10 @@ records › record_destruct_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -29,14 +29,9 @@ records › record_destruct_4
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -81,40 +76,28 @@ records › record_destruct_4
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -146,7 +129,7 @@ records › record_destruct_4
    (local.get $0)
    (i32.const 13)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -163,7 +146,7 @@ records › record_destruct_4
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -179,7 +162,7 @@ records › record_destruct_4
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -195,7 +178,7 @@ records › record_destruct_4
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=24
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -205,19 +188,14 @@ records › record_destruct_4
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -229,7 +207,7 @@ records › record_destruct_4
        (global.get $global_1)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -239,35 +217,31 @@ records › record_destruct_4
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
-     (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_2)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -276,13 +250,7 @@ records › record_destruct_4
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -17,14 +17,9 @@ records › record_value_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -53,40 +48,28 @@ records › record_value_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -110,12 +93,7 @@ records › record_value_trailing
    (local.get $0)
    (i32.const 9)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -28,14 +28,9 @@ records › record_recursive_data_definition
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 72)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 72)
     )
    )
    (i32.const 1)
@@ -76,40 +71,28 @@ records › record_recursive_data_definition
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -151,14 +134,9 @@ records › record_recursive_data_definition
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -182,7 +160,7 @@ records › record_recursive_data_definition
     (global.get $gimport_pervasives_None)
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -193,27 +171,22 @@ records › record_recursive_data_definition
     )
    )
   )
-  (local.set $3
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_Some)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_Some)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -229,7 +202,7 @@ records › record_recursive_data_definition
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $3)
+      (local.get $1)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -240,19 +213,14 @@ records › record_recursive_data_definition
     )
    )
   )
-  (local.set $4
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_Some)
-         )
-         (local.get $0)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_Some)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -260,7 +228,7 @@ records › record_recursive_data_definition
        (local.get $2)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -271,34 +239,35 @@ records › record_recursive_data_definition
    )
   )
   (i32.store offset=16
-   (local.get $1)
+   (local.get $0)
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (local.get $4)
+      (local.get $3)
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.const 1879048190)
-     (local.get $0)
-    )
-   )
+  (local.set $4
+   (i32.const 1879048190)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -313,13 +282,7 @@ records › record_recursive_data_definition
     (local.get $3)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (local.get $0)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_mixed_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_mixed_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_mixed_trailing
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -23,14 +23,9 @@ records › record_destruct_2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -75,40 +70,28 @@ records › record_destruct_2
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -134,14 +117,9 @@ records › record_destruct_2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -176,7 +154,7 @@ records › record_destruct_2
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -187,15 +165,10 @@ records › record_destruct_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $2)
-      )
-     )
+  (local.set $2
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=20
      (local.get $0)
     )
    )
@@ -209,10 +182,10 @@ records › record_destruct_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -53,40 +48,28 @@ records › record_pun_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -110,12 +93,7 @@ records › record_pun_trailing
    (local.get $0)
    (i32.const 9)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -24,14 +24,9 @@ records › record_destruct_deep
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 72)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 72)
     )
    )
    (i32.const 1)
@@ -72,40 +67,28 @@ records › record_destruct_deep
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -144,14 +127,9 @@ records › record_destruct_deep
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -175,7 +153,7 @@ records › record_destruct_deep
     (local.get $2)
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -192,7 +170,7 @@ records › record_destruct_deep
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -202,16 +180,11 @@ records › record_destruct_deep
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
+     (global.get $global_0)
     )
    )
   )
@@ -224,10 +197,10 @@ records › record_destruct_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -27,14 +27,9 @@ records › record_destruct_3
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -79,40 +74,28 @@ records › record_destruct_3
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -144,7 +127,7 @@ records › record_destruct_3
    (local.get $0)
    (i32.const 13)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -161,7 +144,7 @@ records › record_destruct_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -177,7 +160,7 @@ records › record_destruct_3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -187,44 +170,34 @@ records › record_destruct_3
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_0)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
-     (local.get $0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_0)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_1)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -24,14 +24,9 @@ records › record_get_multilevel
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 88)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 88)
     )
    )
    (i32.const 1)
@@ -80,40 +75,28 @@ records › record_get_multilevel
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -156,14 +139,9 @@ records › record_get_multilevel
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -187,10 +165,26 @@ records › record_get_multilevel
     (local.get $2)
    )
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -199,31 +193,10 @@ records › record_get_multilevel
    )
   )
   (local.set $3
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $3)
-      )
-     )
-     (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=20
+     (local.get $1)
     )
    )
   )
@@ -236,16 +209,16 @@ records › record_get_multilevel
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $1)
    )
   )
-  (local.get $0)
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -22,14 +22,9 @@ records › record_multiple_fields_definition_trailing
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -74,40 +69,28 @@ records › record_multiple_fields_definition_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -133,14 +116,9 @@ records › record_multiple_fields_definition_trailing
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -174,14 +152,6 @@ records › record_multiple_fields_definition_trailing
   (i32.store offset=24
    (local.get $0)
    (i32.const -2)
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (local.get $0)
-    )
-   )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -22,14 +22,9 @@ records › record_get_2
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -58,40 +53,28 @@ records › record_get_2
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -115,7 +98,7 @@ records › record_get_2
    (local.get $0)
    (i32.const 9)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -126,15 +109,10 @@ records › record_get_2
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $1)
-      )
-     )
+  (local.set $1
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=16
      (local.get $0)
     )
    )
@@ -142,10 +120,10 @@ records › record_get_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_mixed
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_mixed
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_mixed
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -29,14 +29,9 @@ records › record_destruct_trailing
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -81,40 +76,28 @@ records › record_destruct_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -146,7 +129,7 @@ records › record_destruct_trailing
    (local.get $0)
    (i32.const 13)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -163,7 +146,7 @@ records › record_destruct_trailing
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -179,7 +162,7 @@ records › record_destruct_trailing
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -195,7 +178,7 @@ records › record_destruct_trailing
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=24
-       (local.get $1)
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -205,19 +188,14 @@ records › record_destruct_trailing
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
        )
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -229,7 +207,7 @@ records › record_destruct_trailing
        (global.get $global_1)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -239,35 +217,31 @@ records › record_destruct_trailing
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_+)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $global_2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_+)
      )
-     (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $global_2)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -276,13 +250,7 @@ records › record_destruct_trailing
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_mixed_2
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_mixed_2
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_mixed_2
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -22,14 +22,9 @@ records › record_multiple_fields_both_trailing
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -74,40 +69,28 @@ records › record_multiple_fields_both_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -133,14 +116,9 @@ records › record_multiple_fields_both_trailing
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -174,14 +152,6 @@ records › record_multiple_fields_both_trailing
   (i32.store offset=24
    (local.get $0)
    (i32.const -2)
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (local.get $0)
-    )
-   )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -17,14 +17,9 @@ records › record_both_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -53,40 +48,28 @@ records › record_both_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 3)
@@ -110,12 +93,7 @@ records › record_both_trailing
    (local.get $0)
    (i32.const 9)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_multiple
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_multiple
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_multiple
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_multiple_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_multiple_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_multiple_trailing
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -22,14 +22,9 @@ records › record_multiple_fields_value_trailing
   (local $1 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -74,40 +69,28 @@ records › record_multiple_fields_value_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -133,14 +116,9 @@ records › record_multiple_fields_value_trailing
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -174,14 +152,6 @@ records › record_multiple_fields_value_trailing
   (i32.store offset=24
    (local.get $0)
    (i32.const -2)
-  )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (local.get $0)
-    )
-   )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -17,14 +17,9 @@ records › record_pun_mixed_2_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 64)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 64)
     )
    )
    (i32.const 1)
@@ -61,40 +56,28 @@ records › record_pun_mixed_2_trailing
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 3)
@@ -122,12 +105,7 @@ records › record_pun_mixed_2_trailing
    (local.get $0)
    (i32.const 2147483646)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -28,14 +28,9 @@ stdlib › stdlib_equal_20
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -80,40 +75,28 @@ stdlib › stdlib_equal_20
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -139,14 +122,9 @@ stdlib › stdlib_equal_20
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -196,14 +174,9 @@ stdlib › stdlib_equal_20
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -229,14 +202,9 @@ stdlib › stdlib_equal_20
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -268,7 +236,7 @@ stdlib › stdlib_equal_20
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -279,34 +247,24 @@ stdlib › stdlib_equal_20
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
@@ -331,10 +289,10 @@ stdlib › stdlib_equal_20
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_18
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -45,7 +40,7 @@ stdlib › stdlib_equal_18
    (local.get $0)
    (i64.const -9036296798633758874)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -58,14 +53,9 @@ stdlib › stdlib_equal_18
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -78,7 +68,7 @@ stdlib › stdlib_equal_18
    (local.get $0)
    (i64.const -8891900135581192346)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -89,41 +79,25 @@ stdlib › stdlib_equal_18
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -132,7 +106,13 @@ stdlib › stdlib_equal_18
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -22,14 +22,9 @@ stdlib › stdlib_equal_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -59,14 +54,9 @@ stdlib › stdlib_equal_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -83,7 +73,7 @@ stdlib › stdlib_equal_1
    (local.get $0)
    (i32.const 5)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -94,27 +84,22 @@ stdlib › stdlib_equal_1
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (i32.or
-      (i32.shl
-       (i32.eq
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $1)
-        )
-        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $2)
-        )
-       )
-       (i32.const 31)
+  (local.set $2
+   (i32.or
+    (i32.shl
+     (i32.eq
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
       )
-      (i32.const 2147483646)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $0)
+      )
      )
-     (local.get $0)
+     (i32.const 31)
     )
+    (i32.const 2147483646)
    )
   )
   (drop
@@ -126,10 +111,10 @@ stdlib › stdlib_equal_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -22,19 +22,14 @@ stdlib › stdlib_cons
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 7)
@@ -53,28 +48,23 @@ stdlib › stdlib_cons
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
+       (local.get $0)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -84,32 +74,28 @@ stdlib › stdlib_cons
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_[...])
      )
-     (local.get $0)
     )
+    (i32.const 3)
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -118,13 +104,7 @@ stdlib › stdlib_cons
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -28,14 +28,9 @@ stdlib › stdlib_equal_19
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -80,40 +75,28 @@ stdlib › stdlib_equal_19
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -139,14 +122,9 @@ stdlib › stdlib_equal_19
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -196,14 +174,9 @@ stdlib › stdlib_equal_19
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -229,14 +202,9 @@ stdlib › stdlib_equal_19
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -268,7 +236,7 @@ stdlib › stdlib_equal_19
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -279,34 +247,24 @@ stdlib › stdlib_equal_19
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
@@ -331,10 +289,10 @@ stdlib › stdlib_equal_19
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -25,47 +25,9 @@ stdlib › stdlib_equal_16
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 1)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 3)
-  )
-  (i64.store offset=8
-   (local.get $0)
-   (i64.const 7303014)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -89,41 +51,53 @@ stdlib › stdlib_equal_16
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 1)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 3)
+  )
+  (i64.store offset=8
+   (local.get $0)
+   (i64.const 7303014)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -132,7 +106,13 @@ stdlib › stdlib_equal_16
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -25,59 +25,9 @@ stdlib › stdlib_equal_12
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 4)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 4)
-  )
-  (i32.store offset=8
-   (local.get $0)
-   (i32.const 3)
-  )
-  (i32.store offset=12
-   (local.get $0)
-   (i32.const 5)
-  )
-  (i32.store offset=16
-   (local.get $0)
-   (i32.const 7)
-  )
-  (i32.store offset=20
-   (local.get $0)
-   (i32.const 9)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 4)
@@ -113,41 +63,65 @@ stdlib › stdlib_equal_12
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
+    )
+   )
+   (i32.const 4)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 4)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
+  (i32.store offset=12
+   (local.get $0)
+   (i32.const 5)
+  )
+  (i32.store offset=16
+   (local.get $0)
+   (i32.const 7)
+  )
+  (i32.store offset=20
+   (local.get $0)
+   (i32.const 9)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -156,7 +130,13 @@ stdlib › stdlib_equal_12
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -28,14 +28,9 @@ stdlib › stdlib_equal_21
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -80,40 +75,28 @@ stdlib › stdlib_equal_21
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -139,14 +122,9 @@ stdlib › stdlib_equal_21
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -196,14 +174,9 @@ stdlib › stdlib_equal_21
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -229,14 +202,9 @@ stdlib › stdlib_equal_21
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -268,7 +236,7 @@ stdlib › stdlib_equal_21
    (local.get $0)
    (i32.const -2)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -279,34 +247,24 @@ stdlib › stdlib_equal_21
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
@@ -331,10 +289,10 @@ stdlib › stdlib_equal_21
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_15
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -45,7 +40,7 @@ stdlib › stdlib_equal_15
    (local.get $0)
    (i64.const 102)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -57,27 +52,22 @@ stdlib › stdlib_equal_15
    )
   )
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 0)
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -85,35 +75,31 @@ stdlib › stdlib_equal_15
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -122,13 +108,7 @@ stdlib › stdlib_equal_15
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_14
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -45,7 +40,7 @@ stdlib › stdlib_equal_14
    (local.get $0)
    (i64.const 32)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -57,27 +52,22 @@ stdlib › stdlib_equal_14
    )
   )
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 0)
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -85,35 +75,31 @@ stdlib › stdlib_equal_14
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -122,13 +108,7 @@ stdlib › stdlib_equal_14
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -27,19 +27,14 @@ stdlib › stdlib_equal_3
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
       (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (i32.const 0)
-        )
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
       (i32.const 7)
@@ -49,6 +44,32 @@ stdlib › stdlib_equal_3
       )
       (i32.load offset=8
        (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 5)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $0)
+      )
+      (i32.load offset=8
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -62,24 +83,19 @@ stdlib › stdlib_equal_3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 5)
+      (i32.const 3)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $1)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $2)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -93,24 +109,19 @@ stdlib › stdlib_equal_3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $3
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 3)
+      (i32.const 7)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $3)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -124,24 +135,19 @@ stdlib › stdlib_equal_3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 7)
+      (i32.const 5)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (global.get $gimport_pervasives_[])
+       (local.get $3)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $4)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -155,24 +161,19 @@ stdlib › stdlib_equal_3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
+      (local.tee $5
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
        )
       )
-      (i32.const 5)
+      (i32.const 3)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -183,65 +184,30 @@ stdlib › stdlib_equal_3
    )
   )
   (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_[...])
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (i32.const 3)
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $6
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $5)
+    )
+    (i32.load offset=8
+     (local.get $6)
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
-     (local.get $0)
-    )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -274,13 +240,7 @@ stdlib › stdlib_equal_3
     (local.get $5)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (local.get $0)
+  (local.get $6)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_11
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 4)
@@ -49,7 +44,7 @@ stdlib › stdlib_equal_11
    (local.get $0)
    (i32.const 5)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -62,14 +57,9 @@ stdlib › stdlib_equal_11
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 4)
@@ -82,7 +72,7 @@ stdlib › stdlib_equal_11
    (local.get $0)
    (i32.const 3)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -93,41 +83,25 @@ stdlib › stdlib_equal_11
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -136,7 +110,13 @@ stdlib › stdlib_equal_11
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_9
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 4)
@@ -40,39 +35,6 @@ stdlib › stdlib_equal_9
   (i32.store offset=4
    (local.get $0)
    (i32.const 0)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
-    )
-   )
-   (i32.const 4)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 1)
-  )
-  (i32.store offset=8
-   (local.get $0)
-   (i32.const 3)
   )
   (local.set $2
    (tuple.extract 0
@@ -85,41 +47,53 @@ stdlib › stdlib_equal_9
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
+    )
+   )
+   (i32.const 4)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 1)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -128,7 +102,13 @@ stdlib › stdlib_equal_9
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -25,51 +25,9 @@ stdlib › stdlib_equal_2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 7)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 2)
-  )
-  (i32.store offset=8
-   (local.get $0)
-   (i32.const 3)
-  )
-  (i32.store offset=12
-   (local.get $0)
-   (i32.const 5)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -97,41 +55,57 @@ stdlib › stdlib_equal_2
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 7)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 2)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
+  (i32.store offset=12
+   (local.get $0)
+   (i32.const 5)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -140,7 +114,13 @@ stdlib › stdlib_equal_2
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -28,14 +28,9 @@ stdlib › stdlib_equal_22
   (local $4 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 80)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 80)
     )
    )
    (i32.const 1)
@@ -80,40 +75,28 @@ stdlib › stdlib_equal_22
    (local.get $0)
    (i64.const 0)
   )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (i32.add
-       (local.get $0)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
-    )
-   )
+  (i32.store offset=8
+   (local.get $0)
    (i32.load
     (i32.const 1032)
    )
   )
-  (i32.store offset=4
+  (i32.store offset=12
    (local.get $0)
    (global.get $wimport__grainEnv_moduleRuntimeId)
   )
   (i32.store
    (i32.const 1032)
-   (local.get $0)
+   (i32.add
+    (local.get $0)
+    (i32.const 8)
+   )
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -139,14 +122,9 @@ stdlib › stdlib_equal_22
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -196,14 +174,9 @@ stdlib › stdlib_equal_22
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -229,14 +202,9 @@ stdlib › stdlib_equal_22
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 28)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 28)
     )
    )
    (i32.const 3)
@@ -268,7 +236,7 @@ stdlib › stdlib_equal_22
    (local.get $0)
    (i32.const 2147483646)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -279,34 +247,24 @@ stdlib › stdlib_equal_22
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $3)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
     )
    )
   )
@@ -331,10 +289,10 @@ stdlib › stdlib_equal_22
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (local.get $0)
    )
   )
-  (local.get $0)
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -25,47 +25,9 @@ stdlib › stdlib_equal_10
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 4)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 1)
-  )
-  (i32.store offset=8
-   (local.get $0)
-   (i32.const 3)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 4)
@@ -89,41 +51,53 @@ stdlib › stdlib_equal_10
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
+    )
+   )
+   (i32.const 4)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 1)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -132,7 +106,13 @@ stdlib › stdlib_equal_10
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_13
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 1)
@@ -41,7 +36,7 @@ stdlib › stdlib_equal_13
    (local.get $0)
    (i32.const 0)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -53,27 +48,22 @@ stdlib › stdlib_equal_13
    )
   )
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 0)
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -81,35 +71,31 @@ stdlib › stdlib_equal_13
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -118,13 +104,7 @@ stdlib › stdlib_equal_13
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -25,14 +25,9 @@ stdlib › stdlib_equal_8
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 4)
@@ -41,7 +36,7 @@ stdlib › stdlib_equal_8
    (local.get $0)
    (i32.const 0)
   )
-  (local.set $1
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -53,27 +48,22 @@ stdlib › stdlib_equal_8
    )
   )
   (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 8)
-      )
-      (local.get $0)
-     )
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 8)
     )
    )
    (i32.const 4)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 0)
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -81,35 +71,31 @@ stdlib › stdlib_equal_8
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $2
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $2
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $1)
+    )
+    (i32.load offset=8
+     (local.get $2)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -118,13 +104,7 @@ stdlib › stdlib_equal_8
     (local.get $1)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -25,47 +25,9 @@ stdlib › stdlib_equal_17
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
-    )
-   )
-   (i32.const 1)
-  )
-  (i32.store offset=4
-   (local.get $0)
-   (i32.const 8)
-  )
-  (i64.store offset=8
-   (local.get $0)
-   (i64.const -9036296798633758874)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $0)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -89,41 +51,53 @@ stdlib › stdlib_equal_17
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 1)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 8)
+  )
+  (i64.store offset=8
+   (local.get $0)
+   (i64.const -9036296798633758874)
+  )
   (local.set $0
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_==)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
-     )
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_==)
+     )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $0)
+    )
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -132,7 +106,13 @@ stdlib › stdlib_equal_17
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.434adad0.0.snapshot
+++ b/compiler/test/__snapshots__/strings.434adad0.0.snapshot
@@ -16,14 +16,9 @@ strings › string2
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -36,12 +31,7 @@ strings › string2
    (local.get $0)
    (i64.const 2945622000)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.a67428df.0.snapshot
+++ b/compiler/test/__snapshots__/strings.a67428df.0.snapshot
@@ -16,14 +16,9 @@ strings › string1
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -36,12 +31,7 @@ strings › string1
    (local.get $0)
    (i64.const 7303014)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
+++ b/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
@@ -16,14 +16,9 @@ strings › string3
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 48)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 48)
     )
    )
    (i32.const 1)
@@ -52,12 +47,7 @@ strings › string3
    (local.get $0)
    (i64.const 1953718630)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -25,14 +25,9 @@ strings › concat
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -45,7 +40,7 @@ strings › concat
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -58,14 +53,9 @@ strings › concat
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 1)
@@ -78,7 +68,7 @@ strings › concat
    (local.get $0)
    (i64.const 7496034)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -89,41 +79,25 @@ strings › concat
     )
    )
   )
-  (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (global.get $gimport_pervasives_++)
-         )
-         (local.get $0)
-        )
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (i32.load offset=8
-       (local.get $0)
-      )
+  (local.set $1
+   (call_indirect (type $i32_i32_i32_=>_i32)
+    (local.tee $1
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $gimport_pervasives_++)
      )
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (local.get $2)
+    )
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
+    (i32.load offset=8
+     (local.get $1)
+    )
    )
   )
   (drop
@@ -132,7 +106,13 @@ strings › concat
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (local.get $1)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -24,14 +24,9 @@ tuples › nested_tup_3
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -61,14 +56,9 @@ tuples › nested_tup_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -98,14 +88,9 @@ tuples › nested_tup_3
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -156,15 +141,10 @@ tuples › nested_tup_3
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_1)
-      )
-     )
-     (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_1)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -23,14 +23,9 @@ tuples › nested_tup_1
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -60,14 +55,9 @@ tuples › nested_tup_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -97,14 +87,9 @@ tuples › nested_tup_1
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -139,15 +124,10 @@ tuples › nested_tup_1
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (global.get $global_0)
-      )
-     )
-     (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=8
+     (global.get $global_0)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.2f6e820d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2f6e820d.0.snapshot
@@ -16,14 +16,9 @@ tuples › singleton_tup_annotation
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -36,12 +31,7 @@ tuples › singleton_tup_annotation
    (local.get $0)
    (i32.const 3)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.843a836f.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.843a836f.0.snapshot
@@ -16,14 +16,9 @@ tuples › singleton_tup
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 12)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 12)
     )
    )
    (i32.const 7)
@@ -36,12 +31,7 @@ tuples › singleton_tup
    (local.get $0)
    (i32.const 3)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
@@ -16,14 +16,9 @@ tuples › tup1_trailing
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -44,12 +39,7 @@ tuples › tup1_trailing
    (local.get $0)
    (i32.const 7)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -21,14 +21,9 @@ tuples › big_tup_access
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 24)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 24)
     )
    )
    (i32.const 7)
@@ -64,15 +59,10 @@ tuples › big_tup_access
     )
    )
   )
-  (tuple.extract 0
-   (tuple.make
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=16
-      (global.get $global_0)
-     )
-    )
-    (local.get $0)
+  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+   (i32.load offset=16
+    (global.get $global_0)
    )
   )
  )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -24,14 +24,9 @@ tuples › nested_tup_2
   (local $2 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -61,14 +56,9 @@ tuples › nested_tup_2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -98,14 +88,9 @@ tuples › nested_tup_2
   )
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 16)
-      )
-      (local.get $0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
     )
    )
    (i32.const 7)
@@ -156,15 +141,10 @@ tuples › nested_tup_2
    )
   )
   (local.set $0
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (global.get $global_1)
-      )
-     )
-     (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (i32.load offset=12
+     (global.get $global_1)
     )
    )
   )

--- a/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
@@ -16,14 +16,9 @@ tuples › tup1_trailing_space
   (local $0 i32)
   (i32.store
    (local.tee $0
-    (tuple.extract 0
-     (tuple.make
-      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-       (i32.const 20)
-      )
-      (i32.const 0)
-     )
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
     )
    )
    (i32.const 7)
@@ -44,12 +39,7 @@ tuples › tup1_trailing_space
    (local.get $0)
    (i32.const 7)
   )
-  (tuple.extract 0
-   (tuple.make
-    (local.get $0)
-    (local.get $0)
-   )
-  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop


### PR DESCRIPTION
This avoids an issue in Binaryen v102 where spurious multivalue types appear because of our use of tuples (by using far fewer tuples).