### PR TITLE
chore: Reset ident stamps when compiling

### DIFF
--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -284,6 +284,7 @@ let compile_wasi_polyfill = () => {
 };
 
 let reset_compiler_state = () => {
+  Ident.setup();
   Env.clear_imports();
   Module_resolution.clear_dependency_graph();
   Grain_utils.Fs_access.flush_all_cached_data();

--- a/compiler/src/typed/builtin_types.re
+++ b/compiler/src/typed/builtin_types.re
@@ -193,6 +193,6 @@ let builtin_values =
    be defined in this file (above!) without breaking .cmi
    compatibility. */
 
-let _ = Ident.set_current_time(999);
+let _ = Ident.setup();
 let builtin_idents = List.rev(builtin_idents^);
 let builtin_decls = List.rev(builtin_decls^);

--- a/compiler/src/typed/ident.re
+++ b/compiler/src/typed/ident.re
@@ -100,6 +100,12 @@ let reinit = () =>
     currentstamp := reinit_level^;
   };
 
+let setup = () => {
+  // Identifiers below 1000 are used for Grain builtins
+  currentstamp := 999;
+  reinit_level := (-1);
+};
+
 let hide = i => {...i, stamp: (-1)};
 
 let make_global = i => i.flags = i.flags lor global_flag;

--- a/compiler/src/typed/ident.rei
+++ b/compiler/src/typed/ident.rei
@@ -68,6 +68,7 @@ let binding_time: t => int;
 let current_time: unit => int;
 let set_current_time: int => unit;
 let reinit: unit => unit;
+let setup: unit => unit;
 
 type tbl('a);
 /* Association tables from identifiers to type 'a. */

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › func_shadow
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155 $foo_1157)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131 $foo_1133)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -22,7 +22,7 @@ basic functionality › func_shadow
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -64,7 +64,7 @@ basic functionality › func_shadow
   )
   (local.get $1)
  )
- (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1133 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -164,7 +164,7 @@ basic functionality › func_shadow
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call $foo_1155
+         (call $foo_1131
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_0)
@@ -252,7 +252,7 @@ basic functionality › func_shadow
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $foo_1157
+         (call $foo_1133
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › block_no_expression
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $f_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $f_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ basic functionality › block_no_expression
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $f_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $f_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -81,7 +81,7 @@ basic functionality › block_no_expression
        )
       )
      )
-     (call $f_1155
+     (call $f_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › pattern_match_unsafe_wasm
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $test_1155 $foo_1156)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $test_1131 $foo_1132)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,9 +21,9 @@ basic functionality › pattern_match_unsafe_wasm
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $test_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $test_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
-   (call $foo_1156
+   (call $foo_1132
     (local.tee $0
      (tuple.extract 0
       (tuple.make
@@ -67,29 +67,29 @@ basic functionality › pattern_match_unsafe_wasm
    )
   )
   (drop
-   (call $foo_1156
+   (call $foo_1132
     (local.get $0)
     (i32.const 1)
    )
   )
   (drop
-   (call $foo_1156
+   (call $foo_1132
     (local.get $0)
     (i32.const 5)
    )
   )
   (drop
-   (call $foo_1156
+   (call $foo_1132
     (local.get $0)
     (i32.const 8)
    )
   )
-  (call $foo_1156
+  (call $foo_1132
    (local.get $0)
    (i32.const 42)
   )
  )
- (func $foo_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1132 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (block $switch.31_outer (result i32)
    (drop
@@ -461,7 +461,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
      )
-     (call $test_1155
+     (call $test_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -6,7 +6,7 @@ basic functionality › func_shadow_and_indirect_call
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155 $foo_1157 $foo_1159 $func_1172)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131 $foo_1133 $foo_1135 $func_1148)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -24,7 +24,7 @@ basic functionality › func_shadow_and_indirect_call
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_5))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -66,7 +66,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $foo_1157 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1133 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -108,7 +108,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $foo_1159 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1135 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -157,7 +157,7 @@ basic functionality › func_shadow_and_indirect_call
   )
   (local.get $1)
  )
- (func $func_1172 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $func_1148 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local.set $1
    (tuple.extract 0
@@ -258,7 +258,7 @@ basic functionality › func_shadow_and_indirect_call
       (local.set $1
        (tuple.extract 0
         (tuple.make
-         (call $foo_1155
+         (call $foo_1131
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_0)
@@ -346,7 +346,7 @@ basic functionality › func_shadow_and_indirect_call
       (local.set $2
        (tuple.extract 0
         (tuple.make
-         (call $foo_1157
+         (call $foo_1133
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)
@@ -434,7 +434,7 @@ basic functionality › func_shadow_and_indirect_call
       (global.set $global_3
        (tuple.extract 0
         (tuple.make
-         (call $foo_1159
+         (call $foo_1135
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_2)

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -5,7 +5,7 @@ enums › adt_trailing
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Cheese_1156)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Cheese_1132)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -23,7 +23,7 @@ enums › adt_trailing
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
- (func $Cheese_1156 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $Cheese_1132 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $1
    (tuple.extract 0
@@ -52,7 +52,7 @@ enums › adt_trailing
       )
       (i32.store offset=8
        (local.get $2)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=12
        (local.get $2)
@@ -118,7 +118,7 @@ enums › adt_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 85899347075)
+           (i64.const 85899347051)
           )
           (i64.store offset=32
            (local.get $0)
@@ -239,7 +239,7 @@ enums › adt_trailing
          )
          (i32.store offset=8
           (local.get $0)
-          (i32.const 2311)
+          (i32.const 2263)
          )
          (i32.store offset=12
           (local.get $0)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -6,7 +6,7 @@ enums › enum_recursive_data_definition
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Node_1158 $Cons_1160)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Node_1134 $Cons_1136)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -30,7 +30,7 @@ enums › enum_recursive_data_definition
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_6))
- (func $Node_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Node_1134 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -59,7 +59,7 @@ enums › enum_recursive_data_definition
       )
       (i32.store offset=8
        (local.get $3)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=12
        (local.get $3)
@@ -109,7 +109,7 @@ enums › enum_recursive_data_definition
   )
   (local.get $3)
  )
- (func $Cons_1160 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Cons_1136 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -138,7 +138,7 @@ enums › enum_recursive_data_definition
       )
       (i32.store offset=8
        (local.get $3)
-       (i32.const 2313)
+       (i32.const 2265)
       )
       (i32.store offset=12
        (local.get $3)
@@ -232,7 +232,7 @@ enums › enum_recursive_data_definition
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 85899347076)
+            (i64.const 85899347052)
            )
            (i64.store offset=32
             (local.get $0)
@@ -256,7 +256,7 @@ enums › enum_recursive_data_definition
            )
            (i64.store offset=72
             (local.get $0)
-            (i64.const 85899347075)
+            (i64.const 85899347051)
            )
            (i64.store offset=80
             (local.get $0)
@@ -326,7 +326,7 @@ enums › enum_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -419,7 +419,7 @@ enums › enum_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)
@@ -561,7 +561,7 @@ enums › enum_recursive_data_definition
       (local.set $3
        (tuple.extract 0
         (tuple.make
-         (call $Node_1158
+         (call $Node_1134
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)
@@ -585,7 +585,7 @@ enums › enum_recursive_data_definition
       (local.set $4
        (tuple.extract 0
         (tuple.make
-         (call $Cons_1160
+         (call $Cons_1136
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_3)
@@ -609,7 +609,7 @@ enums › enum_recursive_data_definition
       (local.set $5
        (tuple.extract 0
         (tuple.make
-         (call $Node_1158
+         (call $Node_1134
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_1)
@@ -633,7 +633,7 @@ enums › enum_recursive_data_definition
       (global.set $global_4
        (tuple.extract 0
         (tuple.make
-         (call $Cons_1160
+         (call $Cons_1136
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_3)

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -6,7 +6,7 @@ exceptions › exception_4
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $Foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $Foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -24,7 +24,7 @@ exceptions › exception_4
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_3))
- (func $Foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $1
    (tuple.extract 0
@@ -57,7 +57,7 @@ exceptions › exception_4
       )
       (i32.store offset=12
        (local.get $3)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=16
        (local.get $3)
@@ -136,7 +136,7 @@ exceptions › exception_4
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903043)
+           (i64.const 12884903019)
           )
           (i64.store offset=40
            (local.get $0)
@@ -144,7 +144,7 @@ exceptions › exception_4
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 4969277161492)
+           (i64.const 4866197946388)
           )
           (i64.store offset=56
            (local.get $0)
@@ -253,7 +253,7 @@ exceptions › exception_4
          )
          (i32.store offset=12
           (local.get $0)
-          (i32.const 2315)
+          (i32.const 2267)
          )
          (i32.store offset=16
           (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -61,7 +61,7 @@ exceptions › exception_2
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903043)
+           (i64.const 12884903019)
           )
           (i64.store offset=40
            (local.get $0)
@@ -119,7 +119,7 @@ exceptions › exception_2
          )
          (i32.store offset=12
           (local.get $0)
-          (i32.const 2311)
+          (i32.const 2263)
          )
          (i32.store offset=16
           (local.get $0)

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -6,7 +6,7 @@ exports › let_rec_export
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
@@ -16,11 +16,11 @@ exports › let_rec_export
  (global $global_2 i32 (i32.const 1))
  (export \"memory\" (memory $0))
  (export \"GRAIN$EXPORT$foo\" (global $global_0))
- (export \"foo\" (func $foo_1155))
+ (export \"foo\" (func $foo_1131))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -6,7 +6,7 @@ functions › dup_func
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1159)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1135)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › dup_func
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1159 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $foo_1135 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -81,7 +81,7 @@ functions › dup_func
        )
       )
      )
-     (call $foo_1159
+     (call $foo_1135
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -6,7 +6,7 @@ functions › shorthand_4
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › shorthand_4
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -117,7 +117,7 @@ functions › shorthand_4
        )
       )
      )
-     (call $foo_1155
+     (call $foo_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -5,7 +5,7 @@ functions › shorthand_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -19,7 +19,7 @@ functions › shorthand_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -98,7 +98,7 @@ functions › shorthand_1
        )
       )
      )
-     (call $foo_1155
+     (call $foo_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_5
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1160)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1136)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_5
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1160 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $lam_lambda_1136 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -448,7 +448,7 @@ functions › lam_destructure_5
         )
        )
       )
-      (call $lam_lambda_1160
+      (call $lam_lambda_1136
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -5,7 +5,7 @@ functions › lambda_pat_any
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $x_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $x_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -19,7 +19,7 @@ functions › lambda_pat_any
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $x_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $x_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -123,7 +123,7 @@ functions › lambda_pat_any
         )
        )
       )
-      (call $x_1155
+      (call $x_1131
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -6,7 +6,7 @@ functions › curried_func
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $add_1155 $func_1165)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $add_1131 $func_1141)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › curried_func
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $add_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $add_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -83,7 +83,7 @@ functions › curried_func
   )
   (local.get $2)
  )
- (func $func_1165 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1141 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -189,7 +189,7 @@ functions › curried_func
       (local.set $0
        (tuple.extract 0
         (tuple.make
-         (call $add_1155
+         (call $add_1131
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
            (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -5,7 +5,7 @@ functions › app_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1158)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1134)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -18,7 +18,7 @@ functions › app_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1134 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -91,7 +91,7 @@ functions › app_1
         )
        )
       )
-      (call $lam_lambda_1158
+      (call $lam_lambda_1134
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -5,7 +5,7 @@ functions › shorthand_3
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -19,7 +19,7 @@ functions › shorthand_3
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -98,7 +98,7 @@ functions › shorthand_3
        )
       )
      )
-     (call $foo_1155
+     (call $foo_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_3
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1158)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1134)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_3
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1158 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1134 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -274,7 +274,7 @@ functions › lam_destructure_3
         )
        )
       )
-      (call $lam_lambda_1158
+      (call $lam_lambda_1134
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_7
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1159)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1135)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ functions › lam_destructure_7
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1159 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1135 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -404,7 +404,7 @@ functions › lam_destructure_7
         )
        )
       )
-      (call $lam_lambda_1159
+      (call $lam_lambda_1135
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -6,7 +6,7 @@ functions › shorthand_2
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › shorthand_2
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local.set $2
    (tuple.extract 0
@@ -117,7 +117,7 @@ functions › shorthand_2
        )
       )
      )
-     (call $foo_1155
+     (call $foo_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_4
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › lam_destructure_4
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -277,7 +277,7 @@ functions › lam_destructure_4
         )
        )
       )
-      (call $foo_1155
+      (call $foo_1131
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_8
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › lam_destructure_8
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -407,7 +407,7 @@ functions › lam_destructure_8
         )
        )
       )
-      (call $foo_1155
+      (call $foo_1131
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -5,7 +5,7 @@ functions › lam_destructure_1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1185)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1161)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -18,7 +18,7 @@ functions › lam_destructure_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1185 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1161 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -120,7 +120,7 @@ functions › lam_destructure_1
         )
        )
       )
-      (call $lam_lambda_1185
+      (call $lam_lambda_1161
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (local.get $1)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -5,7 +5,7 @@ functions › lam_destructure_2
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -19,7 +19,7 @@ functions › lam_destructure_2
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -123,7 +123,7 @@ functions › lam_destructure_2
         )
        )
       )
-      (call $foo_1155
+      (call $foo_1131
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -6,7 +6,7 @@ functions › func_record_associativity2
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1165)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1141)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -20,7 +20,7 @@ functions › func_record_associativity2
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1165 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $lam_lambda_1141 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -73,7 +73,7 @@ functions › func_record_associativity2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -85,7 +85,7 @@ functions › func_record_associativity2
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477892)
+            (i64.const 68719477868)
            )
            (i64.store offset=56
             (local.get $0)
@@ -187,7 +187,7 @@ functions › func_record_associativity2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -236,7 +236,7 @@ functions › func_record_associativity2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -6,7 +6,7 @@ functions › fn_trailing_comma
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $testFn_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $testFn_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › fn_trailing_comma
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $testFn_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $testFn_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -126,7 +126,7 @@ functions › fn_trailing_comma
        )
       )
      )
-     (call $testFn_1155
+     (call $testFn_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -6,7 +6,7 @@ functions › lam_destructure_6
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $foo_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -21,7 +21,7 @@ functions › lam_destructure_6
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $foo_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $foo_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -451,7 +451,7 @@ functions › lam_destructure_6
         )
        )
       )
-      (call $foo_1155
+      (call $foo_1131
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $global_0)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -6,7 +6,7 @@ functions › func_record_associativity1
  (type $none_=>_i32 (func (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1161)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $lam_lambda_1137)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $wimport__grainEnv_moduleRuntimeId i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
@@ -20,7 +20,7 @@ functions › func_record_associativity1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
- (func $lam_lambda_1161 (; has Stack IR ;) (param $0 i32) (result i32)
+ (func $lam_lambda_1137 (; has Stack IR ;) (param $0 i32) (result i32)
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -71,7 +71,7 @@ functions › func_record_associativity1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -173,7 +173,7 @@ functions › func_record_associativity1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -6,7 +6,7 @@ optimizations › trs1
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
- (elem $elem (global.get $wimport__grainEnv_relocBase) $f1_1155)
+ (elem $elem (global.get $wimport__grainEnv_relocBase) $f1_1131)
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
@@ -20,7 +20,7 @@ optimizations › trs1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_2))
- (func $f1_1155 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $f1_1131 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local.set $3
    (tuple.extract 0
@@ -105,7 +105,7 @@ optimizations › trs1
        )
       )
      )
-     (call $f1_1155
+     (call $f1_1131
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (global.get $global_0)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -62,7 +62,7 @@ pattern matching › record_match_3
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -136,7 +136,7 @@ pattern matching › record_match_3
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -65,7 +65,7 @@ pattern matching › adt_match_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -123,7 +123,7 @@ pattern matching › adt_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -58,7 +58,7 @@ pattern matching › record_match_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ pattern matching › record_match_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -58,7 +58,7 @@ pattern matching › record_match_1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ pattern matching › record_match_1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -64,7 +64,7 @@ pattern matching › record_match_4
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ pattern matching › record_match_4
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -59,7 +59,7 @@ pattern matching › record_match_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -71,7 +71,7 @@ pattern matching › record_match_deep
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477892)
+            (i64.const 68719477868)
            )
            (i64.store offset=56
             (local.get $0)
@@ -129,7 +129,7 @@ pattern matching › record_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -175,7 +175,7 @@ pattern matching › record_match_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -62,7 +62,7 @@ records › record_get_multiple
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -128,7 +128,7 @@ records › record_get_multiple
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -51,7 +51,7 @@ records › record_definition_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_definition_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_pun
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -58,7 +58,7 @@ records › record_destruct_1
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ records › record_destruct_1
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -64,7 +64,7 @@ records › record_destruct_4
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_4
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -51,7 +51,7 @@ records › record_value_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_value_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -63,7 +63,7 @@ records › record_recursive_data_definition
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477892)
+            (i64.const 68719477868)
            )
            (i64.store offset=32
             (local.get $0)
@@ -75,7 +75,7 @@ records › record_recursive_data_definition
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=56
             (local.get $0)
@@ -133,7 +133,7 @@ records › record_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)
@@ -182,7 +182,7 @@ records › record_recursive_data_definition
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -58,7 +58,7 @@ records › record_destruct_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -167,7 +167,7 @@ records › record_destruct_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_pun_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -59,7 +59,7 @@ records › record_destruct_deep
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -71,7 +71,7 @@ records › record_destruct_deep
            )
            (i64.store offset=48
             (local.get $0)
-            (i64.const 68719477892)
+            (i64.const 68719477868)
            )
            (i64.store offset=56
             (local.get $0)
@@ -129,7 +129,7 @@ records › record_destruct_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -175,7 +175,7 @@ records › record_destruct_deep
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -62,7 +62,7 @@ records › record_destruct_3
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -136,7 +136,7 @@ records › record_destruct_3
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -59,7 +59,7 @@ records › record_get_multilevel
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -79,7 +79,7 @@ records › record_get_multilevel
            )
            (i64.store offset=64
             (local.get $0)
-            (i64.const 68719477892)
+            (i64.const 68719477868)
            )
            (i64.store offset=72
             (local.get $0)
@@ -137,7 +137,7 @@ records › record_get_multilevel
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -187,7 +187,7 @@ records › record_get_multilevel
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2313)
+           (i32.const 2265)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_definition_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_definition_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -57,7 +57,7 @@ records › record_get_2
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -115,7 +115,7 @@ records › record_get_2
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -64,7 +64,7 @@ records › record_destruct_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_trailing
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_2
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_both_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_both_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -51,7 +51,7 @@ records › record_both_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -105,7 +105,7 @@ records › record_both_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_multiple
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_multiple
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_multiple_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_multiple_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -57,7 +57,7 @@ records › record_multiple_fields_value_trailing
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -162,7 +162,7 @@ records › record_multiple_fields_value_trailing
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2311)
+       (i32.const 2263)
       )
       (i32.store offset=12
        (local.get $0)

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -51,7 +51,7 @@ records › record_pun_mixed_2_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477891)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -113,7 +113,7 @@ records › record_pun_mixed_2_trailing
      )
      (i32.store offset=8
       (local.get $0)
-      (i32.const 2311)
+      (i32.const 2263)
      )
      (i32.store offset=12
       (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_20
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_20
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_20
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_19
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_19
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_19
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_21
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_21
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_21
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -63,7 +63,7 @@ stdlib › stdlib_equal_22
            )
            (i64.store offset=24
             (local.get $0)
-            (i64.const 68719477891)
+            (i64.const 68719477867)
            )
            (i64.store offset=32
             (local.get $0)
@@ -172,7 +172,7 @@ stdlib › stdlib_equal_22
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)
@@ -264,7 +264,7 @@ stdlib › stdlib_equal_22
           )
           (i32.store offset=8
            (local.get $0)
-           (i32.const 2311)
+           (i32.const 2263)
           )
           (i32.store offset=12
            (local.get $0)


### PR DESCRIPTION
`Ident.reinit` doesn't actually reset anything—it sort of snapshots where each module begins and ends. This PR adds a `Ident.setup` function which sets the current ident stamp back to 1000 (because builtins use 1-999).