### PR TITLE
feat: Add Pi and TAU Constants To Stdlib

### DIFF
--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -22,8 +22,8 @@ assert toNumber(infinity) == toNumber(infinity)
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
 
-assert pi = 3.1415926535897931d
+assert pi == 3.1415926535897931d
 assert pi == pi
 
-assert tau = 6.2831853071795862d
+assert tau == 6.2831853071795862d
 assert tau == tau

--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -22,8 +22,8 @@ assert toNumber(infinity) == toNumber(infinity)
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
 
-assert pi == 3.1415926535897931d
+assert pi == 3.1415926535897931f
 assert pi == pi
 
-assert tau == 6.2831853071795862d
+assert tau == 6.2831853071795862f
 assert tau == tau

--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -21,3 +21,9 @@ assert gt(infinity, 100000000.f)
 assert toNumber(infinity) == toNumber(infinity)
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
+
+assert pi = 3.1415926535897931d
+assert pi == pi
+
+assert tau = 6.2831853071795862d
+assert tau == tau

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -21,8 +21,8 @@ assert gt(infinity, 100000000.d)
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
 
-assert pi == 3.14159274f
+assert pi == 3.14159274d
 assert pi == pi
 
-assert tau == 6.28318548f
+assert tau == 6.28318548d
 assert tau == tau

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -20,3 +20,9 @@ assert gt(infinity, 100000000.d)
 // test infinity-specific semantics:
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
+
+assert pi = 3.14159274f
+assert pi == pi
+
+assert tau = 6.28318548f
+assert tau == tau

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -21,8 +21,8 @@ assert gt(infinity, 100000000.d)
 assert toNumber(infinity) == (toNumber(infinity) - 1)
 assert nan != nan
 
-assert pi = 3.14159274f
+assert pi == 3.14159274f
 assert pi == pi
 
-assert tau = 6.28318548f
+assert tau == 6.28318548f
 assert tau == tau

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -143,3 +143,10 @@ assert Number.sign(22222) == 1
 assert 1 / Number.sign(0.0) == Float64.toNumber(Float64.infinity)
 // TODO(#693): Replace with -Infinity literal when it exists
 assert 1 / Number.sign(-0.0) == Number.neg(Float64.toNumber(Float64.infinity))
+
+// Constants Test
+assert pi = 3.1415926535897931
+assert pi == pi
+
+assert tau = 6.2831853071795862
+assert tau == tau

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -145,8 +145,8 @@ assert 1 / Number.sign(0.0) == Float64.toNumber(Float64.infinity)
 assert 1 / Number.sign(-0.0) == Number.neg(Float64.toNumber(Float64.infinity))
 
 // Constants Test
-assert pi = 3.1415926535897931
+assert pi == 3.1415926535897931
 assert pi == pi
 
-assert tau = 6.2831853071795862
+assert tau == 6.2831853071795862
 assert tau == tau

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -247,3 +247,17 @@ let rec makeNaN = () => {
  * @since v0.4.0
  */
 export let nan = makeNaN()
+
+/**
+ * PI represented as a Float32 value.
+ * 
+ * @since next
+ */
+export let pi = 3.14159274f
+
+/**
+ * TAU represented as a Float32 value.
+ * 
+ * @since next
+ */
+export let tau = 6.28318548f

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -251,3 +251,17 @@ let rec makeNaN = () => {
  * @since v0.4.0
  */
 export let nan = makeNaN()
+
+/**
+ * PI represented as a Float64 value.
+ * 
+ * @since next
+ */
+export let pi = 3.1415926535897931d
+
+/**
+ * TAU represented as a Float64 value.
+ * 
+ * @since next
+ */
+export let tau = 6.2831853071795862d

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -20,6 +20,10 @@ import { newFloat64, newInt64 } from "runtime/dataStructures"
 import Tags from "runtime/unsafe/tags"
 
 /**
+ * @section Operations: Functions for operating on values of the Number type.
+ */
+
+/**
  * Computes the sum of its operands.
  *
  * @param x: The first operand
@@ -317,3 +321,21 @@ export let isInfinite = (x: Number) => {
  * @since v0.4.5
  */
 export parseInt
+
+/**
+ * @section Constants: Number constant values.
+ */
+
+/**
+ * PI represented as a Number value.
+ * 
+ * @since next
+ */
+export let pi = 3.1415926535897931
+
+/**
+ * TAU represented as a Float32 value.
+ * 
+ * @since next
+ */
+export let tau = 6.2831853071795862


### PR DESCRIPTION
Add PI And TAU Constants to float32, float64, number Stdlib.

Related to #1017.

Graindoc needs to be regenerated but `grain doc` wasn't working on my computer.