### PR TITLE
feat(compiler): Support pattern matching "or" patterns

### DIFF
--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -5,7 +5,6 @@ open Typedtree;
 open Type_utils;
 open Anftree;
 open Anf_helper;
-open Grain_utils.Either;
 
 module MatchCompiler = Matchcomp.MatchTreeCompiler;
 
@@ -116,8 +115,7 @@ let convert_binds = anf_binds => {
 };
 
 let transl_const =
-    (c: Types.constant)
-    : Grain_utils.Either.t(imm_expression, (string, comp_expression)) => {
+    (c: Types.constant): Either.t(imm_expression, (string, comp_expression)) => {
   switch (c) {
   | Const_number(n) => Right(("number", Comp.number(n)))
   | Const_int32(i) => Right(("int32", Comp.int32(i)))

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -5,6 +5,7 @@ open Typedtree;
 open Type_utils;
 open Anftree;
 open Anf_helper;
+open Grain_utils.Either;
 
 module MatchCompiler = Matchcomp.MatchTreeCompiler;
 
@@ -70,9 +71,17 @@ let lookup_symbol = (~allocation_type, mod_, mod_decl, name, original_name) => {
   };
 };
 
-type either('a, 'b) =
-  | Left('a)
-  | Right('b);
+let convert_bind = (body, bind) =>
+  switch (bind) {
+  | BSeq(exp) => AExp.seq(exp, body)
+  | BLet(name, exp, global) =>
+    AExp.let_(~global, Nonrecursive, [(name, exp)], body)
+  | BLetMut(name, exp, global) =>
+    AExp.let_(~mut_flag=Mutable, ~global, Nonrecursive, [(name, exp)], body)
+  | BLetRec(names, global) => AExp.let_(~global, Recursive, names, body)
+  | BLetRecMut(names, global) =>
+    AExp.let_(~mut_flag=Mutable, ~global, Recursive, names, body)
+  };
 
 let convert_binds = anf_binds => {
   let void_comp =
@@ -103,51 +112,12 @@ let convert_binds = anf_binds => {
     | BLetRecMut(names, global) =>
       AExp.let_(~mut_flag=Mutable, ~global, Recursive, names, void)
     };
-  List.fold_left(
-    (body, bind) =>
-      switch (bind) {
-      | BSeq(exp) => AExp.seq(exp, body)
-      | BLet(name, exp, global) =>
-        AExp.let_(~global, Nonrecursive, [(name, exp)], body)
-      | BLetMut(name, exp, global) =>
-        AExp.let_(
-          ~mut_flag=Mutable,
-          ~global,
-          Nonrecursive,
-          [(name, exp)],
-          body,
-        )
-      | BLetRec(names, global) => AExp.let_(~global, Recursive, names, body)
-      | BLetRecMut(names, global) =>
-        AExp.let_(~mut_flag=Mutable, ~global, Recursive, names, body)
-      },
-    ans,
-    top_binds,
-  );
-};
-
-let extract_bindings = (mut_flag, pat, cexpr) => {
-  let get_imm =
-    fun
-    | CImmExpr(imm) => imm
-    | _ => failwith("MatchCompiler returned non-immediate for binding");
-  let map_fn =
-    switch (mut_flag) {
-    | Mutable => (
-        ((name, e)) =>
-          BLet(
-            name,
-            {...e, comp_desc: CPrim1(BoxBind, get_imm(e.comp_desc))},
-            Nonglobal,
-          )
-      )
-    | Immutable => (((name, e)) => BLet(name, e, Nonglobal))
-    };
-  List.map(map_fn, MatchCompiler.extract_bindings(pat, cexpr));
+  List.fold_left(convert_bind, ans, top_binds);
 };
 
 let transl_const =
-    (c: Types.constant): either(imm_expression, (string, comp_expression)) =>
+    (c: Types.constant)
+    : Grain_utils.Either.t(imm_expression, (string, comp_expression)) => {
   switch (c) {
   | Const_number(n) => Right(("number", Comp.number(n)))
   | Const_int32(i) => Right(("int32", Comp.int32(i)))
@@ -159,6 +129,7 @@ let transl_const =
   | Const_char(c) => Right(("char", Comp.char(c)))
   | _ => Left(Imm.const(c))
   };
+};
 
 type item_get =
   | RecordPatGet(int, type_expr)
@@ -168,7 +139,14 @@ type item_get =
 let rec transl_imm =
         (
           ~boxed=false,
-          {exp_desc, exp_loc: loc, exp_env: env, exp_type: typ, _} as e: expression,
+          {
+            exp_desc,
+            exp_loc: loc,
+            exp_env: env,
+            exp_type: typ,
+            exp_attributes: attributes,
+            _,
+          } as e: expression,
         )
         : (imm_expression, list(anf_bind)) => {
   let allocation_type = get_allocation_type(env, typ);
@@ -562,13 +540,62 @@ let rec transl_imm =
       transl_imm({...e, exp_desc: TExpBlock(rest)});
     (rest_ans, fst_setup @ [BSeq(fst_ans)] @ rest_setup);
   | TExpLet(Nonrecursive, _, []) => (Imm.const(Const_void), [])
-  | TExpLet(Nonrecursive, mut_flag, [{vb_expr, vb_pat}, ...rest]) =>
-    /* TODO: Destructuring on letrec */
-    let (exp_ans, exp_setup) = transl_comp_expression(vb_expr);
-    let binds_setup = extract_bindings(mut_flag, vb_pat, exp_ans);
+  | TExpLet(
+      Nonrecursive,
+      mut_flag,
+      [
+        {
+          vb_expr,
+          vb_pat: {
+            pat_desc:
+              TPatVar(id, _) | TPatAlias({pat_desc: TPatAny}, id, _),
+            pat_env,
+            pat_type,
+          },
+        },
+        ...rest,
+      ],
+    ) =>
+    // Fast path for simple bindings
+    let vb_expr = {
+      ...vb_expr,
+      exp_attributes: attributes @ vb_expr.exp_attributes,
+    };
+    let binds =
+      switch (mut_flag) {
+      | Immutable =>
+        let (exp_ans, exp_setup) = transl_comp_expression(vb_expr);
+        exp_setup @ [BLet(id, exp_ans, Nonglobal)];
+      | Mutable =>
+        let (exp_ans, exp_setup) = transl_imm(vb_expr);
+        let boxed =
+          Comp.prim1(
+            ~allocation_type=get_allocation_type(pat_env, pat_type),
+            BoxBind,
+            exp_ans,
+          );
+        exp_setup @ [BLet(id, boxed, Nonglobal)];
+      };
     let (body_ans, body_setup) =
       transl_imm({...e, exp_desc: TExpLet(Nonrecursive, mut_flag, rest)});
-    (body_ans, exp_setup @ binds_setup @ body_setup);
+    (body_ans, binds @ body_setup);
+  | TExpLet(Nonrecursive, mut_flag, [{vb_expr, vb_pat}, ...rest]) =>
+    // More complex bindings use the match compiler
+    let vb_expr = {
+      ...vb_expr,
+      exp_attributes: attributes @ vb_expr.exp_attributes,
+    };
+    let (exp_ans, exp_setup) = transl_imm(vb_expr);
+    let binds =
+      MatchCompiler.destructure(
+        ~mut_flag,
+        ~global=Nonglobal,
+        vb_pat,
+        exp_ans,
+      );
+    let (body_ans, body_setup) =
+      transl_imm({...e, exp_desc: TExpLet(Nonrecursive, mut_flag, rest)});
+    (body_ans, exp_setup @ binds @ body_setup);
   | TExpLet(Recursive, mut_flag, binds) =>
     if (mut_flag == Mutable) {
       failwith("mutable let rec");
@@ -577,7 +604,14 @@ let rec transl_imm =
     let (binds, new_binds_setup) =
       List.split(
         List.map(
-          ({vb_pat, vb_expr}) => (vb_pat, transl_comp_expression(vb_expr)),
+          ({vb_pat, vb_expr}) =>
+            (
+              vb_pat,
+              transl_comp_expression({
+                ...vb_expr,
+                exp_attributes: attributes @ vb_expr.exp_attributes,
+              }),
+            ),
           binds,
         ),
       );
@@ -760,12 +794,10 @@ let rec transl_imm =
     let tmp = gensym("match");
     let (exp_ans, exp_setup) = transl_imm(exp);
     let (ans, setup) =
-      MatchCompiler.compile_result(
+      MatchCompiler.compile_match(
         ~allocation_type,
         ~partial,
-        Matchcomp.convert_match_branches(env, branches),
-        transl_anf_expression,
-        transl_imm,
+        branches,
         exp_ans,
       );
     (
@@ -773,113 +805,6 @@ let rec transl_imm =
       (exp_setup @ setup) @ [BLet(tmp, ans, Nonglobal)],
     );
   | TExpConstruct(_) => failwith("NYI: transl_imm: Construct")
-  };
-}
-
-and bind_patts =
-    (~mut_flag, ~global, pat: pattern): (Ident.t, list(anf_bind)) => {
-  let postprocess_item = (cur, acc) =>
-    switch (cur) {
-    | None => acc
-    | Some((ident, (src, idx), extras)) =>
-      let access =
-        switch (idx) {
-        | RecordPatGet(idx, ty) =>
-          Comp.record_get(
-            ~allocation_type=get_allocation_type(pat.pat_env, ty),
-            Int32.of_int(idx),
-            Imm.id(src),
-          )
-        | TuplePatGet(idx, ty) =>
-          Comp.tuple_get(
-            ~allocation_type=get_allocation_type(pat.pat_env, ty),
-            Int32.of_int(idx),
-            Imm.id(src),
-          )
-        | ArrayPatGet(idx, ty) =>
-          Comp.array_get(
-            ~allocation_type=get_allocation_type(pat.pat_env, ty),
-            Imm.const(Const_number(Const_number_int(Int64.of_int(idx)))),
-            Imm.id(src),
-          )
-        };
-      let binds =
-        switch (mut_flag, global) {
-        | (Mutable, Nonglobal) =>
-          let tmp = gensym("mut_bind_destructure");
-          let boxed =
-            Comp.prim1(
-              ~allocation_type=get_allocation_type(pat.pat_env, pat.pat_type),
-              BoxBind,
-              Imm.id(tmp),
-            );
-          [BLet(tmp, access, Nonglobal), BLet(ident, boxed, global)];
-        | (Mutable, Global(_)) => [BLetMut(ident, access, global)]
-        | _ => [BLet(ident, access, global)]
-        };
-      binds @ extras @ acc;
-    };
-  let postprocess = items => List.fold_right(postprocess_item, items, []);
-  /* Pass one: Some(<identifier>, <access path>, <extra binds>)*/
-  let rec anf_patts_pass_one = (src, i, {pat_desc, pat_extra}) => {
-    switch (pat_extra) {
-    | [] => ()
-    | _ => failwith("NYI: anf_patts_pass_one: TPatConstraint")
-    };
-    switch (pat_desc) {
-    | TPatVar(bind, _) => Some((bind, (src, i), []))
-    | TPatAny => None
-    | TPatTuple(patts) =>
-      let tmp = gensym("tup_patt");
-      Some((
-        tmp,
-        (src, i),
-        postprocess @@
-        List.mapi(
-          (i, pat) =>
-            anf_patts_pass_one(tmp, TuplePatGet(i, pat.pat_type), pat),
-          patts,
-        ),
-      ));
-    | TPatArray(patts) =>
-      let tmp = gensym("arr_patt");
-      Some((
-        tmp,
-        (src, i),
-        postprocess @@
-        List.mapi(
-          (i, pat) =>
-            anf_patts_pass_one(tmp, ArrayPatGet(i, pat.pat_type), pat),
-          patts,
-        ),
-      ));
-    | TPatRecord(fields, _) =>
-      let tmp = gensym("rec_patt");
-      Some((
-        tmp,
-        (src, i),
-        postprocess @@
-        List.map(
-          ((_, ld, pat)) =>
-            anf_patts_pass_one(
-              tmp,
-              RecordPatGet(ld.lbl_pos, pat.pat_type),
-              pat,
-            ),
-          fields,
-        ),
-      ));
-    | TPatConstant(_) => failwith("NYI: anf_patts_pass_one: TPatConstant")
-    | TPatConstruct(_) => failwith("NYI: anf_patts_pass_one: TPatConstruct")
-    | TPatOr(_) => failwith("NYI: anf_patts_pass_one: TPatOr")
-    | TPatAlias(_) => failwith("NYI: anf_patts_pass_one: TPatAlias")
-    };
-  };
-  let dummy_id = gensym("dummy");
-  let dummy_idx = TuplePatGet(0, Builtin_types.type_void);
-  switch (anf_patts_pass_one(dummy_id, dummy_idx, pat)) {
-  | Some((tmp, _, binds)) => (tmp, binds)
-  | None => failwith("Bind pattern was not destructable")
   };
 }
 
@@ -988,8 +913,18 @@ and transl_comp_expression =
   | TExpLet(
       Nonrecursive,
       mut_flag,
-      [{vb_expr, vb_pat: {pat_desc: TPatVar(bind, _)}}, ...rest],
+      [
+        {
+          vb_expr,
+          vb_pat: {
+            pat_desc:
+              TPatVar(bind, _) | TPatAlias({pat_desc: TPatAny}, bind, _),
+          },
+        },
+        ...rest,
+      ],
     ) =>
+    // Fast path for simple binding
     let vb_expr = {
       ...vb_expr,
       exp_attributes: attributes @ vb_expr.exp_attributes,
@@ -1015,36 +950,26 @@ and transl_comp_expression =
         exp_desc: TExpLet(Nonrecursive, mut_flag, rest),
       });
     (body_ans, exp_setup @ [BLet(bind, exp_ans, Nonglobal)] @ body_setup);
-  | TExpLet(
-      Nonrecursive,
-      mut_flag,
-      [{vb_expr, vb_pat: {pat_desc: TPatTuple(_)} as pat}, ...rest],
-    )
-  | TExpLet(
-      Nonrecursive,
-      mut_flag,
-      [{vb_expr, vb_pat: {pat_desc: TPatRecord(_)} as pat}, ...rest],
-    ) =>
+  | TExpLet(Nonrecursive, mut_flag, [{vb_expr, vb_pat}, ...rest]) =>
+    // More complex bindings use the match compiler
     let vb_expr = {
       ...vb_expr,
       exp_attributes: attributes @ vb_expr.exp_attributes,
     };
-    let (exp_ans, exp_setup) = transl_comp_expression(vb_expr);
-
-    /* Extract items from destructure */
-    let (tmp, anf_patts) = bind_patts(~mut_flag, ~global=Nonglobal, pat);
-
+    let (exp_ans, exp_setup) = transl_imm(vb_expr);
+    let binds =
+      MatchCompiler.destructure(
+        ~mut_flag,
+        ~global=Nonglobal,
+        vb_pat,
+        exp_ans,
+      );
     let (body_ans, body_setup) =
       transl_comp_expression({
         ...e,
         exp_desc: TExpLet(Nonrecursive, mut_flag, rest),
       });
-    (
-      body_ans,
-      exp_setup @ [BLet(tmp, exp_ans, Nonglobal), ...anf_patts] @ body_setup,
-    );
-
-  | TExpLet(Nonrecursive, _, [_, ..._]) => failwith("Impossible by pre_anf")
+    (body_ans, exp_setup @ binds @ body_setup);
   | TExpLet(Recursive, mut_flag, binds) =>
     if (mut_flag == Mutable) {
       failwith("mutable let rec");
@@ -1109,24 +1034,28 @@ and transl_comp_expression =
           (arg, (anf_args, body)) => {
             let tmp = gensym("lambda_arg");
             let binds =
-              MatchCompiler.extract_bindings(
-                arg,
-                Comp.imm(
-                  ~loc,
-                  ~env,
-                  ~allocation_type=
-                    get_allocation_type(arg.pat_env, arg.pat_type),
-                  Imm.id(~loc, ~env, tmp),
-                ),
-              );
+              switch (arg.pat_desc) {
+              | TPatVar(id, _)
+              | TPatAlias({pat_desc: TPatAny}, id, _) => [
+                  BLet(
+                    id,
+                    Comp.imm(
+                      ~allocation_type=
+                        get_allocation_type(arg.pat_env, arg.pat_type),
+                      Imm.id(~loc, ~env, tmp),
+                    ),
+                    Nonglobal,
+                  ),
+                ]
+              | _ => MatchCompiler.destructure(arg, Imm.id(~loc, ~env, tmp))
+              };
             (
               [
                 (tmp, get_allocation_type(arg.pat_env, arg.pat_type)),
                 ...anf_args,
               ],
               List.fold_right(
-                (bind, body) =>
-                  AExp.let_(~loc, ~env, Nonrecursive, [bind], body),
+                (bind, body) => convert_bind(body, bind),
                 binds,
                 body,
               ),
@@ -1213,12 +1142,10 @@ and transl_comp_expression =
   | TExpMatch(expr, branches, partial) =>
     let (exp_ans, exp_setup) = transl_imm(expr);
     let (ans, setup) =
-      MatchCompiler.compile_result(
+      MatchCompiler.compile_match(
         ~allocation_type,
         ~partial,
-        Matchcomp.convert_match_branches(env, branches),
-        transl_anf_expression,
-        transl_imm,
+        branches,
         exp_ans,
       );
     (ans, exp_setup @ setup);
@@ -1242,7 +1169,15 @@ and transl_anf_expression =
       | BLet(name, exp, global) =>
         AExp.let_(~loc, ~env, ~global, Nonrecursive, [(name, exp)], body)
       | BLetMut(name, exp, global) =>
-        AExp.let_(~loc, ~env, ~global, Nonrecursive, [(name, exp)], body)
+        AExp.let_(
+          ~loc,
+          ~env,
+          ~mut_flag=Mutable,
+          ~global,
+          Nonrecursive,
+          [(name, exp)],
+          body,
+        )
       | BLetRec(names, global) =>
         AExp.let_(~loc, ~env, ~global, Recursive, names, body)
       | BLetRecMut(names, global) =>
@@ -1357,6 +1292,46 @@ let rec transl_anf_statement =
       export_flag,
       Nonrecursive,
       mut_flag,
+      [
+        {
+          vb_expr,
+          vb_pat: {
+            pat_desc:
+              TPatVar(bind, _) | TPatAlias({pat_desc: TPatAny}, bind, _),
+          },
+        },
+        ...rest,
+      ],
+    ) =>
+    // Fast path for simple bindings
+    let vb_expr = {
+      ...vb_expr,
+      exp_attributes: attributes @ vb_expr.exp_attributes,
+    };
+    let exported = export_flag == Exported;
+    let name =
+      if (exported) {
+        Some(Ident.name(bind));
+      } else {
+        None;
+      };
+    let (exp_ans, exp_setup) = transl_comp_expression(~name?, vb_expr);
+    let binds =
+      switch (mut_flag) {
+      | Mutable => [BLetMut(bind, exp_ans, Global({exported: exported}))]
+      | Immutable => [BLet(bind, exp_ans, Global({exported: exported}))]
+      };
+    let (rest_setup, rest_imp) =
+      transl_anf_statement({
+        ...s,
+        ttop_desc: TTopLet(export_flag, Nonrecursive, mut_flag, rest),
+      });
+    let rest_setup = Option.value(~default=[], rest_setup);
+    (Some(exp_setup @ binds @ rest_setup), rest_imp);
+  | TTopLet(
+      export_flag,
+      Nonrecursive,
+      mut_flag,
       [{vb_expr, vb_pat}, ...rest],
     ) =>
     let vb_expr = {
@@ -1375,6 +1350,8 @@ let rec transl_anf_statement =
         None;
       };
     let (exp_ans, exp_setup) = transl_comp_expression(~name?, vb_expr);
+    let tmp = gensym("destructure_target");
+    let destructure_setup = [BLet(tmp, exp_ans, Nonglobal)];
     let (rest_setup, rest_imp) =
       transl_anf_statement({
         ...s,
@@ -1382,39 +1359,13 @@ let rec transl_anf_statement =
       });
     let rest_setup = Option.value(~default=[], rest_setup);
     let setup =
-      switch (vb_pat.pat_desc) {
-      | TPatVar(bind, _)
-      | TPatAlias({pat_desc: TPatAny}, bind, _) =>
-        switch (mut_flag) {
-        | Mutable => [BLetMut(bind, exp_ans, Global({exported: exported}))]
-        | Immutable => [BLet(bind, exp_ans, Global({exported: exported}))]
-        }
-      | TPatTuple(_)
-      | TPatRecord(_) =>
-        let (tmp, anf_patts) =
-          bind_patts(
-            ~mut_flag,
-            ~global=Global({exported: exported}),
-            vb_pat,
-          );
-        [BLet(tmp, exp_ans, Global({exported: exported})), ...anf_patts];
-      | TPatAlias(patt, bind, _) =>
-        let binds =
-          switch (mut_flag) {
-          | Mutable => [
-              BLetMut(bind, exp_ans, Global({exported: exported})),
-            ]
-          | Immutable => [BLet(bind, exp_ans, Global({exported: exported}))]
-          };
-        let (tmp, anf_patts) =
-          bind_patts(~mut_flag, ~global=Global({exported: exported}), patt);
-        binds @ [BLet(tmp, exp_ans, Nonglobal), ...anf_patts];
-      | TPatAny => [BSeq(exp_ans)]
-      | _ =>
-        failwith(
-          "NYI: transl_anf_statement: Non-record or non-tuple destructuring in let",
-        )
-      };
+      destructure_setup
+      @ MatchCompiler.destructure(
+          ~mut_flag,
+          ~global=Global({exported: exported}),
+          vb_pat,
+          Imm.id(tmp),
+        );
     (Some(exp_setup @ setup @ rest_setup), rest_imp);
   | TTopLet(export_flag, Recursive, mut_flag, binds) =>
     let exported = export_flag == Exported;
@@ -1653,3 +1604,6 @@ let transl_anf_module =
 };
 
 let () = Matchcomp.compile_constructor_tag := compile_constructor_tag;
+let () = Matchcomp.transl_anf_expression := transl_anf_expression;
+let () = Matchcomp.transl_imm_expression := transl_imm;
+let () = Matchcomp.transl_const := transl_const;

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -10,6 +10,7 @@ open Grain_utils;
 open Types;
 open Typedtree;
 open Type_utils;
+open Either;
 
 /** The type for compiled match pattern decision trees.
     These trees are evaluated with respect to a stack of values. */
@@ -22,11 +23,24 @@ type decision_tree =
       to the action number (i.e. switch branch) to be taken */
     Leaf(
       int,
+      list(pattern),
+      list((Ident.t, Ident.t)),
     )
   | /** Represents a guarded branch. The left tree corresponds to a successful
       guard check, and the right tree corresponds to a failed guard check. */
     Guard(
       match_branch,
+      list(pattern),
+      list((Ident.t, Ident.t)),
+      decision_tree,
+      decision_tree,
+    )
+  | /** Represents a conditional check on the current value. The alias is used
+      for any alias bindings. The left tree corresponds to a true result, and
+      the right tree corresponds to a false result. */
+    Conditional(
+      (equality_type, constant),
+      Ident.t,
       decision_tree,
       decision_tree,
     )
@@ -50,28 +64,47 @@ type decision_tree =
     )
   | /** This instruction indicates that the first argument should be
       interpreted as a tuple and expanded into its contents.
-      Argument: (kind of expansion) */
+      Arguments (kind of expansion, alias, rest of the tree) */
     Explode(
       matrix_type,
+      Ident.t,
       decision_tree,
     )
 
 and matrix_type =
   | TupleMatrix(int)
-  | ArrayMatrix(int)
+  | ArrayMatrix(option(int))
   | RecordMatrix(array(int))
   | ConstructorMatrix(option(int))
+  | ConstantMatrix
 
 and switch_type =
   | ConstructorSwitch
-  | ArraySwitch;
+  | ArraySwitch
+
+and equality_type =
+  | PhysicalEquality
+  | StructuralEquality;
 
 type conversion_result = {
   tree: decision_tree,
   branches: list((int, expression, pattern)),
 };
 
-/** Utilities */;
+/** Forward declarations */
+let transl_anf_expression: ref(expression => Anftree.anf_expression) =
+  ref(_ => failwith("forward decl"));
+let transl_imm_expression:
+  ref(expression => (Anftree.imm_expression, list(Anftree.anf_bind))) =
+  ref(_ => failwith("forward decl"));
+let transl_const:
+  ref(
+    Asttypes.constant =>
+    Either.t(Anftree.imm_expression, (string, Anftree.comp_expression)),
+  ) =
+  ref(_ => failwith("forward decl"));
+
+/** Utilities */
 
 /** Swaps the first and 'idx'-th elements of the given list */
 
@@ -105,6 +138,543 @@ let compile_constructor_tag: ref(constructor_tag => int) = (
     ref(constructor_tag => int)
 );
 
+let rec pattern_always_matches = patt =>
+  /* Precondition: Normalized */
+  switch (patt.pat_desc) {
+  | TPatAny
+  | TPatVar(_) => true
+  | TPatAlias(p, _, _) => pattern_always_matches(p)
+  | _ => false
+  };
+
+let rec flatten_matrix = (size, cur, mtx) => {
+  let rec flattened_rows = (row, binds) =>
+    switch (row) {
+    | [] => failwith("Impossible: Empty pattern row in flatten_matrix")
+    | [{pat_desc} as p, ...ptl] =>
+      switch (pat_desc) {
+      | TPatAlias(p, alias, _) =>
+        flattened_rows([p, ...ptl], [(alias, cur), ...binds])
+      | TPatVar(id, _) =>
+        let wildcards = Parmatch.omegas(size);
+        [(wildcards @ ptl, [(id, cur), ...binds])];
+      | TPatTuple(args) => [(args @ ptl, binds)]
+      | TPatRecord([(_, {lbl_all}, _), ..._] as ps, _) =>
+        let patterns = Array.init(Array.length(lbl_all), _ => Parmatch.omega);
+        List.iter(((_, ld, pat)) => patterns[ld.lbl_pos] = pat, ps);
+        [(Array.to_list(patterns) @ ptl, binds)];
+      | TPatOr(p1, p2) =>
+        flattened_rows([p1, ...ptl], binds)
+        @ flattened_rows([p2, ...ptl], binds)
+      | _ when pattern_always_matches(p) =>
+        let wildcards = Parmatch.omegas(size);
+        [(wildcards @ ptl, binds)];
+      | _ => [] /* Flattening for non-tuples and non-records generates no rows. */
+      }
+    };
+
+  List.fold_right(
+    ((row, binds, mb), rem) =>
+      List.map(
+        ((patts, binds)) => (patts, binds, mb),
+        flattened_rows(row, binds),
+      )
+      @ rem,
+    mtx,
+    [],
+  );
+};
+
+let rec matrix_type = {
+  let rec get_kind =
+    fun
+    | TPatConstruct(_) => Some(ConstructorMatrix(None))
+    | TPatTuple(ps) => Some(TupleMatrix(List.length(ps)))
+    | TPatArray(_) => Some(ArrayMatrix(None))
+    | TPatRecord([(_, ld, _), ..._], _) =>
+      Some(RecordMatrix(Array.map(({lbl_pos}) => lbl_pos, ld.lbl_all)))
+    | TPatRecord(_) =>
+      failwith("Impossible: record definition with no fields")
+    | TPatConstant(_) => Some(ConstantMatrix)
+    | TPatAlias({pat_desc}, _, _) => get_kind(pat_desc)
+    | TPatAny
+    | TPatVar(_) => None
+    | TPatOr({pat_desc: a}, {pat_desc: b}) =>
+      switch (get_kind(a)) {
+      | Some(_) as a => a
+      | _ => get_kind(b)
+      };
+  fun
+  | [] => None
+  | [([{pat_desc}, ..._], _, _), ...rest] =>
+    switch (get_kind(pat_desc)) {
+    | Some(_) as hd => hd
+    | None => matrix_type(rest)
+    }
+  | _ => failwith("Internal error: empty matrix row");
+};
+let matrix_type = mtx => {
+  switch (matrix_type(mtx)) {
+  | Some(ty) => ty
+  // This should really only happen if the first column always matches,
+  // a case which is avoided entirely in `compile_matrix`
+  | None => failwith("Internal error: matrix_type unknown")
+  };
+};
+
+module ConstructorSet =
+  Set.Make({
+    type t = constructor_description;
+    let compare = Stdlib.compare;
+  });
+
+let rec pattern_head_constructors_aux = (p, acc) =>
+  switch (p.pat_desc) {
+  | TPatConstruct(_, cd, _) => ConstructorSet.add(cd, acc)
+  | TPatAlias(p, _, _) => pattern_head_constructors_aux(p, acc)
+  | TPatOr(p1, p2) =>
+    pattern_head_constructors_aux(p1, pattern_head_constructors_aux(p2, acc))
+  | _ => acc
+  };
+
+let pattern_head_constructors = patt =>
+  pattern_head_constructors_aux(patt, ConstructorSet.empty);
+
+let matrix_head_constructors = mtx => {
+  let rec help = (mtx, acc) =>
+    switch (mtx) {
+    | [] => acc
+    | [([], _, _), ..._] => failwith("Impossible: Empty pattern matrix")
+    | [([p, ..._], _, mb), ...tl] =>
+      help(tl, pattern_head_constructors_aux(p, acc))
+    };
+  ConstructorSet.elements @@ help(mtx, ConstructorSet.empty);
+};
+
+module IntSet =
+  Set.Make({
+    type t = int;
+    let compare = Stdlib.compare;
+  });
+
+let rec pattern_head_arities_aux = (p, acc) =>
+  switch (p.pat_desc) {
+  | TPatArray(ps) => IntSet.add(List.length(ps), acc)
+  | TPatAlias(p, _, _) => pattern_head_arities_aux(p, acc)
+  | TPatOr(p1, p2) =>
+    pattern_head_arities_aux(p1, pattern_head_arities_aux(p2, acc))
+  | _ => acc
+  };
+
+let pattern_head_arities = patt =>
+  pattern_head_arities_aux(patt, IntSet.empty);
+
+let matrix_head_arities = mtx => {
+  let rec help = (mtx, acc) =>
+    switch (mtx) {
+    | [] => acc
+    | [([], _, _), ..._] => failwith("Impossible: Empty pattern matrix")
+    | [([p, ..._], _, mb), ...tl] =>
+      help(tl, pattern_head_arities_aux(p, acc))
+    };
+  IntSet.elements @@ help(mtx, IntSet.empty);
+};
+
+module ConstantSet =
+  Set.Make({
+    type t = constant;
+    let compare = Stdlib.compare;
+  });
+
+let rec pattern_head_constants_aux = (p, acc) =>
+  switch (p.pat_desc) {
+  | TPatConstant(c) => ConstantSet.add(c, acc)
+  | TPatAlias(p, _, _) => pattern_head_constants_aux(p, acc)
+  | TPatOr(p1, p2) =>
+    pattern_head_constants_aux(p1, pattern_head_constants_aux(p2, acc))
+  | _ => acc
+  };
+
+let pattern_head_constants = patt =>
+  pattern_head_constants_aux(patt, ConstantSet.empty);
+
+let matrix_head_constants = mtx => {
+  let rec help = (mtx, acc) =>
+    switch (mtx) {
+    | [] => acc
+    | [([], _, _), ..._] => failwith("Impossible: Empty pattern matrix")
+    | [([p, ..._], _, mb), ...tl] =>
+      help(tl, pattern_head_constants_aux(p, acc))
+    };
+  ConstantSet.elements @@ help(mtx, ConstantSet.empty);
+};
+
+let make_matrix = branches =>
+  /* Form matrix and assign each branch a number */
+  List.mapi((i, {mb_pat} as mb) => ([mb_pat], [], (mb, i)), branches);
+
+let matrix_width =
+  fun
+  | [] => raise(Not_found)
+  | [(pats, _, _), ..._] => List.length(pats);
+
+let rec col_is_wildcard = (mtx, col) =>
+  switch (mtx) {
+  | [] => true
+  | [(pats, _, _), ..._] when !pattern_always_matches(List.nth(pats, col)) =>
+    false
+  | [_, ...tl] => col_is_wildcard(tl, col)
+  };
+
+let rec rotate_matrix = (mtx, col) =>
+  switch (mtx) {
+  | [] => []
+  | [(pats, binds, mb), ...tl] =>
+    let tl = rotate_matrix(tl, col);
+    let rotated_row = swap_list(col, pats);
+    [(rotated_row, binds, mb), ...tl];
+  };
+
+let rec rotate_if_needed = mtx =>
+  if (!col_is_wildcard(mtx, 0)) {
+    (0, mtx);
+  } else {
+    switch (mtx) {
+    | [] => (0, mtx)
+    | _ =>
+      /* Safe, since size 0 matrix is wildcard */
+      let width = matrix_width(mtx);
+      let rec find_rotation = n =>
+        if (n >= width) {
+          raise(Not_found);
+        } else if (!col_is_wildcard(mtx, n)) {
+          (n, rotate_matrix(mtx, n));
+        } else {
+          find_rotation(n + 1);
+        };
+      find_rotation(1);
+    };
+  };
+
+/* [See paper for details]
+
+      Row: ([p_1; p_2; ...], a_j)
+
+      Pattern p_1 (for row j)             Row(s) of S(c, P -> A)
+      -------------------------           ----------------------
+           c(q_1,...,q_n)           [([q_1; ...; q_n; p_2; ...], a_j)]
+      c'(q_1,...,q_n) (c' <> c)                  No row
+                 _                    [([_; ...; _; p_2; ...], a_j)] [n wildcards]
+            (q_1 | q_2)               [(S(c, ([q_1; p_2; ...], a_j)));
+                                       (S(c, ([q_2; p_2; ...], a_j)))]
+   */
+let rec specialize_matrix = (cd, cur, mtx) => {
+  let arity = cd.cstr_arity;
+  let rec specialized_rows = (row, binds) =>
+    switch (row) {
+    | [] => failwith("Impossible: Empty pattern row in specialize_matrix")
+    | [{pat_desc} as p, ...ptl] =>
+      switch (pat_desc) {
+      | TPatAlias(p, alias, _) =>
+        specialized_rows([p, ...ptl], [(alias, cur), ...binds])
+      | TPatVar(id, _) =>
+        let wildcards = Parmatch.omegas(arity);
+        [(wildcards @ ptl, [(id, cur), ...binds])];
+      | TPatConstruct(_, pcd, args) when cd == pcd => [(args @ ptl, binds)]
+      | TPatOr(p1, p2) =>
+        specialized_rows([p1, ...ptl], binds)
+        @ specialized_rows([p2, ...ptl], binds)
+      | _ when pattern_always_matches(p) =>
+        let wildcards = Parmatch.omegas(arity);
+        [(wildcards @ ptl, binds)];
+      | _ => [] /* Specialization for non-constructors generates no rows. */
+      }
+    };
+
+  List.fold_right(
+    ((row, binds, mb), rem) =>
+      List.map(
+        ((patts, binds)) => (patts, binds, mb),
+        specialized_rows(row, binds),
+      )
+      @ rem,
+    mtx,
+    [],
+  );
+};
+
+let rec specialize_array_matrix = (arity, cur, mtx) => {
+  let rec specialized_rows = (row, binds) =>
+    switch (row) {
+    | [] => failwith("Impossible: Empty pattern row in specialize_matrix")
+    | [{pat_desc} as p, ...ptl] =>
+      switch (pat_desc) {
+      | TPatAlias(p, alias, _) =>
+        specialized_rows([p, ...ptl], [(alias, cur), ...binds])
+      | TPatVar(id, _) =>
+        let wildcards = Parmatch.omegas(arity);
+        [(wildcards @ ptl, [(id, cur), ...binds])];
+      | TPatArray(args) when arity == List.length(args) => [
+          (args @ ptl, binds),
+        ]
+      | TPatOr(p1, p2) =>
+        specialized_rows([p1, ...ptl], binds)
+        @ specialized_rows([p2, ...ptl], binds)
+      | _ when pattern_always_matches(p) =>
+        let wildcards = Parmatch.omegas(arity);
+        [(wildcards @ ptl, binds)];
+      | _ => [] /* Specialization for non-arrays generates no rows. */
+      }
+    };
+
+  List.fold_right(
+    ((row, binds, mb), rem) =>
+      List.map(
+        ((patts, binds)) => (patts, binds, mb),
+        specialized_rows(row, binds),
+      )
+      @ rem,
+    mtx,
+    [],
+  );
+};
+
+let rec specialize_constant_matrix = (const, cur, mtx) => {
+  let rec specialized_rows = (row, binds) =>
+    switch (row) {
+    | [] => failwith("Impossible: Empty pattern row in specialize_matrix")
+    | [{pat_desc} as p, ...ptl] =>
+      switch (pat_desc) {
+      | TPatAlias(p, alias, _) =>
+        specialized_rows([p, ...ptl], [(alias, cur), ...binds])
+      | TPatVar(id, _) =>
+        let wildcard = Parmatch.omega;
+        [([wildcard, ...ptl], [(id, cur), ...binds])];
+      | TPatConstant(c) when c == const =>
+        let wildcard = Parmatch.omega;
+        [([wildcard, ...ptl], binds)];
+      | TPatOr(p1, p2) =>
+        specialized_rows([p1, ...ptl], binds)
+        @ specialized_rows([p2, ...ptl], binds)
+      | _ when pattern_always_matches(p) => [(row, binds)]
+      | _ => [] /* Specialization for non-constants generates no rows. */
+      }
+    };
+
+  List.fold_right(
+    ((row, binds, mb), rem) =>
+      List.map(
+        ((patts, binds)) => (patts, binds, mb),
+        specialized_rows(row, binds),
+      )
+      @ rem,
+    mtx,
+    [],
+  );
+};
+
+/* [See paper for details; modified slightly]
+
+      Row: ([p_1; p_2; ...], a_j)
+
+      Pattern p_1 (for row j)       Row(s) of D(P)
+      -----------------------       --------------
+           c(q_1,...,q_n)               No row
+                 _                [([p_1; p_2; ...], a_j)]
+            (q_1 | q_2)           [D(([q_1; p_2; ...], a_j));
+                                   D(([q_2; p_2; ...], a_j))]
+   */
+let rec default_matrix = (cur, mtx) => {
+  let rec default_rows = (row, binds) =>
+    switch (row) {
+    | [] => failwith("Impossible: Empty pattern row in default_matrix")
+    | [{pat_desc} as p, ...ptl] =>
+      switch (pat_desc) {
+      | TPatAlias(inner, alias, _) =>
+        default_rows([inner, ...ptl], [(alias, cur), ...binds])
+      | _ when pattern_always_matches(p) => [(row, binds)]
+      | TPatOr(p1, p2) =>
+        default_rows([p1, ...ptl], binds)
+        @ default_rows([p2, ...ptl], binds)
+      | _ => []
+      }
+    };
+
+  List.fold_right(
+    ((row, binds, mb), rem) =>
+      List.map(
+        ((patts, binds)) => (patts, binds, mb),
+        default_rows(row, binds),
+      )
+      @ rem,
+    mtx,
+    [],
+  );
+};
+
+let equality_type =
+  fun
+  | Const_number(_)
+  | Const_int32(_)
+  | Const_int64(_)
+  | Const_float32(_)
+  | Const_float64(_)
+  | Const_bytes(_)
+  | Const_string(_) => StructuralEquality
+  | Const_void
+  | Const_bool(_)
+  | Const_char(_)
+  | Const_wasmi32(_) => PhysicalEquality
+  | Const_wasmi64(_)
+  | Const_wasmf32(_)
+  | Const_wasmf64(_) =>
+    failwith(
+      "Pattern matching not supported on low-level i64/f32/f64 types.",
+    );
+
+let rec compile_matrix = mtx =>
+  switch (mtx) {
+  | [] => Fail /* No branches to match. */
+  | [(pats, aliases, (mb, i)), ...rest_mtx]
+      when List.for_all(pattern_always_matches, pats) =>
+    let rest_tree =
+      switch (mb.mb_guard) {
+      | Some(guard) =>
+        let result = compile_matrix(rest_mtx);
+        Guard(mb, pats, aliases, Leaf(i, pats, aliases), result);
+      | None => Leaf(i, pats, aliases)
+      };
+    rest_tree;
+  | _ when !col_is_wildcard(mtx, 0) =>
+    /* If the first column contains a non-wildcard pattern */
+
+    let alias = Ident.create("match_explode_alias");
+
+    let matrix_type = matrix_type(mtx);
+    switch (matrix_type) {
+    | TupleMatrix(arity) =>
+      let mtx = flatten_matrix(arity, alias, mtx);
+      let result = compile_matrix(mtx);
+      Explode(matrix_type, alias, result);
+    | ArrayMatrix(_) =>
+      let arities = matrix_head_arities(mtx);
+      let handle_arity = ((_, switch_branches), arity) => {
+        let specialized = specialize_array_matrix(arity, alias, mtx);
+        let result = compile_matrix(specialized);
+        let final_tree = Explode(ArrayMatrix(Some(arity)), alias, result);
+        (final_tree, [(arity, final_tree), ...switch_branches]);
+      };
+
+      switch (arities) {
+      | [] =>
+        failwith(
+          "Internal error: compile_matrix: non-wildcard column returned no arities",
+        )
+      | _ =>
+        let (_, switch_branches) =
+          List.fold_left(handle_arity, (Fail, []), arities);
+
+        let default = default_matrix(alias, mtx);
+        let default_tree =
+          if (List.length(default) != 0) {
+            let tree = compile_matrix(default);
+            Some(tree);
+          } else {
+            None;
+          };
+        Switch(ArraySwitch, switch_branches, default_tree);
+      };
+    | RecordMatrix(labels) =>
+      let mtx = flatten_matrix(Array.length(labels), alias, mtx);
+      let result = compile_matrix(mtx);
+      Explode(matrix_type, alias, result);
+    | ConstructorMatrix(_) =>
+      let constructors = matrix_head_constructors(mtx);
+      /* Printf.eprintf "constructors:\n%s\n" (Sexplib.Sexp.to_string_hum ((Sexplib.Conv.sexp_of_list sexp_of_constructor_description) constructors)); */
+      let handle_constructor = ((_, switch_branches), cstr) => {
+        let arity = cstr.cstr_arity;
+        let specialized = specialize_matrix(cstr, alias, mtx);
+        let result = compile_matrix(specialized);
+        let final_tree =
+          Explode(ConstructorMatrix(Some(arity)), alias, result);
+        (
+          final_tree,
+          [
+            (compile_constructor_tag^(cstr.cstr_tag), final_tree),
+            ...switch_branches,
+          ],
+        );
+      };
+
+      switch (constructors) {
+      | [] =>
+        failwith(
+          "Internal error: compile_matrix: non-wildcard column returned no constructors",
+        )
+      | _ =>
+        let (result, switch_branches) =
+          List.fold_left(handle_constructor, (Fail, []), constructors);
+
+        let default = default_matrix(alias, mtx);
+        let default_tree =
+          if (List.length(default) != 0) {
+            let tree = compile_matrix(default);
+            Some(tree);
+          } else {
+            None;
+          };
+        Switch(ConstructorSwitch, switch_branches, default_tree);
+      };
+    | ConstantMatrix =>
+      let constants = matrix_head_constants(mtx);
+      let equality_type = equality_type(List.hd(constants));
+
+      // TODO: Optimize physical equality checks into a switch.
+      // We can also do partial switches on Numbers if some of the
+      // patterns are stack-allocated numbers. Addtionally, since we
+      // know the types of the non-Number number types, we can make
+      // compilation smarter and also switch on those values after
+      // loaded from the heap.
+
+      let default = default_matrix(alias, mtx);
+      let default_tree =
+        if (List.length(default) != 0) {
+          compile_matrix(default);
+        } else {
+          Fail;
+        };
+
+      List.fold_right(
+        (const, acc) => {
+          let specialized = specialize_constant_matrix(const, alias, mtx);
+          let result = compile_matrix(specialized);
+          Conditional((equality_type, const), alias, result, acc);
+        },
+        constants,
+        default_tree,
+      );
+    };
+  | _ =>
+    /* Adjust stack so non-wildcard column is on top */
+    let (i, rotated) =
+      try(rotate_if_needed(mtx)) {
+      | Not_found =>
+        failwith(
+          "Internal error: convert_match_branches: no non-wildcard column found but not all patterns always match (should be impossible)",
+        )
+      };
+    let result = compile_matrix(rotated);
+    Swap(i, result);
+  };
+
+let convert_match_branches =
+    (match_branches: list(Typedtree.match_branch)): conversion_result => {
+  let mtx = make_matrix(match_branches);
+  let branches =
+    List.map(((_, _, (mb, i))) => (i, mb.mb_body, mb.mb_pat), mtx);
+  {tree: compile_matrix(mtx), branches};
+};
+
 module MatchTreeCompiler = {
   open Anftree;
   open Anf_helper;
@@ -116,231 +686,112 @@ module MatchTreeCompiler = {
     | _ => true
     };
 
-  let no_op = x => x;
-  let compose_binding = (id, cexp, func, x) =>
-    AExp.let_(Nonrecursive, [(id, cexp)], func(x));
-  let with_binding = (id, cexp) => compose_binding(id, cexp, no_op);
-
-  let extract_bindings =
-      (patt: pattern, expr: Anftree.comp_expression)
-      : list((Ident.t, Anftree.comp_expression)) => {
-    /*Printf.eprintf "Extracting bindings from:\n%s\n" (Sexplib.Sexp.to_string_hum (sexp_of_pattern patt));*/
-    let rec extract_bindings = (patt, expr) => {
-      let {pat_loc: loc, pat_env: env} = patt;
-      switch (patt.pat_desc) {
-      | TPatConstant(_)
-      | TPatAny => []
-      | TPatVar(id, _) => [(id, expr)]
-      | TPatAlias(p, id, _) =>
-        let bindings_p = extract_bindings(p, expr);
-        [(id, expr), ...bindings_p];
-      | TPatTuple(args) =>
-        let tup_name = Ident.create("match_bind_tup");
-        let tup_id = Imm.id(~loc, ~env, tup_name);
-        let process_nested = (other_binds, idx, nested_pat) => {
-          let this_binds =
-            if (pattern_could_contain_binding(nested_pat)) {
-              let allocation_type =
-                get_allocation_type(env, nested_pat.pat_type);
-              let tup_arg_name = Ident.create("match_bind_tup_arg");
-              let tup_arg_imm = Imm.id(~loc, ~env, tup_arg_name);
-              let arg_binds =
-                extract_bindings(
-                  nested_pat,
-                  Comp.imm(~loc, ~env, ~allocation_type, tup_arg_imm),
-                );
-              switch (arg_binds) {
-              | [] => []
-              | _ => [
-                  (
-                    tup_arg_name,
-                    Comp.tuple_get(
-                      ~loc,
-                      ~env,
-                      ~allocation_type,
-                      Int32.of_int(idx),
-                      tup_id,
-                    ),
-                  ),
-                  ...arg_binds,
-                ]
-              };
-            } else {
-              [];
-            };
-          this_binds @ other_binds;
-        };
-        let binds = List_utils.fold_lefti(process_nested, [], args);
-        switch (binds) {
-        | [] => []
-        | _ => [(tup_name, expr), ...binds]
-        };
-      | TPatArray(args) =>
-        let arr_name = Ident.create("match_bind_arr");
-        let arr_id = Imm.id(~loc, ~env, arr_name);
-        let process_nested = (other_binds, idx, nested_pat) => {
-          let this_binds =
-            if (pattern_could_contain_binding(nested_pat)) {
-              let allocation_type =
-                get_allocation_type(env, nested_pat.pat_type);
-              let arr_arg_name = Ident.create("match_bind_arr_arg");
-              let arr_arg_imm = Imm.id(~loc, ~env, arr_arg_name);
-              let arg_binds =
-                extract_bindings(
-                  nested_pat,
-                  Comp.imm(~loc, ~env, ~allocation_type, arr_arg_imm),
-                );
-              switch (arg_binds) {
-              | [] => []
-              | _ => [
-                  (
-                    arr_arg_name,
-                    Comp.array_get(
-                      ~loc,
-                      ~env,
-                      ~allocation_type,
-                      Imm.const(
-                        ~loc,
-                        ~env,
-                        Const_number(Const_number_int(Int64.of_int(idx))),
-                      ),
-                      arr_id,
-                    ),
-                  ),
-                  ...arg_binds,
-                ]
-              };
-            } else {
-              [];
-            };
-          this_binds @ other_binds;
-        };
-        let binds = List_utils.fold_lefti(process_nested, [], args);
-        switch (binds) {
-        | [] => []
-        | _ => [(arr_name, expr), ...binds]
-        };
-      | TPatRecord(fields, _) =>
-        let rec_name = Ident.create("match_bind_rec");
-        let rec_id = Imm.id(~loc, ~env, rec_name);
-        let process_nested = (other_binds, (lid, ld, nested_pat)) => {
-          let this_binds =
-            if (pattern_could_contain_binding(nested_pat)) {
-              let allocation_type =
-                get_allocation_type(env, nested_pat.pat_type);
-              let rec_field_name =
-                Ident.create @@
-                "match_bind_rec_field_"
-                ++ Identifier.last(lid.txt);
-              let rec_field_imm = Imm.id(~loc, ~env, rec_field_name);
-              let field_binds =
-                extract_bindings(
-                  nested_pat,
-                  Comp.imm(~loc, ~env, ~allocation_type, rec_field_imm),
-                );
-              switch (field_binds) {
-              | [] => []
-              | _ => [
-                  (
-                    rec_field_name,
-                    Comp.record_get(
-                      ~loc,
-                      ~env,
-                      ~allocation_type,
-                      Int32.of_int(ld.lbl_pos),
-                      rec_id,
-                    ),
-                  ),
-                  ...field_binds,
-                ]
-              };
-            } else {
-              [];
-            };
-          this_binds @ other_binds;
-        };
-        let binds = List.fold_left(process_nested, [], fields);
-        switch (binds) {
-        | [] => []
-        | _ => [(rec_name, expr), ...binds]
-        };
-      | TPatConstruct(_, _, args) =>
-        let data_name = Ident.create("match_bind_data");
-        let data_id = Imm.id(~loc, ~env, data_name);
-        let process_nested = (other_binds, idx, nested_pat) => {
-          let this_binds =
-            if (pattern_could_contain_binding(nested_pat)) {
-              let allocation_type =
-                get_allocation_type(env, nested_pat.pat_type);
-              let cstr_arg_name = Ident.create("match_bind_cstr_arg");
-              let cstr_arg_imm = Imm.id(~loc, ~env, cstr_arg_name);
-              let arg_binds =
-                extract_bindings(
-                  nested_pat,
-                  Comp.imm(~loc, ~env, ~allocation_type, cstr_arg_imm),
-                );
-              switch (arg_binds) {
-              | [] => []
-              | _ => [
-                  (
-                    cstr_arg_name,
-                    Comp.adt_get(
-                      ~loc,
-                      ~env,
-                      ~allocation_type,
-                      Int32.of_int(idx),
-                      data_id,
-                    ),
-                  ),
-                  ...arg_binds,
-                ]
-              };
-            } else {
-              [];
-            };
-          this_binds @ other_binds;
-        };
-        let binds = List_utils.fold_lefti(process_nested, [], args);
-        switch (binds) {
-        | [] => []
-        | _ => [(data_name, expr), ...binds]
-        };
-      | TPatOr(_) => failwith("NYI: extract_bindings > TPatOr")
-      };
-    };
-    let res = extract_bindings(patt, expr);
-    /*Printf.eprintf "Bindings:\n%s\n" (Sexplib.Sexp.to_string_hum (sexp_of_list (sexp_of_pair sexp_of_string (fun x -> (sexp_of_string (Pretty.string_of_cexpr x)))) res));*/
-    res;
-  };
-
-  let fold_tree = (setup, ans) =>
+  let fold_tree = (setup, ans) => {
     List.fold_right(
       (bind, body) =>
         switch (bind) {
         | BLet(name, exp, global) =>
           AExp.let_(~global, Nonrecursive, [(name, exp)], body)
+        | BLetMut(name, exp, global) =>
+          AExp.let_(
+            ~global,
+            ~mut_flag=Mutable,
+            Nonrecursive,
+            [(name, exp)],
+            body,
+          )
+        | BSeq(exp) => AExp.seq(exp, body)
         | _ =>
-          failwith("match_comp: compile_tree_help: bindings were not BLet")
+          failwith("match_comp: compile_tree_help: unsupported binding type")
         },
       setup,
       AExp.comp(ans),
     );
+  };
 
-  let rec compile_tree_help = (tree, values, expr, helpI) => {
-    let (cur_value, rest_values) =
-      switch (values) {
-      | [] => failwith("Impossible (compile_tree_help): Empty value stack")
-      | [hd, ...tl] => (hd, tl)
-      };
+  let set_alias_bindings = (~mut_boxing, env, binds) => {
+    List.map(
+      ((name, value)) =>
+        if (mut_boxing) {
+          BSeq(
+            Comp.assign(
+              ~env,
+              ~allocation_type=HeapAllocated,
+              Imm.id(name),
+              Imm.id(value),
+            ),
+          );
+        } else {
+          BSeq(
+            Comp.local_assign(
+              ~env,
+              ~allocation_type=HeapAllocated,
+              name,
+              Imm.id(value),
+            ),
+          );
+        },
+      binds,
+    );
+  };
+
+  let set_row_bindings = (~mut_boxing, env, patterns, values) => {
+    List.fold_left2(
+      (binds, pat, value) => {
+        let rec collect_binds = (pat, binds) => {
+          let assign = id =>
+            if (mut_boxing) {
+              Comp.assign(
+                ~env,
+                ~allocation_type=
+                  get_allocation_type(pat.pat_env, pat.pat_type),
+                Imm.id(id),
+                value,
+              );
+            } else {
+              Comp.local_assign(
+                ~env,
+                ~allocation_type=
+                  get_allocation_type(pat.pat_env, pat.pat_type),
+                id,
+                value,
+              );
+            };
+          switch (pat.pat_desc) {
+          | TPatAny => binds
+          | TPatVar(id, _) => [BSeq(assign(id)), ...binds]
+          | TPatAlias(pat, id, _) =>
+            collect_binds(pat, [BSeq(assign(id)), ...binds])
+          | _ =>
+            failwith("compile_tree_help: non-bind pattern in collect_binds")
+          };
+        };
+        collect_binds(pat, []) @ binds;
+      },
+      [],
+      patterns,
+      values,
+    );
+  };
+
+  let get_bindings = (~mut_boxing, env, row, values, aliases) => {
+    set_alias_bindings(~mut_boxing, env, aliases)
+    @ set_row_bindings(~mut_boxing, env, row, values);
+  };
+
+  let rec compile_tree_help =
+          (~mut_boxing=false, tree, values, expr, helpI, helpConst) => {
     switch (tree) {
-    | Leaf(i) => (
+    | Leaf(i, patterns, aliases) =>
+      let env = expr.imm_env;
+      (
         Comp.imm(
           ~allocation_type=StackAllocated(WasmI32),
           Imm.const(Const_number(Const_number_int(Int64.of_int(i)))),
         ),
-        [],
-      )
-    | Guard(mb, true_tree, false_tree) =>
+        get_bindings(~mut_boxing, env, patterns, values, aliases),
+      );
+    | Guard(mb, patterns, aliases, true_tree, false_tree) =>
       let guard =
         switch (mb.mb_guard) {
         | Some(guard) => guard
@@ -350,22 +801,18 @@ module MatchTreeCompiler = {
           )
         };
       let bindings =
-        List.map(
-          ((id, expr)) => BLet(id, expr, Nonglobal),
-          extract_bindings(
-            mb.mb_pat,
-            Comp.imm(
-              ~allocation_type=
-                get_allocation_type(mb.mb_pat.pat_env, mb.mb_pat.pat_type),
-              expr,
-            ),
-          ),
+        get_bindings(
+          ~mut_boxing,
+          mb.mb_body.exp_env,
+          patterns,
+          values,
+          aliases,
         );
       let (cond, cond_setup) = helpI(guard);
       let (true_comp, true_setup) =
-        compile_tree_help(true_tree, values, expr, helpI);
+        compile_tree_help(true_tree, values, expr, helpI, helpConst);
       let (false_comp, false_setup) =
-        compile_tree_help(false_tree, values, expr, helpI);
+        compile_tree_help(false_tree, values, expr, helpI, helpConst);
       (
         Comp.if_(
           ~allocation_type=true_comp.comp_allocation_type,
@@ -375,17 +822,66 @@ module MatchTreeCompiler = {
         ),
         bindings @ cond_setup,
       );
+    | Conditional((equality_type, const), alias, true_tree, false_tree) =>
+      let (cur_value, rest_values) =
+        switch (values) {
+        | [] => failwith("Impossible (compile_tree_help): Empty value stack")
+        | [hd, ...tl] => (hd, tl)
+        };
+      let equality_op =
+        switch (equality_type) {
+        | StructuralEquality => Eq
+        | PhysicalEquality => Is
+        };
+      let (const, const_setup) =
+        switch (helpConst(const)) {
+        | Left(imm) => (imm, [])
+        | Right((name, comp)) =>
+          let id = Ident.create(name);
+          (Imm.id(id), [BLet(id, comp, Nonglobal)]);
+        };
+      let cond =
+        Comp.prim2(
+          ~allocation_type=StackAllocated(WasmI32),
+          equality_op,
+          cur_value,
+          const,
+        );
+      let cond_id = Ident.create("match_conditional");
+      let cond_setup = const_setup @ [BLet(cond_id, cond, Nonglobal)];
+      let (true_comp, true_setup) =
+        compile_tree_help(true_tree, values, expr, helpI, helpConst);
+      let (false_comp, false_setup) =
+        compile_tree_help(false_tree, values, expr, helpI, helpConst);
+
+      // Add a binding for aliases
+      let alias_binding =
+        BLet(
+          alias,
+          Comp.imm(~allocation_type=HeapAllocated, cur_value),
+          Nonglobal,
+        );
+
+      (
+        Comp.if_(
+          ~allocation_type=true_comp.comp_allocation_type,
+          Imm.id(cond_id),
+          fold_tree(true_setup, true_comp),
+          fold_tree(false_setup, false_comp),
+        ),
+        [alias_binding, ...cond_setup],
+      );
     | Fail =>
       /* FIXME: We need a "throw error" node in ANF */
       (Comp.imm(~allocation_type=StackAllocated(WasmI32), Imm.trap()), [])
-    /* Optimizations to avoid unneeded destructuring: */
-    | Explode(_, Leaf(_) as inner)
-    | Explode(_, Guard(_, Leaf(_) | Fail, Leaf(_) | Fail) as inner)
-    | Explode(_, Fail as inner) =>
-      compile_tree_help(inner, values, expr, helpI)
-    | Explode(matrix_type, rest) =>
+    | Explode(matrix_type, alias, rest) =>
       /* Tack on the new bindings. We assume that the indices of 'rest'
          already account for the new indices. */
+      let (cur_value, rest_values) =
+        switch (values) {
+        | [] => failwith("Impossible (compile_tree_help): Empty value stack")
+        | [hd, ...tl] => (hd, tl)
+        };
       let bindings =
         switch (matrix_type) {
         | ConstructorMatrix(Some(arity)) =>
@@ -422,7 +918,7 @@ module MatchTreeCompiler = {
               );
             },
           )
-        | ArrayMatrix(arity) =>
+        | ArrayMatrix(Some(arity)) =>
           List.init(
             arity,
             idx => {
@@ -440,6 +936,8 @@ module MatchTreeCompiler = {
               );
             },
           )
+        | ArrayMatrix(None) =>
+          failwith("Internal error: must supply array arity")
         | RecordMatrix(label_poses) =>
           List.map(
             label_pos => {
@@ -456,6 +954,8 @@ module MatchTreeCompiler = {
             },
             Array.to_list(label_poses),
           )
+        | ConstantMatrix =>
+          failwith("Internal error: Explode of a constant matrix")
         };
 
       let new_values =
@@ -467,15 +967,38 @@ module MatchTreeCompiler = {
           bindings,
         )
         @ rest_values;
+
+      // Add a binding for aliases
+      let bindings = [
+        BLet(
+          alias,
+          Comp.imm(~allocation_type=HeapAllocated, cur_value),
+          Nonglobal,
+        ),
+        ...bindings,
+      ];
+
       let (rest_ans, rest_setup) =
-        compile_tree_help(rest, new_values, expr, helpI);
+        compile_tree_help(rest, new_values, expr, helpI, helpConst);
       (rest_ans, bindings @ rest_setup);
     | Swap(idx, rest_tree) =>
-      compile_tree_help(rest_tree, swap_list(idx, values), expr, helpI)
-    | Switch(switch_type, branches, default_tree) =>
-      /* Runs when no branches match */
+      compile_tree_help(
+        rest_tree,
+        swap_list(idx, values),
+        expr,
+        helpI,
+        helpConst,
+      )
+    | Switch(switch_type, cases, default_tree) =>
+      let (cur_value, rest_values) =
+        switch (values) {
+        | [] => failwith("Impossible (compile_tree_help): Empty value stack")
+        | [hd, ...tl] => (hd, tl)
+        };
+
+      /* Runs when no cases match */
       let base_tree = Option.value(~default=Fail, default_tree);
-      let base = compile_tree_help(base_tree, values, expr, helpI);
+      let base = compile_tree_help(base_tree, values, expr, helpI, helpConst);
       let value_constr_name = Ident.create("match_constructor");
       let value_constr_id = Imm.id(value_constr_name);
       let value_constr =
@@ -512,7 +1035,7 @@ module MatchTreeCompiler = {
               ),
             ];
             let (tree_ans, tree_setup) =
-              compile_tree_help(tree, values, expr, helpI);
+              compile_tree_help(tree, values, expr, helpI, helpConst);
             let ans =
               Comp.if_(
                 ~allocation_type=tree_ans.comp_allocation_type,
@@ -523,7 +1046,7 @@ module MatchTreeCompiler = {
             (ans, setup);
           },
           base,
-          branches,
+          cases,
         );
       (
         switch_body_ans,
@@ -535,30 +1058,66 @@ module MatchTreeCompiler = {
     };
   };
 
-  let compile_result =
-      (~allocation_type, ~partial, {tree, branches}, helpA, helpI, expr)
+  let collect_bindings = (~mut_boxing=false, ~global=Nonglobal, branches) => {
+    let rec collect_bindings = pat => {
+      let bind = id => {
+        // Dummy value to be filled in during matching
+        let dummy_value = Imm.const(Const_wasmi32(0l));
+        if (mut_boxing) {
+          BLet(
+            id,
+            Comp.prim1(~allocation_type=HeapAllocated, BoxBind, dummy_value),
+            Nonglobal,
+          );
+        } else {
+          BLetMut(
+            id,
+            Comp.imm(
+              ~allocation_type=get_allocation_type(pat.pat_env, pat.pat_type),
+              dummy_value,
+            ),
+            global,
+          );
+        };
+      };
+      switch (pat.pat_desc) {
+      | TPatAny
+      | TPatConstant(_) => []
+      | TPatVar(id, _) => [bind(id)]
+      | TPatConstruct(_, _, pats)
+      | TPatTuple(pats)
+      | TPatArray(pats) => List.flatten @@ List.map(collect_bindings, pats)
+      | TPatRecord(pats, _) =>
+        List.flatten @@
+        List.map(((_, _, pat)) => collect_bindings(pat), pats)
+      | TPatAlias(pat, id, _) => [bind(id), ...collect_bindings(pat)]
+      | TPatOr(left, _) =>
+        // Bindings are the same on both sides of the OR
+        collect_bindings(left)
+      };
+    };
+    List.flatten @@
+    List.map(((_, _, pat)) => collect_bindings(pat), branches);
+  };
+
+  let compile_match =
+      (~allocation_type, ~partial, branches, expr)
       : (Anftree.comp_expression, list(Anftree.anf_bind)) => {
-    /*prerr_string "Compiling tree:";
-      prerr_string (Sexplib.Sexp.to_string_hum (sexp_of_decision_tree tree));
-      prerr_newline();*/
-    let (ans, setup) = compile_tree_help(tree, [expr], expr, helpI);
+    let helpA = transl_anf_expression^;
+    let helpI = transl_imm_expression^;
+    let helpConst = transl_const^;
+
+    let {tree, branches} = convert_match_branches(branches);
+
+    // Create slots for bindings in each of the branches
+    let bind_setup = collect_bindings(branches);
+    let (ans, setup) =
+      compile_tree_help(tree, [expr], expr, helpI, helpConst);
     let jmp_name = Ident.create("match_dest");
-    let setup = setup @ [BLet(jmp_name, ans, Nonglobal)];
+    let setup = bind_setup @ setup @ [BLet(jmp_name, ans, Nonglobal)];
     let switch_branches =
       List.map(
-        ((tag, branch, orig_pat)) =>
-          (
-            tag,
-            List.fold_right(
-              ((name, exp), body) =>
-                AExp.let_(Nonrecursive, [(name, exp)], body),
-              extract_bindings(
-                orig_pat,
-                Comp.imm(~allocation_type=HeapAllocated, expr),
-              ),
-              helpA(branch),
-            ),
-          ),
+        ((tag, branch, orig_pat)) => (tag, helpA(branch)),
         branches,
       );
     (
@@ -571,499 +1130,40 @@ module MatchTreeCompiler = {
       setup,
     );
   };
-};
 
-let rec pattern_always_matches = patt =>
-  /* Precondition: Normalized */
-  switch (patt.pat_desc) {
-  | TPatAny
-  | TPatVar(_) => true
-  | TPatAlias(p, _, _) => pattern_always_matches(p)
-  | TPatTuple(args) when List.for_all(pattern_always_matches, args) => true
-  | TPatRecord(fields, _)
-      when List.for_all(((_, _, p)) => pattern_always_matches(p), fields) =>
-    true
-  | _ => false
+  let destructure =
+      (~mut_flag=Immutable, ~global=Nonglobal, pattern, expr)
+      : list(Anftree.anf_bind) => {
+    let helpI = transl_imm_expression^;
+    let helpConst = transl_const^;
+
+    // Treat destructuring as a match on a single (but total) branch
+    let branch = {
+      mb_pat: pattern,
+      mb_body: {
+        exp_desc: TExpConstant(Const_void),
+        exp_loc: Location.dummy_loc,
+        exp_extra: [],
+        exp_attributes: [],
+        exp_type: Builtin_types.type_void,
+        exp_env: pattern.pat_env,
+      },
+      mb_guard: None,
+      mb_loc: Location.dummy_loc,
+    };
+
+    let {tree, branches} = convert_match_branches([branch]);
+
+    let mut_boxing =
+      switch (mut_flag, global) {
+      | (Mutable, Nonglobal) => true
+      | _ => false
+      };
+
+    // Create slots for bindings in each of the branches
+    let bind_setup = collect_bindings(~mut_boxing, ~global, branches);
+    let (ans, setup) =
+      compile_tree_help(~mut_boxing, tree, [expr], expr, helpI, helpConst);
+    bind_setup @ setup @ [BSeq(ans)];
   };
-
-let flatten_pattern = (size, {pat_desc}) =>
-  switch (pat_desc) {
-  | TPatTuple(args) => args
-  | TPatRecord([(_, {lbl_all}, _), ..._] as ps, _) =>
-    let patterns = Array.init(Array.length(lbl_all), _ => Parmatch.omega);
-    List.iter(((_, ld, pat)) => patterns[ld.lbl_pos] = pat, ps);
-    Array.to_list(patterns);
-  | TPatVar(_)
-  | TPatAny => Parmatch.omegas(size)
-  | _ =>
-    failwith(
-      "Internal error: flatten_pattern on non-tuple or non-record pattern",
-    )
-  };
-
-let rec matrix_type =
-  fun
-  | []
-  | [([{pat_desc: TPatConstruct(_)}, ..._], _), ..._] =>
-    ConstructorMatrix(None)
-  | [([{pat_desc: TPatTuple(ps)}, ..._], _), ..._] =>
-    TupleMatrix(List.length(ps))
-  | [([{pat_desc: TPatArray(ps)}, ..._], _), ..._] =>
-    ArrayMatrix(List.length(ps))
-  | [([{pat_desc: TPatRecord([(_, ld, _), ..._], _)}, ..._], _), ..._] =>
-    RecordMatrix(Array.map(({lbl_pos}) => lbl_pos, ld.lbl_all))
-  | [_, ...rest] => matrix_type(rest);
-
-let rec pattern_head_constructors_aux = (p, acc) =>
-  switch (p.pat_desc) {
-  | TPatConstruct(_, cd, _) when !List.mem(cd, acc) => [cd, ...acc]
-  | TPatOr(p1, p2) =>
-    pattern_head_constructors_aux(p1, pattern_head_constructors_aux(p2, acc))
-  | _ => acc
-  };
-
-let pattern_head_constructors = patt =>
-  pattern_head_constructors_aux(patt, []);
-
-let matrix_head_constructors = mtx => {
-  let rec help = (mtx, acc) =>
-    switch (mtx) {
-    | [] => acc
-    | [([], _), ..._] => failwith("Impossible: Empty pattern matrix")
-    | [([p, ..._], mb), ...tl] =>
-      help(tl, pattern_head_constructors_aux(p, acc))
-    };
-  help(mtx, []);
-};
-
-let rec pattern_head_arities_aux = (p, acc) =>
-  switch (p.pat_desc) {
-  | TPatArray(ps) when !List.mem(List.length(ps), acc) => [
-      List.length(ps),
-      ...acc,
-    ]
-  | TPatOr(p1, p2) =>
-    pattern_head_arities_aux(p1, pattern_head_arities_aux(p2, acc))
-  | _ => acc
-  };
-
-let pattern_head_arities = patt => pattern_head_arities_aux(patt, []);
-
-let matrix_head_arities = mtx => {
-  let rec help = (mtx, acc) =>
-    switch (mtx) {
-    | [] => acc
-    | [([], _), ..._] => failwith("Impossible: Empty pattern matrix")
-    | [([p, ..._], mb), ...tl] =>
-      help(tl, pattern_head_arities_aux(p, acc))
-    };
-  help(mtx, []);
-};
-
-let make_matrix = branches =>
-  /* Form matrix and assign each branch a number */
-  List.mapi((i, {mb_pat} as mb) => ([mb_pat], (mb, i)), branches);
-
-let matrix_width =
-  fun
-  | [] => raise(Not_found)
-  | [(pats, _), ..._] => List.length(pats);
-
-let rec col_is_wildcard = (mtx, col) =>
-  switch (mtx) {
-  | [] => true
-  | [(pats, _), ..._] when !pattern_always_matches(List.nth(pats, col)) =>
-    false
-  | [_, ...tl] => col_is_wildcard(tl, col)
-  };
-
-let rec rotate_matrix = (mtx, col) =>
-  switch (mtx) {
-  | [] => []
-  | [(pats, mb), ...tl] =>
-    let tl = rotate_matrix(tl, col);
-    let rotated_row = swap_list(col, pats);
-    [(rotated_row, mb), ...tl];
-  };
-
-let rec rotate_if_needed = mtx =>
-  if (!col_is_wildcard(mtx, 0)) {
-    (0, mtx);
-  } else {
-    switch (mtx) {
-    | [] => (0, mtx)
-    | _ =>
-      /* Safe, since size 0 matrix is wildcard */
-      let width = matrix_width(mtx);
-      let rec find_rotation = n =>
-        if (n >= width) {
-          raise(Not_found);
-        } else if (!col_is_wildcard(mtx, n)) {
-          (n, rotate_matrix(mtx, n));
-        } else {
-          find_rotation(n + 1);
-        };
-      find_rotation(1);
-    };
-  };
-
-/* [See paper for details]
-
-      Row: ([p_1; p_2; ...], a_j)
-
-      Pattern p_1 (for row j)             Row(s) of S(c, P -> A)
-      -------------------------           ----------------------
-           c(q_1,...,q_n)           [([q_1; ...; q_n; p_2; ...], a_j)]
-      c'(q_1,...,q_n) (c' <> c)                  No row
-                 _                    [([_; ...; _; p_2; ...], a_j)] [n wildcards]
-            (q_1 | q_2)               [(S(c, ([q_1; p_2; ...], a_j)));
-                                       (S(c, ([q_2; p_2; ...], a_j)))]
-   */
-let rec specialize_matrix = (cd, mtx) => {
-  let arity = cd.cstr_arity;
-  let rec specialized_rows = row =>
-    switch (row) {
-    | [] => failwith("Impossible: Empty pattern row in specialize_matrix")
-    | [{pat_desc} as p, ...ptl] =>
-      switch (pat_desc) {
-      | _ when pattern_always_matches(p) =>
-        let wildcards = List.init(arity, _ => {...p, pat_desc: TPatAny});
-        [wildcards @ ptl];
-      | TPatConstruct(_, pcd, args) when cd == pcd => [args @ ptl]
-      | TPatOr(p1, p2) =>
-        specialized_rows([p1, ...ptl]) @ specialized_rows([p2, ...ptl])
-      | TPatAlias(p, _, _) => specialized_rows([p, ...ptl])
-      | _ => [] /* Specialization for non-constructors generates no rows. */
-      }
-    };
-
-  List.fold_right(
-    ((row, mb), rem) =>
-      List.map(patts => (patts, mb), specialized_rows(row)) @ rem,
-    mtx,
-    [],
-  );
-};
-
-let rec specialize_array_matrix = (arity, mtx) => {
-  let rec specialized_rows = row =>
-    switch (row) {
-    | [] => failwith("Impossible: Empty pattern row in specialize_matrix")
-    | [{pat_desc} as p, ...ptl] =>
-      switch (pat_desc) {
-      | _ when pattern_always_matches(p) =>
-        let wildcards = List.init(arity, _ => {...p, pat_desc: TPatAny});
-        [wildcards @ ptl];
-      | TPatArray(args) when arity == List.length(args) => [args @ ptl]
-      | TPatOr(p1, p2) =>
-        specialized_rows([p1, ...ptl]) @ specialized_rows([p2, ...ptl])
-      | TPatAlias(p, _, _) => specialized_rows([p, ...ptl])
-      | _ => [] /* Specialization for non-arrays generates no rows. */
-      }
-    };
-
-  List.fold_right(
-    ((row, mb), rem) =>
-      List.map(patts => (patts, mb), specialized_rows(row)) @ rem,
-    mtx,
-    [],
-  );
-};
-
-/* [See paper for details]
-
-      Row: ([p_1; p_2; ...], a_j)
-
-      Pattern p_1 (for row j)       Row(s) of D(P)
-      -----------------------       --------------
-           c(q_1,...,q_n)               No row
-                 _                [([p_2; ...], a_j)]
-            (q_1 | q_2)           [D(([q_1; p_2; ...], a_j));
-                                   D(([q_2; p_2; ...], a_j))]
-   */
-let rec default_matrix = mtx => {
-  let rec default_rows = row =>
-    switch (row) {
-    | [] => failwith("Impossible: Empty pattern row in default_matrix")
-    | [{pat_desc} as p, ...ptl] =>
-      switch (pat_desc) {
-      | _ when pattern_always_matches(p) => [ptl]
-      | TPatOr(p1, p2) =>
-        default_rows([p1, ...ptl]) @ default_rows([p2, ...ptl])
-      | _ => []
-      }
-    };
-
-  List.fold_right(
-    ((row, mb), rem) =>
-      List.map(patts => (patts, mb), default_rows(row)) @ rem,
-    mtx,
-    [],
-  );
-};
-
-let rec compile_matrix = mtx =>
-  switch (mtx) {
-  | [] => Fail /* No branches to match. */
-  | [(pats, (mb, i)), ...rest_mtx]
-      when List.for_all(pattern_always_matches, pats) =>
-    let rest_tree =
-      switch (mb.mb_guard) {
-      | Some(guard) =>
-        let result = compile_matrix(rest_mtx);
-        Guard(mb, Leaf(i), result);
-      | None => Leaf(i)
-      };
-    rest_tree;
-  | _ when !col_is_wildcard(mtx, 0) =>
-    /* If the first column contains a non-wildcard pattern */
-    let matrix_type = matrix_type(mtx);
-    switch (matrix_type) {
-    | TupleMatrix(arity) =>
-      let mtx =
-        List.map(
-          ((row, mb)) => (flatten_pattern(arity, List.hd(row)), mb),
-          mtx,
-        );
-      let result = compile_matrix(mtx);
-      Explode(matrix_type, result);
-    | ArrayMatrix(arity) =>
-      let arities = matrix_head_arities(mtx);
-      let handle_arity = ((_, switch_branches), arity) => {
-        let specialized = specialize_array_matrix(arity, mtx);
-        let result = compile_matrix(specialized);
-        let final_tree = Explode(ArrayMatrix(arity), result);
-        (final_tree, [(arity, final_tree), ...switch_branches]);
-      };
-
-      switch (arities) {
-      | [] =>
-        failwith(
-          "Internal error: compile_matrix: non-wildcard column returned no arities",
-        )
-      | _ =>
-        let (_, switch_branches) =
-          List.fold_left(handle_arity, (Fail, []), arities);
-
-        let default = default_matrix(mtx);
-        let default_tree =
-          if (List.length(default) != 0) {
-            let tree = compile_matrix(default);
-            Some(tree);
-          } else {
-            None;
-          };
-        Switch(ArraySwitch, switch_branches, default_tree);
-      };
-    | RecordMatrix(labels) =>
-      let mtx =
-        List.map(
-          ((row, mb)) =>
-            (flatten_pattern(Array.length(labels), List.hd(row)), mb),
-          mtx,
-        );
-      let result = compile_matrix(mtx);
-      Explode(matrix_type, result);
-    | ConstructorMatrix(_) =>
-      let constructors = matrix_head_constructors(mtx);
-      /* Printf.eprintf "constructors:\n%s\n" (Sexplib.Sexp.to_string_hum ((Sexplib.Conv.sexp_of_list sexp_of_constructor_description) constructors)); */
-      let handle_constructor = ((_, switch_branches), cstr) => {
-        let arity = cstr.cstr_arity;
-        let specialized = specialize_matrix(cstr, mtx);
-        let result = compile_matrix(specialized);
-        let final_tree = Explode(ConstructorMatrix(Some(arity)), result);
-        (
-          final_tree,
-          [
-            (compile_constructor_tag^(cstr.cstr_tag), final_tree),
-            ...switch_branches,
-          ],
-        );
-      };
-
-      switch (constructors) {
-      | [] =>
-        failwith(
-          "Internal error: compile_matrix: non-wildcard column returned no constructors",
-        )
-      | _ =>
-        let (result, switch_branches) =
-          List.fold_left(handle_constructor, (Fail, []), constructors);
-
-        let default = default_matrix(mtx);
-        let default_tree =
-          if (List.length(default) != 0) {
-            let tree = compile_matrix(default);
-            Some(tree);
-          } else {
-            None;
-          };
-        Switch(ConstructorSwitch, switch_branches, default_tree);
-      };
-    };
-  | _ =>
-    /* Adjust stack so non-wildcard column is on top */
-    let (i, rotated) =
-      try(rotate_if_needed(mtx)) {
-      | Not_found =>
-        failwith(
-          "Internal error: convert_match_branches: no non-wildcard column found but not all patterns always match (should be impossible)",
-        )
-      };
-    let result = compile_matrix(rotated);
-    Swap(i, result);
-  };
-
-/* Currently, this only desugars constant patterns into guard expressions,
- * but could be extended to do any other necessary preprocessing.
- */
-let prepare_match_branches = (env, branches) => {
-  let map_branch = branch => {
-    let guard = ref(branch.mb_guard);
-    let make_vd = (id, ty) => {
-      val_type: ty,
-      val_repr: Type_utils.repr_of_type(env, ty),
-      val_kind: TValReg,
-      val_fullpath: PIdent(id),
-      val_mutable: false,
-      val_global: false,
-      val_loc: Location.dummy_loc,
-    };
-    let make_expr = (~ty=Builtin_types.type_bool, desc, env, loc) => {
-      exp_desc: desc,
-      exp_loc: loc,
-      exp_extra: [],
-      exp_attributes: [],
-      exp_env: env,
-      exp_type: ty,
-    };
-    let type_constant = c => {
-      switch (c) {
-      | Const_void => Builtin_types.type_void
-      | Const_bool(_) => Builtin_types.type_bool
-      | Const_number(_) => Builtin_types.type_number
-      | Const_int32(_) => Builtin_types.type_int32
-      | Const_int64(_) => Builtin_types.type_int64
-      | Const_float32(_) => Builtin_types.type_float32
-      | Const_float64(_) => Builtin_types.type_float64
-      | Const_wasmi32(_) => Builtin_types.type_wasmi32
-      | Const_wasmi64(_) => Builtin_types.type_wasmi64
-      | Const_wasmf32(_) => Builtin_types.type_wasmf32
-      | Const_wasmf64(_) => Builtin_types.type_wasmf64
-      | Const_bytes(_) => Builtin_types.type_bytes
-      | Const_string(_) => Builtin_types.type_string
-      | Const_char(_) => Builtin_types.type_char
-      };
-    };
-    let equality_operator = c => {
-      switch (c) {
-      | Const_number(_)
-      | Const_int32(_)
-      | Const_int64(_)
-      | Const_float32(_)
-      | Const_float64(_)
-      | Const_bytes(_)
-      | Const_string(_)
-      | Const_char(_) => Eq
-      | Const_void
-      | Const_bool(_)
-      | Const_wasmi32(_) => Is
-      | Const_wasmi64(_)
-      | Const_wasmf32(_)
-      | Const_wasmf64(_) =>
-        failwith(
-          "Pattern matching not supported on low-level i64/f32/f64 types.",
-        )
-      };
-    };
-    let add_constant_guard = (id, c, loc) => {
-      let ty = type_constant(c);
-      let vd = make_vd(id, ty);
-      let expr = env => {
-        let ident =
-          TExpIdent(
-            PIdent(id),
-            {txt: IdentName(Ident.name(id)), loc},
-            vd,
-          );
-        let ident = make_expr(~ty, ident, env, loc);
-        let const = make_expr(~ty, TExpConstant(c), env, loc);
-        make_expr(TExpPrim2(equality_operator(c), ident, const), env, loc);
-      };
-      switch (guard^) {
-      | Some(g) =>
-        let env = g.exp_env;
-        let env = Env.add_value(id, vd, env);
-        guard := Some(make_expr(TExpPrim2(And, expr(env), g), env, loc));
-      | None =>
-        let env = branch.mb_body.exp_env;
-        let env = Env.add_value(id, vd, env);
-        guard := Some(expr(env));
-      };
-    };
-    let rec extract_constants = pat => {
-      switch (pat.pat_desc) {
-      | TPatAny
-      | TPatVar(_) => pat
-      | TPatConstant(c) =>
-        let id = Ident.create("match_constant");
-        add_constant_guard(id, c, pat.pat_loc);
-        {
-          ...pat,
-          pat_desc: TPatVar(id, {txt: Ident.name(id), loc: pat.pat_loc}),
-        };
-      | TPatAlias(p1, a, b) => {
-          ...pat,
-          pat_desc: TPatAlias(extract_constants(p1), a, b),
-        }
-      | TPatConstruct(a, b, args) => {
-          ...pat,
-          pat_desc: TPatConstruct(a, b, List.map(extract_constants, args)),
-        }
-      | TPatTuple(args) => {
-          ...pat,
-          pat_desc: TPatTuple(List.map(extract_constants, args)),
-        }
-      | TPatArray(args) => {
-          ...pat,
-          pat_desc: TPatArray(List.map(extract_constants, args)),
-        }
-      | TPatRecord(fields, c) => {
-          ...pat,
-          pat_desc:
-            TPatRecord(
-              List.map(
-                ((id, ld, pat)) => (id, ld, extract_constants(pat)),
-                fields,
-              ),
-              c,
-            ),
-        }
-      | TPatOr(p1, p2) => {
-          ...pat,
-          pat_desc: TPatOr(extract_constants(p1), extract_constants(p2)),
-        }
-      };
-    };
-    let pat = extract_constants(branch.mb_pat);
-    let guard = guard^;
-    {...branch, mb_guard: guard, mb_pat: pat};
-  };
-
-  List.map(map_branch, branches);
-};
-
-let convert_match_branches =
-    (env, match_branches: list(Typedtree.match_branch)): conversion_result => {
-  let match_branches = prepare_match_branches(env, match_branches);
-  let mtx = make_matrix(match_branches);
-  /*prerr_string "Initial matrix:\n";
-    prerr_string (Sexplib.Sexp.to_string_hum (Sexplib.Conv.sexp_of_list
-                                                (Sexplib.Conv.sexp_of_pair
-                                                   (Sexplib.Conv.sexp_of_list sexp_of_pattern)
-                                                   sexp_of_match_branch) mtx));
-    prerr_newline();*/
-  let branches =
-    List.map(((_, (mb, i))) => (i, mb.mb_body, mb.mb_pat), mtx);
-  {tree: compile_matrix(mtx), branches};
 };

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -888,9 +888,10 @@ module MatchTreeCompiler = {
         ),
         [alias_binding, ...cond_setup],
       );
-    | Fail =>
-      /* FIXME: We need a "throw error" node in ANF */
-      (Comp.imm(~allocation_type=StackAllocated(WasmI32), Imm.trap()), [])
+    | Fail => (
+        Comp.imm(~allocation_type=StackAllocated(WasmI32), Imm.trap()),
+        [],
+      )
     | Explode(matrix_type, alias, rest) =>
       /* Tack on the new bindings. We assume that the indices of 'rest'
          already account for the new indices. */

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -981,7 +981,9 @@ module MatchTreeCompiler = {
           fun
           | BLet(id, _, _) => Imm.id(id)
           | _ =>
-            failwith("matchcomp: compile_tree_help: binding was not BLet"),
+            failwith(
+              "Impossible: matchcomp: compile_tree_help: binding was not BLet",
+            ),
           bindings,
         )
         @ rest_values;

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -646,7 +646,8 @@ let rec compile_matrix = mtx =>
       let constants = matrix_head_constants(mtx);
       let equality_type = equality_type(List.hd(constants));
 
-      // TODO: Optimize physical equality checks into a switch.
+      // TODO: https://github.com/grain-lang/grain/issues/1185
+      // Optimize physical equality checks into a switch.
       // We can also do partial switches on Numbers if some of the
       // patterns are stack-allocated numbers. Addtionally, since we
       // know the types of the non-Number number types, we can make

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -10,7 +10,7 @@ open Grain_utils;
 open Types;
 open Typedtree;
 open Type_utils;
-open Either;
+open Stdlib.Either;
 
 /** The type for compiled match pattern decision trees.
     These trees are evaluated with respect to a stack of values. */
@@ -480,27 +480,27 @@ let rec specialize_constant_matrix = (const, cur, mtx) => {
 
 /* [See paper for details; modified slightly]
 
-    We differ from the paper in that we don't drop the first pattern of the row
-    in the case of an "any" pattern. This is done to have a fully matching row
-    represent the current value stack—each value on the stack now directly
-    corresponds to a pattern in the row. This allows us to efficiently use the
-    bindings created during the pattern matching process in the selected branch.
+   We differ from the paper in that we don't drop the first pattern of the row
+   in the case of an "any" pattern. This is done to have a fully matching row
+   represent the current value stack—each value on the stack now directly
+   corresponds to a pattern in the row. This allows us to efficiently use the
+   bindings created during the pattern matching process in the selected branch.
 
-    This doesn't significantly change anything about compilation of matching
-    with respect to the paper. From the paper's perspective, the pattern is no
-    longer needed and can just be dropped/disregarded. It is slightly faster to
-    drop the pattern (in terms of compilation time) as it wouldn't need to ever
-    be validated again, but we sacrifice this for ease of implementation.
+   This doesn't significantly change anything about compilation of matching
+   with respect to the paper. From the paper's perspective, the pattern is no
+   longer needed and can just be dropped/disregarded. It is slightly faster to
+   drop the pattern (in terms of compilation time) as it wouldn't need to ever
+   be validated again, but we sacrifice this for ease of implementation.
 
-       Row: ([p_1; p_2; ...], a_j)
+      Row: ([p_1; p_2; ...], a_j)
 
-       Pattern p_1 (for row j)       Row(s) of D(P)
-       -----------------------       --------------
-            c(q_1,...,q_n)               No row
-                  _                [([p_1; p_2; ...], a_j)]
-             (q_1 | q_2)           [D(([q_1; p_2; ...], a_j));
-                                    D(([q_2; p_2; ...], a_j))]
-    */
+      Pattern p_1 (for row j)       Row(s) of D(P)
+      -----------------------       --------------
+           c(q_1,...,q_n)               No row
+                 _                [([p_1; p_2; ...], a_j)]
+            (q_1 | q_2)           [D(([q_1; p_2; ...], a_j));
+                                   D(([q_2; p_2; ...], a_j))]
+   */
 let rec default_matrix = (cur, mtx) => {
   let rec default_rows = (row, binds) =>
     switch (row) {

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -3862,6 +3862,32 @@ program: LET LPAREN WASMI64 COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ##
+program: LET NUMBER_INT PIPE WHILE
+##
+## Ends in an error in state: 345.
+##
+## pattern -> pattern PIPE . pattern [ WHEN THICKARROW RPAREN RBRACK RBRACE PIPE EQUAL EOL COMMA COLON ]
+## pattern -> pattern PIPE . eols pattern [ WHEN THICKARROW RPAREN RBRACK RBRACE PIPE EQUAL EOL COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## pattern PIPE
+##
+program: LET NUMBER_INT PIPE EOL WHILE
+##
+## Ends in an error in state: 404.
+##
+## pattern -> pattern PIPE eols . pattern [ WHEN THICKARROW RPAREN RBRACK RBRACE PIPE EQUAL EOL COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## pattern PIPE eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
 
 Expected a pattern.
 

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -250,6 +250,7 @@ pattern:
   | type_id { Pat.construct ~loc:(to_loc $loc) $1 [] }
   | lbrack rbrack { Pat.list ~loc:(to_loc $loc) [] }
   | lbrack lseparated_nonempty_list(comma, list_item_pat) comma? rbrack { Pat.list ~loc:(to_loc $loc) $2 }
+  | pattern pipe_op opt_eols pattern { Pat.or_ ~loc:(to_loc $loc) $1 $4 }
 
 list_item_pat:
   | ELLIPSIS pattern { ListSpread ($2, to_loc $loc) }

--- a/compiler/src/utils/either.re
+++ b/compiler/src/utils/either.re
@@ -1,4 +1,0 @@
-// Remove in OCaml 4.12
-type t('a, 'b) =
-  | Left('a)
-  | Right('b);

--- a/compiler/src/utils/either.re
+++ b/compiler/src/utils/either.re
@@ -1,0 +1,4 @@
+// Remove in OCaml 4.12
+type t('a, 'b) =
+  | Left('a)
+  | Right('b);

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -30,7 +30,77 @@ functions › lam_destructure_5
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local.set $7
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $14
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -46,13 +116,190 @@ functions › lam_destructure_5
     )
    )
   )
-  (local.set $8
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $5
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $14)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $5)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $13)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $12)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $15
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $16
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $7
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $16)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $7)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $6
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $15)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $6)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $8
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (i32.load offset=8
+       (local.get $8)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -65,10 +312,23 @@ functions › lam_destructure_5
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $9
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $8)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
       (i32.load offset=8
-       (local.get $1)
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -81,10 +341,23 @@ functions › lam_destructure_5
   (local.set $10
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $2)
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $10
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $9)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $6)
+      )
+      (i32.load offset=8
+       (local.get $10)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -97,24 +370,8 @@ functions › lam_destructure_5
   (local.set $11
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $2)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $3
-   (tuple.extract 0
-    (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $11
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -122,104 +379,17 @@ functions › lam_destructure_5
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $4
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (local.get $10)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $7)
       )
       (i32.load offset=8
-       (local.get $4)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $5
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $11)
       )
-      (i32.load offset=8
-       (local.get $5)
-      )
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $6
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
-      )
-      (i32.load offset=8
-       (local.get $6)
-      )
-     )
-     (local.get $6)
+     (local.get $11)
     )
    )
   )
@@ -244,7 +414,61 @@ functions › lam_destructure_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
    )
   )
   (drop
@@ -265,31 +489,7 @@ functions › lam_destructure_5
     (local.get $10)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (local.get $6)
+  (local.get $11)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -26,12 +26,48 @@ functions › lam_destructure_3
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
+      (i32.load offset=8
        (local.get $1)
       )
      )
@@ -42,7 +78,7 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $5
+  (local.set $8
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -58,12 +94,12 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $6
+  (local.set $9
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
+      (i32.load offset=16
        (local.get $1)
       )
      )
@@ -74,11 +110,77 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $2
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $9)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $8)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
+      (local.tee $5
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -86,14 +188,14 @@ functions › lam_destructure_3
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
+       (local.get $3)
       )
       (i32.load offset=8
-       (local.get $2)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -103,11 +205,11 @@ functions › lam_destructure_3
     )
    )
   )
-  (local.set $3
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $6
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -115,17 +217,17 @@ functions › lam_destructure_3
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $5)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $6)
       )
      )
-     (local.get $3)
+     (local.get $6)
     )
    )
   )
@@ -144,7 +246,37 @@ functions › lam_destructure_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
    )
   )
   (drop
@@ -153,19 +285,7 @@ functions › lam_destructure_3
     (local.get $5)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $3)
+  (local.get $6)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -29,12 +29,60 @@ functions › lam_destructure_7
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
+      (i32.load offset=8
        (local.get $1)
       )
      )
@@ -45,39 +93,7 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $7
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $8
+  (local.set $11
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -98,7 +114,7 @@ functions › lam_destructure_7
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
+      (i32.load offset=16
        (local.get $1)
       )
      )
@@ -109,26 +125,29 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $2
+  (local.set $12
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
        (local.get $9)
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (i32.load offset=8
-       (local.get $2)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -138,11 +157,99 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $3
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $10)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $11)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $5
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $13)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $5)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $12)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $6
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -154,10 +261,10 @@ functions › lam_destructure_7
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
+       (local.get $3)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $6)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -167,29 +274,58 @@ functions › lam_destructure_7
     )
    )
   )
-  (local.set $4
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $4
+      (local.tee $7
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
        )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $6)
       )
-      (i32.load offset=8
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
+      (i32.load offset=8
+       (local.get $7)
+      )
      )
-     (local.get $4)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $8
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $7)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (i32.load offset=8
+       (local.get $8)
+      )
+     )
+     (local.get $8)
     )
    )
   )
@@ -208,7 +344,55 @@ functions › lam_destructure_7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
    )
   )
   (drop
@@ -223,31 +407,7 @@ functions › lam_destructure_7
     (local.get $7)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $4)
+  (local.get $8)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -27,12 +27,48 @@ functions › lam_destructure_4
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
+      (i32.load offset=8
        (local.get $1)
       )
      )
@@ -43,7 +79,7 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $5
+  (local.set $8
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -59,12 +95,12 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $6
+  (local.set $9
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
+      (i32.load offset=16
        (local.get $1)
       )
      )
@@ -75,11 +111,77 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $2
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $9)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $8)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
+      (local.tee $5
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -87,14 +189,14 @@ functions › lam_destructure_4
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
+       (local.get $3)
       )
       (i32.load offset=8
-       (local.get $2)
+       (local.get $5)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -104,11 +206,11 @@ functions › lam_destructure_4
     )
    )
   )
-  (local.set $3
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $6
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -116,17 +218,17 @@ functions › lam_destructure_4
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
+       (local.get $5)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $6)
       )
      )
-     (local.get $3)
+     (local.get $6)
     )
    )
   )
@@ -145,7 +247,37 @@ functions › lam_destructure_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
    )
   )
   (drop
@@ -154,19 +286,7 @@ functions › lam_destructure_4
     (local.get $5)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (local.get $3)
+  (local.get $6)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -30,12 +30,60 @@ functions › lam_destructure_8
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
+      (i32.load offset=8
        (local.get $1)
       )
      )
@@ -46,39 +94,7 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $7
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $5)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $8
+  (local.set $11
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -99,7 +115,7 @@ functions › lam_destructure_8
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
+      (i32.load offset=16
        (local.get $1)
       )
      )
@@ -110,26 +126,29 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $2
+  (local.set $12
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
        (local.get $9)
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (i32.load offset=8
-       (local.get $2)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -139,11 +158,99 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $3
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $10)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $11)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $5
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $13)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $5)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $12)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $6
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -155,10 +262,10 @@ functions › lam_destructure_8
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
+       (local.get $3)
       )
       (i32.load offset=8
-       (local.get $3)
+       (local.get $6)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -168,29 +275,58 @@ functions › lam_destructure_8
     )
    )
   )
-  (local.set $4
+  (local.set $7
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $4
+      (local.tee $7
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
        )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $6)
       )
-      (i32.load offset=8
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $4)
       )
+      (i32.load offset=8
+       (local.get $7)
+      )
      )
-     (local.get $4)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $8
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $7)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (i32.load offset=8
+       (local.get $8)
+      )
+     )
+     (local.get $8)
     )
    )
   )
@@ -209,7 +345,55 @@ functions › lam_destructure_8
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
    )
   )
   (drop
@@ -224,31 +408,7 @@ functions › lam_destructure_8
     (local.get $7)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $4)
+  (local.get $8)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -31,7 +31,77 @@ functions › lam_destructure_6
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local.set $7
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $14
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -47,13 +117,190 @@ functions › lam_destructure_6
     )
    )
   )
-  (local.set $8
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $5
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $14)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $5)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $13)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $12)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $15
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $16
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $1)
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $7
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $16)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $7)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $6
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $15)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $6)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $8
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (i32.load offset=8
+       (local.get $8)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -66,10 +313,23 @@ functions › lam_destructure_6
   (local.set $9
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $9
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $8)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
       (i32.load offset=8
-       (local.get $1)
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -82,10 +342,23 @@ functions › lam_destructure_6
   (local.set $10
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $2)
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $10
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $9)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $6)
+      )
+      (i32.load offset=8
+       (local.get $10)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -98,24 +371,8 @@ functions › lam_destructure_6
   (local.set $11
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $2)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $3
-   (tuple.extract 0
-    (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
+      (local.tee $11
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -123,104 +380,17 @@ functions › lam_destructure_6
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
-      )
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $4
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (local.get $10)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $7)
       )
       (i32.load offset=8
-       (local.get $4)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $5
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $11)
       )
-      (i32.load offset=8
-       (local.get $5)
-      )
      )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $6
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
-      )
-      (i32.load offset=8
-       (local.get $6)
-      )
-     )
-     (local.get $6)
+     (local.get $11)
     )
    )
   )
@@ -245,7 +415,61 @@ functions › lam_destructure_6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
    )
   )
   (drop
@@ -266,31 +490,7 @@ functions › lam_destructure_6
     (local.get $10)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (local.get $6)
+  (local.get $11)
  )
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -25,6 +25,8 @@ pattern matching › record_match_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -138,15 +140,10 @@ pattern matching › record_match_3
     )
    )
   )
-  (local.set $2
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -154,7 +151,18 @@ pattern matching › record_match_3
     )
    )
   )
-  (local.set $3
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -170,9 +178,69 @@ pattern matching › record_match_3
     )
    )
   )
-  (local.set $1
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $3
    (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $1
+    (local.tee $3
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_+)
@@ -180,14 +248,14 @@ pattern matching › record_match_3
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $3)
+     (local.get $1)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $2)
     )
     (i32.load offset=8
-     (local.get $1)
+     (local.get $3)
     )
    )
   )
@@ -200,16 +268,28 @@ pattern matching › record_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $4)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -26,6 +26,8 @@ pattern matching › adt_match_deep
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -104,7 +106,7 @@ pattern matching › adt_match_deep
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $0
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -115,15 +117,55 @@ pattern matching › adt_match_deep
     )
    )
   )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $0
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $3)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_pervasives_[])
+      )
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $2
-   (block $switch.21_outer (result i32)
+   (block $switch.28_outer (result i32)
     (drop
-     (block $switch.21_branch_1 (result i32)
+     (block $switch.28_branch_1 (result i32)
       (drop
-       (block $switch.21_branch_2 (result i32)
+       (block $switch.28_branch_2 (result i32)
         (drop
-         (block $switch.21_default (result i32)
-          (br_table $switch.21_branch_1 $switch.21_branch_2 $switch.21_default
+         (block $switch.28_default (result i32)
+          (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_default
            (i32.const 0)
            (i32.shr_s
             (if (result i32)
@@ -133,35 +175,7 @@ pattern matching › adt_match_deep
                 (i32.eq
                  (local.tee $2
                   (i32.load offset=12
-                   (local.tee $1
-                    (tuple.extract 0
-                     (tuple.make
-                      (call_indirect (type $i32_i32_i32_=>_i32)
-                       (local.tee $1
-                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (global.get $gimport_pervasives_[...])
-                        )
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (local.get $0)
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (global.get $gimport_pervasives_[])
-                       )
-                       (i32.load offset=8
-                        (local.get $1)
-                       )
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                       (i32.const 0)
-                      )
-                     )
-                    )
-                   )
+                   (local.get $1)
                   )
                  )
                  (i32.const 3)
@@ -172,7 +186,63 @@ pattern matching › adt_match_deep
               )
               (i32.const 31)
              )
-             (i32.const 3)
+             (block (result i32)
+              (local.set $4
+               (tuple.extract 0
+                (tuple.make
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (i32.load offset=20
+                   (local.get $1)
+                  )
+                 )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                  (i32.const 0)
+                 )
+                )
+               )
+              )
+              (local.set $5
+               (tuple.extract 0
+                (tuple.make
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (i32.load offset=16
+                   (local.get $4)
+                  )
+                 )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                  (i32.const 0)
+                 )
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $0
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $0)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (i32.const 3)
+             )
              (if (result i32)
               (i32.shr_u
                (i32.or
@@ -199,28 +269,10 @@ pattern matching › adt_match_deep
         (unreachable)
        )
       )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $1)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (i32.const 0)
-         )
-        )
-       )
-      )
-      (br $switch.21_outer
+      (br $switch.28_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=16
-         (local.get $3)
-        )
+        (local.get $0)
        )
       )
      )
@@ -231,7 +283,7 @@ pattern matching › adt_match_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $3)
    )
   )
   (drop
@@ -243,7 +295,19 @@ pattern matching › adt_match_deep
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (local.get $2)

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -35,11 +35,19 @@ pattern matching › tuple_match_deep4
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (local.set $10
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local.set $18
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -51,7 +59,7 @@ pattern matching › tuple_match_deep4
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -62,7 +70,7 @@ pattern matching › tuple_match_deep4
    )
   )
   (i32.store
-   (local.tee $0
+   (local.tee $1
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -71,24 +79,134 @@ pattern matching › tuple_match_deep4
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $10)
+    (local.get $18)
    )
   )
-  (local.set $0
+  (local.set $14
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -97,20 +215,36 @@ pattern matching › tuple_match_deep4
    )
   )
   (local.set $1
-   (block $switch.53_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $14)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.91_outer (result i32)
     (drop
-     (block $switch.53_branch_1 (result i32)
+     (block $switch.91_branch_1 (result i32)
       (drop
-       (block $switch.53_branch_2 (result i32)
+       (block $switch.91_branch_2 (result i32)
         (drop
-         (block $switch.53_branch_3 (result i32)
+         (block $switch.91_branch_3 (result i32)
           (drop
-           (block $switch.53_branch_4 (result i32)
+           (block $switch.91_branch_4 (result i32)
             (drop
-             (block $switch.53_branch_5 (result i32)
+             (block $switch.91_branch_5 (result i32)
               (drop
-               (block $switch.53_default (result i32)
-                (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_branch_3 $switch.53_branch_4 $switch.53_branch_5 $switch.53_default
+               (block $switch.91_default (result i32)
+                (br_table $switch.91_branch_1 $switch.91_branch_2 $switch.91_branch_3 $switch.91_branch_4 $switch.91_branch_5 $switch.91_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -118,15 +252,15 @@ pattern matching › tuple_match_deep4
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $11
+                         (local.tee $15
                           (tuple.extract 0
                            (tuple.make
                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                              (i32.load offset=12
-                              (local.get $0)
+                              (local.get $14)
                              )
                             )
                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -146,45 +280,29 @@ pattern matching › tuple_match_deep4
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $11)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $15)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
                            (local.tee $3
                             (tuple.extract 0
@@ -192,7 +310,7 @@ pattern matching › tuple_match_deep4
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $15)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -212,48 +330,291 @@ pattern matching › tuple_match_deep4
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $16
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $3)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $17
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $19
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $17)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $20
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $17)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $10)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $11)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $12
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $16)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $12)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $13
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $19)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $13)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $7
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $7)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $9
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $16)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $9)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -262,23 +623,54 @@ pattern matching › tuple_match_deep4
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $5
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $5)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $6
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $6)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -287,7 +679,7 @@ pattern matching › tuple_match_deep4
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -296,7 +688,31 @@ pattern matching › tuple_match_deep4
                      )
                      (i32.const 31)
                     )
-                    (i32.const 1)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $1)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $4)
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 1879048190)
+                       )
+                      )
+                     )
+                     (i32.const 1)
+                    )
                     (unreachable)
                    )
                   )
@@ -308,7 +724,7 @@ pattern matching › tuple_match_deep4
               (unreachable)
              )
             )
-            (br $switch.53_outer
+            (br $switch.91_outer
              (i32.const 1999)
             )
            )
@@ -316,9 +732,22 @@ pattern matching › tuple_match_deep4
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -332,10 +761,23 @@ pattern matching › tuple_match_deep4
           (local.set $3
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $2)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -345,147 +787,9 @@ pattern matching › tuple_match_deep4
             )
            )
           )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $12
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $8
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $12)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $8)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $9
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $9)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.53_outer
+          (br $switch.91_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -493,14 +797,14 @@ pattern matching › tuple_match_deep4
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $9)
+             (local.get $3)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $13)
             )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
@@ -509,88 +813,8 @@ pattern matching › tuple_match_deep4
         (local.set $2
          (tuple.extract 0
           (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $3)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $5
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -602,22 +826,22 @@ pattern matching › tuple_match_deep4
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $5)
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (local.get $2)
            )
           )
          )
         )
-        (br $switch.53_outer
+        (br $switch.91_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -625,70 +849,22 @@ pattern matching › tuple_match_deep4
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $5)
+           (local.get $2)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $4)
+           (local.get $9)
           )
-          (i32.load offset=8
-           (local.get $1)
-          )
-         )
-        )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=12
-           (local.get $0)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $2)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $2)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $3)
-         )
-        )
-       )
-      )
-      (local.set $4
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
            (local.get $0)
           )
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $4)
-         )
         )
        )
       )
-      (br $switch.53_outer
+      (br $switch.91_outer
        (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
+        (local.tee $0
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (global.get $gimport_pervasives_+)
@@ -696,14 +872,14 @@ pattern matching › tuple_match_deep4
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
+         (local.get $5)
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $3)
+         (local.get $6)
         )
         (i32.load offset=8
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -711,46 +887,32 @@ pattern matching › tuple_match_deep4
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (local.get $0)
-     )
+     (local.get $4)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
+    (local.get $18)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $14)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -768,7 +930,25 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
    )
   )
   (drop
@@ -780,16 +960,58 @@ pattern matching › tuple_match_deep4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $13)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (local.get $1)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $17)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $19)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $20)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -30,11 +30,17 @@ pattern matching › adt_match_4
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local.set $6
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local.set $12
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -46,7 +52,7 @@ pattern matching › adt_match_4
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -56,11 +62,11 @@ pattern matching › adt_match_4
     )
    )
   )
-  (local.set $7
+  (local.set $13
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -69,10 +75,10 @@ pattern matching › adt_match_4
       (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $12)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -83,20 +89,112 @@ pattern matching › adt_match_4
    )
   )
   (local.set $1
-   (block $switch.54_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 9)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $13)
+      )
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.78_outer (result i32)
     (drop
-     (block $switch.54_branch_1 (result i32)
+     (block $switch.78_branch_1 (result i32)
       (drop
-       (block $switch.54_branch_2 (result i32)
+       (block $switch.78_branch_2 (result i32)
         (drop
-         (block $switch.54_branch_3 (result i32)
+         (block $switch.78_branch_3 (result i32)
           (drop
-           (block $switch.54_branch_4 (result i32)
+           (block $switch.78_branch_4 (result i32)
             (drop
-             (block $switch.54_branch_5 (result i32)
+             (block $switch.78_branch_5 (result i32)
               (drop
-               (block $switch.54_default (result i32)
-                (br_table $switch.54_branch_1 $switch.54_branch_2 $switch.54_branch_3 $switch.54_branch_4 $switch.54_branch_5 $switch.54_default
+               (block $switch.78_default (result i32)
+                (br_table $switch.78_branch_1 $switch.78_branch_2 $switch.78_branch_3 $switch.78_branch_4 $switch.78_branch_5 $switch.78_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -104,34 +202,9 @@ pattern matching › adt_match_4
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $0
-                          (tuple.extract 0
-                           (tuple.make
-                            (call_indirect (type $i32_i32_i32_=>_i32)
-                             (local.tee $0
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (global.get $gimport_pervasives_[...])
-                              )
-                             )
-                             (i32.const 9)
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $7)
-                             )
-                             (i32.load offset=8
-                              (local.get $0)
-                             )
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                         )
+                         (local.get $1)
                         )
                        )
                        (i32.const 3)
@@ -142,53 +215,37 @@ pattern matching › adt_match_4
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $0)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $1)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
-                           (local.tee $3
+                           (local.tee $9
                             (tuple.extract 0
                              (tuple.make
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $1)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -208,48 +265,247 @@ pattern matching › adt_match_4
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $10
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $9)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $9)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $14
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $11)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $15
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $11)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $6
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $6)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $7
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $10)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $7)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $8
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $14)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $8)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $4)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $5
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $10)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $5)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -258,23 +514,32 @@ pattern matching › adt_match_4
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $3
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $3)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -283,7 +548,7 @@ pattern matching › adt_match_4
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -304,7 +569,7 @@ pattern matching › adt_match_4
               (unreachable)
              )
             )
-            (br $switch.54_outer
+            (br $switch.78_outer
              (i32.const 1999)
             )
            )
@@ -312,9 +577,22 @@ pattern matching › adt_match_4
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $7)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -325,102 +603,9 @@ pattern matching › adt_match_4
             )
            )
           )
-          (local.set $3
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $3)
-             )
-            )
-           )
-          )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $5
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $9)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (i32.load offset=8
-               (local.get $5)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.54_outer
+          (br $switch.78_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -428,70 +613,22 @@ pattern matching › adt_match_4
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $5)
+             (local.get $2)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $1)
-            )
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
              (local.get $0)
             )
            )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
           )
          )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (br $switch.54_outer
+        (br $switch.78_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -503,21 +640,19 @@ pattern matching › adt_match_4
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
         )
        )
       )
-      (br $switch.54_outer
+      (br $switch.78_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=20
-         (local.get $0)
-        )
+        (local.get $3)
        )
       )
      )
@@ -528,25 +663,19 @@ pattern matching › adt_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
+    (local.get $12)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+    (local.get $13)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
@@ -564,7 +693,31 @@ pattern matching › adt_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
    )
   )
   (drop
@@ -576,10 +729,28 @@ pattern matching › adt_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $10)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -21,6 +21,8 @@ pattern matching › record_match_2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -104,7 +106,7 @@ pattern matching › record_match_2
    (local.get $0)
    (i64.const 7303010)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -147,7 +149,7 @@ pattern matching › record_match_2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (i32.store offset=24
@@ -165,12 +167,71 @@ pattern matching › record_match_2
     )
    )
   )
-  (local.set $2
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $4
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=20
-     (local.get $0)
-    )
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -182,10 +243,10 @@ pattern matching › record_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $3)
    )
   )
-  (local.get $2)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -23,9 +23,8 @@ pattern matching › constant_match_3
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   (i32.store
-   (local.tee $1
+   (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -34,17 +33,17 @@ pattern matching › constant_match_3
    (i32.const 1)
   )
   (i32.store offset=4
-   (local.get $1)
+   (local.get $0)
    (i32.const 3)
   )
   (i64.store offset=8
-   (local.get $1)
+   (local.get $0)
    (i64.const 7303014)
   )
   (local.set $1
    (tuple.extract 0
     (tuple.make
-     (local.get $1)
+     (local.get $0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -69,7 +68,7 @@ pattern matching › constant_match_3
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $2
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -80,106 +79,38 @@ pattern matching › constant_match_3
     )
    )
   )
-  (local.set $0
-   (block $switch.28_outer (result i32)
+  (local.set $2
+   (block $switch.13_outer (result i32)
     (drop
-     (block $switch.28_branch_1 (result i32)
+     (block $switch.13_branch_1 (result i32)
       (drop
-       (block $switch.28_branch_2 (result i32)
+       (block $switch.13_branch_2 (result i32)
         (drop
-         (block $switch.28_branch_3 (result i32)
+         (block $switch.13_branch_3 (result i32)
           (drop
-           (block $switch.28_default (result i32)
-            (br_table $switch.28_branch_1 $switch.28_branch_2 $switch.28_branch_3 $switch.28_default
+           (block $switch.13_default (result i32)
+            (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_branch_3 $switch.13_default
              (i32.const 0)
              (i32.shr_s
-              (if (result i32)
+              (select
+               (i32.const 3)
+               (i32.const 5)
                (i32.shr_u
-                (select
-                 (i32.const 2147483646)
-                 (local.tee $0
-                  (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                   )
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (local.get $1)
-                   )
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (local.get $2)
-                   )
-                  )
+                (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
                  )
-                 (i32.shr_u
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (local.get $1)
+                 )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                   (local.get $0)
-                  (i32.const 31)
                  )
                 )
                 (i32.const 31)
-               )
-               (i32.const 1)
-               (block (result i32)
-                (i32.store
-                 (local.tee $0
-                  (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                   (i32.const 16)
-                  )
-                 )
-                 (i32.const 1)
-                )
-                (i32.store offset=4
-                 (local.get $0)
-                 (i32.const 3)
-                )
-                (i64.store offset=8
-                 (local.get $0)
-                 (i64.const 7303014)
-                )
-                (local.set $3
-                 (tuple.extract 0
-                  (tuple.make
-                   (local.get $0)
-                   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                    (i32.const 0)
-                   )
-                  )
-                 )
-                )
-                (select
-                 (i32.const 3)
-                 (i32.const 5)
-                 (i32.shr_u
-                  (select
-                   (i32.const -2)
-                   (local.tee $0
-                    (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (local.get $1)
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (local.get $3)
-                     )
-                    )
-                   )
-                   (i32.shr_u
-                    (local.get $0)
-                    (i32.const 31)
-                   )
-                  )
-                  (i32.const 31)
-                 )
-                )
                )
               )
               (i32.const 1)
@@ -190,12 +121,12 @@ pattern matching › constant_match_3
           (unreachable)
          )
         )
-        (br $switch.28_outer
+        (br $switch.13_outer
          (i32.const 2147483646)
         )
        )
       )
-      (br $switch.28_outer
+      (br $switch.13_outer
        (i32.const -2)
       )
      )
@@ -212,16 +143,10 @@ pattern matching › constant_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $0)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (local.get $0)
+  (local.get $2)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -23,6 +23,11 @@ pattern matching › guarded_match_2
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -59,7 +64,40 @@ pattern matching › guarded_match_2
     )
    )
   )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -75,23 +113,119 @@ pattern matching › guarded_match_2
     )
    )
   )
-  (local.set $1
-   (block $switch.13_outer (result i32)
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $7
+   (block $switch.29_outer (result i32)
     (drop
-     (block $switch.13_branch_1 (result i32)
+     (block $switch.29_branch_1 (result i32)
       (drop
-       (block $switch.13_branch_2 (result i32)
+       (block $switch.29_branch_2 (result i32)
         (drop
-         (block $switch.13_default (result i32)
-          (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
+         (block $switch.29_default (result i32)
+          (br_table $switch.29_branch_1 $switch.29_branch_2 $switch.29_default
            (i32.const 0)
            (i32.shr_s
-            (select
-             (i32.const 1)
-             (i32.const 3)
+            (if (result i32)
              (i32.shr_u
               (call_indirect (type $i32_i32_i32_=>_i32)
-               (local.tee $1
+               (local.tee $7
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                  (global.get $gimport_pervasives_==)
@@ -99,15 +233,85 @@ pattern matching › guarded_match_2
                )
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (local.get $2)
+                (local.get $1)
                )
                (i32.const 3)
                (i32.load offset=8
-                (local.get $1)
+                (local.get $7)
                )
               )
               (i32.const 31)
              )
+             (block (result i32)
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $3
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $6)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $2)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $4)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.const 3)
             )
             (i32.const 1)
            )
@@ -117,7 +321,7 @@ pattern matching › guarded_match_2
         (unreachable)
        )
       )
-      (br $switch.13_outer
+      (br $switch.29_outer
        (i32.const 199)
       )
      )
@@ -134,10 +338,40 @@ pattern matching › guarded_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (local.get $7)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -30,6 +30,10 @@ pattern matching › tuple_match_deep
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -51,7 +55,7 @@ pattern matching › tuple_match_deep
    (local.get $0)
    (i32.const 11)
   )
-  (local.set $5
+  (local.set $9
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -83,7 +87,7 @@ pattern matching › tuple_match_deep
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $5)
+    (local.get $9)
    )
   )
   (i32.store offset=16
@@ -101,15 +105,21 @@ pattern matching › tuple_match_deep
     )
    )
   )
-  (local.set $6
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -120,9 +130,31 @@ pattern matching › tuple_match_deep
   (local.set $3
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
+      (i32.load offset=8
        (local.get $0)
       )
      )
@@ -139,38 +171,6 @@ pattern matching › tuple_match_deep
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $8
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $9
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
        (local.get $0)
       )
      )
@@ -181,26 +181,13 @@ pattern matching › tuple_match_deep
     )
    )
   )
-  (local.set $1
+  (local.set $11
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $1
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $9)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
-      )
-      (i32.load offset=8
-       (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -210,11 +197,131 @@ pattern matching › tuple_match_deep
     )
    )
   )
-  (local.set $2
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $7)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $7)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $11)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $10)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $13)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $12)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
+      (local.tee $5
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -226,11 +333,40 @@ pattern matching › tuple_match_deep
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $8)
+       (local.get $4)
       )
       (i32.load offset=8
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $6
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $2)
       )
+      (i32.load offset=8
+       (local.get $6)
+      )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -239,9 +375,9 @@ pattern matching › tuple_match_deep
     )
    )
   )
-  (local.set $4
+  (local.set $8
    (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $4
+    (local.tee $8
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_+)
@@ -249,57 +385,27 @@ pattern matching › tuple_match_deep
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $2)
+     (local.get $6)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $7)
+     (local.get $3)
     )
     (i32.load offset=8
-     (local.get $4)
+     (local.get $8)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -314,7 +420,61 @@ pattern matching › tuple_match_deep
     (local.get $2)
    )
   )
-  (local.get $4)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (local.get $8)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -21,6 +21,8 @@ pattern matching › record_match_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -104,7 +106,7 @@ pattern matching › record_match_1
    (local.get $0)
    (i64.const 7303010)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -147,7 +149,7 @@ pattern matching › record_match_1
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (i32.store offset=24
@@ -165,12 +167,71 @@ pattern matching › record_match_1
     )
    )
   )
-  (local.set $2
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $4
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (local.get $0)
-    )
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
    )
   )
   (drop
@@ -182,10 +243,10 @@ pattern matching › record_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $3)
    )
   )
-  (local.get $2)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -45,7 +45,7 @@ pattern matching › constant_match_2
    (local.get $0)
    (i64.const 7303014)
   )
-  (local.set $5
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -73,7 +73,7 @@ pattern matching › constant_match_2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $5)
+    (local.get $4)
    )
   )
   (i32.store offset=12
@@ -95,31 +95,7 @@ pattern matching › constant_match_2
     )
    )
   )
-  (local.set $1
-   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (local.get $0)
-    )
-   )
-  )
-  (local.set $6
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $0)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $7
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -135,294 +111,223 @@ pattern matching › constant_match_2
     )
    )
   )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (i32.store
+   (local.tee $1
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 1)
+  )
+  (i32.store offset=4
+   (local.get $1)
+   (i32.const 3)
+  )
+  (i64.store offset=8
+   (local.get $1)
+   (i64.const 7496034)
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $1
-   (block $switch.60_outer (result i32)
+   (block $switch.45_outer (result i32)
     (drop
-     (block $switch.60_branch_1 (result i32)
+     (block $switch.45_branch_1 (result i32)
       (drop
-       (block $switch.60_branch_2 (result i32)
+       (block $switch.45_branch_2 (result i32)
         (drop
-         (block $switch.60_branch_3 (result i32)
+         (block $switch.45_branch_3 (result i32)
           (drop
-           (block $switch.60_branch_4 (result i32)
+           (block $switch.45_branch_4 (result i32)
             (drop
-             (block $switch.60_default (result i32)
-              (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
+             (block $switch.45_default (result i32)
+              (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_default
                (i32.const 0)
                (i32.shr_s
                 (if (result i32)
                  (i32.shr_u
+                  (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $3)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $6)
+                   )
+                  )
+                  (i32.const 31)
+                 )
+                 (if (result i32)
+                  (i32.shr_u
+                   (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (i32.const 11)
+                   )
+                   (i32.const 31)
+                  )
+                  (select
+                   (i32.const 1)
+                   (i32.const 7)
+                   (i32.shr_u
+                    (i32.or
+                     (i32.shl
+                      (i32.eq
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $2)
+                       )
+                       (i32.const 2147483646)
+                      )
+                      (i32.const 31)
+                     )
+                     (i32.const 2147483646)
+                    )
+                    (i32.const 31)
+                   )
+                  )
+                  (i32.const 7)
+                 )
+                 (block (result i32)
+                  (i32.store
+                   (local.tee $1
+                    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+                     (i32.const 16)
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.store offset=4
+                   (local.get $1)
+                   (i32.const 3)
+                  )
+                  (i64.store offset=8
+                   (local.get $1)
+                   (i64.const 7303014)
+                  )
+                  (local.set $7
+                   (tuple.extract 0
+                    (tuple.make
+                     (local.get $1)
+                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                      (i32.const 0)
+                     )
+                    )
+                   )
+                  )
                   (if (result i32)
                    (i32.shr_u
-                    (local.tee $1
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.get $1)
-                        (i32.const 2147483646)
-                       )
-                       (i32.const 31)
-                      )
-                      (i32.const 2147483646)
+                    (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $3)
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $7)
                      )
                     )
                     (i32.const 31)
                    )
                    (if (result i32)
                     (i32.shr_u
-                     (local.tee $1
-                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (local.get $6)
-                       )
-                       (i32.const 11)
-                      )
-                     )
-                     (i32.const 31)
-                    )
-                    (block (result i32)
-                     (i32.store
-                      (local.tee $2
-                       (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                        (i32.const 16)
-                       )
-                      )
-                      (i32.const 1)
-                     )
-                     (i32.store offset=4
-                      (local.get $2)
-                      (i32.const 3)
-                     )
-                     (i64.store offset=8
-                      (local.get $2)
-                      (i64.const 7496034)
-                     )
-                     (local.set $2
-                      (tuple.extract 0
-                       (tuple.make
-                        (local.get $2)
-                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                         (i32.const 0)
-                        )
-                       )
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $7)
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $2)
-                      )
-                     )
-                    )
-                    (local.get $1)
-                   )
-                   (local.get $1)
-                  )
-                  (i32.const 31)
-                 )
-                 (i32.const 1)
-                 (block (result i32)
-                  (local.set $1
-                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                    (i32.load offset=16
-                     (local.get $0)
-                    )
-                   )
-                  )
-                  (local.set $2
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (i32.load offset=8
-                       (local.get $0)
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                      (local.get $2)
-                     )
-                    )
-                   )
-                  )
-                  (if (result i32)
-                   (i32.shr_u
-                    (if (result i32)
-                     (i32.shr_u
-                      (local.tee $1
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (local.get $1)
-                          (i32.const -2)
-                         )
-                         (i32.const 31)
+                     (i32.or
+                      (i32.shl
+                       (i32.eq
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (local.get $2)
                         )
                         (i32.const 2147483646)
                        )
+                       (i32.const 31)
                       )
-                      (i32.const 31)
+                      (i32.const 2147483646)
                      )
-                     (block (result i32)
-                      (i32.store
-                       (local.tee $3
-                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                         (i32.const 16)
-                        )
-                       )
-                       (i32.const 1)
-                      )
-                      (i32.store offset=4
-                       (local.get $3)
-                       (i32.const 3)
-                      )
-                      (i64.store offset=8
-                       (local.get $3)
-                       (i64.const 7303014)
-                      )
-                      (local.set $3
-                       (tuple.extract 0
-                        (tuple.make
-                         (local.get $3)
-                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                          (i32.const 0)
-                         )
-                        )
-                       )
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (local.get $2)
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (local.get $3)
-                       )
-                      )
-                     )
-                     (local.get $1)
+                     (i32.const 31)
                     )
-                    (i32.const 31)
-                   )
-                   (i32.const 3)
-                   (block (result i32)
-                    (local.set $1
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (i32.load offset=16
-                       (local.get $0)
-                      )
-                     )
-                    )
-                    (local.set $3
-                     (tuple.extract 0
-                      (tuple.make
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (i32.load offset=8
-                         (local.get $0)
-                        )
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (local.get $3)
-                       )
-                      )
-                     )
-                    )
+                    (i32.const 5)
                     (select
-                     (i32.const 5)
+                     (i32.const 3)
                      (i32.const 7)
                      (i32.shr_u
-                      (if (result i32)
-                       (i32.shr_u
-                        (local.tee $1
-                         (i32.or
-                          (i32.shl
-                           (i32.eq
-                            (local.get $1)
-                            (i32.const 2147483646)
-                           )
-                           (i32.const 31)
-                          )
-                          (i32.const 2147483646)
+                      (i32.or
+                       (i32.shl
+                        (i32.eq
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $2)
                          )
+                         (i32.const -2)
                         )
                         (i32.const 31)
                        )
-                       (block (result i32)
-                        (i32.store
-                         (local.tee $4
-                          (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                           (i32.const 16)
-                          )
-                         )
-                         (i32.const 1)
-                        )
-                        (i32.store offset=4
-                         (local.get $4)
-                         (i32.const 3)
-                        )
-                        (i64.store offset=8
-                         (local.get $4)
-                         (i64.const 7303014)
-                        )
-                        (local.set $4
-                         (tuple.extract 0
-                          (tuple.make
-                           (local.get $4)
-                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                            (i32.const 0)
-                           )
-                          )
-                         )
-                        )
-                        (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                         )
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (local.get $3)
-                         )
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (local.get $4)
-                         )
-                        )
-                       )
-                       (local.get $1)
+                       (i32.const 2147483646)
                       )
                       (i32.const 31)
                      )
                     )
                    )
+                   (i32.const 7)
                   )
                  )
                 )
@@ -434,22 +339,40 @@ pattern matching › constant_match_2
             (unreachable)
            )
           )
-          (br $switch.60_outer
+          (br $switch.45_outer
            (i32.const 2147483646)
           )
          )
         )
-        (br $switch.60_outer
+        (br $switch.45_outer
          (i32.const -2)
         )
        )
       )
-      (br $switch.60_outer
+      (br $switch.45_outer
        (i32.const 2147483646)
       )
      )
     )
     (i32.const 2147483646)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (drop
@@ -461,7 +384,7 @@ pattern matching › constant_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $2)
    )
   )
   (drop
@@ -474,24 +397,6 @@ pattern matching › constant_match_2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $7)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (local.get $1)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -27,6 +27,9 @@ pattern matching › record_match_4
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -140,15 +143,32 @@ pattern matching › record_match_4
     )
    )
   )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $3
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=24
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -156,23 +176,7 @@ pattern matching › record_match_4
     )
    )
   )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $0)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
+  (local.set $6
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -188,26 +192,13 @@ pattern matching › record_match_4
     )
    )
   )
-  (local.set $1
+  (local.set $7
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $1
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $5)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (i32.load offset=8
-       (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -217,9 +208,120 @@ pattern matching › record_match_4
     )
    )
   )
-  (local.set $2
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=24
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $8)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $4
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $2)
+      )
+      (i32.load offset=8
+       (local.get $4)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
    (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $2
+    (local.tee $5
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_+)
@@ -227,14 +329,14 @@ pattern matching › record_match_4
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $1)
+     (local.get $4)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $3)
     )
     (i32.load offset=8
-     (local.get $2)
+     (local.get $5)
     )
    )
   )
@@ -247,7 +349,37 @@ pattern matching › record_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
    )
   )
   (drop
@@ -256,19 +388,7 @@ pattern matching › record_match_4
     (local.get $4)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (local.get $2)
+  (local.get $5)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -37,11 +37,19 @@ pattern matching › tuple_match_deep6
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local.set $10
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local.set $18
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -53,7 +61,7 @@ pattern matching › tuple_match_deep6
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -63,11 +71,11 @@ pattern matching › tuple_match_deep6
     )
    )
   )
-  (local.set $11
+  (local.set $19
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -76,10 +84,10 @@ pattern matching › tuple_match_deep6
       (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $18)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -89,11 +97,11 @@ pattern matching › tuple_match_deep6
     )
    )
   )
-  (local.set $12
+  (local.set $20
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -102,10 +110,10 @@ pattern matching › tuple_match_deep6
       (i32.const 9)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $11)
+       (local.get $19)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -116,7 +124,7 @@ pattern matching › tuple_match_deep6
    )
   )
   (i32.store
-   (local.tee $0
+   (local.tee $1
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -125,24 +133,134 @@ pattern matching › tuple_match_deep6
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $12)
+    (local.get $20)
    )
   )
-  (local.set $0
+  (local.set $14
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -151,20 +269,36 @@ pattern matching › tuple_match_deep6
    )
   )
   (local.set $1
-   (block $switch.59_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $14)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.97_outer (result i32)
     (drop
-     (block $switch.59_branch_1 (result i32)
+     (block $switch.97_branch_1 (result i32)
       (drop
-       (block $switch.59_branch_2 (result i32)
+       (block $switch.97_branch_2 (result i32)
         (drop
-         (block $switch.59_branch_3 (result i32)
+         (block $switch.97_branch_3 (result i32)
           (drop
-           (block $switch.59_branch_4 (result i32)
+           (block $switch.97_branch_4 (result i32)
             (drop
-             (block $switch.59_branch_5 (result i32)
+             (block $switch.97_branch_5 (result i32)
               (drop
-               (block $switch.59_default (result i32)
-                (br_table $switch.59_branch_1 $switch.59_branch_2 $switch.59_branch_3 $switch.59_branch_4 $switch.59_branch_5 $switch.59_default
+               (block $switch.97_default (result i32)
+                (br_table $switch.97_branch_1 $switch.97_branch_2 $switch.97_branch_3 $switch.97_branch_4 $switch.97_branch_5 $switch.97_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -172,15 +306,15 @@ pattern matching › tuple_match_deep6
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $13
+                         (local.tee $15
                           (tuple.extract 0
                            (tuple.make
                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                              (i32.load offset=12
-                              (local.get $0)
+                              (local.get $14)
                              )
                             )
                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -200,45 +334,29 @@ pattern matching › tuple_match_deep6
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $13)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $15)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
                            (local.tee $3
                             (tuple.extract 0
@@ -246,7 +364,7 @@ pattern matching › tuple_match_deep6
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $15)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -266,48 +384,291 @@ pattern matching › tuple_match_deep6
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $16
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $3)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $17
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $21
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $17)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $22
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $17)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $10)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $11)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $12
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $16)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $12)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $13
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $21)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $13)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $7
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $7)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $9
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $16)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $9)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -316,23 +677,54 @@ pattern matching › tuple_match_deep6
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $5
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $5)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $6
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $6)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -341,7 +733,7 @@ pattern matching › tuple_match_deep6
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -350,7 +742,31 @@ pattern matching › tuple_match_deep6
                      )
                      (i32.const 31)
                     )
-                    (i32.const 1)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $1)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $4)
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 1879048190)
+                       )
+                      )
+                     )
+                     (i32.const 1)
+                    )
                     (unreachable)
                    )
                   )
@@ -362,7 +778,7 @@ pattern matching › tuple_match_deep6
               (unreachable)
              )
             )
-            (br $switch.59_outer
+            (br $switch.97_outer
              (i32.const 1999)
             )
            )
@@ -370,9 +786,22 @@ pattern matching › tuple_match_deep6
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -386,10 +815,23 @@ pattern matching › tuple_match_deep6
           (local.set $3
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $2)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -399,147 +841,9 @@ pattern matching › tuple_match_deep6
             )
            )
           )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $14
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $8
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $14)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $8)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $9
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $9)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.59_outer
+          (br $switch.97_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -547,14 +851,14 @@ pattern matching › tuple_match_deep6
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $9)
+             (local.get $3)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $13)
             )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
@@ -563,88 +867,8 @@ pattern matching › tuple_match_deep6
         (local.set $2
          (tuple.extract 0
           (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $3)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $5
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -656,22 +880,22 @@ pattern matching › tuple_match_deep6
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $5)
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (local.get $2)
            )
           )
          )
         )
-        (br $switch.59_outer
+        (br $switch.97_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -679,70 +903,22 @@ pattern matching › tuple_match_deep6
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $5)
+           (local.get $2)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $4)
+           (local.get $9)
           )
-          (i32.load offset=8
-           (local.get $1)
-          )
-         )
-        )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=12
-           (local.get $0)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $2)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $2)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $3)
-         )
-        )
-       )
-      )
-      (local.set $4
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
            (local.get $0)
           )
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $4)
-         )
         )
        )
       )
-      (br $switch.59_outer
+      (br $switch.97_outer
        (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
+        (local.tee $0
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (global.get $gimport_pervasives_+)
@@ -750,14 +926,14 @@ pattern matching › tuple_match_deep6
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
+         (local.get $5)
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $3)
+         (local.get $6)
         )
         (i32.load offset=8
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -765,10 +941,68 @@ pattern matching › tuple_match_deep6
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (local.get $0)
-     )
+     (local.get $4)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $18)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $19)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $20)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
    )
   )
   (drop
@@ -792,13 +1026,19 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $13)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $13)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
    )
   )
   (drop
@@ -816,46 +1056,28 @@ pattern matching › tuple_match_deep6
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $16)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
+    (local.get $17)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+    (local.get $21)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $22)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $14)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -23,6 +23,9 @@ pattern matching › tuple_match_3
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -40,7 +43,7 @@ pattern matching › tuple_match_3
    (local.get $0)
    (i64.const 1886351202)
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -72,7 +75,7 @@ pattern matching › tuple_match_3
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $2)
+    (local.get $3)
    )
   )
   (i32.store offset=16
@@ -90,23 +93,21 @@ pattern matching › tuple_match_3
     )
    )
   )
-  (local.set $5
-   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (local.get $1)
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
     )
    )
   )
-  (local.set $3
+  (local.set $2
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -130,6 +131,88 @@ pattern matching › tuple_match_3
     )
    )
   )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $7
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -147,24 +230,24 @@ pattern matching › tuple_match_3
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $4)
+    (local.get $7)
    )
   )
   (i32.store offset=12
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $3)
+    (local.get $2)
    )
   )
   (i32.store offset=16
    (local.get $0)
-   (local.get $5)
+   (local.get $8)
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $3)
    )
   )
   (drop
@@ -176,13 +259,31 @@ pattern matching › tuple_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -33,8 +33,16 @@ pattern matching › tuple_match_deep3
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   (i32.store
-   (local.tee $0
+   (local.tee $1
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -43,24 +51,134 @@ pattern matching › tuple_match_deep3
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_pervasives_[])
    )
   )
-  (local.set $0
+  (local.set $14
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -69,20 +187,36 @@ pattern matching › tuple_match_deep3
    )
   )
   (local.set $1
-   (block $switch.50_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $14)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.88_outer (result i32)
     (drop
-     (block $switch.50_branch_1 (result i32)
+     (block $switch.88_branch_1 (result i32)
       (drop
-       (block $switch.50_branch_2 (result i32)
+       (block $switch.88_branch_2 (result i32)
         (drop
-         (block $switch.50_branch_3 (result i32)
+         (block $switch.88_branch_3 (result i32)
           (drop
-           (block $switch.50_branch_4 (result i32)
+           (block $switch.88_branch_4 (result i32)
             (drop
-             (block $switch.50_branch_5 (result i32)
+             (block $switch.88_branch_5 (result i32)
               (drop
-               (block $switch.50_default (result i32)
-                (br_table $switch.50_branch_1 $switch.50_branch_2 $switch.50_branch_3 $switch.50_branch_4 $switch.50_branch_5 $switch.50_default
+               (block $switch.88_default (result i32)
+                (br_table $switch.88_branch_1 $switch.88_branch_2 $switch.88_branch_3 $switch.88_branch_4 $switch.88_branch_5 $switch.88_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -90,15 +224,15 @@ pattern matching › tuple_match_deep3
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $10
+                         (local.tee $15
                           (tuple.extract 0
                            (tuple.make
                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                              (i32.load offset=12
-                              (local.get $0)
+                              (local.get $14)
                              )
                             )
                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -118,45 +252,29 @@ pattern matching › tuple_match_deep3
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $10)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $15)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
                            (local.tee $3
                             (tuple.extract 0
@@ -164,7 +282,7 @@ pattern matching › tuple_match_deep3
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $15)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -184,48 +302,291 @@ pattern matching › tuple_match_deep3
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $16
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $3)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $17
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $18
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $17)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $19
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $17)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $10)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $11)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $12
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $16)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $12)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $13
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $18)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $13)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $7
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $7)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $9
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $16)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $9)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -234,23 +595,54 @@ pattern matching › tuple_match_deep3
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $5
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $5)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $6
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $6)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -259,7 +651,7 @@ pattern matching › tuple_match_deep3
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -268,7 +660,31 @@ pattern matching › tuple_match_deep3
                      )
                      (i32.const 31)
                     )
-                    (i32.const 1)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $1)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $4)
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 1879048190)
+                       )
+                      )
+                     )
+                     (i32.const 1)
+                    )
                     (unreachable)
                    )
                   )
@@ -280,7 +696,7 @@ pattern matching › tuple_match_deep3
               (unreachable)
              )
             )
-            (br $switch.50_outer
+            (br $switch.88_outer
              (i32.const 1999)
             )
            )
@@ -288,9 +704,22 @@ pattern matching › tuple_match_deep3
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -304,10 +733,23 @@ pattern matching › tuple_match_deep3
           (local.set $3
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $2)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -317,147 +759,9 @@ pattern matching › tuple_match_deep3
             )
            )
           )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $11
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $8
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $11)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $8)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $9
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $9)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.50_outer
+          (br $switch.88_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -465,14 +769,14 @@ pattern matching › tuple_match_deep3
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $9)
+             (local.get $3)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $13)
             )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
@@ -481,88 +785,8 @@ pattern matching › tuple_match_deep3
         (local.set $2
          (tuple.extract 0
           (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $3)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $5
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -574,22 +798,22 @@ pattern matching › tuple_match_deep3
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $5)
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (local.get $2)
            )
           )
          )
         )
-        (br $switch.50_outer
+        (br $switch.88_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -597,70 +821,22 @@ pattern matching › tuple_match_deep3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $5)
+           (local.get $2)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $4)
+           (local.get $9)
           )
-          (i32.load offset=8
-           (local.get $1)
-          )
-         )
-        )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=12
-           (local.get $0)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $2)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $2)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $3)
-         )
-        )
-       )
-      )
-      (local.set $4
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
            (local.get $0)
           )
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $4)
-         )
         )
        )
       )
-      (br $switch.50_outer
+      (br $switch.88_outer
        (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
+        (local.tee $0
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (global.get $gimport_pervasives_+)
@@ -668,14 +844,14 @@ pattern matching › tuple_match_deep3
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
+         (local.get $5)
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $3)
+         (local.get $6)
         )
         (i32.load offset=8
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -683,40 +859,26 @@ pattern matching › tuple_match_deep3
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (local.get $0)
-     )
+     (local.get $4)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $14)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -734,7 +896,19 @@ pattern matching › tuple_match_deep3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
    )
   )
   (drop
@@ -746,16 +920,64 @@ pattern matching › tuple_match_deep3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $12)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (local.get $13)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $17)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $18)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $19)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -26,21 +26,93 @@ pattern matching › adt_match_1
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $0
-   (block $switch.45_outer (result i32)
+   (block $switch.69_outer (result i32)
     (drop
-     (block $switch.45_branch_1 (result i32)
+     (block $switch.69_branch_1 (result i32)
       (drop
-       (block $switch.45_branch_2 (result i32)
+       (block $switch.69_branch_2 (result i32)
         (drop
-         (block $switch.45_branch_3 (result i32)
+         (block $switch.69_branch_3 (result i32)
           (drop
-           (block $switch.45_branch_4 (result i32)
+           (block $switch.69_branch_4 (result i32)
             (drop
-             (block $switch.45_branch_5 (result i32)
+             (block $switch.69_branch_5 (result i32)
               (drop
-               (block $switch.45_default (result i32)
-                (br_table $switch.45_branch_1 $switch.45_branch_2 $switch.45_branch_3 $switch.45_branch_4 $switch.45_branch_5 $switch.45_default
+               (block $switch.69_default (result i32)
+                (br_table $switch.69_branch_1 $switch.69_branch_2 $switch.69_branch_3 $switch.69_branch_4 $switch.69_branch_5 $switch.69_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -61,38 +133,22 @@ pattern matching › adt_match_1
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $0
-                         (i32.load offset=12
-                          (local.tee $1
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (global.get $gimport_pervasives_[])
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $1
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (global.get $gimport_pervasives_[])
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
@@ -101,13 +157,13 @@ pattern matching › adt_match_1
                         (i32.eq
                          (local.tee $0
                           (i32.load offset=12
-                           (local.tee $2
+                           (local.tee $8
                             (tuple.extract 0
                              (tuple.make
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $1)
+                                (global.get $gimport_pervasives_[])
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -127,43 +183,242 @@ pattern matching › adt_match_1
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $3
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $2)
+                     (block (result i32)
+                      (local.set $9
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $8)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $8)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $11
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $10)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $12
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $10)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $5
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $5)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $6
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $9)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $6)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $7
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $11)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $7)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $3
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $3)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $9)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $4)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
@@ -177,23 +432,32 @@ pattern matching › adt_match_1
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $0)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $2
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $2)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -223,7 +487,7 @@ pattern matching › adt_match_1
               (unreachable)
              )
             )
-            (br $switch.45_outer
+            (br $switch.69_outer
              (i32.const 1999)
             )
            )
@@ -231,10 +495,23 @@ pattern matching › adt_match_1
           (local.set $1
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (global.get $gimport_pervasives_[])
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $5)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -244,100 +521,7 @@ pattern matching › adt_match_1
             )
            )
           )
-          (local.set $2
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $2)
-             )
-            )
-           )
-          )
-          (local.set $3
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $3)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $1)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (global.get $gimport_pervasives_[])
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $4
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.45_outer
+          (br $switch.69_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
             (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -347,11 +531,11 @@ pattern matching › adt_match_1
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $1)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $3)
+             (local.get $7)
             )
             (i32.load offset=8
              (local.get $0)
@@ -360,55 +544,7 @@ pattern matching › adt_match_1
           )
          )
         )
-        (local.set $1
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (global.get $gimport_pervasives_[])
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $1)
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (global.get $gimport_pervasives_[])
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (br $switch.45_outer
+        (br $switch.69_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -422,7 +558,7 @@ pattern matching › adt_match_1
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $2)
+           (local.get $4)
           )
           (i32.load offset=8
            (local.get $0)
@@ -431,23 +567,15 @@ pattern matching › adt_match_1
         )
        )
       )
-      (br $switch.45_outer
+      (br $switch.69_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=20
-         (global.get $gimport_pervasives_[])
-        )
+        (local.get $2)
        )
       )
      )
     )
     (i32.const 1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
    )
   )
   (drop
@@ -465,6 +593,12 @@ pattern matching › adt_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $5)
    )
   )
@@ -477,7 +611,43 @@ pattern matching › adt_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -42,6 +42,13 @@ pattern matching › tuple_match_deep2
   (local $19 i32)
   (local $20 i32)
   (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -63,7 +70,7 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (i32.const 15)
   )
-  (local.set $11
+  (local.set $18
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -99,10 +106,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $11)
+    (local.get $18)
    )
   )
-  (local.set $12
+  (local.set $19
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -134,10 +141,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $12)
+    (local.get $19)
    )
   )
-  (local.set $13
+  (local.set $20
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -169,10 +176,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $13)
+    (local.get $20)
    )
   )
-  (local.set $14
+  (local.set $21
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -204,10 +211,10 @@ pattern matching › tuple_match_deep2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $14)
+    (local.get $21)
    )
   )
-  (local.set $6
+  (local.set $13
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -218,13 +225,90 @@ pattern matching › tuple_match_deep2
     )
    )
   )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $7
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $22
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $6)
+      (i32.load offset=8
+       (local.get $13)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -234,13 +318,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $8
+  (local.set $14
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $7)
+       (local.get $13)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -250,29 +334,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $0
+  (local.set $23
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $8)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $9
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
+      (i32.load offset=8
+       (local.get $14)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -288,7 +356,7 @@ pattern matching › tuple_match_deep2
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=12
-       (local.get $9)
+       (local.get $14)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -298,13 +366,13 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $16
+  (local.set $24
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=8
-       (local.get $9)
+       (local.get $15)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -314,7 +382,39 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $17
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $15)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $25
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $26
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -330,12 +430,12 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $18
+  (local.set $16
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
+      (i32.load offset=16
        (local.get $0)
       )
      )
@@ -346,11 +446,210 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $19
+  (local.set $27
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $16)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $28
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $16)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $22)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $23)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $24)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $25)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $5
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $26)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $5)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $7
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $28)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $7)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $6
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $27)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $6)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $8
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $1)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $2)
+      )
       (i32.load offset=8
        (local.get $8)
       )
@@ -362,43 +661,11 @@ pattern matching › tuple_match_deep2
     )
    )
   )
-  (local.set $20
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $7)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $21
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $6)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $1
+  (local.set $9
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $1
+      (local.tee $9
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_+)
@@ -406,130 +673,14 @@ pattern matching › tuple_match_deep2
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $21)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $20)
-      )
-      (i32.load offset=8
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $2
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $2
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $1)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $19)
-      )
-      (i32.load offset=8
-       (local.get $2)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $3
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $3
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $2)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $18)
-      )
-      (i32.load offset=8
-       (local.get $3)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $4
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
+       (local.get $8)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
        (local.get $3)
       )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $17)
-      )
       (i32.load offset=8
-       (local.get $4)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $5
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_pervasives_+)
-       )
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $4)
-      )
-      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $16)
-      )
-      (i32.load offset=8
-       (local.get $5)
+       (local.get $9)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -540,8 +691,95 @@ pattern matching › tuple_match_deep2
    )
   )
   (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $10
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $9)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $4)
+      )
+      (i32.load offset=8
+       (local.get $10)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $11
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $10)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $5)
+      )
+      (i32.load offset=8
+       (local.get $11)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $12
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_+)
+       )
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $11)
+      )
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $6)
+      )
+      (i32.load offset=8
+       (local.get $12)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $17
    (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $10
+    (local.tee $17
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_+)
@@ -549,87 +787,15 @@ pattern matching › tuple_match_deep2
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $5)
+     (local.get $12)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $15)
+     (local.get $7)
     )
     (i32.load offset=8
-     (local.get $10)
+     (local.get $17)
     )
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $12)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $13)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $14)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $15)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $16)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $17)
    )
   )
   (drop
@@ -654,6 +820,12 @@ pattern matching › tuple_match_deep2
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $21)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
    )
   )
   (drop
@@ -686,7 +858,115 @@ pattern matching › tuple_match_deep2
     (local.get $5)
    )
   )
-  (local.get $10)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $22)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $23)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $24)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $25)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $26)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $27)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $28)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (local.get $17)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -22,6 +22,8 @@ pattern matching › record_match_deep
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -167,6 +169,17 @@ pattern matching › record_match_deep
   (local.set $1
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=16
@@ -180,12 +193,48 @@ pattern matching › record_match_deep
     )
    )
   )
-  (local.set $3
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $3)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (local.get $1)
-    )
+    (local.get $1)
    )
   )
   (drop
@@ -206,7 +255,19 @@ pattern matching › record_match_deep
     (local.get $1)
    )
   )
-  (local.get $3)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (local.get $5)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -24,6 +24,10 @@ pattern matching › guarded_match_4
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -63,12 +67,18 @@ pattern matching › guarded_match_4
   (local.set $2
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -77,6 +87,17 @@ pattern matching › guarded_match_4
    )
   )
   (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -92,20 +113,116 @@ pattern matching › guarded_match_4
     )
    )
   )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
   (local.set $1
-   (block $switch.20_outer (result i32)
+   (block $switch.34_outer (result i32)
     (drop
-     (block $switch.20_branch_1 (result i32)
+     (block $switch.34_branch_1 (result i32)
       (drop
-       (block $switch.20_branch_2 (result i32)
+       (block $switch.34_branch_2 (result i32)
         (drop
-         (block $switch.20_default (result i32)
-          (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
+         (block $switch.34_default (result i32)
+          (br_table $switch.34_branch_1 $switch.34_branch_2 $switch.34_default
            (i32.const 0)
            (i32.shr_s
-            (select
-             (i32.const 1)
-             (i32.const 3)
+            (if (result i32)
              (i32.shr_u
               (if (result i32)
                (i32.shr_u
@@ -119,7 +236,7 @@ pattern matching › guarded_match_4
                   )
                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                   (local.get $3)
+                   (local.get $2)
                   )
                   (i32.const 5)
                   (i32.load offset=8
@@ -138,7 +255,7 @@ pattern matching › guarded_match_4
                 )
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $2)
+                 (local.get $3)
                 )
                 (i32.const 7)
                 (i32.load offset=8
@@ -149,6 +266,76 @@ pattern matching › guarded_match_4
               )
               (i32.const 31)
              )
+             (block (result i32)
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $3
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $7)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $4
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $6)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $4)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $2)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.const 3)
             )
             (i32.const 1)
            )
@@ -158,7 +345,7 @@ pattern matching › guarded_match_4
         (unreachable)
        )
       )
-      (br $switch.20_outer
+      (br $switch.34_outer
        (i32.const 199)
       )
      )
@@ -181,7 +368,31 @@ pattern matching › guarded_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
    )
   )
   (local.get $1)

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -23,6 +23,11 @@ pattern matching › guarded_match_1
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -59,7 +64,40 @@ pattern matching › guarded_match_1
     )
    )
   )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -75,23 +113,119 @@ pattern matching › guarded_match_1
     )
    )
   )
-  (local.set $1
-   (block $switch.13_outer (result i32)
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $7
+   (block $switch.29_outer (result i32)
     (drop
-     (block $switch.13_branch_1 (result i32)
+     (block $switch.29_branch_1 (result i32)
       (drop
-       (block $switch.13_branch_2 (result i32)
+       (block $switch.29_branch_2 (result i32)
         (drop
-         (block $switch.13_default (result i32)
-          (br_table $switch.13_branch_1 $switch.13_branch_2 $switch.13_default
+         (block $switch.29_default (result i32)
+          (br_table $switch.29_branch_1 $switch.29_branch_2 $switch.29_default
            (i32.const 0)
            (i32.shr_s
-            (select
-             (i32.const 1)
-             (i32.const 3)
+            (if (result i32)
              (i32.shr_u
               (call_indirect (type $i32_i32_i32_=>_i32)
-               (local.tee $1
+               (local.tee $7
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                  (global.get $gimport_pervasives_==)
@@ -99,15 +233,85 @@ pattern matching › guarded_match_1
                )
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (local.get $2)
+                (local.get $1)
                )
                (i32.const 3)
                (i32.load offset=8
-                (local.get $1)
+                (local.get $7)
                )
               )
               (i32.const 31)
              )
+             (block (result i32)
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $3
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $6)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $2)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $4)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $1)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.const 3)
             )
             (i32.const 1)
            )
@@ -117,7 +321,7 @@ pattern matching › guarded_match_1
         (unreachable)
        )
       )
-      (br $switch.13_outer
+      (br $switch.29_outer
        (i32.const 199)
       )
      )
@@ -134,10 +338,40 @@ pattern matching › guarded_match_1
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (local.get $7)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -28,21 +28,119 @@ pattern matching › adt_match_2
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $2
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 5)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_pervasives_[])
+      )
+      (i32.load offset=8
+       (local.get $2)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $0
-   (block $switch.48_outer (result i32)
+   (block $switch.72_outer (result i32)
     (drop
-     (block $switch.48_branch_1 (result i32)
+     (block $switch.72_branch_1 (result i32)
       (drop
-       (block $switch.48_branch_2 (result i32)
+       (block $switch.72_branch_2 (result i32)
         (drop
-         (block $switch.48_branch_3 (result i32)
+         (block $switch.72_branch_3 (result i32)
           (drop
-           (block $switch.48_branch_4 (result i32)
+           (block $switch.72_branch_4 (result i32)
             (drop
-             (block $switch.48_branch_5 (result i32)
+             (block $switch.72_branch_5 (result i32)
               (drop
-               (block $switch.48_default (result i32)
-                (br_table $switch.48_branch_1 $switch.48_branch_2 $switch.48_branch_3 $switch.48_branch_4 $switch.48_branch_5 $switch.48_default
+               (block $switch.72_default (result i32)
+                (br_table $switch.72_branch_1 $switch.72_branch_2 $switch.72_branch_3 $switch.72_branch_4 $switch.72_branch_5 $switch.72_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -52,32 +150,7 @@ pattern matching › adt_match_2
                       (i32.eq
                        (local.tee $0
                         (i32.load offset=12
-                         (local.tee $1
-                          (tuple.extract 0
-                           (tuple.make
-                            (call_indirect (type $i32_i32_i32_=>_i32)
-                             (local.tee $1
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (global.get $gimport_pervasives_[...])
-                              )
-                             )
-                             (i32.const 5)
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (global.get $gimport_pervasives_[])
-                             )
-                             (i32.load offset=8
-                              (local.get $1)
-                             )
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                         )
+                         (local.get $2)
                         )
                        )
                        (i32.const 3)
@@ -88,38 +161,22 @@ pattern matching › adt_match_2
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $0
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $1)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $1
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $2)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
@@ -128,7 +185,7 @@ pattern matching › adt_match_2
                         (i32.eq
                          (local.tee $0
                           (i32.load offset=12
-                           (local.tee $3
+                           (local.tee $9
                             (tuple.extract 0
                              (tuple.make
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -154,43 +211,242 @@ pattern matching › adt_match_2
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $10
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $9)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $9)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $12
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $11)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $13
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $11)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $6
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $6)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $7
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $10)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $7)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $8
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $12)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $8)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $4)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $5
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $10)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $5)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
@@ -204,23 +460,32 @@ pattern matching › adt_match_2
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $0)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $3
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $3)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -250,96 +515,16 @@ pattern matching › adt_match_2
               (unreachable)
              )
             )
-            (br $switch.48_outer
+            (br $switch.72_outer
              (i32.const 1999)
             )
            )
           )
-          (local.set $2
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $1)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $2)
-             )
-            )
-           )
-          )
-          (local.set $3
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $3)
-             )
-            )
-           )
-          )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $1)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
+          (local.set $1
            (tuple.extract 0
             (tuple.make
              (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $5
+              (local.tee $0
                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                 (global.get $gimport_pervasives_+)
@@ -347,24 +532,24 @@ pattern matching › adt_match_2
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
+               (local.get $6)
               )
               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $6)
+               (local.get $7)
               )
               (i32.load offset=8
-               (local.get $5)
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
+              (local.get $1)
              )
             )
            )
           )
-          (br $switch.48_outer
+          (br $switch.72_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
             (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -374,11 +559,11 @@ pattern matching › adt_match_2
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $5)
+             (local.get $1)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $8)
             )
             (i32.load offset=8
              (local.get $0)
@@ -387,55 +572,7 @@ pattern matching › adt_match_2
           )
          )
         )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $1)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $1)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (br $switch.48_outer
+        (br $switch.72_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
           (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -449,7 +586,7 @@ pattern matching › adt_match_2
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (i32.load offset=8
            (local.get $0)
@@ -458,23 +595,15 @@ pattern matching › adt_match_2
         )
        )
       )
-      (br $switch.48_outer
+      (br $switch.72_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=20
-         (local.get $1)
-        )
+        (local.get $3)
        )
       )
      )
     )
     (i32.const 1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
    )
   )
   (drop
@@ -498,6 +627,12 @@ pattern matching › adt_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $6)
    )
   )
@@ -510,7 +645,43 @@ pattern matching › adt_match_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
    )
   )
   (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -24,6 +24,10 @@ pattern matching › guarded_match_3
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -63,12 +67,18 @@ pattern matching › guarded_match_3
   (local.set $2
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -77,6 +87,17 @@ pattern matching › guarded_match_3
    )
   )
   (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
    (tuple.extract 0
     (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
@@ -92,20 +113,116 @@ pattern matching › guarded_match_3
     )
    )
   )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $4
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $4)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (local.set $2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (local.get $2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
   (local.set $1
-   (block $switch.20_outer (result i32)
+   (block $switch.34_outer (result i32)
     (drop
-     (block $switch.20_branch_1 (result i32)
+     (block $switch.34_branch_1 (result i32)
       (drop
-       (block $switch.20_branch_2 (result i32)
+       (block $switch.34_branch_2 (result i32)
         (drop
-         (block $switch.20_default (result i32)
-          (br_table $switch.20_branch_1 $switch.20_branch_2 $switch.20_default
+         (block $switch.34_default (result i32)
+          (br_table $switch.34_branch_1 $switch.34_branch_2 $switch.34_default
            (i32.const 0)
            (i32.shr_s
-            (select
-             (i32.const 1)
-             (i32.const 3)
+            (if (result i32)
              (i32.shr_u
               (if (result i32)
                (i32.shr_u
@@ -119,7 +236,7 @@ pattern matching › guarded_match_3
                   )
                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                   (local.get $3)
+                   (local.get $2)
                   )
                   (i32.const 5)
                   (i32.load offset=8
@@ -138,7 +255,7 @@ pattern matching › guarded_match_3
                 )
                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                 (local.get $2)
+                 (local.get $3)
                 )
                 (i32.const 7)
                 (i32.load offset=8
@@ -149,6 +266,76 @@ pattern matching › guarded_match_3
               )
               (i32.const 31)
              )
+             (block (result i32)
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $3
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $7)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $3)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $4
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $6)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $4)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (drop
+               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                (block (result i32)
+                 (local.set $2
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $5)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (local.get $2)
+                    )
+                   )
+                  )
+                 )
+                 (i32.const 1879048190)
+                )
+               )
+              )
+              (i32.const 1)
+             )
+             (i32.const 3)
             )
             (i32.const 1)
            )
@@ -158,7 +345,7 @@ pattern matching › guarded_match_3
         (unreachable)
        )
       )
-      (br $switch.20_outer
+      (br $switch.34_outer
        (i32.const 199)
       )
      )
@@ -181,7 +368,31 @@ pattern matching › guarded_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
    )
   )
   (local.get $1)

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -29,11 +29,17 @@ pattern matching › adt_match_3
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local.set $6
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local.set $12
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -45,7 +51,7 @@ pattern matching › adt_match_3
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -56,20 +62,112 @@ pattern matching › adt_match_3
    )
   )
   (local.set $1
-   (block $switch.51_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 9)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $12)
+      )
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.75_outer (result i32)
     (drop
-     (block $switch.51_branch_1 (result i32)
+     (block $switch.75_branch_1 (result i32)
       (drop
-       (block $switch.51_branch_2 (result i32)
+       (block $switch.75_branch_2 (result i32)
         (drop
-         (block $switch.51_branch_3 (result i32)
+         (block $switch.75_branch_3 (result i32)
           (drop
-           (block $switch.51_branch_4 (result i32)
+           (block $switch.75_branch_4 (result i32)
             (drop
-             (block $switch.51_branch_5 (result i32)
+             (block $switch.75_branch_5 (result i32)
               (drop
-               (block $switch.51_default (result i32)
-                (br_table $switch.51_branch_1 $switch.51_branch_2 $switch.51_branch_3 $switch.51_branch_4 $switch.51_branch_5 $switch.51_default
+               (block $switch.75_default (result i32)
+                (br_table $switch.75_branch_1 $switch.75_branch_2 $switch.75_branch_3 $switch.75_branch_4 $switch.75_branch_5 $switch.75_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -77,34 +175,9 @@ pattern matching › adt_match_3
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $0
-                          (tuple.extract 0
-                           (tuple.make
-                            (call_indirect (type $i32_i32_i32_=>_i32)
-                             (local.tee $0
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (global.get $gimport_pervasives_[...])
-                              )
-                             )
-                             (i32.const 9)
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $6)
-                             )
-                             (i32.load offset=8
-                              (local.get $0)
-                             )
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                         )
+                         (local.get $1)
                         )
                        )
                        (i32.const 3)
@@ -115,53 +188,37 @@ pattern matching › adt_match_3
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $0)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $1)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
-                           (local.tee $3
+                           (local.tee $9
                             (tuple.extract 0
                              (tuple.make
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $1)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -181,48 +238,247 @@ pattern matching › adt_match_3
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $10
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $9)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $9)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $13
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $11)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $14
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $11)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $6
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $6)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $7
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $10)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $7)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $8
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $13)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $8)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $4)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $5
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $10)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $5)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -231,23 +487,32 @@ pattern matching › adt_match_3
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $3
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $3)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -256,7 +521,7 @@ pattern matching › adt_match_3
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -277,7 +542,7 @@ pattern matching › adt_match_3
               (unreachable)
              )
             )
-            (br $switch.51_outer
+            (br $switch.75_outer
              (i32.const 1999)
             )
            )
@@ -285,9 +550,22 @@ pattern matching › adt_match_3
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $7)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -298,102 +576,9 @@ pattern matching › adt_match_3
             )
            )
           )
-          (local.set $3
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $3)
-             )
-            )
-           )
-          )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $5
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $5)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.51_outer
+          (br $switch.75_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -401,70 +586,22 @@ pattern matching › adt_match_3
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $5)
+             (local.get $2)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $1)
-            )
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
              (local.get $0)
             )
            )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
           )
          )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (br $switch.51_outer
+        (br $switch.75_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -476,21 +613,19 @@ pattern matching › adt_match_3
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
         )
        )
       )
-      (br $switch.51_outer
+      (br $switch.75_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=20
-         (local.get $0)
-        )
+        (local.get $3)
        )
       )
      )
@@ -501,19 +636,13 @@ pattern matching › adt_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
+    (local.get $12)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
@@ -531,6 +660,18 @@ pattern matching › adt_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $7)
    )
   )
@@ -543,10 +684,40 @@ pattern matching › adt_match_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $2)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -31,11 +31,17 @@ pattern matching › adt_match_5
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local.set $6
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local.set $12
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -47,7 +53,7 @@ pattern matching › adt_match_5
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -57,11 +63,11 @@ pattern matching › adt_match_5
     )
    )
   )
-  (local.set $7
+  (local.set $13
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -70,10 +76,10 @@ pattern matching › adt_match_5
       (i32.const 13)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $6)
+       (local.get $12)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -83,11 +89,11 @@ pattern matching › adt_match_5
     )
    )
   )
-  (local.set $8
+  (local.set $14
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -96,10 +102,10 @@ pattern matching › adt_match_5
       (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $7)
+       (local.get $13)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -110,20 +116,112 @@ pattern matching › adt_match_5
    )
   )
   (local.set $1
-   (block $switch.57_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $1
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 9)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (local.get $14)
+      )
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.81_outer (result i32)
     (drop
-     (block $switch.57_branch_1 (result i32)
+     (block $switch.81_branch_1 (result i32)
       (drop
-       (block $switch.57_branch_2 (result i32)
+       (block $switch.81_branch_2 (result i32)
         (drop
-         (block $switch.57_branch_3 (result i32)
+         (block $switch.81_branch_3 (result i32)
           (drop
-           (block $switch.57_branch_4 (result i32)
+           (block $switch.81_branch_4 (result i32)
             (drop
-             (block $switch.57_branch_5 (result i32)
+             (block $switch.81_branch_5 (result i32)
               (drop
-               (block $switch.57_default (result i32)
-                (br_table $switch.57_branch_1 $switch.57_branch_2 $switch.57_branch_3 $switch.57_branch_4 $switch.57_branch_5 $switch.57_default
+               (block $switch.81_default (result i32)
+                (br_table $switch.81_branch_1 $switch.81_branch_2 $switch.81_branch_3 $switch.81_branch_4 $switch.81_branch_5 $switch.81_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -131,34 +229,9 @@ pattern matching › adt_match_5
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $0
-                          (tuple.extract 0
-                           (tuple.make
-                            (call_indirect (type $i32_i32_i32_=>_i32)
-                             (local.tee $0
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (global.get $gimport_pervasives_[...])
-                              )
-                             )
-                             (i32.const 9)
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (local.get $8)
-                             )
-                             (i32.load offset=8
-                              (local.get $0)
-                             )
-                            )
-                            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                             (i32.const 0)
-                            )
-                           )
-                          )
-                         )
+                         (local.get $1)
                         )
                        )
                        (i32.const 3)
@@ -169,53 +242,37 @@ pattern matching › adt_match_5
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $0)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $1)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
-                           (local.tee $3
+                           (local.tee $9
                             (tuple.extract 0
                              (tuple.make
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $1)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -235,48 +292,247 @@ pattern matching › adt_match_5
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $10
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $9)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $9)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $15
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $11)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $16
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $11)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $6
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $6)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $7
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $10)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $7)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $8
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $15)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $8)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $4
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $4)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $5
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $10)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $5)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -285,23 +541,32 @@ pattern matching › adt_match_5
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $3
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $3)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -310,7 +575,7 @@ pattern matching › adt_match_5
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -331,7 +596,7 @@ pattern matching › adt_match_5
               (unreachable)
              )
             )
-            (br $switch.57_outer
+            (br $switch.81_outer
              (i32.const 1999)
             )
            )
@@ -339,9 +604,22 @@ pattern matching › adt_match_5
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $6)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $7)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -352,102 +630,9 @@ pattern matching › adt_match_5
             )
            )
           )
-          (local.set $3
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $3)
-             )
-            )
-           )
-          )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $10
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $5
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $10)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $9)
-              )
-              (i32.load offset=8
-               (local.get $5)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.57_outer
+          (br $switch.81_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -455,70 +640,22 @@ pattern matching › adt_match_5
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $5)
+             (local.get $2)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $4)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $1)
-            )
-           )
-          )
-         )
-        )
-        (local.set $2
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
              (local.get $0)
             )
            )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
           )
          )
         )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (br $switch.57_outer
+        (br $switch.81_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -530,26 +667,66 @@ pattern matching › adt_match_5
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $3)
+           (local.get $5)
           )
           (i32.load offset=8
-           (local.get $1)
+           (local.get $0)
           )
          )
         )
        )
       )
-      (br $switch.57_outer
+      (br $switch.81_outer
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (i32.load offset=20
-         (local.get $0)
-        )
+        (local.get $3)
        )
       )
      )
     )
     (i32.const 1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $13)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -573,25 +750,7 @@ pattern matching › adt_match_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (drop
@@ -609,10 +768,22 @@ pattern matching › adt_match_5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $11)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $15)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -36,11 +36,19 @@ pattern matching › tuple_match_deep5
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local.set $10
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local.set $18
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -52,7 +60,7 @@ pattern matching › tuple_match_deep5
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -62,11 +70,11 @@ pattern matching › tuple_match_deep5
     )
    )
   )
-  (local.set $11
+  (local.set $19
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -75,10 +83,10 @@ pattern matching › tuple_match_deep5
       (i32.const 9)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $18)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -89,7 +97,7 @@ pattern matching › tuple_match_deep5
    )
   )
   (i32.store
-   (local.tee $0
+   (local.tee $1
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -98,24 +106,134 @@ pattern matching › tuple_match_deep5
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $11)
+    (local.get $19)
    )
   )
-  (local.set $0
+  (local.set $14
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -124,20 +242,36 @@ pattern matching › tuple_match_deep5
    )
   )
   (local.set $1
-   (block $switch.56_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $14)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.94_outer (result i32)
     (drop
-     (block $switch.56_branch_1 (result i32)
+     (block $switch.94_branch_1 (result i32)
       (drop
-       (block $switch.56_branch_2 (result i32)
+       (block $switch.94_branch_2 (result i32)
         (drop
-         (block $switch.56_branch_3 (result i32)
+         (block $switch.94_branch_3 (result i32)
           (drop
-           (block $switch.56_branch_4 (result i32)
+           (block $switch.94_branch_4 (result i32)
             (drop
-             (block $switch.56_branch_5 (result i32)
+             (block $switch.94_branch_5 (result i32)
               (drop
-               (block $switch.56_default (result i32)
-                (br_table $switch.56_branch_1 $switch.56_branch_2 $switch.56_branch_3 $switch.56_branch_4 $switch.56_branch_5 $switch.56_default
+               (block $switch.94_default (result i32)
+                (br_table $switch.94_branch_1 $switch.94_branch_2 $switch.94_branch_3 $switch.94_branch_4 $switch.94_branch_5 $switch.94_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -145,15 +279,15 @@ pattern matching › tuple_match_deep5
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $12
+                         (local.tee $15
                           (tuple.extract 0
                            (tuple.make
                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                              (i32.load offset=12
-                              (local.get $0)
+                              (local.get $14)
                              )
                             )
                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -173,45 +307,29 @@ pattern matching › tuple_match_deep5
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $12)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $15)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
                            (local.tee $3
                             (tuple.extract 0
@@ -219,7 +337,7 @@ pattern matching › tuple_match_deep5
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $15)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -239,48 +357,291 @@ pattern matching › tuple_match_deep5
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $16
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $3)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $17
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $20
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $17)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $21
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $17)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $10)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $11)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $12
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $16)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $12)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $13
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $20)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $13)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $7
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $7)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $9
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $16)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $9)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -289,23 +650,54 @@ pattern matching › tuple_match_deep5
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $5
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $5)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $6
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $6)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -314,7 +706,7 @@ pattern matching › tuple_match_deep5
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -323,7 +715,31 @@ pattern matching › tuple_match_deep5
                      )
                      (i32.const 31)
                     )
-                    (i32.const 1)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $1)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $4)
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 1879048190)
+                       )
+                      )
+                     )
+                     (i32.const 1)
+                    )
                     (unreachable)
                    )
                   )
@@ -335,7 +751,7 @@ pattern matching › tuple_match_deep5
               (unreachable)
              )
             )
-            (br $switch.56_outer
+            (br $switch.94_outer
              (i32.const 1999)
             )
            )
@@ -343,9 +759,22 @@ pattern matching › tuple_match_deep5
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -359,10 +788,23 @@ pattern matching › tuple_match_deep5
           (local.set $3
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $2)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -372,147 +814,9 @@ pattern matching › tuple_match_deep5
             )
            )
           )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $13
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $8
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $13)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $8)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $9
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $9)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.56_outer
+          (br $switch.94_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -520,14 +824,14 @@ pattern matching › tuple_match_deep5
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $9)
+             (local.get $3)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $13)
             )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
@@ -536,88 +840,8 @@ pattern matching › tuple_match_deep5
         (local.set $2
          (tuple.extract 0
           (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $3)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $5
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -629,22 +853,22 @@ pattern matching › tuple_match_deep5
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $5)
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (local.get $2)
            )
           )
          )
         )
-        (br $switch.56_outer
+        (br $switch.94_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -652,70 +876,22 @@ pattern matching › tuple_match_deep5
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $5)
+           (local.get $2)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $4)
+           (local.get $9)
           )
-          (i32.load offset=8
-           (local.get $1)
-          )
-         )
-        )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=12
-           (local.get $0)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $2)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $2)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $3)
-         )
-        )
-       )
-      )
-      (local.set $4
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
            (local.get $0)
           )
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $4)
-         )
         )
        )
       )
-      (br $switch.56_outer
+      (br $switch.94_outer
        (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
+        (local.tee $0
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (global.get $gimport_pervasives_+)
@@ -723,14 +899,14 @@ pattern matching › tuple_match_deep5
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
+         (local.get $5)
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $3)
+         (local.get $6)
         )
         (i32.load offset=8
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -738,52 +914,38 @@ pattern matching › tuple_match_deep5
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (local.get $0)
-     )
+     (local.get $4)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
+    (local.get $18)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $11)
+    (local.get $19)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $12)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
+    (local.get $14)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -801,7 +963,31 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $10)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $11)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $12)
    )
   )
   (drop
@@ -813,16 +999,52 @@ pattern matching › tuple_match_deep5
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $1)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (local.get $15)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $16)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $17)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $20)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $21)
+   )
+  )
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -30,104 +30,6 @@ pattern matching › constant_match_4
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (i32.store
-   (local.tee $1
-    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-     (i32.const 16)
-    )
-   )
-   (i32.const 1)
-  )
-  (i32.store offset=4
-   (local.get $1)
-   (i32.const 3)
-  )
-  (i64.store offset=8
-   (local.get $1)
-   (i64.const 7303014)
-  )
-  (local.set $3
-   (tuple.extract 0
-    (tuple.make
-     (local.get $1)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (i32.store
-   (local.tee $1
-    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-     (i32.const 16)
-    )
-   )
-   (i32.const 7)
-  )
-  (i32.store offset=4
-   (local.get $1)
-   (i32.const 2)
-  )
-  (i32.store offset=8
-   (local.get $1)
-   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $3)
-   )
-  )
-  (i32.store offset=12
-   (local.get $1)
-   (i32.const 11)
-  )
-  (local.set $1
-   (tuple.extract 0
-    (tuple.make
-     (local.get $1)
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $4
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
-  (local.set $5
-   (tuple.extract 0
-    (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=8
-       (local.get $1)
-      )
-     )
-     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (i32.const 0)
-     )
-    )
-   )
-  )
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -156,26 +58,226 @@ pattern matching › constant_match_4
     )
    )
   )
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 7)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 2)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (local.get $6)
+   )
+  )
+  (i32.store offset=12
+   (local.get $0)
+   (i32.const 11)
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
   (local.set $0
-   (block $switch.60_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $5)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (i32.store
+   (local.tee $3
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 16)
+    )
+   )
+   (i32.const 1)
+  )
+  (i32.store offset=4
+   (local.get $3)
+   (i32.const 3)
+  )
+  (i64.store offset=8
+   (local.get $3)
+   (i64.const 7303014)
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (local.get $3)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (block $switch.42_outer (result i32)
     (drop
-     (block $switch.60_branch_1 (result i32)
+     (block $switch.42_branch_1 (result i32)
       (drop
-       (block $switch.60_branch_2 (result i32)
+       (block $switch.42_branch_2 (result i32)
         (drop
-         (block $switch.60_branch_3 (result i32)
+         (block $switch.42_branch_3 (result i32)
           (drop
-           (block $switch.60_branch_4 (result i32)
+           (block $switch.42_branch_4 (result i32)
             (drop
-             (block $switch.60_default (result i32)
-              (br_table $switch.60_branch_1 $switch.60_branch_2 $switch.60_branch_3 $switch.60_branch_4 $switch.60_default
+             (block $switch.42_default (result i32)
+              (br_table $switch.42_branch_1 $switch.42_branch_2 $switch.42_branch_3 $switch.42_branch_4 $switch.42_default
                (i32.const 0)
                (i32.shr_s
                 (if (result i32)
                  (i32.shr_u
+                  (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $7)
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (local.get $3)
+                   )
+                  )
+                  (i32.const 31)
+                 )
+                 (block (result i32)
+                  (drop
+                   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                    (block (result i32)
+                     (local.set $0
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (local.get $2)
+                        )
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (local.get $0)
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 1879048190)
+                    )
+                   )
+                  )
                   (if (result i32)
                    (i32.shr_u
-                    (local.tee $0
+                    (call_indirect (type $i32_i32_i32_=>_i32)
+                     (local.tee $4
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (global.get $gimport_pervasives_==)
+                      )
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $0)
+                     )
+                     (i32.const 15)
+                     (i32.load offset=8
+                      (local.get $4)
+                     )
+                    )
+                    (i32.const 31)
+                   )
+                   (block (result i32)
+                    (drop
+                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                      (block (result i32)
+                       (local.set $0
+                        (tuple.extract 0
+                         (tuple.make
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (local.get $2)
+                          )
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (local.get $0)
+                          )
+                         )
+                        )
+                       )
+                       (i32.const 1879048190)
+                      )
+                     )
+                    )
+                    (i32.const 1)
+                   )
+                   (if (result i32)
+                    (i32.shr_u
                      (call $wimport_GRAIN$MODULE$runtime/equal_equal
                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -183,234 +285,40 @@ pattern matching › constant_match_4
                       )
                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $5)
-                      )
-                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                       (local.get $6)
-                      )
-                     )
-                    )
-                    (i32.const 31)
-                   )
-                   (call_indirect (type $i32_i32_i32_=>_i32)
-                    (local.tee $0
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (global.get $gimport_pervasives_==)
-                     )
-                    )
-                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                     (local.get $4)
-                    )
-                    (i32.const 15)
-                    (i32.load offset=8
-                     (local.get $0)
-                    )
-                   )
-                   (local.get $0)
-                  )
-                  (i32.const 31)
-                 )
-                 (i32.const 1)
-                 (block (result i32)
-                  (local.set $7
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (i32.load offset=12
-                       (local.get $1)
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                      (i32.const 0)
-                     )
-                    )
-                   )
-                  )
-                  (local.set $8
-                   (tuple.extract 0
-                    (tuple.make
-                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                      (i32.load offset=8
-                       (local.get $1)
-                      )
-                     )
-                     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                      (i32.const 0)
-                     )
-                    )
-                   )
-                  )
-                  (if (result i32)
-                   (i32.shr_u
-                    (if (result i32)
-                     (i32.shr_u
-                      (local.tee $0
-                       (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                        )
-                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (local.get $7)
-                        )
-                        (i32.const 19)
-                       )
-                      )
-                      (i32.const 31)
-                     )
-                     (block (result i32)
-                      (i32.store
-                       (local.tee $2
-                        (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                         (i32.const 16)
-                        )
-                       )
-                       (i32.const 1)
-                      )
-                      (i32.store offset=4
                        (local.get $2)
-                       (i32.const 3)
                       )
-                      (i64.store offset=8
-                       (local.get $2)
-                       (i64.const 7303014)
-                      )
-                      (local.set $2
-                       (tuple.extract 0
-                        (tuple.make
-                         (local.get $2)
-                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                          (i32.const 0)
-                         )
-                        )
-                       )
-                      )
-                      (select
-                       (i32.const -2)
-                       (local.tee $0
-                        (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                         )
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (local.get $8)
-                         )
-                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                          (local.get $2)
-                         )
-                        )
-                       )
-                       (i32.shr_u
-                        (local.get $0)
-                        (i32.const 31)
-                       )
-                      )
+                      (i32.const 19)
                      )
-                     (local.get $0)
+                     (i32.const 31)
                     )
-                    (i32.const 31)
-                   )
-                   (i32.const 3)
-                   (block (result i32)
-                    (local.set $2
-                     (tuple.extract 0
-                      (tuple.make
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (i32.load offset=12
-                         (local.get $1)
-                        )
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (local.get $2)
-                       )
-                      )
-                     )
-                    )
-                    (local.set $9
-                     (tuple.extract 0
-                      (tuple.make
-                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                        (i32.load offset=8
-                         (local.get $1)
-                        )
-                       )
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (i32.const 0)
-                       )
-                      )
-                     )
-                    )
-                    (i32.store
-                     (local.tee $0
-                      (call $wimport_GRAIN$MODULE$runtime/gc_malloc
-                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
-                       (i32.const 16)
-                      )
-                     )
-                     (i32.const 1)
-                    )
-                    (i32.store offset=4
-                     (local.get $0)
-                     (i32.const 3)
-                    )
-                    (i64.store offset=8
-                     (local.get $0)
-                     (i64.const 7303014)
-                    )
-                    (local.set $10
-                     (tuple.extract 0
-                      (tuple.make
-                       (local.get $0)
-                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                        (i32.const 0)
-                       )
-                      )
-                     )
-                    )
-                    (select
-                     (i32.const 5)
-                     (i32.const 7)
-                     (i32.shr_u
-                      (if (result i32)
-                       (i32.shr_u
-                        (local.tee $0
-                         (call $wimport_GRAIN$MODULE$runtime/equal_equal
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $9)
-                          )
-                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                           (local.get $10)
+                    (i32.const 3)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $1
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $2)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $1)
+                           )
                           )
                          )
                         )
-                        (i32.const 31)
+                        (i32.const 1879048190)
                        )
+                      )
+                     )
+                     (if (result i32)
+                      (i32.shr_u
                        (call_indirect (type $i32_i32_i32_=>_i32)
-                        (local.tee $0
+                        (local.tee $4
                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                           (global.get $gimport_pervasives_==)
@@ -418,21 +326,47 @@ pattern matching › constant_match_4
                         )
                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                         (local.get $2)
+                         (local.get $1)
                         )
                         (i32.const 11)
                         (i32.load offset=8
-                         (local.get $0)
+                         (local.get $4)
                         )
                        )
-                       (local.get $0)
+                       (i32.const 31)
                       )
-                      (i32.const 31)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $1
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $1)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 5)
+                      )
+                      (i32.const 7)
                      )
                     )
                    )
                   )
                  )
+                 (i32.const 7)
                 )
                 (i32.const 1)
                )
@@ -442,46 +376,22 @@ pattern matching › constant_match_4
             (unreachable)
            )
           )
-          (br $switch.60_outer
+          (br $switch.42_outer
            (i32.const 2147483646)
           )
          )
         )
-        (br $switch.60_outer
+        (br $switch.42_outer
          (i32.const -2)
         )
        )
       )
-      (br $switch.60_outer
+      (br $switch.42_outer
        (i32.const 2147483646)
       )
      )
     )
     (i32.const 2147483646)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $1)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
    )
   )
   (drop
@@ -493,13 +403,25 @@ pattern matching › constant_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+    (local.get $5)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
    )
   )
   (drop
@@ -511,16 +433,10 @@ pattern matching › constant_match_4
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
+    (local.get $3)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $10)
-   )
-  )
-  (local.get $0)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -38,11 +38,19 @@ pattern matching › tuple_match_deep7
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local.set $10
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local.set $18
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -54,7 +62,7 @@ pattern matching › tuple_match_deep7
        (global.get $gimport_pervasives_[])
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -64,11 +72,11 @@ pattern matching › tuple_match_deep7
     )
    )
   )
-  (local.set $11
+  (local.set $19
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -77,10 +85,10 @@ pattern matching › tuple_match_deep7
       (i32.const 13)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $10)
+       (local.get $18)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -90,11 +98,11 @@ pattern matching › tuple_match_deep7
     )
    )
   )
-  (local.set $12
+  (local.set $20
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -103,10 +111,10 @@ pattern matching › tuple_match_deep7
       (i32.const 11)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $11)
+       (local.get $19)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -116,11 +124,11 @@ pattern matching › tuple_match_deep7
     )
    )
   )
-  (local.set $13
+  (local.set $21
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
-      (local.tee $0
+      (local.tee $1
        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
         (global.get $gimport_pervasives_[...])
@@ -129,10 +137,10 @@ pattern matching › tuple_match_deep7
       (i32.const 9)
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $12)
+       (local.get $20)
       )
       (i32.load offset=8
-       (local.get $0)
+       (local.get $1)
       )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -143,7 +151,7 @@ pattern matching › tuple_match_deep7
    )
   )
   (i32.store
-   (local.tee $0
+   (local.tee $1
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
      (i32.const 16)
@@ -152,24 +160,134 @@ pattern matching › tuple_match_deep7
    (i32.const 7)
   )
   (i32.store offset=4
-   (local.get $0)
+   (local.get $1)
    (i32.const 2)
   )
   (i32.store offset=8
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (i32.store offset=12
-   (local.get $0)
+   (local.get $1)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $13)
+    (local.get $21)
    )
   )
-  (local.set $0
+  (local.set $14
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (local.get $1)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $8
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $9
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $10
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $11
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $12
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $13
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (i32.const 0)
@@ -178,20 +296,36 @@ pattern matching › tuple_match_deep7
    )
   )
   (local.set $1
-   (block $switch.62_outer (result i32)
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $14)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (block $switch.100_outer (result i32)
     (drop
-     (block $switch.62_branch_1 (result i32)
+     (block $switch.100_branch_1 (result i32)
       (drop
-       (block $switch.62_branch_2 (result i32)
+       (block $switch.100_branch_2 (result i32)
         (drop
-         (block $switch.62_branch_3 (result i32)
+         (block $switch.100_branch_3 (result i32)
           (drop
-           (block $switch.62_branch_4 (result i32)
+           (block $switch.100_branch_4 (result i32)
             (drop
-             (block $switch.62_branch_5 (result i32)
+             (block $switch.100_branch_5 (result i32)
               (drop
-               (block $switch.62_default (result i32)
-                (br_table $switch.62_branch_1 $switch.62_branch_2 $switch.62_branch_3 $switch.62_branch_4 $switch.62_branch_5 $switch.62_default
+               (block $switch.100_default (result i32)
+                (br_table $switch.100_branch_1 $switch.100_branch_2 $switch.100_branch_3 $switch.100_branch_4 $switch.100_branch_5 $switch.100_default
                  (i32.const 0)
                  (i32.shr_s
                   (if (result i32)
@@ -199,15 +333,15 @@ pattern matching › tuple_match_deep7
                     (i32.or
                      (i32.shl
                       (i32.eq
-                       (local.tee $1
+                       (local.tee $0
                         (i32.load offset=12
-                         (local.tee $14
+                         (local.tee $15
                           (tuple.extract 0
                            (tuple.make
                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                              (i32.load offset=12
-                              (local.get $0)
+                              (local.get $14)
                              )
                             )
                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -227,45 +361,29 @@ pattern matching › tuple_match_deep7
                     )
                     (i32.const 31)
                    )
-                   (if (result i32)
-                    (i32.shr_u
-                     (i32.or
-                      (i32.shl
-                       (i32.eq
-                        (local.tee $1
-                         (i32.load offset=12
-                          (local.tee $2
-                           (tuple.extract 0
-                            (tuple.make
-                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                              (i32.load offset=24
-                               (local.get $14)
-                              )
-                             )
-                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                              (i32.const 0)
-                             )
-                            )
-                           )
-                          )
-                         )
+                   (block (result i32)
+                    (local.set $2
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (i32.load offset=20
+                         (local.get $15)
                         )
-                        (i32.const 3)
                        )
-                       (i32.const 31)
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (i32.const 0)
+                       )
                       )
-                      (i32.const 2147483646)
                      )
-                     (i32.const 31)
                     )
                     (if (result i32)
                      (i32.shr_u
                       (i32.or
                        (i32.shl
                         (i32.eq
-                         (local.tee $1
+                         (local.tee $0
                           (i32.load offset=12
                            (local.tee $3
                             (tuple.extract 0
@@ -273,7 +391,7 @@ pattern matching › tuple_match_deep7
                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                                (i32.load offset=24
-                                (local.get $2)
+                                (local.get $15)
                                )
                               )
                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -293,48 +411,291 @@ pattern matching › tuple_match_deep7
                       )
                       (i32.const 31)
                      )
-                     (select
-                      (i32.const 7)
-                      (i32.const 9)
-                      (i32.shr_u
-                       (i32.or
-                        (i32.shl
-                         (i32.eq
-                          (i32.load offset=12
-                           (local.tee $4
-                            (tuple.extract 0
-                             (tuple.make
-                              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                               (i32.load offset=24
-                                (local.get $3)
+                     (block (result i32)
+                      (local.set $16
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (i32.load offset=20
+                           (local.get $3)
+                          )
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (i32.const 0)
+                         )
+                        )
+                       )
+                      )
+                      (if (result i32)
+                       (i32.shr_u
+                        (i32.or
+                         (i32.shl
+                          (i32.eq
+                           (local.tee $0
+                            (i32.load offset=12
+                             (local.tee $17
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (i32.load offset=24
+                                  (local.get $3)
+                                 )
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (i32.const 0)
+                                )
                                )
-                              )
-                              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-                               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-                               (i32.const 0)
                               )
                              )
                             )
                            )
+                           (i32.const 3)
                           )
-                          (i32.const 1)
+                          (i32.const 31)
+                         )
+                         (i32.const 2147483646)
+                        )
+                        (i32.const 31)
+                       )
+                       (block (result i32)
+                        (local.set $22
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (i32.load offset=20
+                             (local.get $17)
+                            )
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (i32.const 0)
+                           )
+                          )
+                         )
+                        )
+                        (if (result i32)
+                         (i32.shr_u
+                          (i32.or
+                           (i32.shl
+                            (i32.eq
+                             (i32.load offset=12
+                              (local.tee $23
+                               (tuple.extract 0
+                                (tuple.make
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                  (i32.load offset=24
+                                   (local.get $17)
+                                  )
+                                 )
+                                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                  (i32.const 0)
+                                 )
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1)
+                            )
+                            (i32.const 31)
+                           )
+                           (i32.const 2147483646)
+                          )
+                          (i32.const 31)
+                         )
+                         (block (result i32)
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $10
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $1)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $10)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $11
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $2)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $11)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $12
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $16)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $12)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (drop
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (block (result i32)
+                             (local.set $13
+                              (tuple.extract 0
+                               (tuple.make
+                                (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                 (local.get $22)
+                                )
+                                (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                 (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                 (local.get $13)
+                                )
+                               )
+                              )
+                             )
+                             (i32.const 1879048190)
+                            )
+                           )
+                          )
+                          (i32.const 7)
+                         )
+                         (i32.const 9)
+                        )
+                       )
+                       (if (result i32)
+                        (i32.shr_u
+                         (i32.or
+                          (i32.shl
+                           (i32.eq
+                            (local.get $0)
+                            (i32.const 1)
+                           )
+                           (i32.const 31)
+                          )
+                          (i32.const 2147483646)
                          )
                          (i32.const 31)
                         )
-                        (i32.const 2147483646)
+                        (block (result i32)
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $7
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $1)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $7)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $8
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $2)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $8)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (drop
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (block (result i32)
+                            (local.set $9
+                             (tuple.extract 0
+                              (tuple.make
+                               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                                (local.get $16)
+                               )
+                               (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                                (local.get $9)
+                               )
+                              )
+                             )
+                            )
+                            (i32.const 1879048190)
+                           )
+                          )
+                         )
+                         (i32.const 5)
+                        )
+                        (i32.const 9)
                        )
-                       (i32.const 31)
                       )
                      )
-                     (select
-                      (i32.const 5)
-                      (i32.const 9)
+                     (if (result i32)
                       (i32.shr_u
                        (i32.or
                         (i32.shl
                          (i32.eq
-                          (local.get $1)
+                          (local.get $0)
                           (i32.const 1)
                          )
                          (i32.const 31)
@@ -343,23 +704,54 @@ pattern matching › tuple_match_deep7
                        )
                        (i32.const 31)
                       )
-                     )
-                    )
-                    (select
-                     (i32.const 3)
-                     (i32.const 9)
-                     (i32.shr_u
-                      (i32.or
-                       (i32.shl
-                        (i32.eq
-                         (local.get $1)
-                         (i32.const 1)
+                      (block (result i32)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $5
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $1)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $5)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
                         )
-                        (i32.const 31)
                        )
-                       (i32.const 2147483646)
+                       (drop
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (block (result i32)
+                          (local.set $6
+                           (tuple.extract 0
+                            (tuple.make
+                             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                              (local.get $2)
+                             )
+                             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                              (local.get $6)
+                             )
+                            )
+                           )
+                          )
+                          (i32.const 1879048190)
+                         )
+                        )
+                       )
+                       (i32.const 3)
                       )
-                      (i32.const 31)
+                      (i32.const 9)
                      )
                     )
                    )
@@ -368,7 +760,7 @@ pattern matching › tuple_match_deep7
                      (i32.or
                       (i32.shl
                        (i32.eq
-                        (local.get $1)
+                        (local.get $0)
                         (i32.const 1)
                        )
                        (i32.const 31)
@@ -377,7 +769,31 @@ pattern matching › tuple_match_deep7
                      )
                      (i32.const 31)
                     )
-                    (i32.const 1)
+                    (block (result i32)
+                     (drop
+                      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                       (block (result i32)
+                        (local.set $4
+                         (tuple.extract 0
+                          (tuple.make
+                           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                            (local.get $1)
+                           )
+                           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                            (local.get $4)
+                           )
+                          )
+                         )
+                        )
+                        (i32.const 1879048190)
+                       )
+                      )
+                     )
+                     (i32.const 1)
+                    )
                     (unreachable)
                    )
                   )
@@ -389,7 +805,7 @@ pattern matching › tuple_match_deep7
               (unreachable)
              )
             )
-            (br $switch.62_outer
+            (br $switch.100_outer
              (i32.const 1999)
             )
            )
@@ -397,9 +813,22 @@ pattern matching › tuple_match_deep7
           (local.set $2
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=12
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $10)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $11)
+              )
+              (i32.load offset=8
                (local.get $0)
               )
              )
@@ -413,10 +842,23 @@ pattern matching › tuple_match_deep7
           (local.set $3
            (tuple.extract 0
             (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
+             (call_indirect (type $i32_i32_i32_=>_i32)
+              (local.tee $0
+               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                (global.get $gimport_pervasives_+)
+               )
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
                (local.get $2)
+              )
+              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+               (local.get $12)
+              )
+              (i32.load offset=8
+               (local.get $0)
               )
              )
              (call $wimport_GRAIN$MODULE$runtime/gc_decRef
@@ -426,147 +868,9 @@ pattern matching › tuple_match_deep7
             )
            )
           )
-          (local.set $4
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=24
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (local.get $4)
-             )
-            )
-           )
-          )
-          (local.set $6
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $4)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $7
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $3)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $5
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=20
-               (local.get $2)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $15
-           (tuple.extract 0
-            (tuple.make
-             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-              (i32.load offset=8
-               (local.get $0)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $8
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $8
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $15)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $5)
-              )
-              (i32.load offset=8
-               (local.get $8)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (local.set $9
-           (tuple.extract 0
-            (tuple.make
-             (call_indirect (type $i32_i32_i32_=>_i32)
-              (local.tee $9
-               (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-                (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-                (global.get $gimport_pervasives_+)
-               )
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $8)
-              )
-              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-               (local.get $7)
-              )
-              (i32.load offset=8
-               (local.get $9)
-              )
-             )
-             (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-              (i32.const 0)
-             )
-            )
-           )
-          )
-          (br $switch.62_outer
+          (br $switch.100_outer
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $1
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -574,14 +878,14 @@ pattern matching › tuple_match_deep7
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $9)
+             (local.get $3)
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $13)
             )
             (i32.load offset=8
-             (local.get $1)
+             (local.get $0)
             )
            )
           )
@@ -590,88 +894,8 @@ pattern matching › tuple_match_deep7
         (local.set $2
          (tuple.extract 0
           (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=12
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $2)
-           )
-          )
-         )
-        )
-        (local.set $3
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=24
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $3)
-           )
-          )
-         )
-        )
-        (local.set $4
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $3)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (local.get $4)
-           )
-          )
-         )
-        )
-        (local.set $6
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=20
-             (local.get $2)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $7
-         (tuple.extract 0
-          (tuple.make
-           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-            (i32.load offset=8
-             (local.get $0)
-            )
-           )
-           (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
-           )
-          )
-         )
-        )
-        (local.set $5
-         (tuple.extract 0
-          (tuple.make
            (call_indirect (type $i32_i32_i32_=>_i32)
-            (local.tee $5
+            (local.tee $0
              (call $wimport_GRAIN$MODULE$runtime/gc_incRef
               (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
               (global.get $gimport_pervasives_+)
@@ -683,22 +907,22 @@ pattern matching › tuple_match_deep7
             )
             (call $wimport_GRAIN$MODULE$runtime/gc_incRef
              (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-             (local.get $6)
+             (local.get $8)
             )
             (i32.load offset=8
-             (local.get $5)
+             (local.get $0)
             )
            )
            (call $wimport_GRAIN$MODULE$runtime/gc_decRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-            (i32.const 0)
+            (local.get $2)
            )
           )
          )
         )
-        (br $switch.62_outer
+        (br $switch.100_outer
          (call_indirect (type $i32_i32_i32_=>_i32)
-          (local.tee $1
+          (local.tee $0
            (call $wimport_GRAIN$MODULE$runtime/gc_incRef
             (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
             (global.get $gimport_pervasives_+)
@@ -706,70 +930,22 @@ pattern matching › tuple_match_deep7
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $5)
+           (local.get $2)
           )
           (call $wimport_GRAIN$MODULE$runtime/gc_incRef
            (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-           (local.get $4)
+           (local.get $9)
           )
-          (i32.load offset=8
-           (local.get $1)
-          )
-         )
-        )
-       )
-      )
-      (local.set $2
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=12
-           (local.get $0)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $2)
-         )
-        )
-       )
-      )
-      (local.set $3
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-          (i32.load offset=20
-           (local.get $2)
-          )
-         )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $3)
-         )
-        )
-       )
-      )
-      (local.set $4
-       (tuple.extract 0
-        (tuple.make
-         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (i32.load offset=8
            (local.get $0)
           )
          )
-         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-          (local.get $4)
-         )
         )
        )
       )
-      (br $switch.62_outer
+      (br $switch.100_outer
        (call_indirect (type $i32_i32_i32_=>_i32)
-        (local.tee $1
+        (local.tee $0
          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
           (global.get $gimport_pervasives_+)
@@ -777,14 +953,14 @@ pattern matching › tuple_match_deep7
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $4)
+         (local.get $5)
         )
         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-         (local.get $3)
+         (local.get $6)
         )
         (i32.load offset=8
-         (local.get $1)
+         (local.get $0)
         )
        )
       )
@@ -792,10 +968,74 @@ pattern matching › tuple_match_deep7
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (i32.load offset=8
-      (local.get $0)
-     )
+     (local.get $4)
     )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $18)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $19)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $20)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $21)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $14)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $8)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $9)
    )
   )
   (drop
@@ -825,13 +1065,13 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $14)
+    (local.get $15)
    )
   )
   (drop
@@ -849,46 +1089,28 @@ pattern matching › tuple_match_deep7
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
+    (local.get $16)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $6)
+    (local.get $17)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $7)
+    (local.get $22)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $5)
+    (local.get $23)
    )
   )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $15)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $8)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $9)
-   )
-  )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
@@ -1,0 +1,406 @@
+pattern matching › or_match_3
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_none (func))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $gimport_pervasives_[] (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $gimport_pervasives_[...] (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (global $global_1 i32 (i32.const 0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call_indirect (type $i32_i32_i32_=>_i32)
+      (local.tee $0
+       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+        (global.get $gimport_pervasives_[...])
+       )
+      )
+      (i32.const 11)
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_pervasives_[])
+      )
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (block $switch.53_outer (result i32)
+    (drop
+     (block $switch.53_branch_1 (result i32)
+      (drop
+       (block $switch.53_branch_2 (result i32)
+        (drop
+         (block $switch.53_default (result i32)
+          (br_table $switch.53_branch_1 $switch.53_branch_2 $switch.53_default
+           (i32.const 0)
+           (i32.shr_s
+            (if (result i32)
+             (i32.shr_u
+              (i32.or
+               (i32.shl
+                (i32.eq
+                 (i32.load offset=12
+                  (local.get $2)
+                 )
+                 (i32.const 3)
+                )
+                (i32.const 31)
+               )
+               (i32.const 2147483646)
+              )
+              (i32.const 31)
+             )
+             (block (result i32)
+              (local.set $3
+               (tuple.extract 0
+                (tuple.make
+                 (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                  (i32.load offset=20
+                   (local.get $2)
+                  )
+                 )
+                 (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                  (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                  (i32.const 0)
+                 )
+                )
+               )
+              )
+              (if (result i32)
+               (i32.shr_u
+                (i32.or
+                 (i32.shl
+                  (i32.eq
+                   (local.tee $1
+                    (i32.load offset=12
+                     (local.tee $4
+                      (tuple.extract 0
+                       (tuple.make
+                        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                         (i32.load offset=24
+                          (local.get $2)
+                         )
+                        )
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (i32.const 0)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const 31)
+                 )
+                 (i32.const 2147483646)
+                )
+                (i32.const 31)
+               )
+               (block (result i32)
+                (local.set $5
+                 (tuple.extract 0
+                  (tuple.make
+                   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                    (i32.load offset=20
+                     (local.get $4)
+                    )
+                   )
+                   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                    (i32.const 0)
+                   )
+                  )
+                 )
+                )
+                (if (result i32)
+                 (i32.shr_u
+                  (i32.or
+                   (i32.shl
+                    (i32.eq
+                     (local.tee $1
+                      (i32.load offset=12
+                       (local.tee $6
+                        (tuple.extract 0
+                         (tuple.make
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (i32.load offset=24
+                            (local.get $4)
+                           )
+                          )
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                       )
+                      )
+                     )
+                     (i32.const 3)
+                    )
+                    (i32.const 31)
+                   )
+                   (i32.const 2147483646)
+                  )
+                  (i32.const 31)
+                 )
+                 (if (result i32)
+                  (i32.shr_u
+                   (i32.or
+                    (i32.shl
+                     (i32.eq
+                      (i32.load offset=12
+                       (local.tee $7
+                        (tuple.extract 0
+                         (tuple.make
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (i32.load offset=24
+                            (local.get $6)
+                           )
+                          )
+                          (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                           (i32.const 0)
+                          )
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 1)
+                     )
+                     (i32.const 31)
+                    )
+                    (i32.const 2147483646)
+                   )
+                   (i32.const 31)
+                  )
+                  (block (result i32)
+                   (drop
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (block (result i32)
+                      (local.set $0
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $5)
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 1879048190)
+                     )
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 3)
+                 )
+                 (if (result i32)
+                  (i32.shr_u
+                   (i32.or
+                    (i32.shl
+                     (i32.eq
+                      (local.get $1)
+                      (i32.const 1)
+                     )
+                     (i32.const 31)
+                    )
+                    (i32.const 2147483646)
+                   )
+                   (i32.const 31)
+                  )
+                  (block (result i32)
+                   (drop
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (block (result i32)
+                      (local.set $0
+                       (tuple.extract 0
+                        (tuple.make
+                         (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                          (local.get $3)
+                         )
+                         (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                          (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                          (local.get $0)
+                         )
+                        )
+                       )
+                      )
+                      (i32.const 1879048190)
+                     )
+                    )
+                   )
+                   (i32.const 1)
+                  )
+                  (i32.const 3)
+                 )
+                )
+               )
+               (if (result i32)
+                (i32.shr_u
+                 (i32.or
+                  (i32.shl
+                   (i32.eq
+                    (local.get $1)
+                    (i32.const 1)
+                   )
+                   (i32.const 31)
+                  )
+                  (i32.const 2147483646)
+                 )
+                 (i32.const 31)
+                )
+                (block (result i32)
+                 (drop
+                  (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                   (block (result i32)
+                    (local.set $0
+                     (tuple.extract 0
+                      (tuple.make
+                       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                        (local.get $3)
+                       )
+                       (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                        (local.get $0)
+                       )
+                      )
+                     )
+                    )
+                    (i32.const 1879048190)
+                   )
+                  )
+                 )
+                 (i32.const 1)
+                )
+                (i32.const 3)
+               )
+              )
+             )
+             (i32.const 3)
+            )
+            (i32.const 1)
+           )
+          )
+         )
+        )
+        (unreachable)
+       )
+      )
+      (br $switch.53_outer
+       (i32.const 2147483646)
+      )
+     )
+    )
+    (i32.const -2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $6)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (local.get $1)
+ )
+ (func $_start (; has Stack IR ;)
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 242
+)

--- a/compiler/test/__snapshots__/pattern_matching.f3d48b0e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f3d48b0e.0.snapshot
@@ -1,0 +1,19 @@
+pattern matching › or_match_1
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (global $global_1 i32 (i32.const 0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (func $_gmain (; has Stack IR ;) (result i32)
+  (i32.const 7)
+ )
+ (func $_start (; has Stack IR ;)
+  (nop)
+ )
+ ;; custom section \"cmi\", size 242
+)

--- a/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
@@ -1,0 +1,207 @@
+pattern matching › or_match_2
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $gimport_pervasives_Some (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $wimport_GRAIN$MODULE$runtime/equal_equal (param i32 i32 i32) (result i32)))
+ (global $global_1 i32 (i32.const 0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (func $_gmain (; has Stack IR ;) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local.set $2
+   (block $switch.30_outer (result i32)
+    (drop
+     (block $switch.30_branch_1 (result i32)
+      (drop
+       (block $switch.30_branch_2 (result i32)
+        (drop
+         (block $switch.30_branch_3 (result i32)
+          (drop
+           (block $switch.30_default (result i32)
+            (br_table $switch.30_branch_1 $switch.30_branch_2 $switch.30_branch_3 $switch.30_default
+             (i32.const 0)
+             (i32.shr_s
+              (if (result i32)
+               (i32.shr_u
+                (i32.or
+                 (i32.shl
+                  (i32.eq
+                   (local.tee $2
+                    (i32.load offset=12
+                     (local.tee $0
+                      (tuple.extract 0
+                       (tuple.make
+                        (call_indirect (type $i32_i32_=>_i32)
+                         (local.tee $0
+                          (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                           (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                           (global.get $gimport_pervasives_Some)
+                          )
+                         )
+                         (i32.const 11)
+                         (i32.load offset=8
+                          (local.get $0)
+                         )
+                        )
+                        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                         (i32.const 0)
+                        )
+                       )
+                      )
+                     )
+                    )
+                   )
+                   (i32.const 3)
+                  )
+                  (i32.const 31)
+                 )
+                 (i32.const 2147483646)
+                )
+                (i32.const 31)
+               )
+               (i32.const 3)
+               (if (result i32)
+                (i32.shr_u
+                 (i32.or
+                  (i32.shl
+                   (i32.eq
+                    (local.get $2)
+                    (i32.const 1)
+                   )
+                   (i32.const 31)
+                  )
+                  (i32.const 2147483646)
+                 )
+                 (i32.const 31)
+                )
+                (block (result i32)
+                 (local.set $1
+                  (tuple.extract 0
+                   (tuple.make
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (i32.load offset=20
+                      (local.get $0)
+                     )
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+                     (i32.const 0)
+                    )
+                   )
+                  )
+                 )
+                 (if (result i32)
+                  (i32.shr_u
+                   (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                    )
+                    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                     (local.get $1)
+                    )
+                    (i32.const 7)
+                   )
+                   (i32.const 31)
+                  )
+                  (i32.const 1)
+                  (if (result i32)
+                   (i32.shr_u
+                    (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                     )
+                     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                      (local.get $1)
+                     )
+                     (i32.const 9)
+                    )
+                    (i32.const 31)
+                   )
+                   (i32.const 1)
+                   (select
+                    (i32.const 3)
+                    (i32.const 5)
+                    (i32.shr_u
+                     (call $wimport_GRAIN$MODULE$runtime/equal_equal
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (global.get $wimport_GRAIN$MODULE$runtime/equal_GRAIN$EXPORT$equal)
+                      )
+                      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+                       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+                       (local.get $1)
+                      )
+                      (i32.const 11)
+                     )
+                     (i32.const 31)
+                    )
+                   )
+                  )
+                 )
+                )
+                (i32.const 5)
+               )
+              )
+              (i32.const 1)
+             )
+            )
+           )
+          )
+          (unreachable)
+         )
+        )
+        (br $switch.30_outer
+         (i32.const 2147483646)
+        )
+       )
+      )
+      (br $switch.30_outer
+       (i32.const -2)
+      )
+     )
+    )
+    (i32.const 2147483646)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (local.get $2)
+ )
+ (func $_start (; has Stack IR ;)
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 242
+)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -12,15 +12,17 @@ records › record_destruct_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -165,12 +167,59 @@ records › record_destruct_1
     )
    )
   )
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_0)
+     )
+    )
+   )
+  )
   (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $2)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $3
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (local.get $0)
-    )
+    (global.get $global_0)
    )
   )
   (drop
@@ -185,7 +234,13 @@ records › record_destruct_1
     (local.get $0)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -27,6 +27,9 @@ records › record_destruct_4
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -143,12 +146,7 @@ records › record_destruct_4
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -159,12 +157,7 @@ records › record_destruct_4
   (global.set $global_1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_1)
@@ -175,6 +168,49 @@ records › record_destruct_4
   (global.set $global_2
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=24
@@ -183,8 +219,74 @@ records › record_destruct_4
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (global.get $global_2)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
     )
    )
   )
@@ -242,6 +344,24 @@ records › record_destruct_4
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -12,15 +12,17 @@ records › record_destruct_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 i32 (i32.const 0))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_2))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -165,12 +167,59 @@ records › record_destruct_2
     )
    )
   )
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_0)
+     )
+    )
+   )
+  )
   (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $2)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $3
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=20
-     (local.get $0)
-    )
+    (global.get $global_0)
    )
   )
   (drop
@@ -185,7 +234,13 @@ records › record_destruct_2
     (local.get $0)
    )
   )
-  (local.get $2)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (local.get $3)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -22,6 +22,8 @@ records › record_destruct_deep
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -167,12 +169,7 @@ records › record_destruct_deep
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -181,11 +178,63 @@ records › record_destruct_deep
    )
   )
   (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $4
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=16
-     (global.get $global_0)
-    )
+    (global.get $global_0)
    )
   )
   (drop
@@ -200,7 +249,19 @@ records › record_destruct_deep
     (local.get $0)
    )
   )
-  (local.get $1)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -25,6 +25,8 @@ records › record_destruct_3
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -141,12 +143,7 @@ records › record_destruct_3
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -157,6 +154,33 @@ records › record_destruct_3
   (global.set $global_1
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_1)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=20
@@ -165,8 +189,52 @@ records › record_destruct_3
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (global.get $global_1)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $2)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
     )
    )
   )
@@ -195,6 +263,18 @@ records › record_destruct_3
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
    )
   )
   (local.get $1)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -27,6 +27,9 @@ records › record_destruct_trailing
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -143,12 +146,7 @@ records › record_destruct_trailing
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=16
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -159,12 +157,7 @@ records › record_destruct_trailing
   (global.set $global_1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=20
-       (local.get $0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_1)
@@ -175,6 +168,49 @@ records › record_destruct_trailing
   (global.set $global_2
    (tuple.extract 0
     (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (i32.load offset=24
@@ -183,8 +219,74 @@ records › record_destruct_trailing
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-      (global.get $global_2)
+      (i32.const 0)
      )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
     )
    )
   )
@@ -242,6 +344,24 @@ records › record_destruct_trailing
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -11,17 +11,25 @@ tuples › nested_tup_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (global $global_3 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
  (global $global_1 (mut i32) (i32.const 0))
  (global $global_0 (mut i32) (i32.const 0))
- (global $global_3 i32 (i32.const 0))
+ (global $global_5 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_3))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_5))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -43,7 +51,7 @@ tuples › nested_tup_3
    (local.get $0)
    (i32.const 5)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -75,7 +83,7 @@ tuples › nested_tup_3
    (local.get $0)
    (i32.const 9)
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -103,20 +111,31 @@ tuples › nested_tup_3
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (i32.store offset=12
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $2)
+    (local.get $3)
+   )
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -127,12 +146,7 @@ tuples › nested_tup_3
   (global.set $global_1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (global.get $global_0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_1)
@@ -140,12 +154,228 @@ tuples › nested_tup_3
     )
    )
   )
-  (local.set $0
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_1)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (global.set $global_2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (global.set $global_3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_3)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $8
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=8
-     (global.get $global_1)
-    )
+    (global.get $global_2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -157,10 +387,16 @@ tuples › nested_tup_3
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $6)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (local.get $8)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -11,16 +11,20 @@ tuples › nested_tup_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (global $global_1 (mut i32) (i32.const 0))
  (global $global_0 (mut i32) (i32.const 0))
- (global $global_2 i32 (i32.const 0))
+ (global $global_3 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_3))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -112,10 +116,21 @@ tuples › nested_tup_1
     (local.get $2)
    )
   )
-  (global.set $global_0
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -123,12 +138,97 @@ tuples › nested_tup_1
     )
    )
   )
-  (local.set $0
+  (global.set $global_1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_1)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=8
-     (global.get $global_0)
-    )
+    (global.get $global_0)
    )
   )
   (drop
@@ -143,7 +243,25 @@ tuples › nested_tup_1
     (local.get $2)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (local.get $5)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
@@ -1,19 +1,246 @@
 tuples › tup1_destruct_trailing
 (module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
- (global $global_1 i32 (i32.const 0))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (global $global_0 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_4 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_1))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_4))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (i32.const 1879048190)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (i32.store
+   (local.tee $0
+    (call $wimport_GRAIN$MODULE$runtime/gc_malloc
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$malloc)
+     (i32.const 20)
+    )
+   )
+   (i32.const 7)
+  )
+  (i32.store offset=4
+   (local.get $0)
+   (i32.const 3)
+  )
+  (i32.store offset=8
+   (local.get $0)
+   (i32.const 3)
+  )
+  (i32.store offset=12
+   (local.get $0)
+   (i32.const 5)
+  )
+  (i32.store offset=16
+   (local.get $0)
+   (i32.const 7)
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_0)
+     )
+    )
+   )
+  )
+  (global.set $global_1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_1)
+     )
+    )
+   )
+  )
+  (global.set $global_2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $2)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $1)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $4
+   (i32.const 1)
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
-  (nop)
+  (drop
+   (call $_gmain)
+  )
  )
  ;; custom section \"cmi\", size 254
 )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -12,13 +12,21 @@ tuples › big_tup_access
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
  (global $global_0 (mut i32) (i32.const 0))
- (global $global_2 i32 (i32.const 0))
+ (global $global_3 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_5 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_2))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_5))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -48,10 +56,21 @@ tuples › big_tup_access
    (local.get $0)
    (i32.const 9)
   )
-  (global.set $global_0
+  (local.set $0
    (tuple.extract 0
     (tuple.make
      (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (global.set $global_0
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -59,12 +78,228 @@ tuples › big_tup_access
     )
    )
   )
-  (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-   (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-   (i32.load offset=16
-    (global.get $global_0)
+  (global.set $global_1
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_1)
+     )
+    )
    )
   )
+  (global.set $global_2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (global.set $global_3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_3)
+     )
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $2
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $3
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=16
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=20
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $3)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $2)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $1)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $5
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $global_2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $1)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (local.get $5)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -11,17 +11,25 @@ tuples › nested_tup_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
- (global $global_1 (mut i32) (i32.const 0))
  (global $global_0 (mut i32) (i32.const 0))
- (global $global_3 i32 (i32.const 0))
+ (global $global_3 (mut i32) (i32.const 0))
+ (global $global_2 (mut i32) (i32.const 0))
+ (global $global_1 (mut i32) (i32.const 0))
+ (global $global_5 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
- (export \"GRAIN$TABLE_SIZE\" (global $global_3))
+ (export \"GRAIN$TABLE_SIZE\" (global $global_5))
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   (i32.store
    (local.tee $0
     (call $wimport_GRAIN$MODULE$runtime/gc_malloc
@@ -43,7 +51,7 @@ tuples › nested_tup_2
    (local.get $0)
    (i32.const 5)
   )
-  (local.set $1
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -75,7 +83,7 @@ tuples › nested_tup_2
    (local.get $0)
    (i32.const 9)
   )
-  (local.set $2
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -103,20 +111,31 @@ tuples › nested_tup_2
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $1)
+    (local.get $2)
    )
   )
   (i32.store offset=12
    (local.get $0)
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (local.get $2)
+    (local.get $3)
+   )
+  )
+  (local.set $0
+   (tuple.extract 0
+    (tuple.make
+     (local.get $0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
    )
   )
   (global.set $global_0
    (tuple.extract 0
     (tuple.make
-     (local.get $0)
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_0)
@@ -127,12 +146,7 @@ tuples › nested_tup_2
   (global.set $global_1
    (tuple.extract 0
     (tuple.make
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (i32.load offset=12
-       (global.get $global_0)
-      )
-     )
+     (i32.const 0)
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
       (global.get $global_1)
@@ -140,12 +154,228 @@ tuples › nested_tup_2
     )
    )
   )
-  (local.set $0
+  (local.set $4
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $5
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $0)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_1
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $5)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_1)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_0
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $4)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_0)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $1
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (global.get $global_1)
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (global.set $global_2
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_2)
+     )
+    )
+   )
+  )
+  (global.set $global_3
+   (tuple.extract 0
+    (tuple.make
+     (i32.const 0)
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (global.get $global_3)
+     )
+    )
+   )
+  )
+  (local.set $6
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=8
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (local.set $7
+   (tuple.extract 0
+    (tuple.make
+     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+      (i32.load offset=12
+       (local.get $1)
+      )
+     )
+     (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_3
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $7)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_3)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (block (result i32)
+     (global.set $global_2
+      (tuple.extract 0
+       (tuple.make
+        (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+         (local.get $6)
+        )
+        (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+         (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+         (global.get $global_2)
+        )
+       )
+      )
+     )
+     (i32.const 1879048190)
+    )
+   )
+  )
+  (local.set $8
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-    (i32.load offset=12
-     (global.get $global_1)
-    )
+    (global.get $global_3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $3)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $0)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $4)
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $5)
    )
   )
   (drop
@@ -157,10 +387,16 @@ tuples › nested_tup_2
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $2)
+    (local.get $6)
    )
   )
-  (local.get $0)
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $7)
+   )
+  )
+  (local.get $8)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/input/mixedPatternMatching.gr
+++ b/compiler/test/input/mixedPatternMatching.gr
@@ -1,62 +1,90 @@
-import * from "list";
+import * from "list"
 
 export record Rec {
   foo: List<Number>,
-  bar: String
-};
+  bar: String,
+}
 
 export enum Poly {
   PList(List<Number>),
   PArray(Array<Poly>),
   PAssoc(Rec),
   PMulti(List<String>, Number, Rec),
-  PPoly(List<Poly>)
-};
+  PPoly(List<Poly>),
+}
 
-let test = (test) => {
-  let (input, expected) = test;
+let test = test => {
+  let (input, expected) = test
   let result = match (input) {
     PList([]) => 1,
-    PList([a, b]) => a + b,
+    PList([a, b] | [_, a, b]) => a + b,
     PList([a, ..._]) => a,
-    PAssoc({foo: [], _}) => 1,
-    PAssoc({foo: [a, b], _}) => a + b,
-    PAssoc({foo: [a, ..._], _}) => a,
-    PMulti([], a, {foo: [], _}) => a,
-    PMulti([_, ..._], a, {foo: [b, ..._], _}) => a + b,
-    PMulti([], _, {foo: [b, ..._], _}) => b,
-    PMulti([_, ..._], a, {foo: [b, c, ..._], _}) => a + b + c,
-    PPoly([PList([a]), PAssoc({foo: [b], _}), PMulti([], c, {foo: [d], _})]) => a + b + c + d,
+    PAssoc({ foo: [], _ }) => 1,
+    PAssoc({ foo: [a, b], _ }) => a + b,
+    PAssoc({ foo: [a, ..._], _ }) => a,
+    PMulti([], a, { foo: [], _ }) => a,
+    PMulti([_, ..._], a, { foo: [b, ..._], _ }) => a + b,
+    PMulti([], _, { foo: [b, ..._], _ }) => b,
+    PMulti([_, ..._], a, { foo: [b, c, ..._], _ }) => a + b + c,
+    PPoly(
+      [PList([a]), PAssoc({ foo: [b], _ }), PMulti([], c, { foo: [d], _ })]
+    ) =>
+      a +
+      b +
+      c +
+      d,
     PPoly([]) => 42,
+    PPoly([PList([]) | PPoly([])]) => 50,
+    PPoly([PList([a, b]) | PPoly([PList([a, b]) | PPoly([PList([a, b])])])]) =>
+      a +
+      b,
     PPoly([_, ..._]) => 43,
-    PArray([>]) => 44,
+    PArray([> ]) => 44,
     PArray([> PList([a, b])]) => a + b,
     PArray([> PPoly([PList([a, b])]), PList([c, d])]) => a + b + c + d,
-    PArray(_) => 45
-  };
+    PArray(_) => 45,
+  }
+  if (result != expected) {
+    print("Failed case " ++ toString(input) ++ ":")
+    print("Expected " ++ toString(expected) ++ " but got " ++ toString(result))
+  }
   result == expected
-};
+}
 
 let tests = [
   (PList([]), 1),
   (PList([2]), 2),
   (PList([2, 7]), 9),
-  (PList([2, 7, 10]), 2),
-  (PAssoc({foo: [], bar: "bar"}), 1),
-  (PAssoc({foo: [2], bar: "bar"}), 2),
-  (PAssoc({foo: [2, 7], bar: "bar"}), 9),
-  (PAssoc({foo: [2, 7, 10], bar: "bar"}), 2),
-  (PMulti([], 17, {foo: [], bar: "bar"}), 17),
-  (PMulti(["foo"], 17, {foo: [3], bar: "bar"}), 20),
-  (PMulti([], 11, {foo: [4], bar: "bar"}), 4),
-  (PMulti(["foo"], 17, {foo: [3, 5], bar: "bar"}), 20),
-  (PPoly([PList([1]), PAssoc({foo: [2], bar: "bar"}), PMulti([], 3, {foo: [4], bar: "bar"})]), 10),
+  (PList([2, 7, 10]), 17),
+  (PList([2, 7, 10, 11]), 2),
+  (PAssoc({ foo: [], bar: "bar" }), 1),
+  (PAssoc({ foo: [2], bar: "bar" }), 2),
+  (PAssoc({ foo: [2, 7], bar: "bar" }), 9),
+  (PAssoc({ foo: [2, 7, 10], bar: "bar" }), 2),
+  (PMulti([], 17, { foo: [], bar: "bar" }), 17),
+  (PMulti(["foo"], 17, { foo: [3], bar: "bar" }), 20),
+  (PMulti([], 11, { foo: [4], bar: "bar" }), 4),
+  (PMulti(["foo"], 17, { foo: [3, 5], bar: "bar" }), 20),
+  (
+    PPoly(
+      [
+        PList([1]),
+        PAssoc({ foo: [2], bar: "bar" }),
+        PMulti([], 3, { foo: [4], bar: "bar" }),
+      ]
+    ),
+    10,
+  ),
   (PPoly([]), 42),
-  (PPoly([PPoly([])]), 43),
+  (PPoly([PPoly([])]), 50),
+  (PPoly([PList([])]), 50),
+  (PPoly([PList([7, 8])]), 15),
+  (PPoly([PPoly([PList([7, 8])])]), 15),
+  (PPoly([PPoly([PPoly([PList([7, 8])])])]), 15),
   (PArray([>]), 44),
   (PArray([> PList([3, 4])]), 7),
   (PArray([> PPoly([PList([3, 4])]), PList([5, 6])]), 18),
   (PArray([> PList([3, 4]), PList([3, 4])]), 45),
-];
+]
 
 print(every(test, tests))

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -215,6 +215,16 @@ describe("pattern matching", ({test, testSkip}) => {
     "constant_match_4",
     "match ((\"foo\", 5)) { (\"foo\", n) when n == 7 => false, (\"foo\", 9) when true => false, (\"foo\", n) when n == 5 => true, _ => false }",
   );
+  // Or patterns
+  assertSnapshot("or_match_1", "match (true) { true | false => 3 }");
+  assertSnapshot(
+    "or_match_2",
+    "match (Some(5)) { Some(3 | 4) => false, Some(5) | None => true, _ => false }",
+  );
+  assertSnapshot(
+    "or_match_3",
+    "match ([5]) { [a, _] | [_, a, _] | [a] => true, _ => false }",
+  );
   assertFileRun("mixed_matching", "mixedPatternMatching", "true\n");
   assertWarning(
     "bool_exhaustiveness1",

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -301,4 +301,51 @@ describe("pattern matching", ({test, testSkip}) => {
     |},
     "Expected `=>` followed by an expression.",
   );
+
+  // destructuring
+  assertRun(
+    "destructure_constant",
+    {|
+      let 1 | _ = 5
+      print("ok")
+    |},
+    "ok\n",
+  );
+  assertRun(
+    "destructure_singleton_adt",
+    {|
+      enum NumWrapper { NumWrapper(Number) }
+      let NumWrapper(a) = NumWrapper(5)
+      print(a)
+    |},
+    "5\n",
+  );
+  assertRun(
+    "destructure_adt",
+    {|
+      enum Foo { A(Number), B(Number) }
+      let A(val1) | B(val1) = A(5)
+      let A(val2) | B(val2) = B(6)
+      print(val1)
+      print(val2)
+    |},
+    "5\n6\n",
+  );
+  assertRun(
+    "destructure_tuple",
+    {|
+      let (a, b) = (3, 4)
+      print(a + b)
+    |},
+    "7\n",
+  );
+  assertRun(
+    "destructure_record",
+    {|
+      record Rec { a: Number, b: Number }
+      let {a, b} = { a: 3, b: 4 }
+      print(a + b)
+    |},
+    "7\n",
+  );
 });


### PR DESCRIPTION
This PR refactors the match compiler to properly support or-patterns. The two major changes are how bindings work and how constant patterns are compiled. Slots for each of the bindings needed in each of the branches are created, and during the branch selection process these slots are filled with the proper values. Constant patterns are now compiled the same way constructors are and should be more efficient now.

This opens the door for a number of optimizations we can write, but I left them out of this PR to keep it relatively simple.

You may notice that a fair number of snapshots are a bit bigger now; we need a few optimizations to remove the cruft, which will come after this PR.

Closes #264 