### PR TITLE
feat(compiler): Call known functions across module boundaries

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -92,7 +92,7 @@ let grain_env_name = "_grainEnv";
 
 let is_grain_env = str => grain_env_name == str;
 
-let get_exported_names = (~local_functions=?, ~local_globals=?, wasm_mod) => {
+let get_exported_names = (~function_names=?, ~global_names=?, wasm_mod) => {
   let num_exports = Export.get_num_exports(wasm_mod);
   let exported_names: Hashtbl.t(string, string) = Hashtbl.create(10);
   for (i in 0 to num_exports - 1) {
@@ -103,16 +103,15 @@ let get_exported_names = (~local_functions=?, ~local_globals=?, wasm_mod) => {
 
     if (export_kind == Export.external_function) {
       let new_internal_name =
-        switch (local_functions) {
-        | Some(local_functions) =>
-          Hashtbl.find(local_functions, internal_name)
+        switch (function_names) {
+        | Some(function_names) => Hashtbl.find(function_names, internal_name)
         | None => internal_name
         };
       Hashtbl.add(exported_names, exported_name, new_internal_name);
     } else if (export_kind == Export.external_global) {
       let new_internal_name =
-        switch (local_globals) {
-        | Some(local_globals) => Hashtbl.find(local_globals, internal_name)
+        switch (global_names) {
+        | Some(global_names) => Hashtbl.find(global_names, internal_name)
         | None => internal_name
         };
       Hashtbl.add(exported_names, exported_name, new_internal_name);

--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -116,7 +116,6 @@ let get_exported_names = (~function_names=?, ~global_names=?, wasm_mod) => {
         };
       Hashtbl.add(exported_names, exported_name, new_internal_name);
     };
-    ();
   };
   exported_names;
 };

--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -180,7 +180,7 @@ let write_universal_exports =
                   arguments,
                   call_result_types,
                 )
-              | _ =>
+              | Indirect =>
                 let call_arg_types =
                   Type.create(
                     Array.of_list(
@@ -204,6 +204,7 @@ let write_universal_exports =
                   call_arg_types,
                   call_result_types,
                 );
+              | Unknown => failwith("Impossible: Unknown function call type")
               };
             let function_body =
               switch (rets) {

--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -92,23 +92,32 @@ let grain_env_name = "_grainEnv";
 
 let is_grain_env = str => grain_env_name == str;
 
-let get_exported_names = (~local_names=?, wasm_mod) => {
+let get_exported_names = (~local_functions=?, ~local_globals=?, wasm_mod) => {
   let num_exports = Export.get_num_exports(wasm_mod);
   let exported_names: Hashtbl.t(string, string) = Hashtbl.create(10);
   for (i in 0 to num_exports - 1) {
     let export = Export.get_export_by_index(wasm_mod, i);
     let export_kind = Export.export_get_kind(export);
-    if (export_kind == Export.external_function
-        || export_kind == Export.external_global) {
-      let exported_name = Export.get_name(export);
-      let internal_name = Export.get_value(export);
+    let exported_name = Export.get_name(export);
+    let internal_name = Export.get_value(export);
+
+    if (export_kind == Export.external_function) {
       let new_internal_name =
-        switch (local_names) {
-        | Some(local_names) => Hashtbl.find(local_names, internal_name)
+        switch (local_functions) {
+        | Some(local_functions) =>
+          Hashtbl.find(local_functions, internal_name)
+        | None => internal_name
+        };
+      Hashtbl.add(exported_names, exported_name, new_internal_name);
+    } else if (export_kind == Export.external_global) {
+      let new_internal_name =
+        switch (local_globals) {
+        | Some(local_globals) => Hashtbl.find(local_globals, internal_name)
         | None => internal_name
         };
       Hashtbl.add(exported_names, exported_name, new_internal_name);
     };
+    ();
   };
   exported_names;
 };
@@ -133,12 +142,23 @@ let write_universal_exports =
       List.iter(
         item => {
           switch (item) {
-          | TSigValue(id, {val_repr: ReprFunction(args, rets)}) =>
+          | TSigValue(
+              id,
+              {
+                val_repr: ReprFunction(args, rets, direct),
+                val_fullpath: path,
+              },
+            ) =>
             let name = Ident.name(id);
             let exported_name = "GRAIN$EXPORT$" ++ name;
-            let internal_name = Hashtbl.find(exported_names, exported_name);
+            let internal_global_name =
+              Hashtbl.find(exported_names, exported_name);
             let get_closure = () =>
-              Expression.Global_get.make(wasm_mod, internal_name, Type.int32);
+              Expression.Global_get.make(
+                wasm_mod,
+                internal_global_name,
+                Type.int32,
+              );
             let arguments =
               List.mapi(
                 (i, arg) =>
@@ -146,34 +166,46 @@ let write_universal_exports =
                 args,
               );
             let arguments = [get_closure(), ...arguments];
-            let call_arg_types =
-              Type.create(
-                Array.of_list(List.map(type_of_repr, [WasmI32, ...args])),
-              );
             let call_result_types =
               Type.create(
                 Array.of_list(
                   List.map(type_of_repr, rets == [] ? [WasmI32] : rets),
                 ),
               );
-            let func_ptr =
-              Expression.Load.make(
-                wasm_mod,
-                4,
-                8,
-                2,
-                Type.int32,
-                get_closure(),
-              );
             let function_call =
-              Expression.Call_indirect.make(
-                wasm_mod,
-                global_function_table,
-                func_ptr,
-                arguments,
-                call_arg_types,
-                call_result_types,
-              );
+              switch (direct) {
+              | Direct(name) =>
+                Expression.Call.make(
+                  wasm_mod,
+                  Hashtbl.find(exported_names, name),
+                  arguments,
+                  call_result_types,
+                )
+              | _ =>
+                let call_arg_types =
+                  Type.create(
+                    Array.of_list(
+                      List.map(type_of_repr, [WasmI32, ...args]),
+                    ),
+                  );
+                let func_ptr =
+                  Expression.Load.make(
+                    wasm_mod,
+                    4,
+                    8,
+                    2,
+                    Type.int32,
+                    get_closure(),
+                  );
+                Expression.Call_indirect.make(
+                  wasm_mod,
+                  global_function_table,
+                  func_ptr,
+                  arguments,
+                  call_arg_types,
+                  call_result_types,
+                );
+              };
             let function_body =
               switch (rets) {
               | [] => Expression.Drop.make(wasm_mod, function_call)

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -315,9 +315,8 @@ let get_wasm_imported_name = (~runtime_import=true, mod_, name) => {
   Printf.sprintf("wimport_%s_%s", Ident.name(mod_), Ident.name(name));
 };
 
-let get_grain_imported_name = (mod_, name) => {
+let get_grain_imported_name = (mod_, name) =>
   Printf.sprintf("gimport_%s_%s", Ident.name(mod_), Ident.name(name));
-};
 
 let call_exception_printer = (wasm_mod, env, args) => {
   let args = [
@@ -3323,14 +3322,15 @@ let compile_imports = (wasm_mod, env, {imports}) => {
     | MImportWasm => Ident.name(name)
     | MImportGrain => "GRAIN$MODULE$" ++ Ident.name(name);
 
-  let compile_import_name = name =>
-    fun
-    | MImportWasm => Ident.name(name)
-    | MImportGrain => "GRAIN$EXPORT$" ++ Ident.name(name);
+  let compile_import_name = (name, kind, ty) =>
+    switch (kind, ty) {
+    | (MImportGrain, MGlobalImport(_)) => "GRAIN$EXPORT$" ++ Ident.name(name)
+    | _ => Ident.name(name)
+    };
 
   let compile_import = ({mimp_mod, mimp_name, mimp_type, mimp_kind}) => {
     let module_name = compile_module_name(mimp_mod, mimp_kind);
-    let item_name = compile_import_name(mimp_name, mimp_kind);
+    let item_name = compile_import_name(mimp_name, mimp_kind, mimp_type);
     let internal_name =
       switch (mimp_kind) {
       | MImportGrain => get_grain_imported_name(mimp_mod, mimp_name)

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -539,16 +539,24 @@ let compile_imm = (env, i: imm_expression) =>
   | ImmTrap => MImmTrap
   };
 
+type known_function =
+  | Internal(Ident.t)
+  | Imported(Ident.t, string);
+
 let known_functions = Ident_tbl.create(50);
-let register_function = id => Ident_tbl.add(known_functions, id, ());
+let register_function = func =>
+  switch (func) {
+  | Internal(id)
+  | Imported(id, _) => Ident_tbl.add(known_functions, id, func)
+  };
 let clear_known_functions = () => Ident_tbl.clear(known_functions);
 let known_function = f =>
   switch (f.imm_desc) {
   | ImmId(id) =>
-    if (Ident_tbl.mem(known_functions, id)) {
-      Some(Ident.unique_name(id));
-    } else {
-      None;
+    switch (Ident_tbl.find_opt(known_functions, id)) {
+    | Some(Internal(id)) => Some(Ident.unique_name(id))
+    | Some(Imported(id, name)) => Some(name)
+    | None => None
     }
   | ImmConst(_)
   | ImmTrap => failwith("Impossible: function application of non-function")
@@ -556,7 +564,7 @@ let known_function = f =>
 
 let compile_lambda =
     (~name=?, id, env, args, body, attrs, loc): Mashtree.closure_data => {
-  register_function(id);
+  register_function(Internal(id));
   let (body, return_type) = body;
   // NOTE: we special-case `id`, since we want to
   //       have simply-recursive uses of identifiers use
@@ -643,7 +651,9 @@ let compile_lambda =
   };
 };
 
-let compile_wrapper = (id, env, func_name, args, rets): Mashtree.closure_data => {
+let compile_wrapper =
+    (~export_name=?, id, env, func_name, args, rets): Mashtree.closure_data => {
+  register_function(Internal(id));
   let body = [
     {
       instr_desc:
@@ -691,7 +701,7 @@ let compile_wrapper = (id, env, func_name, args, rets): Mashtree.closure_data =>
     env: lam_env,
     idx,
     id,
-    name: None,
+    name: export_name,
     args: [Types.HeapAllocated, ...args],
     return_type,
     stack_size: {
@@ -1048,36 +1058,55 @@ let lift_imports = (env, imports) => {
     | GrainValue(mod_, name) =>
       let mimp_mod = Ident.create_persistent(mod_);
       let mimp_name = Ident.create_persistent(name);
-      let alloc =
+      let import_name = Printf.sprintf("gimport_%s_%s", mod_, name);
+      let (alloc, mods) =
         switch (imp_shape) {
-        | GlobalShape(alloc) => alloc
+        | GlobalShape(alloc) => (
+            alloc,
+            [
+              {
+                mimp_mod,
+                mimp_name,
+                mimp_type: process_shape(true, imp_shape),
+                mimp_kind: MImportGrain,
+                mimp_setup: MCallGetter,
+                mimp_used: true,
+              },
+            ],
+          )
         | FunctionShape(_) =>
-          failwith("internal: GrainValue had FunctionShape")
+          register_function(Imported(imp_use_id, import_name));
+          (
+            HeapAllocated,
+            [
+              {
+                mimp_mod,
+                mimp_name,
+                mimp_type: process_shape(true, GlobalShape(HeapAllocated)),
+                mimp_kind: MImportGrain,
+                mimp_setup: MCallGetter,
+                mimp_used: true,
+              },
+              {
+                mimp_mod,
+                mimp_name,
+                mimp_type: process_shape(true, imp_shape),
+                mimp_kind: MImportGrain,
+                mimp_setup: MSetupNone,
+                mimp_used: true,
+              },
+            ],
+          );
         };
-      let new_mod = {
-        mimp_mod,
-        mimp_name,
-        mimp_type: process_shape(true, imp_shape),
-        mimp_kind: MImportGrain,
-        mimp_setup: MCallGetter,
-        mimp_used: true,
-      };
       (
-        [new_mod, ...imports],
+        mods @ imports,
         setups,
         {
           ...env,
           ce_binds:
             Ident.add(
               imp_use_id,
-              MGlobalBind(
-                Printf.sprintf(
-                  "gimport_%s_%s",
-                  Ident.name(mimp_mod),
-                  Ident.name(mimp_name),
-                ),
-                alloc,
-              ),
+              MGlobalBind(import_name, alloc),
               env.ce_binds,
             ),
         },
@@ -1120,12 +1149,9 @@ let lift_imports = (env, imports) => {
         },
       );
     | WasmFunction(mod_, name) =>
+      let exported = imp_exported == Global({exported: true});
       let glob =
-        next_global(
-          ~exported=imp_exported == Global({exported: true}),
-          imp_use_id,
-          Types.StackAllocated(WasmI32),
-        );
+        next_global(~exported, imp_use_id, Types.StackAllocated(WasmI32));
       let new_mod = {
         mimp_mod: Ident.create_persistent(mod_),
         mimp_name: Ident.create_persistent(name),
@@ -1134,12 +1160,13 @@ let lift_imports = (env, imports) => {
         mimp_setup: MWrap(Int32.zero),
         mimp_used: true,
       };
-      let func_name =
-        Printf.sprintf(
-          "wimport_%s_%s",
-          Ident.name(new_mod.mimp_mod),
-          Ident.name(new_mod.mimp_name),
-        );
+      let func_name = Printf.sprintf("wimport_%s_%s", mod_, name);
+      let export_name =
+        if (exported) {
+          Some(name);
+        } else {
+          None;
+        };
       (
         [new_mod, ...imports],
         [
@@ -1160,6 +1187,7 @@ let lift_imports = (env, imports) => {
                             MAllocate(
                               MClosure(
                                 compile_wrapper(
+                                  ~export_name?,
                                   imp_use_id,
                                   env,
                                   func_name,
@@ -1200,6 +1228,46 @@ let lift_imports = (env, imports) => {
   (imports, setups, env);
 };
 
+let transl_signature = (functions, signature) => {
+  open Types;
+
+  // At this point in compilation, we know which functions can be called
+  // directly/indirectly at the wasm level. We add this information to the
+  // module signature.
+  let func_map = Ident_tbl.create(30);
+  List.iter(
+    func => Ident_tbl.add(func_map, (func: mash_function).id, func),
+    functions,
+  );
+  let sign =
+    List.map(
+      fun
+      | TSigValue(
+          _,
+          {
+            val_repr: ReprFunction(args, rets, _),
+            val_fullpath: Path.PIdent(id),
+          } as vd,
+        ) => {
+          switch (Ident_tbl.find_opt(func_map, id)) {
+          | Some({name: Some(name)}) =>
+            TSigValue(
+              id,
+              {...vd, val_repr: ReprFunction(args, rets, Direct(name))},
+            )
+          | _ =>
+            TSigValue(
+              id,
+              {...vd, val_repr: ReprFunction(args, rets, Indirect)},
+            )
+          };
+        }
+      | _ as item => item,
+      signature.Cmi_format.cmi_sign,
+    );
+  {...signature, cmi_sign: sign};
+};
+
 let transl_anf_program =
     (anf_prog: Anftree.anf_program): Mashtree.mash_program => {
   reset_lift();
@@ -1236,6 +1304,7 @@ let transl_anf_program =
         {...f, body: run_register_allocation(body)},
       compile_remaining_worklist(),
     );
+  let signature = transl_signature(functions, anf_prog.signature);
 
   {
     functions,
@@ -1249,7 +1318,7 @@ let transl_anf_program =
         global_table^,
         [],
       ),
-    signature: anf_prog.signature,
+    signature,
     type_metadata: anf_prog.type_metadata,
   };
 };

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -135,7 +135,16 @@ let is_function_imported = func =>
 //       constructing the AST (either through constructing two separate instances or by
 //       using Expression.copy())
 
-let rec globalize_names = (local_names, expr) => {
+let rec globalize_names = (local_functions, local_globals, local_labels, expr) => {
+  let globalize_names =
+    globalize_names(local_functions, local_globals, local_labels);
+
+  let add_label = Hashtbl.add(local_labels);
+
+  let find_function = Hashtbl.find(local_functions);
+  let find_global = Hashtbl.find(local_globals);
+  let find_label = Hashtbl.find(local_labels);
+
   let kind = Expression.get_kind(expr);
   switch (kind) {
   | Invalid => failwith("Invalid expression")
@@ -145,7 +154,7 @@ let rec globalize_names = (local_names, expr) => {
     Option.iter(
       internal_name => {
         let new_name = gensym(internal_name);
-        Hashtbl.add(local_names, internal_name, new_name);
+        add_label(internal_name, new_name);
 
         Expression.Block.set_name(expr, new_name);
       },
@@ -154,77 +163,51 @@ let rec globalize_names = (local_names, expr) => {
 
     let num_children = Expression.Block.get_num_children(expr);
     for (i in 0 to num_children - 1) {
-      globalize_names(local_names, Expression.Block.get_child_at(expr, i));
+      globalize_names(Expression.Block.get_child_at(expr, i));
     };
   | If =>
-    globalize_names(local_names, Expression.If.get_condition(expr));
-    globalize_names(local_names, Expression.If.get_if_true(expr));
-    Option.iter(
-      globalize_names(local_names),
-      Expression.If.get_if_false(expr),
-    );
+    globalize_names(Expression.If.get_condition(expr));
+    globalize_names(Expression.If.get_if_true(expr));
+    Option.iter(globalize_names, Expression.If.get_if_false(expr));
   | Loop =>
     let internal_name = Expression.Loop.get_name(expr);
     let new_name = gensym(internal_name);
-    Hashtbl.add(local_names, internal_name, new_name);
+    add_label(internal_name, new_name);
 
     Expression.Loop.set_name(expr, new_name);
 
-    globalize_names(local_names, Expression.Loop.get_body(expr));
+    globalize_names(Expression.Loop.get_body(expr));
   | Break =>
     let internal_name = Expression.Break.get_name(expr);
-    Expression.Break.set_name(
-      expr,
-      Hashtbl.find(local_names, internal_name),
-    );
+    Expression.Break.set_name(expr, find_label(internal_name));
 
-    Option.iter(
-      globalize_names(local_names),
-      Expression.Break.get_condition(expr),
-    );
-    Option.iter(
-      globalize_names(local_names),
-      Expression.Break.get_value(expr),
-    );
+    Option.iter(globalize_names, Expression.Break.get_condition(expr));
+    Option.iter(globalize_names, Expression.Break.get_value(expr));
   | Switch =>
     let num_names = Expression.Switch.get_num_names(expr);
     for (i in 0 to num_names - 1) {
       let internal_name = Expression.Switch.get_name_at(expr, i);
-      Expression.Switch.set_name_at(
-        expr,
-        i,
-        Hashtbl.find(local_names, internal_name),
-      );
+      Expression.Switch.set_name_at(expr, i, find_label(internal_name));
     };
 
     let internal_default_name = Expression.Switch.get_default_name(expr);
     Option.iter(
-      name =>
-        Expression.Switch.set_default_name(
-          expr,
-          Hashtbl.find(local_names, name),
-        ),
+      name => Expression.Switch.set_default_name(expr, find_label(name)),
       internal_default_name,
     );
 
-    globalize_names(local_names, Expression.Switch.get_condition(expr));
-    Option.iter(
-      globalize_names(local_names),
-      Expression.Switch.get_value(expr),
-    );
+    globalize_names(Expression.Switch.get_condition(expr));
+    Option.iter(globalize_names, Expression.Switch.get_value(expr));
   | Call =>
     let internal_name = Expression.Call.get_target(expr);
-    Expression.Call.set_target(
-      expr,
-      Hashtbl.find(local_names, internal_name),
-    );
+    Expression.Call.set_target(expr, find_function(internal_name));
 
     let num_operands = Expression.Call.get_num_operands(expr);
     for (i in 0 to num_operands - 1) {
-      globalize_names(local_names, Expression.Call.get_operand_at(expr, i));
+      globalize_names(Expression.Call.get_operand_at(expr, i));
     };
   | CallIndirect =>
-    globalize_names(local_names, Expression.Call_indirect.get_target(expr));
+    globalize_names(Expression.Call_indirect.get_target(expr));
 
     Expression.Call_indirect.set_table(
       expr,
@@ -233,64 +216,49 @@ let rec globalize_names = (local_names, expr) => {
 
     let num_operands = Expression.Call_indirect.get_num_operands(expr);
     for (i in 0 to num_operands - 1) {
-      globalize_names(
-        local_names,
-        Expression.Call_indirect.get_operand_at(expr, i),
-      );
+      globalize_names(Expression.Call_indirect.get_operand_at(expr, i));
     };
   | LocalGet => ()
-  | LocalSet =>
-    globalize_names(local_names, Expression.Local_set.get_value(expr))
+  | LocalSet => globalize_names(Expression.Local_set.get_value(expr))
   | GlobalGet =>
     let internal_name = Expression.Global_get.get_name(expr);
-    Expression.Global_get.set_name(
-      expr,
-      Hashtbl.find(local_names, internal_name),
-    );
+    Expression.Global_get.set_name(expr, find_global(internal_name));
   | GlobalSet =>
     let internal_name = Expression.Global_set.get_name(expr);
-    Expression.Global_set.set_name(
-      expr,
-      Hashtbl.find(local_names, internal_name),
-    );
-    globalize_names(local_names, Expression.Global_set.get_value(expr));
-  | Load => globalize_names(local_names, Expression.Load.get_ptr(expr))
+    Expression.Global_set.set_name(expr, find_global(internal_name));
+    globalize_names(Expression.Global_set.get_value(expr));
+  | Load => globalize_names(Expression.Load.get_ptr(expr))
   | Store =>
-    globalize_names(local_names, Expression.Store.get_ptr(expr));
-    globalize_names(local_names, Expression.Store.get_value(expr));
+    globalize_names(Expression.Store.get_ptr(expr));
+    globalize_names(Expression.Store.get_value(expr));
   | MemoryCopy =>
-    globalize_names(local_names, Expression.Memory_copy.get_dest(expr));
-    globalize_names(local_names, Expression.Memory_copy.get_source(expr));
-    globalize_names(local_names, Expression.Memory_copy.get_size(expr));
+    globalize_names(Expression.Memory_copy.get_dest(expr));
+    globalize_names(Expression.Memory_copy.get_source(expr));
+    globalize_names(Expression.Memory_copy.get_size(expr));
   | MemoryFill =>
-    globalize_names(local_names, Expression.Memory_fill.get_dest(expr));
-    globalize_names(local_names, Expression.Memory_fill.get_value(expr));
-    globalize_names(local_names, Expression.Memory_fill.get_size(expr));
+    globalize_names(Expression.Memory_fill.get_dest(expr));
+    globalize_names(Expression.Memory_fill.get_value(expr));
+    globalize_names(Expression.Memory_fill.get_size(expr));
   | Const => ()
-  | Unary => globalize_names(local_names, Expression.Unary.get_value(expr))
+  | Unary => globalize_names(Expression.Unary.get_value(expr))
   | Binary =>
-    globalize_names(local_names, Expression.Binary.get_left(expr));
-    globalize_names(local_names, Expression.Binary.get_right(expr));
+    globalize_names(Expression.Binary.get_left(expr));
+    globalize_names(Expression.Binary.get_right(expr));
   | Select =>
-    globalize_names(local_names, Expression.Select.get_if_true(expr));
-    globalize_names(local_names, Expression.Select.get_if_false(expr));
-    globalize_names(local_names, Expression.Select.get_condition(expr));
-  | Drop => globalize_names(local_names, Expression.Drop.get_value(expr))
-  | Return => globalize_names(local_names, Expression.Return.get_value(expr))
+    globalize_names(Expression.Select.get_if_true(expr));
+    globalize_names(Expression.Select.get_if_false(expr));
+    globalize_names(Expression.Select.get_condition(expr));
+  | Drop => globalize_names(Expression.Drop.get_value(expr))
+  | Return => globalize_names(Expression.Return.get_value(expr))
   | MemorySize => ()
-  | MemoryGrow =>
-    globalize_names(local_names, Expression.Memory_grow.get_delta(expr))
+  | MemoryGrow => globalize_names(Expression.Memory_grow.get_delta(expr))
   | Unreachable => ()
   | TupleMake =>
     let num_operands = Expression.Tuple_make.get_num_operands(expr);
     for (i in 0 to num_operands - 1) {
-      globalize_names(
-        local_names,
-        Expression.Tuple_make.get_operand_at(expr, i),
-      );
+      globalize_names(Expression.Tuple_make.get_operand_at(expr, i));
     };
-  | TupleExtract =>
-    globalize_names(local_names, Expression.Tuple_extract.get_tuple(expr))
+  | TupleExtract => globalize_names(Expression.Tuple_extract.get_tuple(expr))
   | AtomicRMW
   | AtomicCmpxchg
   | AtomicWait
@@ -339,7 +307,9 @@ let link_all = (linked_mod, dependencies, signature) => {
   table_offset := 0;
 
   let link_one = dep => {
-    let local_names: Hashtbl.t(string, string) = Hashtbl.create(128);
+    let local_functions: Hashtbl.t(string, string) = Hashtbl.create(128);
+    let local_globals: Hashtbl.t(string, string) = Hashtbl.create(128);
+    let local_labels: Hashtbl.t(string, string) = Hashtbl.create(128);
 
     let wasm_mod = Hashtbl.find(modules, dep);
 
@@ -359,12 +329,12 @@ let link_all = (linked_mod, dependencies, signature) => {
               ),
               imported_name,
             );
-          Hashtbl.add(local_names, internal_name, new_name);
+          Hashtbl.add(local_globals, internal_name, new_name);
         } else {
           let imported_name = Import.global_import_get_base(global);
           let internal_name = Global.get_name(global);
           let new_name = gensym(internal_name);
-          Hashtbl.add(local_names, internal_name, new_name);
+          Hashtbl.add(local_globals, internal_name, new_name);
 
           if (Comp_utils.is_grain_env(imported_module)) {
             let value =
@@ -403,13 +373,13 @@ let link_all = (linked_mod, dependencies, signature) => {
       } else {
         let internal_name = Global.get_name(global);
         let new_name = gensym(internal_name);
-        Hashtbl.add(local_names, internal_name, new_name);
+        Hashtbl.add(local_globals, internal_name, new_name);
 
         let ty = Global.get_type(global);
         let mut = Global.is_mutable(global);
         let init = Global.get_init_expr(global);
 
-        globalize_names(local_names, init);
+        globalize_names(local_functions, local_globals, local_labels, init);
         ignore @@ Global.add_global(linked_mod, new_name, ty, mut, init);
       };
     };
@@ -435,7 +405,7 @@ let link_all = (linked_mod, dependencies, signature) => {
               ),
               imported_name,
             );
-          Hashtbl.add(local_names, internal_name, new_name);
+          Hashtbl.add(local_functions, internal_name, new_name);
         } else if (has_wasi_polyfill
                    && is_wasi_module(imported_module)
                    && !is_wasi_polyfill_module(dep)) {
@@ -461,12 +431,12 @@ let link_all = (linked_mod, dependencies, signature) => {
                 ),
               )
             };
-          Hashtbl.add(local_names, internal_name, new_name);
+          Hashtbl.add(local_functions, internal_name, new_name);
         } else {
           let imported_name = Import.function_import_get_base(func);
           let internal_name = Function.get_name(func);
           let new_name = gensym(internal_name);
-          Hashtbl.add(local_names, internal_name, new_name);
+          Hashtbl.add(local_functions, internal_name, new_name);
 
           let params = Function.get_params(func);
           let results = Function.get_results(func);
@@ -488,7 +458,7 @@ let link_all = (linked_mod, dependencies, signature) => {
       func => {
         let internal_name = Function.get_name(func);
         let new_name = gensym(internal_name);
-        Hashtbl.add(local_names, internal_name, new_name);
+        Hashtbl.add(local_functions, internal_name, new_name);
       },
       funcs,
     );
@@ -496,14 +466,14 @@ let link_all = (linked_mod, dependencies, signature) => {
     List.iter(
       func => {
         let internal_name = Function.get_name(func);
-        let new_name = Hashtbl.find(local_names, internal_name);
+        let new_name = Hashtbl.find(local_functions, internal_name);
 
         let params = Function.get_params(func);
         let results = Function.get_results(func);
         let num_locals = Function.get_num_vars(func);
         let locals = Array.init(num_locals, i => Function.get_var(func, i));
         let body = Function.get_body(func);
-        globalize_names(local_names, body);
+        globalize_names(local_functions, local_globals, local_labels, body);
         ignore @@
         Function.add_function(
           linked_mod,
@@ -518,7 +488,11 @@ let link_all = (linked_mod, dependencies, signature) => {
     );
 
     let local_exported_names =
-      Comp_utils.get_exported_names(~local_names, wasm_mod);
+      Comp_utils.get_exported_names(
+        ~local_functions,
+        ~local_globals,
+        wasm_mod,
+      );
     Hashtbl.add(exported_names, dep, local_exported_names);
 
     let num_element_segments = Table.get_num_element_segments(wasm_mod);
@@ -529,7 +503,7 @@ let link_all = (linked_mod, dependencies, signature) => {
       let size = Element_segment.get_length(segment);
       let elems =
         List.init(size, i =>
-          Hashtbl.find(local_names, Element_segment.get_data(segment, i))
+          Hashtbl.find(local_functions, Element_segment.get_data(segment, i))
         );
       ignore @@
       Table.add_active_element_segment(

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -135,9 +135,9 @@ let is_function_imported = func =>
 //       constructing the AST (either through constructing two separate instances or by
 //       using Expression.copy())
 
-let rec globalize_names = (function_names, global_names, label_names, expr) => {
+let rec globalize_names = (~function_names, ~global_names, ~label_names, expr) => {
   let globalize_names =
-    globalize_names(function_names, global_names, label_names);
+    globalize_names(~function_names, ~global_names, ~label_names);
 
   let add_label = Hashtbl.add(label_names);
 
@@ -379,7 +379,7 @@ let link_all = (linked_mod, dependencies, signature) => {
         let mut = Global.is_mutable(global);
         let init = Global.get_init_expr(global);
 
-        globalize_names(function_names, global_names, label_names, init);
+        globalize_names(~function_names, ~global_names, ~label_names, init);
         ignore @@ Global.add_global(linked_mod, new_name, ty, mut, init);
       };
     };
@@ -473,7 +473,7 @@ let link_all = (linked_mod, dependencies, signature) => {
         let num_locals = Function.get_num_vars(func);
         let locals = Array.init(num_locals, i => Function.get_var(func, i));
         let body = Function.get_body(func);
-        globalize_names(function_names, global_names, label_names, body);
+        globalize_names(~function_names, ~global_names, ~label_names, body);
         ignore @@
         Function.add_function(
           linked_mod,

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -40,7 +40,8 @@ let get_type_id = typath =>
     id;
   };
 
-let lookup_symbol = (~allocation_type, mod_, mod_decl, name, original_name) => {
+let lookup_symbol =
+    (~allocation_type, ~repr, mod_, mod_decl, name, original_name) => {
   switch (Ident.find_same_opt(mod_, symbol_table^)) {
   | Some(_) => ()
   | None => symbol_table := Ident.add(mod_, Ident.empty, symbol_table^)
@@ -52,16 +53,29 @@ let lookup_symbol = (~allocation_type, mod_, mod_decl, name, original_name) => {
     let fresh = gensym(name);
     switch (mod_decl.md_filepath) {
     | Some(filepath) =>
+      let shape =
+        switch (repr) {
+        | ReprFunction(args, rets, Direct(_)) =>
+          // Add closure argument
+          let args = [
+            HeapAllocated,
+            ...List.map(allocation_type_of_wasm_repr, args),
+          ];
+          // Add return type for functions that return void
+          let rets =
+            switch (rets) {
+            | [] => [StackAllocated(WasmI32)]
+            | _ => List.map(allocation_type_of_wasm_repr, rets)
+            };
+          FunctionShape(args, rets);
+        | _ => GlobalShape(allocation_type)
+        };
       value_imports :=
         [
-          Imp.grain_value(
-            fresh,
-            filepath,
-            original_name,
-            GlobalShape(allocation_type),
-          ),
+          Imp.grain_value(fresh, filepath, original_name, shape),
           ...value_imports^,
-        ]
+        ];
+
     | None => ()
     };
     symbol_table :=
@@ -182,6 +196,7 @@ let rec transl_imm =
         val_fullpath: Path.PExternal(_, original_name, _),
         val_mutable,
         val_global,
+        val_repr,
       },
     ) =>
     let mod_decl = Env.find_module(p, None, env);
@@ -189,7 +204,14 @@ let rec transl_imm =
       Imm.id(
         ~loc,
         ~env,
-        lookup_symbol(~allocation_type, mod_, mod_decl, ident, original_name),
+        lookup_symbol(
+          ~allocation_type,
+          ~repr=val_repr,
+          mod_,
+          mod_decl,
+          ident,
+          original_name,
+        ),
       );
     if (val_mutable && !val_global && !boxed) {
       let tmp = gensym("unbox_mut");
@@ -207,14 +229,21 @@ let rec transl_imm =
   | TExpIdent(
       Path.PExternal(Path.PIdent(mod_) as p, ident, _),
       _,
-      {val_mutable, val_global},
+      {val_mutable, val_global, val_repr},
     ) =>
     let mod_decl = Env.find_module(p, None, env);
     let id =
       Imm.id(
         ~loc,
         ~env,
-        lookup_symbol(~allocation_type, mod_, mod_decl, ident, ident),
+        lookup_symbol(
+          ~allocation_type,
+          ~repr=val_repr,
+          mod_,
+          mod_decl,
+          ident,
+          ident,
+        ),
       );
     if (val_mutable && !val_global && !boxed) {
       let tmp = gensym("unbox_mut");
@@ -252,13 +281,21 @@ let rec transl_imm =
         val_fullpath: Path.PExternal(Path.PIdent(mod_) as p, ident, _),
         val_mutable,
         val_global,
+        val_repr,
       } =>
       let mod_decl = Env.find_module(p, None, env);
       let id =
         Imm.id(
           ~loc,
           ~env,
-          lookup_symbol(~allocation_type, mod_, mod_decl, ident, ident),
+          lookup_symbol(
+            ~allocation_type,
+            ~repr=val_repr,
+            mod_,
+            mod_decl,
+            ident,
+            ident,
+          ),
         );
       if (val_mutable && !val_global && !boxed) {
         let tmp = gensym("unbox_mut");

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1630,7 +1630,11 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                 switch (desc.cstr_args) {
                 | [] => ReprValue(WasmI32)
                 | args =>
-                  ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+                  ReprFunction(
+                    List.map(_ => WasmI32, args),
+                    [WasmI32],
+                    Unknown,
+                  )
                 };
               let get_path = name =>
                 switch (path) {
@@ -1689,7 +1693,8 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
           let val_repr =
             switch (desc.cstr_args) {
             | [] => ReprValue(WasmI32)
-            | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+            | args =>
+              ReprFunction(List.map(_ => WasmI32, args), [WasmI32], Unknown)
             };
           let get_path = name =>
             switch (path) {
@@ -1769,7 +1774,8 @@ and store_type = (~check, id, info, env) => {
         let val_repr =
           switch (desc.cstr_args) {
           | [] => ReprValue(WasmI32)
-          | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+          | args =>
+            ReprFunction(List.map(_ => WasmI32, args), [WasmI32], Unknown)
           };
         let val_desc = {
           val_type,
@@ -1863,7 +1869,8 @@ and store_extension = (~check, id, ext, env) => {
     let val_repr =
       switch (cstr.cstr_args) {
       | [] => ReprValue(WasmI32)
-      | args => ReprFunction(List.map(_ => WasmI32, args), [WasmI32])
+      | args =>
+        ReprFunction(List.map(_ => WasmI32, args), [WasmI32], Unknown)
       };
     {
       val_type,

--- a/compiler/src/typed/type_utils.re
+++ b/compiler/src/typed/type_utils.re
@@ -83,6 +83,10 @@ let wasm_repr_of_allocation_type = alloc_type => {
   };
 };
 
+let allocation_type_of_wasm_repr = repr => {
+  StackAllocated(repr);
+};
+
 let repr_of_type = (env, ty) =>
   if (is_function(ty)) {
     let (args, ret) = get_fn_allocation_type(env, ty);
@@ -93,7 +97,7 @@ let repr_of_type = (env, ty) =>
       } else {
         [wasm_repr_of_allocation_type(ret)];
       };
-    ReprFunction(args, rets);
+    ReprFunction(args, rets, Unknown);
   } else {
     ReprValue(wasm_repr_of_allocation_type(get_allocation_type(env, ty)));
   };

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -127,8 +127,14 @@ and wasm_repr =
 
 [@deriving (sexp, yojson)]
 type val_repr =
-  | ReprFunction(list(wasm_repr), list(wasm_repr))
-  | ReprValue(wasm_repr);
+  | ReprFunction(list(wasm_repr), list(wasm_repr), func_direct)
+  | ReprValue(wasm_repr)
+
+[@deriving (sexp, yojson)]
+and func_direct =
+  | Direct(string)
+  | Indirect
+  | Unknown;
 
 [@deriving (sexp, yojson)]
 type value_description = {

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -1,13 +1,12 @@
 basic functionality › unsafe_wasm_globals
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
- (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
+ (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
+ (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F64_VAL\" (global $gimport_unsafeWasmGlobalsExports__F64_VAL (mut f64)))
  (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printF64\" (global $gimport_runtime/unsafe/printWasm_printF64 (mut i32)))
@@ -17,54 +16,37 @@ basic functionality › unsafe_wasm_globals
  (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI64\" (global $gimport_runtime/unsafe/printWasm_printI64 (mut i32)))
  (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I32_VAL\" (global $gimport_unsafeWasmGlobalsExports__I32_VAL (mut i32)))
  (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI32\" (global $gimport_runtime/unsafe/printWasm_printI32 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF64\" (func $gimport_runtime/unsafe/printWasm_printF64 (param i32 f64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF32\" (func $gimport_runtime/unsafe/printWasm_printF32 (param i32 f32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI64\" (func $gimport_runtime/unsafe/printWasm_printI64 (param i32 i64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI32\" (func $gimport_runtime/unsafe/printWasm_printI32 (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
   (drop
-   (call_indirect (type $i32_i32_=>_i32)
-    (local.tee $0
-     (global.get $gimport_runtime/unsafe/printWasm_printI32)
-    )
+   (call $gimport_runtime/unsafe/printWasm_printI32
+    (global.get $gimport_runtime/unsafe/printWasm_printI32)
     (global.get $gimport_unsafeWasmGlobalsExports__I32_VAL)
-    (i32.load offset=8
-     (local.get $0)
-    )
    )
   )
   (drop
-   (call_indirect (type $i32_i64_=>_i32)
-    (local.tee $0
-     (global.get $gimport_runtime/unsafe/printWasm_printI64)
-    )
+   (call $gimport_runtime/unsafe/printWasm_printI64
+    (global.get $gimport_runtime/unsafe/printWasm_printI64)
     (global.get $gimport_unsafeWasmGlobalsExports__I64_VAL)
-    (i32.load offset=8
-     (local.get $0)
-    )
    )
   )
   (drop
-   (call_indirect (type $i32_f32_=>_i32)
-    (local.tee $0
-     (global.get $gimport_runtime/unsafe/printWasm_printF32)
-    )
+   (call $gimport_runtime/unsafe/printWasm_printF32
+    (global.get $gimport_runtime/unsafe/printWasm_printF32)
     (global.get $gimport_unsafeWasmGlobalsExports__F32_VAL)
-    (i32.load offset=8
-     (local.get $0)
-    )
    )
   )
-  (call_indirect (type $i32_f64_=>_i32)
-   (local.tee $0
-    (global.get $gimport_runtime/unsafe/printWasm_printF64)
-   )
+  (call $gimport_runtime/unsafe/printWasm_printF64
+   (global.get $gimport_runtime/unsafe/printWasm_printF64)
    (global.get $gimport_unsafeWasmGlobalsExports__F64_VAL)
-   (i32.load offset=8
-    (local.get $0)
-   )
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -16,6 +16,7 @@ basic functionality › comp22
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $wimport_GRAIN$MODULE$runtime/gc_malloc (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $gimport_pervasives_isnt (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -44,7 +45,7 @@ basic functionality › comp22
    (local.get $0)
    (i32.const 3)
   )
-  (local.set $3
+  (local.set $2
    (tuple.extract 0
     (tuple.make
      (local.get $0)
@@ -55,7 +56,7 @@ basic functionality › comp22
     )
    )
   )
-  (local.set $4
+  (local.set $3
    (tuple.extract 0
     (tuple.make
      (call_indirect (type $i32_i32_i32_=>_i32)
@@ -67,7 +68,7 @@ basic functionality › comp22
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-       (local.get $3)
+       (local.get $2)
       )
       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -141,37 +142,32 @@ basic functionality › comp22
     )
    )
   )
-  (local.set $2
-   (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $2
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_pervasives_isnt)
-     )
+  (local.set $4
+   (call $gimport_pervasives_isnt
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_isnt)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $4)
+     (local.get $3)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $1)
     )
-    (i32.load offset=8
-     (local.get $2)
-    )
+   )
+  )
+  (drop
+   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
+    (local.get $2)
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
     (local.get $3)
-   )
-  )
-  (drop
-   (call $wimport_GRAIN$MODULE$runtime/gc_decRef
-    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $4)
    )
   )
   (drop
@@ -186,7 +182,7 @@ basic functionality › comp22
     (local.get $1)
    )
   )
-  (local.get $2)
+  (local.get $4)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -1,34 +1,28 @@
 basic functionality › comp17
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $gimport_pervasives_isnt (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $gimport_pervasives_isnt (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_pervasives_isnt)
-    )
+  (call $gimport_pervasives_isnt
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_pervasives_isnt)
    )
    (i32.const 2147483646)
    (i32.const -2)
-   (i32.load offset=8
-    (local.get $0)
-   )
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -14,6 +14,7 @@ basic functionality › comp20
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $gimport_pervasives_isnt (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $gimport_pervasives_isnt (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -130,12 +131,10 @@ basic functionality › comp20
    )
   )
   (local.set $4
-   (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $4
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_pervasives_isnt)
-     )
+   (call $gimport_pervasives_isnt
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_pervasives_isnt)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
@@ -144,9 +143,6 @@ basic functionality › comp20
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $3)
-    )
-    (i32.load offset=8
-     (local.get $4)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -1,34 +1,28 @@
 basic functionality › comp18
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $gimport_pervasives_isnt (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $gimport_pervasives_isnt (param i32 i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_pervasives_isnt)
-    )
+  (call $gimport_pervasives_isnt
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_pervasives_isnt)
    )
    (i32.const 9)
    (i32.const 3)
-   (i32.load offset=8
-    (local.get $0)
-   )
   )
  )
  (func $_start (; has Stack IR ;)

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -70,5 +70,5 @@ exports › let_rec_export
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 625
+ ;; custom section \"cmi\", size 642
 )

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -4,32 +4,26 @@ exports › export9
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $gimport_exportStar_z (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_z)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -14,6 +14,7 @@ exports › export8
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $gimport_pervasives_+ (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -22,20 +23,15 @@ exports › export8
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_exportStar_y)
-       )
+     (call $gimport_exportStar_y
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_exportStar_y)
       )
       (i32.const 9)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -44,9 +40,9 @@ exports › export8
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (call_indirect (type $i32_i32_i32_=>_i32)
-    (local.tee $1
+    (local.tee $0
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_+)
@@ -58,20 +54,20 @@ exports › export8
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $0)
+     (local.get $1)
     )
     (i32.load offset=8
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -571,5 +571,5 @@ functions › func_recursive_closure
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 635
+ ;; custom section \"cmi\", size 653
 )

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -14,6 +14,7 @@ imports › import_alias_multiple_constructor
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $gimport_tlists_sum (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $gimport_tlists_sum (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -49,19 +50,14 @@ imports › import_alias_multiple_constructor
    )
   )
   (local.set $1
-   (call_indirect (type $i32_i32_=>_i32)
-    (local.tee $1
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_sum)
-     )
+   (call $gimport_tlists_sum
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_sum)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
-    )
-    (i32.load offset=8
-     (local.get $1)
     )
    )
   )

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -4,32 +4,26 @@ imports › import_alias_multiple
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $gimport_exportStar_x (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_x)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
@@ -4,32 +4,26 @@ imports › import_some_multiple_trailing
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $gimport_exportStar_x (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_x)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -4,32 +4,26 @@ imports › import_some_multiple
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $gimport_exportStar_x (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_x)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -12,6 +12,7 @@ imports › import_relative_path4
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $gimport_pervasives_print (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $gimport_./bar/bar_bar (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -20,20 +21,15 @@ imports › import_relative_path4
  (func $_gmain (; has Stack IR ;) (result i32)
   (local $0 i32)
   (local $1 i32)
-  (local.set $0
+  (local.set $1
    (tuple.extract 0
     (tuple.make
-     (call_indirect (type $i32_i32_=>_i32)
-      (local.tee $0
-       (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-        (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-        (global.get $gimport_./bar/bar_bar)
-       )
+     (call $gimport_./bar/bar_bar
+      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+       (global.get $gimport_./bar/bar_bar)
       )
       (i32.const 5)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
      (call $wimport_GRAIN$MODULE$runtime/gc_decRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
@@ -42,9 +38,9 @@ imports › import_relative_path4
     )
    )
   )
-  (local.set $1
+  (local.set $0
    (call_indirect (type $i32_i32_=>_i32)
-    (local.tee $1
+    (local.tee $0
      (call $wimport_GRAIN$MODULE$runtime/gc_incRef
       (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
       (global.get $gimport_pervasives_print)
@@ -52,20 +48,20 @@ imports › import_relative_path4
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (local.get $0)
+     (local.get $1)
     )
     (i32.load offset=8
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (call $wimport_GRAIN$MODULE$runtime/gc_decRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$decRef)
-    (local.get $0)
+    (local.get $1)
    )
   )
-  (local.get $1)
+  (local.get $0)
  )
  (func $_start (; has Stack IR ;)
   (drop

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -4,32 +4,26 @@ imports › import_module2
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $gimport_exportStar_x (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_x)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
@@ -1,31 +1,25 @@
 imports › import_with_export_multiple
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$sameExport\" \"GRAIN$EXPORT$foo\" (global $gimport_sameExport_foo (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$sameExport\" \"foo\" (func $gimport_sameExport_foo (param i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_sameExport_foo)
-    )
-   )
-   (i32.load offset=8
-    (local.get $0)
+  (call $gimport_sameExport_foo
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_sameExport_foo)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -4,32 +4,26 @@ imports › import_all_except_multiple_constructor
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $gimport_tlists_Empty (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $gimport_tlists_sum (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $gimport_tlists_sum (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_tlists_sum)
-    )
+  (call $gimport_tlists_sum
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_sum)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_tlists_Empty)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
+++ b/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
@@ -4,32 +4,26 @@ imports › import_some_multiple_trailing2
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $gimport_exportStar_x (mut i32)))
  (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $gimport_exportStar_y (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $gimport_exportStar_y (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_exportStar_y)
-    )
+  (call $gimport_exportStar_y
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_exportStar_y)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_exportStar_x)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -4,32 +4,26 @@ imports › import_alias_constructor
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_grainEnv\" \"mem\" (memory $0 0))
- (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $wimport__grainEnv_relocBase i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $gimport_tlists_Empty (mut i32)))
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $gimport_tlists_sum (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $gimport_tlists_sum (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $global_1))
  (func $_gmain (; has Stack IR ;) (result i32)
-  (local $0 i32)
-  (call_indirect (type $i32_i32_=>_i32)
-   (local.tee $0
-    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-     (global.get $gimport_tlists_sum)
-    )
+  (call $gimport_tlists_sum
+   (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+    (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+    (global.get $gimport_tlists_sum)
    )
    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
     (global.get $gimport_tlists_Empty)
-   )
-   (i32.load offset=8
-    (local.get $0)
    )
   )
  )

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -14,6 +14,7 @@ imports › import_some_mixed
  (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $gimport_tlists_sum (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $wimport_GRAIN$MODULE$runtime/gc_incRef (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $wimport_GRAIN$MODULE$runtime/gc_decRef (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $gimport_tlists_sum (param i32 i32) (result i32)))
  (global $global_1 i32 (i32.const 0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
@@ -49,19 +50,14 @@ imports › import_some_mixed
    )
   )
   (local.set $1
-   (call_indirect (type $i32_i32_=>_i32)
-    (local.tee $1
-     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
-      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
-      (global.get $gimport_tlists_sum)
-     )
+   (call $gimport_tlists_sum
+    (call $wimport_GRAIN$MODULE$runtime/gc_incRef
+     (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
+     (global.get $gimport_tlists_sum)
     )
     (call $wimport_GRAIN$MODULE$runtime/gc_incRef
      (global.get $wimport_GRAIN$MODULE$runtime/gc_GRAIN$EXPORT$incRef)
      (local.get $0)
-    )
-    (i32.load offset=8
-     (local.get $1)
     )
    )
   )

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -248,7 +248,12 @@ let rec combineRightsHelp = (acc, dirflags) => {
         PathUnlinkFile => _RIGHT_PATH_UNLINK_FILE,
         PollFdReadwrite => _RIGHT_POLL_FD_READWRITE,
         SockShutdown => _RIGHT_SOCK_SHUTDOWN,
-        _ => fail "Unknown file right",
+        _ => {
+          ignore(fail "Unknown file right")
+          // `fail` won't allow us to get here, but this is necessary
+          // to make the wasm types work out
+          0N
+        },
       }
       combineRightsHelp(WasmI64.or(flag, acc), tl)
     },


### PR DESCRIPTION
This PR uses regular `call`s where possible between modules. This should be fairly significant for performance, as direct `call`s are much faster than `call_indirect`s. Additionally, Binaryen can now provide better optimizations after linking.