### PR TITLE
chore(cli): Clean exe and jsoo code before we build compiler

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
     "node": ">=14"
   },
   "scripts": {
+    "clean": "del-cli 'bin/*.exe' 'bin/*.bc.js'",
     "link": "yarn link",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
@@ -39,6 +40,7 @@
     "commander": "^8.1.0"
   },
   "devDependencies": {
+    "del-cli": "^4.0.1",
     "pkg": "^5.3.1",
     "prettier": "^2.3.2"
   }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -15,6 +15,7 @@
     "link": "yarn link",
     "clean": "esy clean",
     "prepare": "esy install",
+    "prebuild": "yarn workspace cli clean",
     "build": "esy",
     "postbuild": "esy copy:exe",
     "build:js": "esy b dune build @js --no-buffer",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -15,7 +15,7 @@
     "link": "yarn link",
     "clean": "esy clean",
     "prepare": "esy install",
-    "prebuild": "yarn workspace cli clean",
+    "prebuild": "yarn workspace @grain/cli clean",
     "build": "esy",
     "postbuild": "esy copy:exe",
     "build:js": "esy b dune build @js --no-buffer",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "yarn compiler test",
     "cli": "yarn workspace @grain/cli run",
     "js-runner": "yarn workspace @grain/js-runner run",
+    "precompiler": "yarn cli clean",
     "compiler": "yarn workspace @grain/compiler run",
     "stdlib": "yarn workspace @grain/stdlib run",
     "postcompiler": "yarn stdlib clean"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "yarn compiler test",
     "cli": "yarn workspace @grain/cli run",
     "js-runner": "yarn workspace @grain/js-runner run",
-    "precompiler": "yarn cli clean",
     "compiler": "yarn workspace @grain/compiler run",
     "stdlib": "yarn workspace @grain/stdlib run",
     "postcompiler": "yarn stdlib clean"


### PR DESCRIPTION
In this PR, I'm cleaning all the compiler-generated code before we run the compiler build.

This should solve the codesign sigkill that @ospencer was experiencing on the latest MacOS on M1.

I believe what is happening is that we were overwriting the exe but for some reason MacOS didn't see it as a new file but instead a modification to the old file (inode?). If we delete these exe files before we generate them again, it seems to work fine.

I'm also deleting the `.bc.js` files, too, because I can.