### PR TITLE
chore(compiler)!: Disallow end-of-line before `=>`

### DIFF
--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -2354,7 +2354,7 @@ program: FOR WHILE
 
 Expected `(` to set the for loop parameters.
 
-program: FUN ID EOL THICKARROW WHEN
+program: FUN ID THICKARROW WHEN
 ##
 ## Ends in an error in state: 29.
 ##
@@ -2367,7 +2367,7 @@ program: FUN ID EOL THICKARROW WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 711, spurious reduction of production thickarrow -> eols THICKARROW
+## In state 27, spurious reduction of production thickarrow -> THICKARROW
 ##
 program: WHILE LPAREN WASMI64 RPAREN WHILE
 ##
@@ -2381,23 +2381,6 @@ program: WHILE LPAREN WASMI64 RPAREN WHILE
 
 Expected an expression or `{` to start a block.
 
-program: FUN ID EOL WHILE
-##
-## Ends in an error in state: 710.
-##
-## thickarrow -> eols . THICKARROW [ WHILE WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TRUE THROW STRING NUMBER_INT NUMBER_FLOAT NOT MATCH LPAREN LBRACKRCARET LBRACK LBRACE INT64 INT32 IF ID FUN FOR FLOAT64 FLOAT32 FALSE FAIL DASH CONTINUE CHAR BREAK ASSERT ]
-## thickarrow -> eols . THICKARROW eols [ WHILE WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TRUE THROW STRING NUMBER_INT NUMBER_FLOAT NOT MATCH LPAREN LBRACKRCARET LBRACK LBRACE INT64 INT32 IF ID FUN FOR FLOAT64 FLOAT32 FALSE FAIL DASH CONTINUE CHAR BREAK ASSERT ]
-##
-## The known suffix of the stack is as follows:
-## eols
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-##
 program: FUN ID WHILE
 ##
 ## Ends in an error in state: 26.

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -12,9 +12,9 @@ Expected an expression after `assert`.
 
 program: AT ID EOL WHILE
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 412.
 ##
-## list(attribute) -> attribute . list(attribute) [ TYPE RECORD LET EXPORT ENUM ]
+## list(attribute) -> attribute . list(attribute) [ TYPE RECORD LET IMPORT EXPORT ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## attribute
@@ -25,14 +25,14 @@ program: AT ID EOL WHILE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 187, spurious reduction of production attribute -> AT id_str eols
+## In state 196, spurious reduction of production attribute -> AT id_str loption(attribute_arguments) eols
 ##
 program: AT ID WHILE
 ##
 ## Ends in an error in state: 186.
 ##
-## attribute -> AT id_str . [ TYPE RECORD LET EXPORT ENUM AT ]
-## attribute -> AT id_str . eols [ TYPE RECORD LET EXPORT ENUM AT ]
+## attribute -> AT id_str . loption(attribute_arguments) [ TYPE RECORD LET IMPORT EXPORT ENUM AT ]
+## attribute -> AT id_str . loption(attribute_arguments) eols [ TYPE RECORD LET IMPORT EXPORT ENUM AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AT id_str
@@ -41,8 +41,8 @@ program: AT WHILE
 ##
 ## Ends in an error in state: 181.
 ##
-## attribute -> AT . id_str [ TYPE RECORD LET EXPORT ENUM AT ]
-## attribute -> AT . id_str eols [ TYPE RECORD LET EXPORT ENUM AT ]
+## attribute -> AT . id_str loption(attribute_arguments) [ TYPE RECORD LET IMPORT EXPORT ENUM AT ]
+## attribute -> AT . id_str loption(attribute_arguments) eols [ TYPE RECORD LET IMPORT EXPORT ENUM AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AT
@@ -130,7 +130,7 @@ Expected a number to follow the minus sign.
 
 program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK LPAREN TYPEID RCARET
 ##
-## Ends in an error in state: 900.
+## Ends in an error in state: 934.
 ##
 ## data_constructor -> lbrack ELLIPSIS rbrack lparen option(typs) . rparen [ RBRACE EOL COMMA ]
 ##
@@ -151,7 +151,7 @@ program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK LPAREN TYPEID RCARET
 ##
 program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK LPAREN WHILE
 ##
-## Ends in an error in state: 899.
+## Ends in an error in state: 933.
 ##
 ## data_constructor -> lbrack ELLIPSIS rbrack lparen . option(typs) rparen [ RBRACE EOL COMMA ]
 ##
@@ -166,7 +166,7 @@ program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK LPAREN WHILE
 ##
 program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK WHILE
 ##
-## Ends in an error in state: 898.
+## Ends in an error in state: 932.
 ##
 ## data_constructor -> lbrack ELLIPSIS rbrack . lparen option(typs) rparen [ RBRACE EOL COMMA ]
 ##
@@ -175,7 +175,7 @@ program: ENUM TYPEID LBRACE LBRACK ELLIPSIS RBRACK WHILE
 ##
 program: ENUM TYPEID LBRACE LBRACK ELLIPSIS WHILE
 ##
-## Ends in an error in state: 897.
+## Ends in an error in state: 931.
 ##
 ## data_constructor -> lbrack ELLIPSIS . rbrack lparen option(typs) rparen [ RBRACE EOL COMMA ]
 ##
@@ -184,7 +184,7 @@ program: ENUM TYPEID LBRACE LBRACK ELLIPSIS WHILE
 ##
 program: ENUM TYPEID LBRACE LBRACK RBRACK WHILE
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 926.
 ##
 ## data_constructors -> lbrace lseparated_nonempty_list_inner(comma,data_constructor) . option(comma) rbrace [ SEMI EOL EOF COMMA ]
 ## lseparated_nonempty_list_inner(comma,data_constructor) -> lseparated_nonempty_list_inner(comma,data_constructor) . comma data_constructor [ RBRACE EOL COMMA ]
@@ -194,7 +194,7 @@ program: ENUM TYPEID LBRACE LBRACK RBRACK WHILE
 ##
 program: ENUM TYPEID LBRACE LBRACK WHILE
 ##
-## Ends in an error in state: 896.
+## Ends in an error in state: 930.
 ##
 ## data_constructor -> lbrack . rbrack [ RBRACE EOL COMMA ]
 ## data_constructor -> lbrack . ELLIPSIS rbrack lparen option(typs) rparen [ RBRACE EOL COMMA ]
@@ -213,7 +213,7 @@ Expected a list enum declaration using the syntax `enum List<a> { [], [...](a, L
 
 program: ENUM TYPEID LBRACE TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 929.
 ##
 ## lseparated_nonempty_list_inner(comma,data_constructor) -> lseparated_nonempty_list_inner(comma,data_constructor) comma . data_constructor [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -234,7 +234,7 @@ Expected a variant definition or `}` to complete the enum declaration.
 
 program: ENUM TYPEID LBRACE TYPEID LPAREN TYPEID RCARET
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 924.
 ##
 ## data_constructor -> TYPEID lparen option(typs) . rparen [ RBRACE EOL COMMA ]
 ##
@@ -258,7 +258,7 @@ Expected type parameters surrounded by `<`/`>`, a comma followed by more types, 
 
 program: ENUM TYPEID LBRACE TYPEID LPAREN WHILE
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 923.
 ##
 ## data_constructor -> TYPEID lparen . option(typs) rparen [ RBRACE EOL COMMA ]
 ##
@@ -276,7 +276,7 @@ Expected a type or `)` to complete the variant definition.
 
 program: ENUM TYPEID LBRACE TYPEID RBRACE COMMA EOL WHILE
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 959.
 ##
 ## separated_nonempty_list(comma,data_declaration_stmt) -> data_declaration_stmt comma . separated_nonempty_list(comma,data_declaration_stmt) [ SEMI EOL EOF ]
 ##
@@ -293,19 +293,19 @@ program: ENUM TYPEID LBRACE TYPEID RBRACE COMMA EOL WHILE
 ##
 program: ENUM TYPEID LBRACE TYPEID RBRACE COMMA EXPORT WHILE
 ##
-## Ends in an error in state: 883.
+## Ends in an error in state: 960.
 ##
-## data_declaration_stmt -> attributes EXPORT . data_declaration [ SEMI EOL EOF COMMA ]
+## data_declaration_stmt -> EXPORT . data_declaration [ SEMI EOL EOF COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## attributes EXPORT
+## EXPORT
 ##
 
 Mutually recursive data declarations are separated by commas, but cannot be mixed with other kinds of expressions.
 
 program: ENUM TYPEID LBRACE TYPEID WHILE
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 922.
 ##
 ## data_constructor -> TYPEID . [ RBRACE EOL COMMA ]
 ## data_constructor -> TYPEID . lparen option(typs) rparen [ RBRACE EOL COMMA ]
@@ -318,7 +318,7 @@ Expected `(` followed by comma-separated types, a comma followed by more variant
 
 program: ENUM TYPEID LBRACE WHILE
 ##
-## Ends in an error in state: 887.
+## Ends in an error in state: 921.
 ##
 ## data_constructors -> lbrace . lseparated_nonempty_list_inner(comma,data_constructor) option(comma) rbrace [ SEMI EOL EOF COMMA ]
 ##
@@ -336,7 +336,7 @@ Expected a capitalized variant name.
 
 program: ENUM TYPEID LBRACE TYPEID RBRACE WHILE
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 958.
 ##
 ## separated_nonempty_list(comma,data_declaration_stmt) -> data_declaration_stmt . [ SEMI EOL EOF ]
 ## separated_nonempty_list(comma,data_declaration_stmt) -> data_declaration_stmt . comma separated_nonempty_list(comma,data_declaration_stmt) [ SEMI EOL EOF ]
@@ -349,7 +349,7 @@ Expected a comma followed by more mutually-recursive data declarations or a newl
 
 program: ENUM TYPEID LCARET ID RCARET ISNT
 ##
-## Ends in an error in state: 886.
+## Ends in an error in state: 920.
 ##
 ## data_declaration -> ENUM TYPEID option(id_vec) . data_constructors [ SEMI EOL EOF COMMA ]
 ##
@@ -361,7 +361,7 @@ Expected `{` followed by comma-separated variants.
 
 program: ENUM TYPEID WHILE
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 919.
 ##
 ## data_declaration -> ENUM TYPEID . option(id_vec) data_constructors [ SEMI EOL EOF COMMA ]
 ##
@@ -373,7 +373,7 @@ Expected type parameters surrounded by angle brackets or `{` followed by comma-s
 
 program: TYPE TYPEID WHILE
 ##
-## Ends in an error in state: 848.
+## Ends in an error in state: 804.
 ##
 ## data_declaration -> TYPE TYPEID . option(id_vec) equal typ [ SEMI EOL EOF COMMA ]
 ##
@@ -385,7 +385,7 @@ Expected type parameters surrounded by angle brackets or `=` followed by a type.
 
 program: ENUM WHILE
 ##
-## Ends in an error in state: 884.
+## Ends in an error in state: 918.
 ##
 ## data_declaration -> ENUM . TYPEID option(id_vec) data_constructors [ SEMI EOL EOF COMMA ]
 ##
@@ -397,7 +397,7 @@ Expected a capitalized name for the enum declaration.
 
 program: TYPE WHILE
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 803.
 ##
 ## data_declaration -> TYPE . TYPEID option(id_vec) equal typ [ SEMI EOL EOF COMMA ]
 ##
@@ -409,10 +409,9 @@ Expected a capitalized name for the type alias.
 
 program: EOL UNDERSCORE
 ##
-## Ends in an error in state: 952.
+## Ends in an error in state: 963.
 ##
 ## program -> eols . toplevel_stmts EOF [ # ]
-## program -> eols . toplevel_stmts eos EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
 ## eols
@@ -426,19 +425,19 @@ program: EOL UNDERSCORE
 ##
 program: EOL WASMI64 SEMI RBRACE
 ##
-## Ends in an error in state: 955.
+## Ends in an error in state: 797.
 ##
-## program -> eols toplevel_stmts eos . EOF [ # ]
-## toplevel_stmts -> toplevel_stmts eos . toplevel_stmt [ SEMI EOL EOF ]
+## lseparated_nonempty_list_inner(eos,toplevel_stmt) -> lseparated_nonempty_list_inner(eos,toplevel_stmt) eos . toplevel_stmt [ SEMI EOL EOF ]
+## option(eos) -> eos . [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## eols toplevel_stmts eos
+## lseparated_nonempty_list_inner(eos,toplevel_stmt) eos
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 311, spurious reduction of production eos -> SEMI
+## In state 321, spurious reduction of production eos -> SEMI
 ##
 program: WHEN
 ##
@@ -454,14 +453,13 @@ Expected an import, export, expression, or type declaration.
 
 program: EOL WASMI64 THICKARROW
 ##
-## Ends in an error in state: 953.
+## Ends in an error in state: 795.
 ##
-## program -> eols toplevel_stmts . EOF [ # ]
-## program -> eols toplevel_stmts . eos EOF [ # ]
-## toplevel_stmts -> toplevel_stmts . eos toplevel_stmt [ SEMI EOL EOF ]
+## lseparated_nonempty_list_inner(eos,toplevel_stmt) -> lseparated_nonempty_list_inner(eos,toplevel_stmt) . eos toplevel_stmt [ SEMI EOL EOF ]
+## toplevel_stmts -> lseparated_nonempty_list_inner(eos,toplevel_stmt) . option(eos) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## eols toplevel_stmts
+## lseparated_nonempty_list_inner(eos,toplevel_stmt)
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -470,17 +468,17 @@ program: EOL WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 839, spurious reduction of production toplevel_stmt -> expr
-## In state 950, spurious reduction of production toplevel_stmts -> toplevel_stmt
+## In state 799, spurious reduction of production toplevel_stmt -> expr
+## In state 792, spurious reduction of production lseparated_nonempty_list_inner(eos,toplevel_stmt) -> toplevel_stmt
 ##
 
 Expected an infix operator to continue the expression or a newline character to terminate it.
 
 program: LBRACE BREAK RBRACE DOT EOL ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 295.
 ##
 ## record_set -> braced_expr DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -493,11 +491,11 @@ program: LBRACE BREAK RBRACE DOT EOL ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LBRACE BREAK RBRACE DOT ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 291.
 ##
 ## record_set -> braced_expr DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -510,11 +508,11 @@ program: LBRACE BREAK RBRACE DOT ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LBRACE BREAK RBRACE GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 232.
 ##
 ## assign_expr -> braced_expr GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -530,7 +528,7 @@ program: LBRACE BREAK RBRACE GETS EOL UNDERSCORE
 ##
 program: LBRACE BREAK RBRACE GETS WHEN
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 230.
 ##
 ## assign_expr -> braced_expr GETS . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## assign_expr -> braced_expr GETS . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -540,7 +538,7 @@ program: LBRACE BREAK RBRACE GETS WHEN
 ##
 program: LBRACE BREAK RBRACE LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 306.
 ##
 ## array_set -> braced_expr lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -553,11 +551,11 @@ program: LBRACE BREAK RBRACE LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LBRACE TYPEID COLON EOL UNDERSCORE
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 313.
 ##
 ## non_punned_record_field -> id COLON eols . expr [ RBRACE EOL COMMA ]
 ##
@@ -573,7 +571,7 @@ program: LBRACE TYPEID COLON EOL UNDERSCORE
 ##
 program: LBRACE TYPEID COLON WHEN
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 213.
 ##
 ## non_punned_record_field -> id COLON . expr [ RBRACE EOL COMMA ]
 ## non_punned_record_field -> id COLON . eols expr [ RBRACE EOL COMMA ]
@@ -592,7 +590,7 @@ program: LBRACK ELLIPSIS WHEN
 ##
 program: LET WASMI64 EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 403.
 ##
 ## value_bind -> pattern equal . expr [ SEMI RBRACE EOL EOF COMMA ]
 ##
@@ -605,11 +603,11 @@ program: LET WASMI64 EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LPAREN BREAK RPAREN DOT EOL ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 595.
 ##
 ## record_set -> paren_expr DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -622,11 +620,11 @@ program: LPAREN BREAK RPAREN DOT EOL ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LPAREN BREAK RPAREN DOT ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 581.
+## Ends in an error in state: 591.
 ##
 ## record_set -> paren_expr DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -639,11 +637,11 @@ program: LPAREN BREAK RPAREN DOT ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LPAREN BREAK RPAREN GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 587.
 ##
 ## assign_expr -> paren_expr GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -669,7 +667,7 @@ program: LPAREN BREAK RPAREN GETS WHEN
 ##
 program: LPAREN BREAK RPAREN LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 597.
 ##
 ## array_get -> paren_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> paren_expr lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -685,7 +683,7 @@ program: LPAREN BREAK RPAREN LBRACK UNDERSCORE
 ##
 program: LPAREN BREAK RPAREN LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 600.
 ##
 ## array_set -> paren_expr lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -698,7 +696,7 @@ program: LPAREN BREAK RPAREN LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: LPAREN UNDERSCORE
 ##
@@ -719,7 +717,7 @@ program: LPAREN UNDERSCORE
 ##
 program: LPAREN WASMI64 COMMA EOL UNDERSCORE
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 496.
 ##
 ## tuple_exprs -> expr COMMA eols . lseparated_nonempty_list_inner(comma,expr) option(comma) [ RPAREN EOL ]
 ##
@@ -750,12 +748,12 @@ program: MATCH LPAREN UNDERSCORE
 ##
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 THICKARROW EOL UNDERSCORE
 ##
-## Ends in an error in state: 740.
+## Ends in an error in state: 748.
 ##
-## match_branch -> pattern option(when_guard) thickarrow . expr [ RBRACE EOL COMMA ]
+## match_branch -> pattern thickarrow . expr [ RBRACE EOL COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## pattern option(when_guard) thickarrow
+## pattern thickarrow
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -767,9 +765,9 @@ program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 THICKARROW EOL UNDERSCORE
 ##
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 WHEN WHEN
 ##
-## Ends in an error in state: 736.
+## Ends in an error in state: 743.
 ##
-## when_guard -> WHEN . expr [ THICKARROW EOL ]
+## when_guard -> WHEN . expr [ THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## WHEN
@@ -794,7 +792,7 @@ program: THROW WHEN
 ##
 program: WASMI64 AMP EOL UNDERSCORE
 ##
-## Ends in an error in state: 564.
+## Ends in an error in state: 574.
 ##
 ## binop_expr -> non_stmt_expr AMP eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -810,7 +808,7 @@ program: WASMI64 AMP EOL UNDERSCORE
 ##
 program: WHILE LPAREN WASMI64 RPAREN LBRACE UNDERSCORE
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 642.
 ##
 ## block -> lbrace . block_body rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -825,12 +823,12 @@ program: WHILE LPAREN WASMI64 RPAREN LBRACE UNDERSCORE
 ##
 program: MATCH LPAREN FLOAT32 RPAREN LBRACE NUMBER_INT WHEN FLOAT32 THICKARROW WHEN
 ##
-## Ends in an error in state: 738.
+## Ends in an error in state: 746.
 ##
-## match_branch -> pattern WHEN expr thickarrow . expr [ RBRACE EOL COMMA ]
+## match_branch -> pattern when_guard thickarrow . expr [ RBRACE EOL COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## pattern WHEN expr thickarrow
+## pattern when_guard thickarrow
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -840,12 +838,12 @@ program: MATCH LPAREN FLOAT32 RPAREN LBRACE NUMBER_INT WHEN FLOAT32 THICKARROW W
 ##
 program: MATCH LPAREN FLOAT32 RPAREN LBRACE NUMBER_INT EOL WHEN WHEN
 ##
-## Ends in an error in state: 743.
+## Ends in an error in state: 751.
 ##
-## match_branch -> pattern eols WHEN . expr thickarrow expr [ RBRACE EOL COMMA ]
+## when_guard -> eols WHEN . expr [ THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
-## pattern eols WHEN
+## eols WHEN
 ##
 
 Expected an expression.
@@ -870,7 +868,7 @@ program: EXCEPTION TYPEID LPAREN TYPEID COMMA EOL WHILE
 ##
 program: EXCEPTION TYPEID LPAREN WHILE
 ##
-## Ends in an error in state: 828.
+## Ends in an error in state: 787.
 ##
 ## exception_stmt -> EXCEPTION type_id_str lparen . option(typs) rparen [ SEMI EOL EOF ]
 ##
@@ -885,7 +883,7 @@ program: EXCEPTION TYPEID LPAREN WHILE
 ##
 program: LET WASMI64 COLON EOL WHILE
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 347.
 ##
 ## pattern -> pattern COLON eols . typ [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -901,7 +899,7 @@ program: LET WASMI64 COLON EOL WHILE
 ##
 program: LET WASMI64 COLON WHILE
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 345.
 ##
 ## pattern -> pattern COLON . typ [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ## pattern -> pattern COLON . eols typ [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
@@ -911,7 +909,7 @@ program: LET WASMI64 COLON WHILE
 ##
 program: PRIMITIVE ID COLON EOL WHILE
 ##
-## Ends in an error in state: 769.
+## Ends in an error in state: 780.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON eols . typ equal STRING [ SEMI EOL EOF ]
 ##
@@ -927,7 +925,7 @@ program: PRIMITIVE ID COLON EOL WHILE
 ##
 program: PRIMITIVE ID COLON WHILE
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 776.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON . typ equal STRING [ SEMI EOL EOF ]
 ## primitive_stmt -> PRIMITIVE id_str COLON . eols typ equal STRING [ SEMI EOL EOF ]
@@ -937,7 +935,7 @@ program: PRIMITIVE ID COLON WHILE
 ##
 program: PRIMITIVE THROW COLON EOL WHILE
 ##
-## Ends in an error in state: 760.
+## Ends in an error in state: 771.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON eols . typ equal STRING [ SEMI EOL EOF ]
 ##
@@ -953,7 +951,7 @@ program: PRIMITIVE THROW COLON EOL WHILE
 ##
 program: PRIMITIVE THROW COLON WHILE
 ##
-## Ends in an error in state: 756.
+## Ends in an error in state: 767.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON . typ equal STRING [ SEMI EOL EOF ]
 ## primitive_stmt -> PRIMITIVE prim COLON . eols typ equal STRING [ SEMI EOL EOF ]
@@ -963,7 +961,7 @@ program: PRIMITIVE THROW COLON WHILE
 ##
 program: RECORD TYPEID LBRACE ID COLON EOL WHILE
 ##
-## Ends in an error in state: 874.
+## Ends in an error in state: 830.
 ##
 ## data_label -> simple_id COLON eols . typ [ RBRACE EOL COMMA ]
 ##
@@ -979,7 +977,7 @@ program: RECORD TYPEID LBRACE ID COLON EOL WHILE
 ##
 program: RECORD TYPEID LBRACE ID COLON WHILE
 ##
-## Ends in an error in state: 872.
+## Ends in an error in state: 828.
 ##
 ## data_label -> simple_id COLON . typ [ RBRACE EOL COMMA ]
 ## data_label -> simple_id COLON . eols typ [ RBRACE EOL COMMA ]
@@ -992,7 +990,7 @@ Expected a type.
 
 program: EXCEPTION TYPEID LPAREN TYPEID RCARET
 ##
-## Ends in an error in state: 829.
+## Ends in an error in state: 788.
 ##
 ## exception_stmt -> EXCEPTION type_id_str lparen option(typs) . rparen [ SEMI EOL EOF ]
 ##
@@ -1038,7 +1036,7 @@ Expected type parameters surrounded by angle brackets or a comma followed by mor
 
 program: EXCEPTION TYPEID WHILE
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 786.
 ##
 ## exception_stmt -> EXCEPTION type_id_str . [ SEMI EOL EOF ]
 ## exception_stmt -> EXCEPTION type_id_str . lparen option(typs) rparen [ SEMI EOL EOF ]
@@ -1051,7 +1049,7 @@ Expected `(` followed by comma-separated types or a newline to complete the exce
 
 program: EXCEPTION WHILE
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 784.
 ##
 ## exception_stmt -> EXCEPTION . type_id_str [ SEMI EOL EOF ]
 ## exception_stmt -> EXCEPTION . type_id_str lparen option(typs) rparen [ SEMI EOL EOF ]
@@ -1064,7 +1062,7 @@ Expected a capitalized name for the exception.
 
 program: EXPORT LET MUT WHILE
 ##
-## Ends in an error in state: 933.
+## Ends in an error in state: 915.
 ##
 ## export_stmt -> attributes EXPORT LET MUT . value_binds [ SEMI EOL EOF ]
 ##
@@ -1073,7 +1071,7 @@ program: EXPORT LET MUT WHILE
 ##
 program: EXPORT LET REC MUT WHILE
 ##
-## Ends in an error in state: 930.
+## Ends in an error in state: 912.
 ##
 ## export_stmt -> attributes EXPORT LET REC MUT . value_binds [ SEMI EOL EOF ]
 ##
@@ -1082,7 +1080,7 @@ program: EXPORT LET REC MUT WHILE
 ##
 program: EXPORT LET REC WHILE
 ##
-## Ends in an error in state: 929.
+## Ends in an error in state: 911.
 ##
 ## export_stmt -> attributes EXPORT LET REC . value_binds [ SEMI EOL EOF ]
 ## export_stmt -> attributes EXPORT LET REC . MUT value_binds [ SEMI EOL EOF ]
@@ -1092,7 +1090,7 @@ program: EXPORT LET REC WHILE
 ##
 program: LBRACE LET MUT WHILE
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 409.
 ##
 ## let_expr -> attributes LET MUT . value_binds [ SEMI RBRACE EOL ]
 ##
@@ -1101,7 +1099,7 @@ program: LBRACE LET MUT WHILE
 ##
 program: LBRACE LET REC MUT WHILE
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 333.
 ##
 ## let_expr -> attributes LET REC MUT . value_binds [ SEMI RBRACE EOL ]
 ##
@@ -1110,7 +1108,7 @@ program: LBRACE LET REC MUT WHILE
 ##
 program: LET MUT WHILE
 ##
-## Ends in an error in state: 914.
+## Ends in an error in state: 844.
 ##
 ## toplevel_stmt -> attributes LET MUT . value_binds [ SEMI EOL EOF ]
 ##
@@ -1119,7 +1117,7 @@ program: LET MUT WHILE
 ##
 program: LET REC MUT WHILE
 ##
-## Ends in an error in state: 911.
+## Ends in an error in state: 841.
 ##
 ## toplevel_stmt -> attributes LET REC MUT . value_binds [ SEMI EOL EOF ]
 ##
@@ -1131,7 +1129,7 @@ Expected a binding pattern, such as an identifier.
 
 program: EXPORT LET WHILE
 ##
-## Ends in an error in state: 928.
+## Ends in an error in state: 910.
 ##
 ## export_stmt -> attributes EXPORT LET . REC value_binds [ SEMI EOL EOF ]
 ## export_stmt -> attributes EXPORT LET . value_binds [ SEMI EOL EOF ]
@@ -1143,7 +1141,7 @@ program: EXPORT LET WHILE
 ##
 program: LBRACE LET WHILE
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 329.
 ##
 ## let_expr -> attributes LET . REC value_binds [ SEMI RBRACE EOL ]
 ## let_expr -> attributes LET . value_binds [ SEMI RBRACE EOL ]
@@ -1155,7 +1153,7 @@ program: LBRACE LET WHILE
 ##
 program: LET WHILE
 ##
-## Ends in an error in state: 909.
+## Ends in an error in state: 839.
 ##
 ## toplevel_stmt -> attributes LET . REC value_binds [ SEMI EOL EOF ]
 ## toplevel_stmt -> attributes LET . value_binds [ SEMI EOL EOF ]
@@ -1170,7 +1168,7 @@ Expected the keyword `rec`, the keyword `mut`, or a binding pattern, such as an 
 
 program: EXPORT STAR EXCEPT TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 922.
+## Ends in an error in state: 904.
 ##
 ## lseparated_nonempty_list_inner(comma,export_id_str) -> lseparated_nonempty_list_inner(comma,export_id_str) comma . export_id_str [ SEMI EOL EOF COMMA ]
 ##
@@ -1190,7 +1188,7 @@ Expected an identifier to exclude from the export.
 
 program: EXPORT STAR EXCEPT TYPEID COMMA TYPEID WHILE
 ##
-## Ends in an error in state: 921.
+## Ends in an error in state: 903.
 ##
 ## export_exception -> EXCEPT lseparated_nonempty_list_inner(comma,export_id_str) . [ SEMI EOL EOF ]
 ## lseparated_nonempty_list_inner(comma,export_id_str) -> lseparated_nonempty_list_inner(comma,export_id_str) . comma export_id_str [ SEMI EOL EOF COMMA ]
@@ -1203,7 +1201,7 @@ Expected a comma followed by another identifier to exclude or a newline characte
 
 program: EXPORT STAR EXCEPT WHILE
 ##
-## Ends in an error in state: 919.
+## Ends in an error in state: 901.
 ##
 ## export_exception -> EXCEPT . lseparated_nonempty_list_inner(comma,export_id_str) [ SEMI EOL EOF ]
 ##
@@ -1215,7 +1213,7 @@ Expected an identifier to exclude from the export.
 
 program: EXPORT STAR WHILE
 ##
-## Ends in an error in state: 918.
+## Ends in an error in state: 900.
 ##
 ## export_stmt -> attributes EXPORT STAR . option(export_exception) [ SEMI EOL EOF ]
 ##
@@ -1227,7 +1225,7 @@ Expected the keyword `except` followed by comma-separated identifiers to exclude
 
 program: EXPORT TYPEID AS TYPEID WHILE
 ##
-## Ends in an error in state: 947.
+## Ends in an error in state: 952.
 ##
 ## separated_nonempty_list(comma,aliasable(any_id_str)) -> aliasable(any_id_str) . [ SEMI EOL EOF ]
 ## separated_nonempty_list(comma,aliasable(any_id_str)) -> aliasable(any_id_str) . comma separated_nonempty_list(comma,aliasable(any_id_str)) [ SEMI EOL EOF ]
@@ -1240,7 +1238,7 @@ Expected a comma followed by another identifier to export or a newline character
 
 program: EXPORT TYPEID AS WHILE
 ##
-## Ends in an error in state: 943.
+## Ends in an error in state: 948.
 ##
 ## as_prefix(any_id_str) -> AS . any_id_str [ SEMI EOL EOF COMMA ]
 ##
@@ -1252,7 +1250,7 @@ Expected an identifier to use as an alias.
 
 program: EXPORT TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 948.
+## Ends in an error in state: 953.
 ##
 ## separated_nonempty_list(comma,aliasable(any_id_str)) -> aliasable(any_id_str) comma . separated_nonempty_list(comma,aliasable(any_id_str)) [ SEMI EOL EOF ]
 ##
@@ -1272,7 +1270,7 @@ Expected another identifier to export.
 
 program: EXPORT TYPEID WHILE
 ##
-## Ends in an error in state: 942.
+## Ends in an error in state: 947.
 ##
 ## aliasable(any_id_str) -> any_id_str . option(as_prefix(any_id_str)) [ SEMI EOL EOF COMMA ]
 ##
@@ -1284,9 +1282,9 @@ Expected a comma followed by another identifier to export or a newline character
 
 program: EXPORT WHILE
 ##
-## Ends in an error in state: 917.
+## Ends in an error in state: 899.
 ##
-## data_declaration_stmt -> attributes EXPORT . data_declaration [ SEMI EOL EOF COMMA ]
+## data_declaration_stmt -> EXPORT . data_declaration [ SEMI EOL EOF COMMA ]
 ## export_stmt -> attributes EXPORT . LET REC value_binds [ SEMI EOL EOF ]
 ## export_stmt -> attributes EXPORT . LET value_binds [ SEMI EOL EOF ]
 ## export_stmt -> attributes EXPORT . LET REC MUT value_binds [ SEMI EOL EOF ]
@@ -1317,7 +1315,7 @@ Expected the `fail` keyword followed by an expression.
 
 program: FOR LPAREN SEMI EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 668.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1326,7 +1324,7 @@ program: FOR LPAREN SEMI EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN SEMI EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 654.
+## Ends in an error in state: 664.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1335,7 +1333,7 @@ program: FOR LPAREN SEMI EOL SEMI RPAREN WHILE
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 667.
+## Ends in an error in state: 677.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1344,7 +1342,7 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 663.
+## Ends in an error in state: 673.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1353,7 +1351,7 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
 ##
 program: FOR LPAREN SEMI SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 649.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1362,7 +1360,7 @@ program: FOR LPAREN SEMI SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN SEMI SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 631.
+## Ends in an error in state: 641.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1371,7 +1369,7 @@ program: FOR LPAREN SEMI SEMI RPAREN WHILE
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 658.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1380,7 +1378,7 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 654.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1389,7 +1387,7 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 697.
+## Ends in an error in state: 707.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1398,7 +1396,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 693.
+## Ends in an error in state: 703.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1407,7 +1405,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 706.
+## Ends in an error in state: 716.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1416,7 +1414,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 702.
+## Ends in an error in state: 712.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1425,7 +1423,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 678.
+## Ends in an error in state: 688.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1434,7 +1432,7 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 674.
+## Ends in an error in state: 684.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1443,7 +1441,7 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
-## Ends in an error in state: 687.
+## Ends in an error in state: 697.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1452,7 +1450,7 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI RPAREN WHILE
 ##
-## Ends in an error in state: 683.
+## Ends in an error in state: 693.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1464,7 +1462,7 @@ Expected `{` to start a block.
 
 program: FOR LPAREN SEMI EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 667.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1478,13 +1476,13 @@ program: FOR LPAREN SEMI EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 663.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1498,13 +1496,13 @@ program: FOR LPAREN SEMI EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 675.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1520,7 +1518,7 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 676.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1534,13 +1532,13 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 672.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1554,13 +1552,13 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 648.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1574,13 +1572,13 @@ program: FOR LPAREN SEMI SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 640.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1594,13 +1592,13 @@ program: FOR LPAREN SEMI SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 657.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1614,13 +1612,13 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 643.
+## Ends in an error in state: 653.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1634,13 +1632,13 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 696.
+## Ends in an error in state: 706.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1654,13 +1652,13 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 702.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1674,13 +1672,13 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 705.
+## Ends in an error in state: 715.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1694,13 +1692,13 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 701.
+## Ends in an error in state: 711.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1714,13 +1712,13 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 677.
+## Ends in an error in state: 687.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1734,13 +1732,13 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 673.
+## Ends in an error in state: 683.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1754,13 +1752,13 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 686.
+## Ends in an error in state: 696.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1774,13 +1772,13 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI WASMI64 RBRACK
 ##
-## Ends in an error in state: 682.
+## Ends in an error in state: 692.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1794,16 +1792,16 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI WASMI64 RBRACK
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 
 Expected `)` followed by `{` to start a block.
 
 program: FOR LPAREN SEMI EOL SEMI WHEN
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 662.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1813,7 +1811,7 @@ program: FOR LPAREN SEMI EOL SEMI WHEN
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI WHEN
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 671.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1823,7 +1821,7 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL SEMI WHEN
 ##
 program: FOR LPAREN SEMI SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 647.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1839,7 +1837,7 @@ program: FOR LPAREN SEMI SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN SEMI SEMI WHEN
 ##
-## Ends in an error in state: 629.
+## Ends in an error in state: 639.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1849,7 +1847,7 @@ program: FOR LPAREN SEMI SEMI WHEN
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 646.
+## Ends in an error in state: 656.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1865,7 +1863,7 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN SEMI WASMI64 EOL SEMI WHEN
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 652.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1875,7 +1873,7 @@ program: FOR LPAREN SEMI WASMI64 EOL SEMI WHEN
 ##
 program: FOR LPAREN SEMI EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 666.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1891,7 +1889,7 @@ program: FOR LPAREN SEMI EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 695.
+## Ends in an error in state: 705.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1907,7 +1905,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI WHEN
 ##
-## Ends in an error in state: 691.
+## Ends in an error in state: 701.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1917,7 +1915,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL SEMI WHEN
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 704.
+## Ends in an error in state: 714.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1933,7 +1931,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI WHEN
 ##
-## Ends in an error in state: 700.
+## Ends in an error in state: 710.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1943,7 +1941,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI WHEN
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 676.
+## Ends in an error in state: 686.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1959,7 +1957,7 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI SEMI WHEN
 ##
-## Ends in an error in state: 672.
+## Ends in an error in state: 682.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1969,7 +1967,7 @@ program: FOR LPAREN WASMI64 EOL SEMI SEMI WHEN
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 685.
+## Ends in an error in state: 695.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -1985,7 +1983,7 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI WHEN
 ##
-## Ends in an error in state: 681.
+## Ends in an error in state: 691.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI . for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI . eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -1998,7 +1996,7 @@ Expected an expression or an immediate `)` to skip the increment expression.
 
 program: FOR LPAREN SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 660.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols . for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols . for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2017,7 +2015,7 @@ program: FOR LPAREN SEMI EOL UNDERSCORE
 ##
 program: FOR LPAREN SEMI EOL WASMI64 EOL WHILE
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 670.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2034,7 +2032,7 @@ program: FOR LPAREN SEMI EOL WASMI64 EOL WHILE
 ##
 program: FOR LPAREN SEMI WHEN
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 637.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI . for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI . for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2050,7 +2048,7 @@ program: FOR LPAREN SEMI WHEN
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL UNDERSCORE
 ##
-## Ends in an error in state: 689.
+## Ends in an error in state: 699.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols . for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols . for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2072,7 +2070,7 @@ Expected an expression or an immediate semicolon to skip the condition expressio
 
 program: FOR LPAREN SEMI EOL WASMI64 RPAREN
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 661.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2089,13 +2087,13 @@ program: FOR LPAREN SEMI EOL WASMI64 RPAREN
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN SEMI WASMI64 EOL WHILE
 ##
-## Ends in an error in state: 641.
+## Ends in an error in state: 651.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2112,7 +2110,7 @@ program: FOR LPAREN SEMI WASMI64 EOL WHILE
 ##
 program: FOR LPAREN SEMI WASMI64 RPAREN
 ##
-## Ends in an error in state: 628.
+## Ends in an error in state: 638.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2129,13 +2127,13 @@ program: FOR LPAREN SEMI WASMI64 RPAREN
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL WHILE
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 709.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2152,7 +2150,7 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 RPAREN
 ##
-## Ends in an error in state: 690.
+## Ends in an error in state: 700.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2169,13 +2167,13 @@ program: FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 RPAREN
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL WHILE
 ##
-## Ends in an error in state: 680.
+## Ends in an error in state: 690.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2192,7 +2190,7 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL WHILE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WASMI64 RPAREN
 ##
-## Ends in an error in state: 671.
+## Ends in an error in state: 681.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr . SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr . SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2209,9 +2207,9 @@ program: FOR LPAREN WASMI64 EOL SEMI WASMI64 RPAREN
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 636, spurious reduction of production for_inner_expr -> expr
+## In state 646, spurious reduction of production for_inner_expr -> expr
 ##
 
 Expected a semicolon to complete the loop condition.
@@ -2248,7 +2246,7 @@ program: FOR LPAREN UNDERSCORE
 ##
 program: FOR LPAREN WASMI64 EOL SEMI WHEN
 ##
-## Ends in an error in state: 670.
+## Ends in an error in state: 680.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI . for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols SEMI . for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2267,7 +2265,7 @@ Expected an expression or an immediate semicolon to skip the loop initializer ex
 
 program: FOR LPAREN WASMI64 EOL WHILE
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 679.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) eols . SEMI for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) eols . SEMI for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2290,7 +2288,7 @@ program: FOR LPAREN WASMI64 EOL WHILE
 ##
 program: FOR LPAREN WASMI64 RPAREN
 ##
-## Ends in an error in state: 626.
+## Ends in an error in state: 636.
 ##
 ## for_expr -> FOR lparen option(block_body_expr) . SEMI for_inner_expr SEMI for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## for_expr -> FOR lparen option(block_body_expr) . SEMI for_inner_expr SEMI eols for_inner_expr rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2319,10 +2317,10 @@ program: FOR LPAREN WASMI64 RPAREN
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 316, spurious reduction of production block_body_expr -> expr
-## In state 708, spurious reduction of production option(block_body_expr) -> block_body_expr
+## In state 326, spurious reduction of production block_body_expr -> expr
+## In state 718, spurious reduction of production option(block_body_expr) -> block_body_expr
 ##
 
 Expected a semicolon to complete the loop initializer expression.
@@ -2371,7 +2369,7 @@ program: FUN ID THICKARROW WHEN
 ##
 program: WHILE LPAREN WASMI64 RPAREN WHILE
 ##
-## Ends in an error in state: 751.
+## Ends in an error in state: 762.
 ##
 ## while_expr -> WHILE lparen expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2392,7 +2390,7 @@ program: FUN ID WHILE
 ##
 program: FUN LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 716.
+## Ends in an error in state: 723.
 ##
 ## lam_expr -> FUN lparen option(patterns) rparen . thickarrow expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2405,7 +2403,7 @@ Expected `=>` after the function argument.
 
 program: FUN LPAREN RPAREN THICKARROW EOL UNDERSCORE
 ##
-## Ends in an error in state: 717.
+## Ends in an error in state: 724.
 ##
 ## lam_expr -> FUN lparen option(patterns) rparen thickarrow . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2425,7 +2423,7 @@ Expected a function body—a block surrounded by `{`/`}` or a single expression.
 
 program: FUN LPAREN WASMI64 COMMA EOL WASMI64 WHILE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 357.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma pattern . [ RPAREN RBRACK EOL COMMA ]
 ## pattern -> pattern . COLON typ [ RPAREN RBRACK EOL COMMA COLON ]
@@ -2436,7 +2434,7 @@ program: FUN LPAREN WASMI64 COMMA EOL WASMI64 WHILE
 ##
 program: FUN LPAREN WASMI64 WHILE
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 344.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> pattern . [ RPAREN RBRACK EOL COMMA ]
 ## pattern -> pattern . COLON typ [ RPAREN RBRACK EOL COMMA COLON ]
@@ -2450,7 +2448,7 @@ Expected a type annotation, a comma followed by more patterns, `)`, or `]`.
 
 program: FUN LPAREN WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 356.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma . pattern [ RPAREN RBRACK EOL COMMA ]
 ## option(comma) -> comma . [ RPAREN RBRACK EOL ]
@@ -2471,7 +2469,7 @@ Expected another pattern, `)`, or `]`.
 
 program: FUN LPAREN WASMI64 RBRACK
 ##
-## Ends in an error in state: 715.
+## Ends in an error in state: 722.
 ##
 ## lam_expr -> FUN lparen option(patterns) . rparen thickarrow expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2482,17 +2480,17 @@ program: FUN LPAREN WASMI64 RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 334, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
-## In state 344, spurious reduction of production option(comma) ->
-## In state 345, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
-## In state 714, spurious reduction of production option(patterns) -> patterns
+## In state 344, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
+## In state 354, spurious reduction of production option(comma) ->
+## In state 355, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
+## In state 721, spurious reduction of production option(patterns) -> patterns
 ##
 
 Expected `)` to complete the function arguments.
 
 program: FUN LPAREN WHILE
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 720.
 ##
 ## lam_expr -> FUN lparen . option(patterns) rparen thickarrow expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2547,7 +2545,7 @@ Expected a condition expression.
 
 program: IF LPAREN WASMI64 RPAREN CONTINUE WHILE
 ##
-## Ends in an error in state: 721.
+## Ends in an error in state: 728.
 ##
 ## if_expr -> IF lparen expr rparen expr . [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen expr . ELSE expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2558,7 +2556,7 @@ program: IF LPAREN WASMI64 RPAREN CONTINUE WHILE
 ##
 program: IF LPAREN WASMI64 RPAREN EOL CONTINUE WHILE
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 734.
 ##
 ## if_expr -> IF lparen expr rparen eols expr . [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen eols expr . ELSE expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2572,7 +2570,7 @@ Expected a newline character to end the `if` statement or `else` to provide an �
 
 program: IF LPAREN WASMI64 RPAREN EOL UNDERSCORE
 ##
-## Ends in an error in state: 726.
+## Ends in an error in state: 733.
 ##
 ## if_expr -> IF lparen expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen eols . expr ELSE expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2590,7 +2588,7 @@ program: IF LPAREN WASMI64 RPAREN EOL UNDERSCORE
 ##
 program: IF LPAREN WASMI64 RPAREN EOL WASMI64 ELSE EOL UNDERSCORE
 ##
-## Ends in an error in state: 730.
+## Ends in an error in state: 737.
 ##
 ## if_expr -> IF lparen expr rparen eols expr ELSE eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2606,7 +2604,7 @@ program: IF LPAREN WASMI64 RPAREN EOL WASMI64 ELSE EOL UNDERSCORE
 ##
 program: IF LPAREN WASMI64 RPAREN EOL WASMI64 ELSE WHEN
 ##
-## Ends in an error in state: 728.
+## Ends in an error in state: 735.
 ##
 ## if_expr -> IF lparen expr rparen eols expr ELSE . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen eols expr ELSE . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2616,7 +2614,7 @@ program: IF LPAREN WASMI64 RPAREN EOL WASMI64 ELSE WHEN
 ##
 program: IF LPAREN WASMI64 RPAREN WASMI64 ELSE EOL UNDERSCORE
 ##
-## Ends in an error in state: 724.
+## Ends in an error in state: 731.
 ##
 ## if_expr -> IF lparen expr rparen expr ELSE eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2632,7 +2630,7 @@ program: IF LPAREN WASMI64 RPAREN WASMI64 ELSE EOL UNDERSCORE
 ##
 program: IF LPAREN WASMI64 RPAREN WASMI64 ELSE WHEN
 ##
-## Ends in an error in state: 722.
+## Ends in an error in state: 729.
 ##
 ## if_expr -> IF lparen expr rparen expr ELSE . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen expr ELSE . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2642,7 +2640,7 @@ program: IF LPAREN WASMI64 RPAREN WASMI64 ELSE WHEN
 ##
 program: IF LPAREN WASMI64 RPAREN WHEN
 ##
-## Ends in an error in state: 720.
+## Ends in an error in state: 727.
 ##
 ## if_expr -> IF lparen expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr rparen . expr ELSE expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2659,7 +2657,7 @@ Expected a block surrounded by `{`/`}` or a single expression.
 
 program: IF LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 719.
+## Ends in an error in state: 726.
 ##
 ## if_expr -> IF lparen expr . rparen expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## if_expr -> IF lparen expr . rparen expr ELSE expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -2678,7 +2676,7 @@ program: IF LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -2703,7 +2701,7 @@ Expected `(` followed by a condition expression.
 
 program: IMPORT FOREIGN WASM ID COLON EOL TYPEID AS ID WHILE
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 873.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON eols typ option(as_prefix(id_str)) . FROM file_path [ SEMI EOL EOF ]
 ##
@@ -2712,7 +2710,7 @@ program: IMPORT FOREIGN WASM ID COLON EOL TYPEID AS ID WHILE
 ##
 program: IMPORT FOREIGN WASM ID COLON TYPEID AS ID WHILE
 ##
-## Ends in an error in state: 792.
+## Ends in an error in state: 866.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON typ option(as_prefix(id_str)) . FROM file_path [ SEMI EOL EOF ]
 ##
@@ -2724,7 +2722,7 @@ Expected the keyword `from` followed by a file path.
 
 program: IMPORT FOREIGN WASM ID COLON EOL TYPEID FROM WHILE
 ##
-## Ends in an error in state: 800.
+## Ends in an error in state: 874.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON eols typ option(as_prefix(id_str)) FROM . file_path [ SEMI EOL EOF ]
 ##
@@ -2733,7 +2731,7 @@ program: IMPORT FOREIGN WASM ID COLON EOL TYPEID FROM WHILE
 ##
 program: IMPORT FOREIGN WASM ID COLON TYPEID FROM WHILE
 ##
-## Ends in an error in state: 793.
+## Ends in an error in state: 867.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON typ option(as_prefix(id_str)) FROM . file_path [ SEMI EOL EOF ]
 ##
@@ -2742,7 +2740,7 @@ program: IMPORT FOREIGN WASM ID COLON TYPEID FROM WHILE
 ##
 program: IMPORT TYPEID FROM WHILE
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 878.
 ##
 ## import_stmt -> IMPORT lseparated_nonempty_list_inner(comma,import_shape) option(comma) FROM . file_path [ SEMI EOL EOF ]
 ##
@@ -2754,7 +2752,7 @@ Expected a file path surrounded by `”`.
 
 program: IMPORT FOREIGN WASM ID COLON EOL TYPEID WHEN
 ##
-## Ends in an error in state: 798.
+## Ends in an error in state: 872.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON eols typ . option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ##
@@ -2771,7 +2769,7 @@ program: IMPORT FOREIGN WASM ID COLON EOL TYPEID WHEN
 ##
 program: IMPORT FOREIGN WASM ID COLON TYPEID WHEN
 ##
-## Ends in an error in state: 789.
+## Ends in an error in state: 863.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON typ . option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ##
@@ -2791,7 +2789,7 @@ Expected an alias, like `as foo`, for the foreign value's name or the keyword `f
 
 program: IMPORT FOREIGN WASM ID COLON EOL WHILE
 ##
-## Ends in an error in state: 797.
+## Ends in an error in state: 871.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON eols . typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ##
@@ -2807,7 +2805,7 @@ program: IMPORT FOREIGN WASM ID COLON EOL WHILE
 ##
 program: IMPORT FOREIGN WASM ID COLON WHILE
 ##
-## Ends in an error in state: 788.
+## Ends in an error in state: 862.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str COLON . typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ## foreign_stmt -> FOREIGN WASM id_str COLON . eols typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
@@ -2820,7 +2818,7 @@ Expected a type for the foreign value.
 
 program: IMPORT FOREIGN WASM ID COLON TYPEID AS WHILE
 ##
-## Ends in an error in state: 790.
+## Ends in an error in state: 864.
 ##
 ## as_prefix(id_str) -> AS . id_str [ FROM ]
 ##
@@ -2832,7 +2830,7 @@ Expected an identifier to use as the alias.
 
 program: IMPORT FOREIGN WASM ID WHILE
 ##
-## Ends in an error in state: 787.
+## Ends in an error in state: 861.
 ##
 ## foreign_stmt -> FOREIGN WASM id_str . COLON typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ## foreign_stmt -> FOREIGN WASM id_str . COLON eols typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
@@ -2845,7 +2843,7 @@ Expected a type annotation for the foreign value.
 
 program: IMPORT FOREIGN WASM WHILE
 ##
-## Ends in an error in state: 786.
+## Ends in an error in state: 860.
 ##
 ## foreign_stmt -> FOREIGN WASM . id_str COLON typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ## foreign_stmt -> FOREIGN WASM . id_str COLON eols typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
@@ -2858,7 +2856,7 @@ Expected an identifier for the foreign value.
 
 program: IMPORT FOREIGN WHILE
 ##
-## Ends in an error in state: 785.
+## Ends in an error in state: 859.
 ##
 ## foreign_stmt -> FOREIGN . WASM id_str COLON typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
 ## foreign_stmt -> FOREIGN . WASM id_str COLON eols typ option(as_prefix(id_str)) FROM file_path [ SEMI EOL EOF ]
@@ -2871,7 +2869,7 @@ Expected the keyword `wasm`.
 
 program: IMPORT LBRACE TYPEID AS ID WHILE
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 884.
 ##
 ## import_ids -> lseparated_nonempty_list_inner(comma,aliasable(id)) . option(comma) [ RBRACE EOL ]
 ## lseparated_nonempty_list_inner(comma,aliasable(id)) -> lseparated_nonempty_list_inner(comma,aliasable(id)) . comma aliasable(id) [ RBRACE EOL COMMA ]
@@ -2884,7 +2882,7 @@ Expected a comma followed by more imports or `}` to complete the imports block.
 
 program: IMPORT LBRACE TYPEID AS WHILE
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 888.
 ##
 ## as_prefix(id) -> AS . id [ RBRACE EOL COMMA ]
 ##
@@ -2896,7 +2894,7 @@ Expected an identifier to use as an alias.
 
 program: IMPORT LBRACE TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 886.
 ##
 ## lseparated_nonempty_list_inner(comma,aliasable(id)) -> lseparated_nonempty_list_inner(comma,aliasable(id)) comma . aliasable(id) [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -2917,7 +2915,7 @@ Expected an identifier to import or `}` to complete the imports block.
 
 program: IMPORT LBRACE TYPEID EOL WHILE
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 201.
 ##
 ## rbrace -> eols . RBRACE [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS FROM EQUAL EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -2936,7 +2934,7 @@ Expected `}` to complete the block.
 
 program: IMPORT LBRACE TYPEID THICKARROW
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 887.
 ##
 ## aliasable(id) -> id . option(as_prefix(id)) [ RBRACE EOL COMMA ]
 ##
@@ -2954,7 +2952,7 @@ Expected an alias like`as foo`, a comma followed by another identifier, or `}` t
 
 program: IMPORT LBRACE WHILE
 ##
-## Ends in an error in state: 807.
+## Ends in an error in state: 881.
 ##
 ## import_shape -> lbrace . option(import_ids) rbrace [ FROM COMMA ]
 ##
@@ -2990,7 +2988,7 @@ Expected an infix or prefix operator, e.g. `+`, `-`, `!`.
 
 program: IMPORT STAR EXCEPT LBRACE TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 780.
+## Ends in an error in state: 854.
 ##
 ## lseparated_nonempty_list_inner(comma,id) -> lseparated_nonempty_list_inner(comma,id) comma . id [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -3011,7 +3009,7 @@ Expected an identifier or `}` to complete the block.
 
 program: IMPORT STAR EXCEPT LBRACE TYPEID THICKARROW
 ##
-## Ends in an error in state: 777.
+## Ends in an error in state: 851.
 ##
 ## import_exception -> EXCEPT lbrace lseparated_nonempty_list_inner(comma,id) . option(comma) rbrace [ FROM COMMA ]
 ## lseparated_nonempty_list_inner(comma,id) -> lseparated_nonempty_list_inner(comma,id) . comma id [ RBRACE EOL COMMA ]
@@ -3024,14 +3022,14 @@ program: IMPORT STAR EXCEPT LBRACE TYPEID THICKARROW
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 122, spurious reduction of production id -> lseparated_nonempty_list_inner(dot,TYPEID)
-## In state 782, spurious reduction of production lseparated_nonempty_list_inner(comma,id) -> id
+## In state 856, spurious reduction of production lseparated_nonempty_list_inner(comma,id) -> id
 ##
 
 Expected a comma followed by an identifier or `}` to end the block.
 
 program: IMPORT STAR EXCEPT LBRACE WHILE
 ##
-## Ends in an error in state: 776.
+## Ends in an error in state: 850.
 ##
 ## import_exception -> EXCEPT lbrace . lseparated_nonempty_list_inner(comma,id) option(comma) rbrace [ FROM COMMA ]
 ##
@@ -3049,7 +3047,7 @@ Expected a comma-separated list of identifiers to exclude from the import.
 
 program: IMPORT STAR EXCEPT WHILE
 ##
-## Ends in an error in state: 775.
+## Ends in an error in state: 849.
 ##
 ## import_exception -> EXCEPT . lbrace lseparated_nonempty_list_inner(comma,id) option(comma) rbrace [ FROM COMMA ]
 ##
@@ -3061,7 +3059,7 @@ Expected `{` followed by a comma-separated list of identifiers to exclude from t
 
 program: IMPORT STAR WHILE
 ##
-## Ends in an error in state: 774.
+## Ends in an error in state: 848.
 ##
 ## import_shape -> STAR . option(import_exception) [ FROM COMMA ]
 ##
@@ -3073,7 +3071,7 @@ Expected the keyword `except` followed by comma-separated identifiers surrounded
 
 program: IMPORT TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 880.
 ##
 ## lseparated_nonempty_list_inner(comma,import_shape) -> lseparated_nonempty_list_inner(comma,import_shape) comma . import_shape [ FROM COMMA ]
 ## option(comma) -> comma . [ FROM ]
@@ -3094,7 +3092,7 @@ Expected another import or the `from` keyword followed by a file path.
 
 program: IMPORT TYPEID THICKARROW
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 876.
 ##
 ## import_stmt -> IMPORT lseparated_nonempty_list_inner(comma,import_shape) . option(comma) FROM file_path [ SEMI EOL EOF ]
 ## lseparated_nonempty_list_inner(comma,import_shape) -> lseparated_nonempty_list_inner(comma,import_shape) . comma import_shape [ FROM COMMA ]
@@ -3107,28 +3105,28 @@ program: IMPORT TYPEID THICKARROW
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 122, spurious reduction of production id -> lseparated_nonempty_list_inner(dot,TYPEID)
-## In state 822, spurious reduction of production import_shape -> id
-## In state 823, spurious reduction of production lseparated_nonempty_list_inner(comma,import_shape) -> import_shape
+## In state 896, spurious reduction of production import_shape -> id
+## In state 897, spurious reduction of production lseparated_nonempty_list_inner(comma,import_shape) -> import_shape
 ##
 
 Expected a comma followed by a module identifier, `*`, a list of comma-separated identifiers surrounded by `{`/`}`, or the `from` keyword followed by a file path.
 
 program: IMPORT WHILE
 ##
-## Ends in an error in state: 773.
+## Ends in an error in state: 847.
 ##
 ## import_stmt -> IMPORT . lseparated_nonempty_list_inner(comma,import_shape) option(comma) FROM file_path [ SEMI EOL EOF ]
-## toplevel_stmt -> IMPORT . foreign_stmt [ SEMI EOL EOF ]
+## toplevel_stmt -> attributes IMPORT . foreign_stmt [ SEMI EOL EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT
+## attributes IMPORT
 ##
 
 Expected a module identifier, `*`, a list of comma-separated identifiers surrounded by `{`/`}`, or the `foreign` keyword.
 
 program: LBRACE AT ID RECORD
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 328.
 ##
 ## let_expr -> attributes . LET REC value_binds [ SEMI RBRACE EOL ]
 ## let_expr -> attributes . LET value_binds [ SEMI RBRACE EOL ]
@@ -3142,17 +3140,18 @@ program: LBRACE AT ID RECORD
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 186, spurious reduction of production attribute -> AT id_str
-## In state 402, spurious reduction of production list(attribute) ->
-## In state 403, spurious reduction of production list(attribute) -> attribute list(attribute)
-## In state 314, spurious reduction of production attributes -> list(attribute)
+## In state 186, spurious reduction of production loption(attribute_arguments) ->
+## In state 195, spurious reduction of production attribute -> AT id_str loption(attribute_arguments)
+## In state 412, spurious reduction of production list(attribute) ->
+## In state 413, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 324, spurious reduction of production attributes -> list(attribute)
 ##
 
 Expected a let binding.
 
 program: LBRACE BREAK RBRACE DOT EOL WHILE
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 293.
 ##
 ## record_get -> braced_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> braced_expr DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3169,7 +3168,7 @@ program: LBRACE BREAK RBRACE DOT EOL WHILE
 ##
 program: LBRACE BREAK RBRACE DOT WHILE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 289.
 ##
 ## record_get -> braced_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> braced_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3184,7 +3183,7 @@ Expected a record field name.
 
 program: LBRACE BREAK RBRACE LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 303.
 ##
 ## array_get -> braced_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> braced_expr lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3200,7 +3199,7 @@ program: LBRACE BREAK RBRACE LBRACK UNDERSCORE
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LBRACK WHEN
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 284.
 ##
 ## array_get -> array_get lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> array_get lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3219,7 +3218,7 @@ Expected an array index expression.
 
 program: LBRACE BREAK RBRACE LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 294.
+## Ends in an error in state: 304.
 ##
 ## array_get -> braced_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> braced_expr lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3234,7 +3233,7 @@ program: LBRACE BREAK RBRACE LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -3242,7 +3241,7 @@ Expected `]` to complete the array index expression.
 
 program: LBRACE BREAK RBRACE LPAREN COMMA EOL WHILE
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 298.
 ##
 ## app_expr -> braced_expr lparen option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -3256,11 +3255,11 @@ program: LBRACE BREAK RBRACE LPAREN COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 89, spurious reduction of production comma -> COMMA eols
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: LBRACE BREAK RBRACE LPAREN WASMI64 COMMA RBRACK
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 301.
 ##
 ## app_expr -> braced_expr lparen lseparated_nonempty_list_inner(comma,expr) option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -3276,7 +3275,7 @@ program: LBRACE BREAK RBRACE LPAREN WASMI64 COMMA RBRACK
 ##
 program: LPAREN BREAK RPAREN LPAREN COMMA EOL WHILE
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 456.
 ##
 ## app_expr -> paren_expr lparen option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -3290,11 +3289,11 @@ program: LPAREN BREAK RPAREN LPAREN COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 89, spurious reduction of production comma -> COMMA eols
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: LPAREN BREAK RPAREN LPAREN WASMI64 COMMA RBRACK
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 459.
 ##
 ## app_expr -> paren_expr lparen lseparated_nonempty_list_inner(comma,expr) option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -3313,7 +3312,7 @@ Expected `)` to complete the function call.
 
 program: LBRACE BREAK RBRACE LPAREN UNDERSCORE
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 297.
 ##
 ## app_expr -> braced_expr lparen . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## app_expr -> braced_expr lparen . lseparated_nonempty_list_inner(comma,expr) option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3329,7 +3328,7 @@ program: LBRACE BREAK RBRACE LPAREN UNDERSCORE
 ##
 program: LBRACE BREAK RBRACE LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 300.
 ##
 ## app_expr -> braced_expr lparen lseparated_nonempty_list_inner(comma,expr) . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
@@ -3344,13 +3343,13 @@ program: LBRACE BREAK RBRACE LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 program: LPAREN BREAK RPAREN LPAREN UNDERSCORE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 455.
 ##
 ## app_expr -> paren_expr lparen . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## app_expr -> paren_expr lparen . lseparated_nonempty_list_inner(comma,expr) option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -3369,7 +3368,7 @@ Expected a comma-separated list of expressions or an immediate `)` to complete t
 
 program: LBRACE LET REC WHILE
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 332.
 ##
 ## let_expr -> attributes LET REC . value_binds [ SEMI RBRACE EOL ]
 ## let_expr -> attributes LET REC . MUT value_binds [ SEMI RBRACE EOL ]
@@ -3379,7 +3378,7 @@ program: LBRACE LET REC WHILE
 ##
 program: LET REC WHILE
 ##
-## Ends in an error in state: 910.
+## Ends in an error in state: 840.
 ##
 ## toplevel_stmt -> attributes LET REC . value_binds [ SEMI EOL EOF ]
 ## toplevel_stmt -> attributes LET REC . MUT value_binds [ SEMI EOL EOF ]
@@ -3392,7 +3391,7 @@ Expected the keyword `mut` or a binding pattern, like an identifier.
 
 program: LBRACE TYPEID COLON BREAK COMMA EOL TYPEID COLON BREAK WHILE
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 318.
 ##
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma punned_record_field [ RBRACE EOL COMMA ]
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma non_punned_record_field [ RBRACE EOL COMMA ]
@@ -3403,7 +3402,7 @@ program: LBRACE TYPEID COLON BREAK COMMA EOL TYPEID COLON BREAK WHILE
 ##
 program: LBRACE TYPEID COLON BREAK WHILE
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 315.
 ##
 ## record_exprs -> non_punned_record_field . option(comma) [ RBRACE EOL ]
 ## record_exprs -> non_punned_record_field . comma lseparated_nonempty_list_inner(comma,record_field) option(comma) [ RBRACE EOL ]
@@ -3413,7 +3412,7 @@ program: LBRACE TYPEID COLON BREAK WHILE
 ##
 program: LBRACE TYPEID COMMA EOL TYPEID COLON BREAK WHILE
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 207.
 ##
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma punned_record_field [ RBRACE EOL COMMA ]
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma non_punned_record_field [ RBRACE EOL COMMA ]
@@ -3427,7 +3426,7 @@ Expected a comma followed by more record fields or an immediate `}` to complete 
 
 program: LBRACE TYPEID COLON BREAK COMMA EOL WHILE
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 317.
 ##
 ## option(comma) -> comma . [ RBRACE EOL ]
 ## record_exprs -> non_punned_record_field comma . lseparated_nonempty_list_inner(comma,record_field) option(comma) [ RBRACE EOL ]
@@ -3445,7 +3444,7 @@ program: LBRACE TYPEID COLON BREAK COMMA EOL WHILE
 ##
 program: LBRACE TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 204.
 ##
 ## record_exprs -> punned_record_field comma . [ RBRACE EOL ]
 ## record_exprs -> punned_record_field comma . lseparated_nonempty_list_inner(comma,record_field) option(comma) [ RBRACE EOL ]
@@ -3463,7 +3462,7 @@ program: LBRACE TYPEID COMMA EOL WHILE
 ##
 program: LBRACE TYPEID COMMA TYPEID COMMA EOL WHILE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 209.
 ##
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) comma . punned_record_field [ RBRACE EOL COMMA ]
 ## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) comma . non_punned_record_field [ RBRACE EOL COMMA ]
@@ -3485,7 +3484,7 @@ Expected more record fields or an immediate `}` to complete the record expressio
 
 program: LBRACE TYPEID COMMA TYPEID THICKARROW
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 212.
 ##
 ## non_punned_record_field -> id . COLON expr [ RBRACE EOL COMMA ]
 ## non_punned_record_field -> id . COLON eols expr [ RBRACE EOL COMMA ]
@@ -3505,7 +3504,7 @@ Expected a colon followed by an expression, a comma followed by more record fiel
 
 program: LBRACE TYPEID THICKARROW
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 320.
 ##
 ## block_body -> lseparated_nonempty_list_inner(eos,block_body_expr) . [ RBRACE EOL ]
 ## block_body -> lseparated_nonempty_list_inner(eos,block_body_expr) . eos [ RBRACE EOL ]
@@ -3519,15 +3518,15 @@ program: LBRACE TYPEID THICKARROW
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 122, spurious reduction of production id -> lseparated_nonempty_list_inner(dot,TYPEID)
-## In state 405, spurious reduction of production id_expr -> id
-## In state 206, spurious reduction of production simple_expr -> id_expr
+## In state 415, spurious reduction of production id_expr -> id
+## In state 216, spurious reduction of production simple_expr -> id_expr
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 316, spurious reduction of production block_body_expr -> expr
-## In state 406, spurious reduction of production lseparated_nonempty_list_inner(eos,block_body_expr) -> block_body_expr
+## In state 326, spurious reduction of production block_body_expr -> expr
+## In state 416, spurious reduction of production lseparated_nonempty_list_inner(eos,block_body_expr) -> block_body_expr
 ##
 
 Expected a newline character followed by more statements or `}` to complete the block.
@@ -3553,7 +3552,7 @@ Expected an expression or a record field.
 
 program: LBRACE WASMI64 SEMI RECORD
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 323.
 ##
 ## block_body -> lseparated_nonempty_list_inner(eos,block_body_expr) eos . [ RBRACE EOL ]
 ## lseparated_nonempty_list_inner(eos,block_body_expr) -> lseparated_nonempty_list_inner(eos,block_body_expr) eos . block_body_expr [ SEMI RBRACE EOL ]
@@ -3565,7 +3564,7 @@ program: LBRACE WASMI64 SEMI RECORD
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 311, spurious reduction of production eos -> SEMI
+## In state 321, spurious reduction of production eos -> SEMI
 ##
 
 Expected another statement or `}` to complete the block.
@@ -3591,7 +3590,7 @@ Expected a comma-separated list of expressions or `]` to complete the list expre
 
 program: LBRACK WASMI64 COMMA EOL UNDERSCORE
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 424.
 ##
 ## lseparated_nonempty_list_inner(comma,list_item) -> lseparated_nonempty_list_inner(comma,list_item) comma . list_item [ RBRACK EOL COMMA ]
 ## option(comma) -> comma . [ RBRACK EOL ]
@@ -3612,7 +3611,7 @@ Expected an expression,  `...` followed by an expression, or `]` to complete the
 
 program: LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 421.
 ##
 ## list_expr -> lbrack lseparated_nonempty_list_inner(comma,list_item) . option(comma) rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,list_item) -> lseparated_nonempty_list_inner(comma,list_item) . comma list_item [ RBRACK EOL COMMA ]
@@ -3627,10 +3626,10 @@ program: LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 416, spurious reduction of production list_item -> expr
-## In state 417, spurious reduction of production lseparated_nonempty_list_inner(comma,list_item) -> list_item
+## In state 426, spurious reduction of production list_item -> expr
+## In state 427, spurious reduction of production lseparated_nonempty_list_inner(comma,list_item) -> list_item
 ##
 
 Expected a comma followed by an expression, `...` followed by an expression, or `]` to complete the list expression.
@@ -3731,16 +3730,16 @@ program: LBRACKRCARET WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 
 Expected a comma followed by an expression or `]` to complete the array expression.
 
 program: LET DASH WHILE
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 349.
 ##
 ## const -> option(dash_op) . NUMBER_INT [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ## const -> option(dash_op) . NUMBER_FLOAT [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
@@ -3759,7 +3758,7 @@ program: LET DASH WHILE
 ##
 program: LET NUMBER_INT SLASH DASH WHILE
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 352.
 ##
 ## pattern -> option(dash_op) NUMBER_INT SLASH option(dash_op) . NUMBER_INT [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -3771,7 +3770,7 @@ Expected a number.
 
 program: LET LBRACE TYPEID COLON EOL WASMI64 WHILE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 388.
 ##
 ## pattern -> pattern . COLON typ [ RBRACE EOL COMMA COLON ]
 ## pattern -> pattern . COLON eols typ [ RBRACE EOL COMMA COLON ]
@@ -3782,7 +3781,7 @@ program: LET LBRACE TYPEID COLON EOL WASMI64 WHILE
 ##
 program: LET LBRACE TYPEID COLON WASMI64 WHILE
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 386.
 ##
 ## pattern -> pattern . COLON typ [ RBRACE EOL COMMA COLON ]
 ## pattern -> pattern . COLON eols typ [ RBRACE EOL COMMA COLON ]
@@ -3796,7 +3795,7 @@ Expected a type annotation, a comma followed by more record field patterns, or `
 
 program: LET LBRACE TYPEID COLON EOL WHILE
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 387.
 ##
 ## record_pattern -> id COLON eols . pattern [ RBRACE EOL COMMA ]
 ##
@@ -3812,7 +3811,7 @@ program: LET LBRACE TYPEID COLON EOL WHILE
 ##
 program: LET LBRACE TYPEID COLON WHILE
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 385.
 ##
 ## record_pattern -> id COLON . pattern [ RBRACE EOL COMMA ]
 ## record_pattern -> id COLON . eols pattern [ RBRACE EOL COMMA ]
@@ -3822,7 +3821,7 @@ program: LET LBRACE TYPEID COLON WHILE
 ##
 program: LET LPAREN WHILE
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 358.
 ##
 ## pattern -> lparen . special_op rparen [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ## pattern -> lparen . tuple_patterns rparen [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
@@ -3839,7 +3838,7 @@ program: LET LPAREN WHILE
 ##
 program: LET LBRACK ELLIPSIS WHILE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 373.
 ##
 ## list_item_pat -> ELLIPSIS . pattern [ RBRACK EOL COMMA ]
 ##
@@ -3848,7 +3847,7 @@ program: LET LBRACK ELLIPSIS WHILE
 ##
 program: LET LPAREN WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 398.
 ##
 ## tuple_patterns -> pattern COMMA eols . lseparated_nonempty_list_inner(comma,pattern) [ RPAREN EOL ]
 ## tuple_patterns -> pattern COMMA eols . lseparated_nonempty_list_inner(comma,pattern) comma [ RPAREN EOL ]
@@ -3868,7 +3867,7 @@ Expected a pattern.
 
 program: LET LBRACE TYPEID THICKARROW
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 384.
 ##
 ## record_pattern -> id . COLON pattern [ RBRACE EOL COMMA ]
 ## record_pattern -> id . COLON eols pattern [ RBRACE EOL COMMA ]
@@ -3888,7 +3887,7 @@ Expected `:` followed by a pattern, a comma followed by another record field pat
 
 program: LET LBRACE UNDERSCORE COMMA EOL WHILE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 382.
 ##
 ## lseparated_nonempty_list_inner(comma,record_pattern) -> lseparated_nonempty_list_inner(comma,record_pattern) comma . record_pattern [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -3909,7 +3908,7 @@ Expected another record field pattern or `}` to complete the record pattern.
 
 program: LET LBRACE UNDERSCORE WHILE
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 380.
 ##
 ## lseparated_nonempty_list_inner(comma,record_pattern) -> lseparated_nonempty_list_inner(comma,record_pattern) . comma record_pattern [ RBRACE EOL COMMA ]
 ## record_patterns -> lseparated_nonempty_list_inner(comma,record_pattern) . option(comma) [ RBRACE EOL ]
@@ -3922,7 +3921,7 @@ Expected a comma followed by more record field patterns or `}` to complete the r
 
 program: LET LBRACE WHILE
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 375.
 ##
 ## pattern -> lbrace . record_patterns rbrace [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -3940,7 +3939,7 @@ Expected a comma-separated list of record field patterns.
 
 program: LET LBRACK ELLIPSIS WASMI64 WHILE
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 374.
 ##
 ## list_item_pat -> ELLIPSIS pattern . [ RBRACK EOL COMMA ]
 ## pattern -> pattern . COLON typ [ RBRACK EOL COMMA COLON ]
@@ -3954,7 +3953,7 @@ Expected a type annotation, a comma followed by more patterns, or `]` to complet
 
 program: LET LBRACK WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 395.
 ##
 ## lseparated_nonempty_list_inner(comma,list_item_pat) -> lseparated_nonempty_list_inner(comma,list_item_pat) comma . list_item_pat [ RBRACK EOL COMMA ]
 ## option(comma) -> comma . [ RBRACK EOL ]
@@ -3975,7 +3974,7 @@ Expected a pattern, `...` followed by a pattern, or `]` to complete the list pat
 
 program: LET LBRACK WASMI64 WHILE
 ##
-## Ends in an error in state: 381.
+## Ends in an error in state: 391.
 ##
 ## list_item_pat -> pattern . [ RBRACK EOL COMMA ]
 ## pattern -> pattern . COLON typ [ RBRACK EOL COMMA COLON ]
@@ -3989,7 +3988,7 @@ Expected a type annotation, a comma followed by another pattern, or `]` to compl
 
 program: LET LBRACK WHILE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 372.
 ##
 ## pattern -> lbrack . rbrack [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ## pattern -> lbrack . lseparated_nonempty_list_inner(comma,list_item_pat) option(comma) rbrack [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
@@ -4008,7 +4007,7 @@ Expected a comma-separated list of patterns or `]` to complete the list pattern.
 
 program: LET LBRACKRCARET WASMI64 RPAREN
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 370.
 ##
 ## pattern -> lbrackrcaret patterns . rbrack [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -4019,16 +4018,16 @@ program: LET LBRACKRCARET WASMI64 RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 334, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
-## In state 344, spurious reduction of production option(comma) ->
-## In state 345, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
+## In state 344, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
+## In state 354, spurious reduction of production option(comma) ->
+## In state 355, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
 ##
 
 Expected `]` to complete the array pattern.
 
 program: LET LBRACKRCARET WHILE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 368.
 ##
 ## pattern -> lbrackrcaret . patterns rbrack [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ## pattern -> lbrackrcaret . rbrack [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
@@ -4047,7 +4046,7 @@ Expected a comma-separated list of patterns or `]` to complete the array pattern
 
 program: LET LPAREN STAR WHILE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 362.
 ##
 ## pattern -> lparen special_op . rparen [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -4059,7 +4058,7 @@ Expected `)` to complete the pattern.
 
 program: LET LPAREN WASMI64 COMMA EOL WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 400.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma . pattern [ RPAREN EOL COMMA ]
 ## tuple_patterns -> pattern COMMA eols lseparated_nonempty_list_inner(comma,pattern) comma . [ RPAREN EOL ]
@@ -4080,7 +4079,7 @@ Expected a pattern or `)` to complete the tuple pattern.
 
 program: LET LPAREN WASMI64 COMMA EOL WASMI64 RBRACK
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 399.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) . comma pattern [ RPAREN EOL COMMA ]
 ## tuple_patterns -> pattern COMMA eols lseparated_nonempty_list_inner(comma,pattern) . [ RPAREN EOL ]
@@ -4093,14 +4092,14 @@ program: LET LPAREN WASMI64 COMMA EOL WASMI64 RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 334, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
+## In state 344, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
 ##
 
 Expected a comma followed by another pattern or `)` to complete the tuple pattern.
 
 program: LET LPAREN WASMI64 COMMA WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 367.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma . pattern [ RPAREN EOL COMMA ]
 ## tuple_patterns -> pattern COMMA lseparated_nonempty_list_inner(comma,pattern) comma . [ RPAREN EOL ]
@@ -4121,7 +4120,7 @@ Expected another pattern or `)` to complete the tuple pattern.
 
 program: LET LPAREN WASMI64 COMMA WASMI64 RBRACK
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 366.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) . comma pattern [ RPAREN EOL COMMA ]
 ## tuple_patterns -> pattern COMMA lseparated_nonempty_list_inner(comma,pattern) . [ RPAREN EOL ]
@@ -4134,14 +4133,14 @@ program: LET LPAREN WASMI64 COMMA WASMI64 RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 334, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
+## In state 344, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
 ##
 
 Expected a comma followed by another pattern or `)` to complete the tuple pattern.
 
 program: LET LPAREN WASMI64 COMMA WHILE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 365.
 ##
 ## tuple_patterns -> pattern COMMA . [ RPAREN EOL ]
 ## tuple_patterns -> pattern COMMA . lseparated_nonempty_list_inner(comma,pattern) [ RPAREN EOL ]
@@ -4157,7 +4156,7 @@ Expected a pattern or an immediate `)` for a single-argument tuple pattern.
 
 program: LET LPAREN WASMI64 WHILE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 364.
 ##
 ## pattern -> pattern . COLON typ [ RPAREN EOL COMMA COLON ]
 ## pattern -> pattern . COLON eols typ [ RPAREN EOL COMMA COLON ]
@@ -4176,7 +4175,7 @@ Expected a type annotation, `)` for a grouped pattern, or a comma for a tuple pa
 
 program: LET NUMBER_INT SLASH WHILE
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 351.
 ##
 ## pattern -> option(dash_op) NUMBER_INT SLASH . option(dash_op) NUMBER_INT [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -4188,7 +4187,7 @@ Expected a number or a minus sign followed by a number.
 
 program: LET NUMBER_INT WHILE
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 402.
 ##
 ## pattern -> pattern . COLON typ [ EQUAL COLON ]
 ## pattern -> pattern . COLON eols typ [ EQUAL COLON ]
@@ -4201,8 +4200,8 @@ program: LET NUMBER_INT WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 340, spurious reduction of production const -> option(dash_op) NUMBER_INT
-## In state 379, spurious reduction of production pattern -> const
+## In state 350, spurious reduction of production const -> option(dash_op) NUMBER_INT
+## In state 389, spurious reduction of production pattern -> const
 ##
 
 Expected a type annotation or `=`.
@@ -4238,7 +4237,7 @@ Expected a capitalized identifier.
 
 program: LET TYPEID LPAREN WASMI64 RBRACK
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 342.
 ##
 ## pattern -> type_id lparen patterns . rparen [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -4249,16 +4248,16 @@ program: LET TYPEID LPAREN WASMI64 RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 334, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
-## In state 344, spurious reduction of production option(comma) ->
-## In state 345, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
+## In state 344, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
+## In state 354, spurious reduction of production option(comma) ->
+## In state 355, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
 ##
 
 Expected `)` to complete the variant pattern.
 
 program: LET TYPEID LPAREN WHILE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 340.
 ##
 ## pattern -> type_id lparen . patterns rparen [ WHEN THICKARROW RPAREN RBRACK RBRACE EQUAL EOL COMMA COLON ]
 ##
@@ -4276,7 +4275,7 @@ Expected a comma-separated list of patterns.
 
 program: LET WASMI64 EQUAL WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 406.
 ##
 ## lseparated_nonempty_list_inner(comma,value_bind) -> lseparated_nonempty_list_inner(comma,value_bind) comma . value_bind [ SEMI RBRACE EOL EOF COMMA ]
 ##
@@ -4296,7 +4295,7 @@ Expected a binding, e.g. `foo = 5`.
 
 program: LPAREN BREAK RPAREN DOT EOL WHILE
 ##
-## Ends in an error in state: 583.
+## Ends in an error in state: 593.
 ##
 ## record_get -> paren_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> paren_expr DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4313,7 +4312,7 @@ program: LPAREN BREAK RPAREN DOT EOL WHILE
 ##
 program: LPAREN BREAK RPAREN DOT WHILE
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 589.
 ##
 ## record_get -> paren_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> paren_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4328,7 +4327,7 @@ Expected a record field identifier.
 
 program: LPAREN BREAK RPAREN LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 598.
 ##
 ## array_get -> paren_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> paren_expr lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4343,7 +4342,7 @@ program: LPAREN BREAK RPAREN LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -4351,7 +4350,7 @@ Expected `]` to complete the array access expression.
 
 program: LPAREN BREAK RPAREN LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 458.
 ##
 ## app_expr -> paren_expr lparen lseparated_nonempty_list_inner(comma,expr) . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
@@ -4366,16 +4365,16 @@ program: LPAREN BREAK RPAREN LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 
 Expected a comma followed by an expression or `)` to complete the function call.
 
 program: LPAREN DASH WHILE
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 359.
 ##
 ## option(dash_op) -> DASH . [ WASMI64 WASMI32 WASMF64 WASMF32 NUMBER_INT NUMBER_FLOAT INT64 INT32 FLOAT64 FLOAT32 ]
 ## special_op -> DASH . [ RPAREN EOL ]
@@ -4434,7 +4433,7 @@ Expected `)` to complete infix or prefix operator reference.
 
 program: LPAREN WASMI64 COMMA BREAK COMMA RBRACK
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 490.
 ##
 ## simple_expr -> lparen tuple_exprs . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4447,14 +4446,14 @@ program: LPAREN WASMI64 COMMA BREAK COMMA RBRACK
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 88, spurious reduction of production comma -> COMMA
 ## In state 168, spurious reduction of production option(comma) -> comma
-## In state 485, spurious reduction of production tuple_exprs -> expr COMMA lseparated_nonempty_list_inner(comma,expr) option(comma)
+## In state 495, spurious reduction of production tuple_exprs -> expr COMMA lseparated_nonempty_list_inner(comma,expr) option(comma)
 ##
 
 Expected `)` to complete the tuple expression.
 
 program: LPAREN WASMI64 COMMA EOL WASMI64 THICKARROW
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 497.
 ##
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
 ## tuple_exprs -> expr COMMA eols lseparated_nonempty_list_inner(comma,expr) . option(comma) [ RPAREN EOL ]
@@ -4469,13 +4468,13 @@ program: LPAREN WASMI64 COMMA EOL WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 program: LPAREN WASMI64 COMMA WASMI64 THICKARROW
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 494.
 ##
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
 ## tuple_exprs -> expr COMMA lseparated_nonempty_list_inner(comma,expr) . option(comma) [ RPAREN EOL ]
@@ -4490,16 +4489,16 @@ program: LPAREN WASMI64 COMMA WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 
 Expected a comma followed by an expression or `)` to complete the tuple expression.
 
 program: LPAREN WASMI64 COMMA WHEN
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 493.
 ##
 ## tuple_exprs -> expr COMMA . [ RPAREN EOL ]
 ## tuple_exprs -> expr COMMA . lseparated_nonempty_list_inner(comma,expr) option(comma) [ RPAREN EOL ]
@@ -4515,7 +4514,7 @@ program: LPAREN WASMI64 EOL WHILE
 ##
 ## Ends in an error in state: 106.
 ##
-## rparen -> eols . RPAREN [ WHILE WHEN WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TYPE TRUE THROW THICKARROW STRING STAREQ STAR SLASHEQ SLASH SEMI RPAREN RECORD RCARET RBRACK RBRACE PLUSPLUS PLUSEQ PLUS PIPEPIPE PIPE PERCENTEQ PERCENT NUMBER_INT NUMBER_FLOAT NOTEQ NOT MATCH LPAREN LET LESSEQ LCARETLCARET LCARET LBRACKRCARET LBRACK LBRACE ISNT IS INT64 INT32 IF ID GREATEREQ GETS FUN FROM FOR FLOAT64 FLOAT32 FALSE FAIL EXPORT EQUAL EQEQ EOL EOF ENUM ELSE DOT DASHEQ DASH CONTINUE COMMA COLON CHAR CARET BREAK AT ASSERT AS ARROW AMPAMP AMP ]
+## rparen -> eols . RPAREN [ WHILE WHEN WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TYPE TRUE THROW THICKARROW STRING STAREQ STAR SLASHEQ SLASH SEMI RPAREN RECORD RCARET RBRACK RBRACE PLUSPLUS PLUSEQ PLUS PIPEPIPE PIPE PERCENTEQ PERCENT NUMBER_INT NUMBER_FLOAT NOTEQ NOT MATCH LPAREN LET LESSEQ LCARETLCARET LCARET LBRACKRCARET LBRACK LBRACE ISNT IS INT64 INT32 IMPORT IF ID GREATEREQ GETS FUN FROM FOR FLOAT64 FLOAT32 FALSE FAIL EXPORT EQUAL EQEQ EOL EOF ENUM ELSE DOT DASHEQ DASH CONTINUE COMMA COLON CHAR CARET BREAK AT ASSERT AS ARROW AMPAMP AMP ]
 ##
 ## The known suffix of the stack is as follows:
 ## eols
@@ -4532,7 +4531,7 @@ Expected `)`.
 
 program: LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 492.
 ##
 ## paren_expr -> lparen expr . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## tuple_exprs -> expr . COMMA [ RPAREN EOL ]
@@ -4549,7 +4548,7 @@ program: LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -4557,7 +4556,7 @@ Expected `)` for a grouped expression or a comma for a tuple expression.
 
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 THICKARROW CONTINUE WHILE
 ##
-## Ends in an error in state: 745.
+## Ends in an error in state: 756.
 ##
 ## lseparated_nonempty_list_inner(comma,match_branch) -> lseparated_nonempty_list_inner(comma,match_branch) . comma match_branch [ RBRACE EOL COMMA ]
 ## match_branches -> lseparated_nonempty_list_inner(comma,match_branch) . option(comma) [ RBRACE EOL ]
@@ -4570,7 +4569,7 @@ Expected a comma followed by another match branch or `}` to complete the match e
 
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 THICKARROW WASMI64 COMMA EOL WHILE
 ##
-## Ends in an error in state: 747.
+## Ends in an error in state: 758.
 ##
 ## lseparated_nonempty_list_inner(comma,match_branch) -> lseparated_nonempty_list_inner(comma,match_branch) comma . match_branch [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -4591,12 +4590,12 @@ Expected another match branch or `}` to complete the match expression.
 
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 WHEN VOID EOF
 ##
-## Ends in an error in state: 739.
+## Ends in an error in state: 745.
 ##
-## match_branch -> pattern option(when_guard) . thickarrow expr [ RBRACE EOL COMMA ]
+## match_branch -> pattern when_guard . thickarrow expr [ RBRACE EOL COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## pattern option(when_guard)
+## pattern when_guard
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -4605,19 +4604,19 @@ program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 WHEN VOID EOF
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 737, spurious reduction of production when_guard -> WHEN expr
-## In state 738, spurious reduction of production option(when_guard) -> when_guard
+## In state 744, spurious reduction of production when_guard -> WHEN expr
 ##
 
 Expected `=>` followed by an expression.
 
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WASMI64 WHILE
 ##
-## Ends in an error in state: 735.
+## Ends in an error in state: 742.
 ##
-## match_branch -> pattern . option(when_guard) thickarrow expr [ RBRACE EOL COMMA ]
+## match_branch -> pattern . thickarrow expr [ RBRACE EOL COMMA ]
+## match_branch -> pattern . when_guard thickarrow expr [ RBRACE EOL COMMA ]
 ## pattern -> pattern . COLON typ [ WHEN THICKARROW EOL COLON ]
 ## pattern -> pattern . COLON eols typ [ WHEN THICKARROW EOL COLON ]
 ##
@@ -4629,7 +4628,7 @@ Expected a type annotation, the keyword `when` followed by a guard expression, o
 
 program: MATCH LPAREN WASMI64 RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 741.
 ##
 ## match_expr -> MATCH lparen expr rparen lbrace . match_branches rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4647,7 +4646,7 @@ Expected a pattern.
 
 program: MATCH LPAREN WASMI64 RPAREN WHILE
 ##
-## Ends in an error in state: 733.
+## Ends in an error in state: 740.
 ##
 ## match_expr -> MATCH lparen expr rparen . lbrace match_branches rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4659,7 +4658,7 @@ Expected `{` to start the body of the match statement.
 
 program: MATCH LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 732.
+## Ends in an error in state: 739.
 ##
 ## match_expr -> MATCH lparen expr . rparen lbrace match_branches rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4673,7 +4672,7 @@ program: MATCH LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -4693,7 +4692,7 @@ Expected `(` after the `match` keyword.
 
 program: NOT LBRACE BREAK RBRACE DOT EOL WHILE
 ##
-## Ends in an error in state: 459.
+## Ends in an error in state: 469.
 ##
 ## record_get -> braced_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4709,7 +4708,7 @@ program: NOT LBRACE BREAK RBRACE DOT EOL WHILE
 ##
 program: NOT LBRACE BREAK RBRACE DOT WHILE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 467.
 ##
 ## record_get -> braced_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> braced_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4719,7 +4718,7 @@ program: NOT LBRACE BREAK RBRACE DOT WHILE
 ##
 program: NOT LPAREN BREAK RPAREN DOT EOL WHILE
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 453.
 ##
 ## record_get -> paren_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4735,7 +4734,7 @@ program: NOT LPAREN BREAK RPAREN DOT EOL WHILE
 ##
 program: NOT LPAREN BREAK RPAREN DOT WHILE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 451.
 ##
 ## record_get -> paren_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> paren_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4761,7 +4760,7 @@ program: NOT WASMI64 DOT EOL WHILE
 ##
 program: NOT WASMI64 DOT ID DOT EOL WHILE
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 439.
 ##
 ## record_get -> record_get DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4777,7 +4776,7 @@ program: NOT WASMI64 DOT ID DOT EOL WHILE
 ##
 program: NOT WASMI64 DOT ID DOT WHILE
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 437.
 ##
 ## record_get -> record_get DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> record_get DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4797,7 +4796,7 @@ program: NOT WASMI64 DOT WHILE
 ##
 program: NOT WASMI64 LPAREN RPAREN DOT EOL WHILE
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 485.
 ##
 ## record_get -> app_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4813,7 +4812,7 @@ program: NOT WASMI64 LPAREN RPAREN DOT EOL WHILE
 ##
 program: NOT WASMI64 LPAREN RPAREN DOT WHILE
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 483.
 ##
 ## record_get -> app_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> app_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4823,7 +4822,7 @@ program: NOT WASMI64 LPAREN RPAREN DOT WHILE
 ##
 program: WASMI64 DOT EOL WHILE
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 625.
 ##
 ## record_get -> simple_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> simple_expr DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4840,7 +4839,7 @@ program: WASMI64 DOT EOL WHILE
 ##
 program: WASMI64 DOT ID DOT EOL WHILE
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 609.
 ##
 ## record_get -> record_get DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> record_get DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4857,7 +4856,7 @@ program: WASMI64 DOT ID DOT EOL WHILE
 ##
 program: WASMI64 DOT ID DOT WHILE
 ##
-## Ends in an error in state: 595.
+## Ends in an error in state: 605.
 ##
 ## record_get -> record_get DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> record_get DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4869,7 +4868,7 @@ program: WASMI64 DOT ID DOT WHILE
 ##
 program: WASMI64 DOT WHILE
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 621.
 ##
 ## record_get -> simple_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> simple_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4881,7 +4880,7 @@ program: WASMI64 DOT WHILE
 ##
 program: WASMI64 LPAREN RPAREN DOT EOL WHILE
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 253.
 ##
 ## record_get -> app_expr DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> app_expr DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4898,7 +4897,7 @@ program: WASMI64 LPAREN RPAREN DOT EOL WHILE
 ##
 program: WASMI64 LPAREN RPAREN DOT WHILE
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 249.
 ##
 ## record_get -> app_expr DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> app_expr DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4910,7 +4909,7 @@ program: WASMI64 LPAREN RPAREN DOT WHILE
 ##
 program: NOT WASMI64 LBRACK WASMI64 RBRACK DOT EOL WHILE
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 477.
 ##
 ## record_get -> array_get DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4926,7 +4925,7 @@ program: NOT WASMI64 LBRACK WASMI64 RBRACK DOT EOL WHILE
 ##
 program: NOT WASMI64 LBRACK WASMI64 RBRACK DOT WHILE
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 475.
 ##
 ## record_get -> array_get DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> array_get DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4936,7 +4935,7 @@ program: NOT WASMI64 LBRACK WASMI64 RBRACK DOT WHILE
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK DOT EOL WHILE
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 274.
 ##
 ## record_get -> array_get DOT eols . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_set -> array_get DOT eols . simple_id equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4953,7 +4952,7 @@ program: WASMI64 LBRACK WASMI64 RBRACK DOT EOL WHILE
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK DOT WHILE
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 270.
 ##
 ## record_get -> array_get DOT . simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## record_get -> array_get DOT . eols simple_id [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -4968,7 +4967,7 @@ Expected a record field identifier.
 
 program: NOT LBRACE BREAK RBRACE LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 471.
 ##
 ## array_get -> braced_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4983,7 +4982,7 @@ program: NOT LBRACE BREAK RBRACE LBRACK UNDERSCORE
 ##
 program: NOT LPAREN BREAK RPAREN LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 461.
 ##
 ## array_get -> paren_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -4998,7 +4997,7 @@ program: NOT LPAREN BREAK RPAREN LBRACK UNDERSCORE
 ##
 program: NOT WASMI64 DOT ID LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 447.
 ##
 ## array_get -> record_get lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5013,7 +5012,7 @@ program: NOT WASMI64 DOT ID LBRACK UNDERSCORE
 ##
 program: NOT WASMI64 LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 433.
 ##
 ## array_get -> simple_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5028,7 +5027,7 @@ program: NOT WASMI64 LBRACK UNDERSCORE
 ##
 program: WASMI64 DOT ID LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 613.
 ##
 ## array_get -> record_get lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> record_get lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5044,7 +5043,7 @@ program: WASMI64 DOT ID LBRACK UNDERSCORE
 ##
 program: WASMI64 LPAREN RPAREN LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 265.
 ##
 ## array_get -> app_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> app_expr lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5060,7 +5059,7 @@ program: WASMI64 LPAREN RPAREN LBRACK UNDERSCORE
 ##
 program: NOT WASMI64 LBRACK WASMI64 RBRACK LBRACK WHEN
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 479.
 ##
 ## array_get -> array_get lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5078,7 +5077,7 @@ Expected an array index expression.
 
 program: NOT LBRACE BREAK RBRACE LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 472.
 ##
 ## array_get -> braced_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5092,12 +5091,12 @@ program: NOT LBRACE BREAK RBRACE LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: NOT LPAREN BREAK RPAREN LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 462.
 ##
 ## array_get -> paren_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5111,12 +5110,12 @@ program: NOT LPAREN BREAK RPAREN LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: NOT WASMI64 DOT ID LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 448.
 ##
 ## array_get -> record_get lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5130,12 +5129,12 @@ program: NOT WASMI64 DOT ID LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: NOT WASMI64 LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 434.
 ##
 ## array_get -> simple_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5149,12 +5148,12 @@ program: NOT WASMI64 LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: NOT WASMI64 LPAREN RPAREN LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 487.
 ##
 ## array_get -> app_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5169,7 +5168,7 @@ program: NOT WASMI64 LPAREN RPAREN LBRACK UNDERSCORE
 ##
 program: NOT WASMI64 LPAREN RPAREN LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 488.
 ##
 ## array_get -> app_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5183,12 +5182,12 @@ program: NOT WASMI64 LPAREN RPAREN LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: WASMI64 DOT ID LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 604.
+## Ends in an error in state: 614.
 ##
 ## array_get -> record_get lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> record_get lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5203,12 +5202,12 @@ program: WASMI64 DOT ID LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: WASMI64 LBRACK UNDERSCORE
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 629.
 ##
 ## array_get -> simple_expr lbrack . expr rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> simple_expr lbrack . expr rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5224,7 +5223,7 @@ program: WASMI64 LBRACK UNDERSCORE
 ##
 program: WASMI64 LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 620.
+## Ends in an error in state: 630.
 ##
 ## array_get -> simple_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> simple_expr lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5239,12 +5238,12 @@ program: WASMI64 LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: WASMI64 LPAREN RPAREN LBRACK WASMI64 THICKARROW
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 266.
 ##
 ## array_get -> app_expr lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> app_expr lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5259,12 +5258,12 @@ program: WASMI64 LPAREN RPAREN LBRACK WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: NOT WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 WHILE
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 480.
 ##
 ## array_get -> array_get lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5278,12 +5277,12 @@ program: NOT WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 WHILE
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 WHILE
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 285.
 ##
 ## array_get -> array_get lbrack expr . rbrack [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## array_set -> array_get lbrack expr . rbrack equal expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5298,7 +5297,7 @@ program: WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 WHILE
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -5306,7 +5305,7 @@ Expected `]` to complete the array index expression.
 
 program: PRIMITIVE ID COLON EOL TYPEID EQUAL WHILE
 ##
-## Ends in an error in state: 771.
+## Ends in an error in state: 782.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON eols typ equal . STRING [ SEMI EOL EOF ]
 ##
@@ -5317,11 +5316,11 @@ program: PRIMITIVE ID COLON EOL TYPEID EQUAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 program: PRIMITIVE ID COLON TYPEID EQUAL WHILE
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 778.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON typ equal . STRING [ SEMI EOL EOF ]
 ##
@@ -5332,11 +5331,11 @@ program: PRIMITIVE ID COLON TYPEID EQUAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 program: PRIMITIVE THROW COLON EOL TYPEID EQUAL WHILE
 ##
-## Ends in an error in state: 762.
+## Ends in an error in state: 773.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON eols typ equal . STRING [ SEMI EOL EOF ]
 ##
@@ -5347,11 +5346,11 @@ program: PRIMITIVE THROW COLON EOL TYPEID EQUAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 program: PRIMITIVE THROW COLON TYPEID EQUAL WHILE
 ##
-## Ends in an error in state: 758.
+## Ends in an error in state: 769.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON typ equal . STRING [ SEMI EOL EOF ]
 ##
@@ -5362,14 +5361,14 @@ program: PRIMITIVE THROW COLON TYPEID EQUAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 
 Expected a string declaring the primitive's internal name.
 
 program: PRIMITIVE ID COLON EOL TYPEID WHEN
 ##
-## Ends in an error in state: 770.
+## Ends in an error in state: 781.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON eols typ . equal STRING [ SEMI EOL EOF ]
 ##
@@ -5386,7 +5385,7 @@ program: PRIMITIVE ID COLON EOL TYPEID WHEN
 ##
 program: PRIMITIVE ID COLON TYPEID WHEN
 ##
-## Ends in an error in state: 766.
+## Ends in an error in state: 777.
 ##
 ## primitive_stmt -> PRIMITIVE id_str COLON typ . equal STRING [ SEMI EOL EOF ]
 ##
@@ -5403,7 +5402,7 @@ program: PRIMITIVE ID COLON TYPEID WHEN
 ##
 program: PRIMITIVE THROW COLON EOL TYPEID WHEN
 ##
-## Ends in an error in state: 761.
+## Ends in an error in state: 772.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON eols typ . equal STRING [ SEMI EOL EOF ]
 ##
@@ -5420,7 +5419,7 @@ program: PRIMITIVE THROW COLON EOL TYPEID WHEN
 ##
 program: PRIMITIVE THROW COLON TYPEID WHEN
 ##
-## Ends in an error in state: 757.
+## Ends in an error in state: 768.
 ##
 ## primitive_stmt -> PRIMITIVE prim COLON typ . equal STRING [ SEMI EOL EOF ]
 ##
@@ -5440,7 +5439,7 @@ Expected `=` followed by a string declaring the primitive's internal name.
 
 program: PRIMITIVE ID WHILE
 ##
-## Ends in an error in state: 764.
+## Ends in an error in state: 775.
 ##
 ## primitive_stmt -> PRIMITIVE id_str . COLON typ equal STRING [ SEMI EOL EOF ]
 ## primitive_stmt -> PRIMITIVE id_str . COLON eols typ equal STRING [ SEMI EOL EOF ]
@@ -5450,7 +5449,7 @@ program: PRIMITIVE ID WHILE
 ##
 program: PRIMITIVE THROW WHILE
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 766.
 ##
 ## primitive_stmt -> PRIMITIVE prim . COLON typ equal STRING [ SEMI EOL EOF ]
 ## primitive_stmt -> PRIMITIVE prim . COLON eols typ equal STRING [ SEMI EOL EOF ]
@@ -5465,7 +5464,7 @@ program: PRIMITIVE LPAREN STAR WHILE
 ##
 ## Ends in an error in state: 184.
 ##
-## id_str -> lparen special_op . rparen [ TYPE SEMI RECORD LET FROM EXPORT EOL EOF ENUM COMMA COLON AT AS ]
+## id_str -> lparen special_op . rparen [ TYPE SEMI RECORD LPAREN LET IMPORT FROM EXPORT EOL EOF ENUM COMMA COLON AT AS ]
 ##
 ## The known suffix of the stack is as follows:
 ## lparen special_op
@@ -5477,7 +5476,7 @@ program: PRIMITIVE LPAREN WHILE
 ##
 ## Ends in an error in state: 183.
 ##
-## id_str -> lparen . special_op rparen [ TYPE SEMI RECORD LET FROM EXPORT EOL EOF ENUM COMMA COLON AT AS ]
+## id_str -> lparen . special_op rparen [ TYPE SEMI RECORD LPAREN LET IMPORT FROM EXPORT EOL EOF ENUM COMMA COLON AT AS ]
 ##
 ## The known suffix of the stack is as follows:
 ## lparen
@@ -5493,7 +5492,7 @@ Expected an infix or prefix operator.
 
 program: PRIMITIVE WHILE
 ##
-## Ends in an error in state: 753.
+## Ends in an error in state: 764.
 ##
 ## primitive_stmt -> PRIMITIVE . id_str COLON typ equal STRING [ SEMI EOL EOF ]
 ## primitive_stmt -> PRIMITIVE . id_str COLON eols typ equal STRING [ SEMI EOL EOF ]
@@ -5508,7 +5507,7 @@ Expected an identifier for the primitive.
 
 program: RECORD TYPEID LBRACE ID COLON ID COMMA EOL WHILE
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 835.
 ##
 ## lseparated_nonempty_list_inner(comma,data_label) -> lseparated_nonempty_list_inner(comma,data_label) comma . data_label [ RBRACE EOL COMMA ]
 ## option(comma) -> comma . [ RBRACE EOL ]
@@ -5529,7 +5528,7 @@ Expected another record field definition or an immediate `}` to complete the rec
 
 program: RECORD TYPEID LBRACE ID COLON ID WHILE
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 832.
 ##
 ## data_labels -> lbrace lseparated_nonempty_list_inner(comma,data_label) . option(comma) rbrace [ SEMI EOL EOF COMMA ]
 ## lseparated_nonempty_list_inner(comma,data_label) -> lseparated_nonempty_list_inner(comma,data_label) . comma data_label [ RBRACE EOL COMMA ]
@@ -5542,7 +5541,7 @@ Expected a comma followed by another record field definition or an immediate `}`
 
 program: RECORD TYPEID LBRACE ID WHILE
 ##
-## Ends in an error in state: 871.
+## Ends in an error in state: 827.
 ##
 ## data_label -> simple_id . COLON typ [ RBRACE EOL COMMA ]
 ## data_label -> simple_id . COLON eols typ [ RBRACE EOL COMMA ]
@@ -5552,7 +5551,7 @@ program: RECORD TYPEID LBRACE ID WHILE
 ##
 program: RECORD TYPEID LBRACE MUT ID WHILE
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 822.
 ##
 ## data_label -> MUT simple_id . COLON typ [ RBRACE EOL COMMA ]
 ## data_label -> MUT simple_id . COLON eols typ [ RBRACE EOL COMMA ]
@@ -5565,7 +5564,7 @@ Expected `:` followed by a type.
 
 program: RECORD TYPEID LBRACE MUT ID COLON EOL WHILE
 ##
-## Ends in an error in state: 869.
+## Ends in an error in state: 825.
 ##
 ## data_label -> MUT simple_id COLON eols . typ [ RBRACE EOL COMMA ]
 ##
@@ -5581,7 +5580,7 @@ program: RECORD TYPEID LBRACE MUT ID COLON EOL WHILE
 ##
 program: RECORD TYPEID LBRACE MUT ID COLON WHILE
 ##
-## Ends in an error in state: 867.
+## Ends in an error in state: 823.
 ##
 ## data_label -> MUT simple_id COLON . typ [ RBRACE EOL COMMA ]
 ## data_label -> MUT simple_id COLON . eols typ [ RBRACE EOL COMMA ]
@@ -5607,7 +5606,7 @@ program: WASMI64 COLON LPAREN WHILE
 ##
 program: TYPE TYPEID EQUAL WHILE
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 806.
 ##
 ## data_declaration -> TYPE TYPEID option(id_vec) equal . typ [ SEMI EOL EOF COMMA ]
 ##
@@ -5618,14 +5617,14 @@ program: TYPE TYPEID EQUAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 
 Expected a type.
 
 program: TYPE TYPEID LCARET ID RCARET EQEQ
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 805.
 ##
 ## data_declaration -> TYPE TYPEID option(id_vec) . equal typ [ SEMI EOL EOF COMMA ]
 ##
@@ -5637,7 +5636,7 @@ Expected `=` followed by a type.
 
 program: RECORD TYPEID LBRACE MUT WHILE
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 821.
 ##
 ## data_label -> MUT . simple_id COLON typ [ RBRACE EOL COMMA ]
 ## data_label -> MUT . simple_id COLON eols typ [ RBRACE EOL COMMA ]
@@ -5650,7 +5649,7 @@ Expected an identifier for the record field.
 
 program: RECORD TYPEID LBRACE WHILE
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 820.
 ##
 ## data_labels -> lbrace . lseparated_nonempty_list_inner(comma,data_label) option(comma) rbrace [ SEMI EOL EOF COMMA ]
 ##
@@ -5668,7 +5667,7 @@ Expected a comma-separated list of record field declarations.
 
 program: RECORD TYPEID LCARET ID COMMA EOL WHILE
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 813.
 ##
 ## lseparated_nonempty_list_inner(comma,id_typ) -> lseparated_nonempty_list_inner(comma,id_typ) comma . id_typ [ RCARET EOL COMMA ]
 ## option(comma) -> comma . [ RCARET EOL ]
@@ -5689,7 +5688,7 @@ Expected another type variable or `>` to complete the type arguments.
 
 program: RECORD TYPEID LCARET ID COMMA ID WHILE
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 810.
 ##
 ## id_vec -> lcaret lseparated_nonempty_list_inner(comma,id_typ) . option(comma) rcaret [ LBRACE EQUAL ]
 ## lseparated_nonempty_list_inner(comma,id_typ) -> lseparated_nonempty_list_inner(comma,id_typ) . comma id_typ [ RCARET EOL COMMA ]
@@ -5721,7 +5720,7 @@ Expected `>` to complete the type arguments.
 
 program: RECORD TYPEID LCARET ID RCARET ISNT
 ##
-## Ends in an error in state: 863.
+## Ends in an error in state: 819.
 ##
 ## data_declaration -> RECORD TYPEID option(id_vec) . data_labels [ SEMI EOL EOF COMMA ]
 ##
@@ -5733,7 +5732,7 @@ Expected `{` to list record fields.
 
 program: RECORD TYPEID LCARET TYPEID
 ##
-## Ends in an error in state: 852.
+## Ends in an error in state: 808.
 ##
 ## id_vec -> lcaret . lseparated_nonempty_list_inner(comma,id_typ) option(comma) rcaret [ LBRACE EQUAL ]
 ##
@@ -5751,7 +5750,7 @@ Expected a comma-separated list of type variables.
 
 program: RECORD TYPEID WHILE
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 818.
 ##
 ## data_declaration -> RECORD TYPEID . option(id_vec) data_labels [ SEMI EOL EOF COMMA ]
 ##
@@ -5763,7 +5762,7 @@ Expected a comma-separated list of type variables surrounded by `<`/`>`, or `{` 
 
 program: RECORD WHILE
 ##
-## Ends in an error in state: 861.
+## Ends in an error in state: 817.
 ##
 ## data_declaration -> RECORD . TYPEID option(id_vec) data_labels [ SEMI EOL EOF COMMA ]
 ##
@@ -5807,7 +5806,7 @@ Expected an identifier.
 
 program: TYPEID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 224.
 ##
 ## assign_expr -> id_expr equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5820,11 +5819,11 @@ program: TYPEID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: TYPEID STAREQ EOL UNDERSCORE
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 310.
 ##
 ## assign_expr -> id_expr assign_binop_op eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5840,7 +5839,7 @@ program: TYPEID STAREQ EOL UNDERSCORE
 ##
 program: TYPEID STAREQ WHEN
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 308.
 ##
 ## assign_expr -> id_expr assign_binop_op . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## assign_expr -> id_expr assign_binop_op . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -5850,7 +5849,7 @@ program: TYPEID STAREQ WHEN
 ##
 program: WASMI64 DOT EOL ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 627.
 ##
 ## record_set -> simple_expr DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5863,11 +5862,11 @@ program: WASMI64 DOT EOL ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 DOT ID DOT EOL ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 601.
+## Ends in an error in state: 611.
 ##
 ## record_set -> record_get DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5880,11 +5879,11 @@ program: WASMI64 DOT ID DOT EOL ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 DOT ID DOT ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 607.
 ##
 ## record_set -> record_get DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5897,11 +5896,11 @@ program: WASMI64 DOT ID DOT ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 DOT ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 623.
 ##
 ## record_set -> simple_expr DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5914,11 +5913,11 @@ program: WASMI64 DOT ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 DOT ID GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 593.
+## Ends in an error in state: 603.
 ##
 ## assign_expr -> record_get GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5944,7 +5943,7 @@ program: WASMI64 DOT ID GETS WHEN
 ##
 program: WASMI64 DOT ID LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 616.
 ##
 ## array_set -> record_get lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5957,7 +5956,7 @@ program: WASMI64 DOT ID LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 GETS WHEN
 ##
@@ -5971,7 +5970,7 @@ program: WASMI64 GETS WHEN
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 632.
 ##
 ## array_set -> simple_expr lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -5984,11 +5983,11 @@ program: WASMI64 LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 LPAREN RPAREN DOT EOL ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 255.
 ##
 ## record_set -> app_expr DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6001,11 +6000,11 @@ program: WASMI64 LPAREN RPAREN DOT EOL ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 LPAREN RPAREN DOT ID EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 251.
 ##
 ## record_set -> app_expr DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6018,11 +6017,11 @@ program: WASMI64 LPAREN RPAREN DOT ID EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 LPAREN RPAREN GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 246.
 ##
 ## assign_expr -> app_expr GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6038,7 +6037,7 @@ program: WASMI64 LPAREN RPAREN GETS EOL UNDERSCORE
 ##
 program: WASMI64 LPAREN RPAREN GETS WHEN
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 244.
 ##
 ## assign_expr -> app_expr GETS . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## assign_expr -> app_expr GETS . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6048,7 +6047,7 @@ program: WASMI64 LPAREN RPAREN GETS WHEN
 ##
 program: WASMI64 LPAREN RPAREN LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 268.
 ##
 ## array_set -> app_expr lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6061,11 +6060,11 @@ program: WASMI64 LPAREN RPAREN LBRACK WASMI64 RBRACK EQUAL EOL UNDERSCORE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 212, spurious reduction of production equal -> EQUAL eols
+## In state 222, spurious reduction of production equal -> EQUAL eols
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK DOT EOL ID EQUAL WHEN
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 276.
 ##
 ## record_set -> array_get DOT eols simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6076,11 +6075,11 @@ program: WASMI64 LBRACK WASMI64 RBRACK DOT EOL ID EQUAL WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK DOT ID EQUAL WHEN
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 272.
 ##
 ## record_set -> array_get DOT simple_id equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6091,11 +6090,11 @@ program: WASMI64 LBRACK WASMI64 RBRACK DOT ID EQUAL WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 240.
 ##
 ## assign_expr -> array_get GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6111,7 +6110,7 @@ program: WASMI64 LBRACK WASMI64 RBRACK GETS EOL UNDERSCORE
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK GETS WHEN
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 238.
 ##
 ## assign_expr -> array_get GETS . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## assign_expr -> array_get GETS . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6121,7 +6120,7 @@ program: WASMI64 LBRACK WASMI64 RBRACK GETS WHEN
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 RBRACK EQUAL WHEN
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 287.
 ##
 ## array_set -> array_get lbrack expr rbrack equal . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6132,14 +6131,14 @@ program: WASMI64 LBRACK WASMI64 RBRACK LBRACK WASMI64 RBRACK EQUAL WHEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 211, spurious reduction of production equal -> EQUAL
+## In state 221, spurious reduction of production equal -> EQUAL
 ##
 
 Expected an expression to assign.
 
 program: WASMI64 AMP WHEN
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 572.
 ##
 ## binop_expr -> non_stmt_expr AMP . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr AMP . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6149,7 +6148,7 @@ program: WASMI64 AMP WHEN
 ##
 program: WASMI64 AMPAMP EOL UNDERSCORE
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 582.
 ##
 ## binop_expr -> non_stmt_expr AMPAMP eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6165,7 +6164,7 @@ program: WASMI64 AMPAMP EOL UNDERSCORE
 ##
 program: WASMI64 AMPAMP WHEN
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 580.
 ##
 ## binop_expr -> non_stmt_expr AMPAMP . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr AMPAMP . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6175,7 +6174,7 @@ program: WASMI64 AMPAMP WHEN
 ##
 program: WASMI64 CARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 576.
 ##
 ## binop_expr -> non_stmt_expr CARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6191,7 +6190,7 @@ program: WASMI64 CARET EOL UNDERSCORE
 ##
 program: WASMI64 CARET WHEN
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 570.
 ##
 ## binop_expr -> non_stmt_expr CARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr CARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6201,7 +6200,7 @@ program: WASMI64 CARET WHEN
 ##
 program: WASMI64 DASH EOL UNDERSCORE
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 526.
 ##
 ## binop_expr -> non_stmt_expr DASH eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6217,7 +6216,7 @@ program: WASMI64 DASH EOL UNDERSCORE
 ##
 program: WASMI64 DASH WHEN
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 524.
 ##
 ## binop_expr -> non_stmt_expr DASH . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr DASH . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6227,7 +6226,7 @@ program: WASMI64 DASH WHEN
 ##
 program: WASMI64 EQEQ EOL UNDERSCORE
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 568.
 ##
 ## binop_expr -> non_stmt_expr EQEQ eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6243,7 +6242,7 @@ program: WASMI64 EQEQ EOL UNDERSCORE
 ##
 program: WASMI64 EQEQ WHEN
 ##
-## Ends in an error in state: 556.
+## Ends in an error in state: 566.
 ##
 ## binop_expr -> non_stmt_expr EQEQ . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr EQEQ . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6253,7 +6252,7 @@ program: WASMI64 EQEQ WHEN
 ##
 program: WASMI64 GETS EOL UNDERSCORE
 ##
-## Ends in an error in state: 609.
+## Ends in an error in state: 619.
 ##
 ## assign_expr -> simple_expr GETS eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6269,7 +6268,7 @@ program: WASMI64 GETS EOL UNDERSCORE
 ##
 program: WASMI64 GREATEREQ EOL UNDERSCORE
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 554.
 ##
 ## binop_expr -> non_stmt_expr GREATEREQ eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6285,7 +6284,7 @@ program: WASMI64 GREATEREQ EOL UNDERSCORE
 ##
 program: WASMI64 GREATEREQ WHEN
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 552.
 ##
 ## binop_expr -> non_stmt_expr GREATEREQ . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr GREATEREQ . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6295,7 +6294,7 @@ program: WASMI64 GREATEREQ WHEN
 ##
 program: WASMI64 IS EOL UNDERSCORE
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 564.
 ##
 ## binop_expr -> non_stmt_expr IS eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6311,7 +6310,7 @@ program: WASMI64 IS EOL UNDERSCORE
 ##
 program: WASMI64 IS WHEN
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 562.
 ##
 ## binop_expr -> non_stmt_expr IS . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr IS . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6321,7 +6320,7 @@ program: WASMI64 IS WHEN
 ##
 program: WASMI64 ISNT EOL UNDERSCORE
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 560.
 ##
 ## binop_expr -> non_stmt_expr ISNT eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6337,7 +6336,7 @@ program: WASMI64 ISNT EOL UNDERSCORE
 ##
 program: WASMI64 ISNT WHEN
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 558.
 ##
 ## binop_expr -> non_stmt_expr ISNT . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr ISNT . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6347,7 +6346,7 @@ program: WASMI64 ISNT WHEN
 ##
 program: WASMI64 LCARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 550.
 ##
 ## binop_expr -> non_stmt_expr LCARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6363,7 +6362,7 @@ program: WASMI64 LCARET EOL UNDERSCORE
 ##
 program: WASMI64 LCARET WHEN
 ##
-## Ends in an error in state: 538.
+## Ends in an error in state: 548.
 ##
 ## binop_expr -> non_stmt_expr LCARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr LCARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6373,7 +6372,7 @@ program: WASMI64 LCARET WHEN
 ##
 program: WASMI64 LCARETLCARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 528.
 ##
 ## binop_expr -> non_stmt_expr LCARETLCARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6389,7 +6388,7 @@ program: WASMI64 LCARETLCARET EOL UNDERSCORE
 ##
 program: WASMI64 LCARETLCARET WHEN
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 522.
 ##
 ## binop_expr -> non_stmt_expr LCARETLCARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr LCARETLCARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6399,7 +6398,7 @@ program: WASMI64 LCARETLCARET WHEN
 ##
 program: WASMI64 LESSEQ EOL UNDERSCORE
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 546.
 ##
 ## binop_expr -> non_stmt_expr LESSEQ eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6415,7 +6414,7 @@ program: WASMI64 LESSEQ EOL UNDERSCORE
 ##
 program: WASMI64 LESSEQ WHEN
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 544.
 ##
 ## binop_expr -> non_stmt_expr LESSEQ . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr LESSEQ . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6425,7 +6424,7 @@ program: WASMI64 LESSEQ WHEN
 ##
 program: WASMI64 NOTEQ EOL UNDERSCORE
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 556.
 ##
 ## binop_expr -> non_stmt_expr NOTEQ eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6441,7 +6440,7 @@ program: WASMI64 NOTEQ EOL UNDERSCORE
 ##
 program: WASMI64 NOTEQ WHEN
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 542.
 ##
 ## binop_expr -> non_stmt_expr NOTEQ . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr NOTEQ . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6451,7 +6450,7 @@ program: WASMI64 NOTEQ WHEN
 ##
 program: WASMI64 PERCENT EOL UNDERSCORE
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 514.
 ##
 ## binop_expr -> non_stmt_expr PERCENT eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6467,7 +6466,7 @@ program: WASMI64 PERCENT EOL UNDERSCORE
 ##
 program: WASMI64 PERCENT WHEN
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 512.
 ##
 ## binop_expr -> non_stmt_expr PERCENT . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr PERCENT . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6477,7 +6476,7 @@ program: WASMI64 PERCENT WHEN
 ##
 program: WASMI64 PIPE EOL UNDERSCORE
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 578.
 ##
 ## binop_expr -> non_stmt_expr PIPE eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6493,7 +6492,7 @@ program: WASMI64 PIPE EOL UNDERSCORE
 ##
 program: WASMI64 PIPE WHEN
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 540.
 ##
 ## binop_expr -> non_stmt_expr PIPE . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr PIPE . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6503,7 +6502,7 @@ program: WASMI64 PIPE WHEN
 ##
 program: WASMI64 PIPEPIPE EOL UNDERSCORE
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 584.
 ##
 ## binop_expr -> non_stmt_expr PIPEPIPE eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6519,7 +6518,7 @@ program: WASMI64 PIPEPIPE EOL UNDERSCORE
 ##
 program: WASMI64 PIPEPIPE WHEN
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 538.
 ##
 ## binop_expr -> non_stmt_expr PIPEPIPE . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr PIPEPIPE . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6529,7 +6528,7 @@ program: WASMI64 PIPEPIPE WHEN
 ##
 program: WASMI64 PLUS EOL UNDERSCORE
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 520.
 ##
 ## binop_expr -> non_stmt_expr PLUS eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6545,7 +6544,7 @@ program: WASMI64 PLUS EOL UNDERSCORE
 ##
 program: WASMI64 PLUS WHEN
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 518.
 ##
 ## binop_expr -> non_stmt_expr PLUS . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr PLUS . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6555,7 +6554,7 @@ program: WASMI64 PLUS WHEN
 ##
 program: WASMI64 PLUSPLUS EOL UNDERSCORE
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 516.
 ##
 ## binop_expr -> non_stmt_expr PLUSPLUS eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6571,7 +6570,7 @@ program: WASMI64 PLUSPLUS EOL UNDERSCORE
 ##
 program: WASMI64 PLUSPLUS WHEN
 ##
-## Ends in an error in state: 500.
+## Ends in an error in state: 510.
 ##
 ## binop_expr -> non_stmt_expr PLUSPLUS . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr PLUSPLUS . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6581,7 +6580,7 @@ program: WASMI64 PLUSPLUS WHEN
 ##
 program: WASMI64 RCARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 536.
 ##
 ## binop_expr -> non_stmt_expr RCARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6597,7 +6596,7 @@ program: WASMI64 RCARET EOL UNDERSCORE
 ##
 program: WASMI64 RCARET RCARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 533.
 ##
 ## binop_expr -> non_stmt_expr RCARET RCARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6613,7 +6612,7 @@ program: WASMI64 RCARET RCARET EOL UNDERSCORE
 ##
 program: WASMI64 RCARET RCARET RCARET EOL UNDERSCORE
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 530.
 ##
 ## binop_expr -> non_stmt_expr RCARET RCARET RCARET eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6629,7 +6628,7 @@ program: WASMI64 RCARET RCARET RCARET EOL UNDERSCORE
 ##
 program: WASMI64 RCARET RCARET RCARET WHEN
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 508.
 ##
 ## binop_expr -> non_stmt_expr RCARET RCARET RCARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr RCARET RCARET RCARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6639,7 +6638,7 @@ program: WASMI64 RCARET RCARET RCARET WHEN
 ##
 program: WASMI64 RCARET RCARET WHEN
 ##
-## Ends in an error in state: 497.
+## Ends in an error in state: 507.
 ##
 ## binop_expr -> non_stmt_expr RCARET RCARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr RCARET RCARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6651,7 +6650,7 @@ program: WASMI64 RCARET RCARET WHEN
 ##
 program: WASMI64 RCARET WHEN
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 506.
 ##
 ## binop_expr -> non_stmt_expr RCARET . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr RCARET . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6665,7 +6664,7 @@ program: WASMI64 RCARET WHEN
 ##
 program: WASMI64 SLASH EOL UNDERSCORE
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 504.
 ##
 ## binop_expr -> non_stmt_expr SLASH eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -6681,7 +6680,7 @@ program: WASMI64 SLASH EOL UNDERSCORE
 ##
 program: WASMI64 SLASH WHEN
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 502.
 ##
 ## binop_expr -> non_stmt_expr SLASH . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ## binop_expr -> non_stmt_expr SLASH . eols non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
@@ -6691,7 +6690,7 @@ program: WASMI64 SLASH WHEN
 ##
 program: WASMI64 STAR EOL UNDERSCORE
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 500.
 ##
 ## binop_expr -> non_stmt_expr STAR eols . non_stmt_expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7068,7 +7067,7 @@ Expected `>` to complete the type.
 
 program: WASMI64 DOT ID LPAREN COMMA EOL WHILE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 442.
 ##
 ## app_expr -> record_get lparen option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7082,11 +7081,11 @@ program: WASMI64 DOT ID LPAREN COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 89, spurious reduction of production comma -> COMMA eols
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: WASMI64 DOT ID LPAREN WASMI64 COMMA RBRACK
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 445.
 ##
 ## app_expr -> record_get lparen lseparated_nonempty_list_inner(comma,expr) option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7116,11 +7115,11 @@ program: WASMI64 LPAREN COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 89, spurious reduction of production comma -> COMMA eols
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: WASMI64 LPAREN RPAREN LPAREN COMMA EOL WHILE
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 258.
 ##
 ## app_expr -> app_expr lparen option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7134,11 +7133,11 @@ program: WASMI64 LPAREN RPAREN LPAREN COMMA EOL WHILE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 89, spurious reduction of production comma -> COMMA eols
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: WASMI64 LPAREN RPAREN LPAREN WASMI64 COMMA RBRACK
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 261.
 ##
 ## app_expr -> app_expr lparen lseparated_nonempty_list_inner(comma,expr) option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7170,7 +7169,7 @@ program: WASMI64 LPAREN WASMI64 COMMA RBRACK
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LPAREN COMMA WHILE
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 279.
 ##
 ## app_expr -> array_get lparen option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7182,11 +7181,11 @@ program: WASMI64 LBRACK WASMI64 RBRACK LPAREN COMMA WHILE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 88, spurious reduction of production comma -> COMMA
-## In state 254, spurious reduction of production option(comma) -> comma
+## In state 264, spurious reduction of production option(comma) -> comma
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LPAREN WASMI64 COMMA RBRACK
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 282.
 ##
 ## app_expr -> array_get lparen lseparated_nonempty_list_inner(comma,expr) option(comma) . rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7205,7 +7204,7 @@ Expected `)` to complete the function call.
 
 program: WASMI64 DOT ID LPAREN UNDERSCORE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 441.
 ##
 ## app_expr -> record_get lparen . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## app_expr -> record_get lparen . lseparated_nonempty_list_inner(comma,expr) option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -7221,7 +7220,7 @@ program: WASMI64 DOT ID LPAREN UNDERSCORE
 ##
 program: WASMI64 LPAREN RPAREN LPAREN UNDERSCORE
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 257.
 ##
 ## app_expr -> app_expr lparen . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## app_expr -> app_expr lparen . lseparated_nonempty_list_inner(comma,expr) option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -7253,7 +7252,7 @@ program: WASMI64 LPAREN UNDERSCORE
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LPAREN WHEN
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 278.
 ##
 ## app_expr -> array_get lparen . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## app_expr -> array_get lparen . lseparated_nonempty_list_inner(comma,expr) option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
@@ -7272,7 +7271,7 @@ Expected a comma-separated list of expressions or `)` to complete the function c
 
 program: WASMI64 DOT ID LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 444.
 ##
 ## app_expr -> record_get lparen lseparated_nonempty_list_inner(comma,expr) . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
@@ -7287,13 +7286,13 @@ program: WASMI64 DOT ID LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 program: WASMI64 LPAREN RPAREN LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 260.
 ##
 ## app_expr -> app_expr lparen lseparated_nonempty_list_inner(comma,expr) . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
@@ -7308,9 +7307,9 @@ program: WASMI64 LPAREN RPAREN LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 program: WASMI64 LPAREN WASMI64 THICKARROW
 ##
@@ -7329,13 +7328,13 @@ program: WASMI64 LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 program: WASMI64 LBRACK WASMI64 RBRACK LPAREN WASMI64 WHILE
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 281.
 ##
 ## app_expr -> array_get lparen lseparated_nonempty_list_inner(comma,expr) . option(comma) rparen [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LPAREN LESSEQ LCARETLCARET LCARET LBRACK ISNT IS GREATEREQ GETS EQEQ EOL EOF ELSE DOT DASH COMMA COLON CARET AMPAMP AMP ]
 ## lseparated_nonempty_list_inner(comma,expr) -> lseparated_nonempty_list_inner(comma,expr) . comma expr [ RPAREN EOL COMMA ]
@@ -7350,9 +7349,9 @@ program: WASMI64 LBRACK WASMI64 RBRACK LPAREN WASMI64 WHILE
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
-## In state 253, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
+## In state 263, spurious reduction of production lseparated_nonempty_list_inner(comma,expr) -> expr
 ##
 
 Expected a comma followed by more expressions or `)` to complete the function call.
@@ -7377,7 +7376,7 @@ Expected an expression for the while loop condition.
 
 program: WHILE LPAREN WASMI64 THICKARROW
 ##
-## Ends in an error in state: 750.
+## Ends in an error in state: 761.
 ##
 ## while_expr -> WHILE lparen expr . rparen block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PLUSPLUS PLUS PIPEPIPE PIPE PERCENT NOTEQ LESSEQ LCARETLCARET LCARET ISNT IS GREATEREQ EQEQ EOL EOF ELSE DASH COMMA COLON CARET AMPAMP AMP ]
 ##
@@ -7391,7 +7390,7 @@ program: WHILE LPAREN WASMI64 THICKARROW
 ## In state 41, spurious reduction of production non_assign_expr -> simple_expr
 ## In state 120, spurious reduction of production non_binop_expr -> non_assign_expr
 ## In state 64, spurious reduction of production annotated_expr -> non_binop_expr
-## In state 238, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 248, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 60, spurious reduction of production expr -> non_stmt_expr
 ##
 
@@ -7411,14 +7410,12 @@ Expected `(` followed by an expression for the while loop condition.
 
 program: MATCH LPAREN FLOAT32 RPAREN LBRACE NUMBER_INT EOL WHILE
 ##
-## Ends in an error in state: 742.
+## Ends in an error in state: 750.
 ##
-## match_branch -> pattern eols . WHEN expr thickarrow expr [ RBRACE EOL COMMA ]
-## thickarrow -> eols . THICKARROW [ WHILE WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TRUE THROW STRING NUMBER_INT NUMBER_FLOAT NOT MATCH LPAREN LBRACKRCARET LBRACK LBRACE INT64 INT32 IF ID FUN FOR FLOAT64 FLOAT32 FALSE FAIL DASH CONTINUE CHAR BREAK ASSERT ]
-## thickarrow -> eols . THICKARROW eols [ WHILE WASMI64 WASMI32 WASMF64 WASMF32 VOID TYPEID TRUE THROW STRING NUMBER_INT NUMBER_FLOAT NOT MATCH LPAREN LBRACKRCARET LBRACK LBRACE INT64 INT32 IF ID FUN FOR FLOAT64 FLOAT32 FALSE FAIL DASH CONTINUE CHAR BREAK ASSERT ]
+## when_guard -> eols . WHEN expr [ THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
-## pattern eols
+## eols
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -185,7 +185,7 @@ arrow:
   | ARROW opt_eols {}
 
 thickarrow:
-  | opt_eols THICKARROW opt_eols {}
+  | THICKARROW opt_eols {}
 
 equal:
   | EQUAL opt_eols {}

--- a/compiler/test/formatter_inputs/lambda.gr
+++ b/compiler/test/formatter_inputs/lambda.gr
@@ -12,12 +12,6 @@ let testfn = forEachCodePoint(c /* arg */ => {
     void 
     }, "")
 
-let testfn2 = forEachCodePoint(c  // arg 1
- => { 
-    // a 
-    void 
-    }, "")
-
 let testfn3 = forEachCodePoint((c,  /* arg 1 */
 d, // eol2
 e /* arg */

--- a/compiler/test/formatter_outputs/lambda.gr
+++ b/compiler/test/formatter_outputs/lambda.gr
@@ -14,12 +14,6 @@ let testfn = forEachCodePoint(c /* arg */ => {
   void
 }, "")
 
-let testfn2 = forEachCodePoint(c // arg 1
- => {
-  // a
-  void
-}, "")
-
 let testfn3 = forEachCodePoint((
   c, /* arg 1 */
   d, // eol2

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -188,4 +188,12 @@ export let truc = () => {
 }
 truc()|},
   );
+  assertCompileError(
+    "newline_before_arrow",
+    {|
+    let x = ()
+      => 1
+    |},
+    "Expected an expression.",
+  );
 });

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -271,4 +271,24 @@ describe("pattern matching", ({test, testSkip}) => {
       "true\n(However, some guarded clause may match this value.)",
     ),
   );
+  assertCompileError(
+    "newline_before_arrow",
+    {|
+      match (1) {
+        a
+          => a
+      }
+    |},
+    "Expected `=>` followed by an expression or a branch guard—the keyword `when` followed by an expression",
+  );
+  assertCompileError(
+    "newline_before_arrow_2",
+    {|
+      match (1) {
+        a when a = 1
+          => a
+      }
+    |},
+    "Expected `=>` followed by an expression.",
+  );
 });


### PR DESCRIPTION
This removes support for newlines before `=>`. This came up while I was trying to work on #1113 with @ospencer. We don't allow newlines before `->`, so menhir got really mad when I switched them to `=>` and Oscar said it would be really hard to resolve.

I started typing out examples of eol before arrow and they looked really terrible:

```grain
let a =
  () => 1
```

```grain
match (a) {
    x
      => 2
}
```

It seems easiest to just remove support for eol before an arrow. I hope y'all agree.

(Is it a chore? Who knows 🤷 )