### PR TITLE
chore(compiler): Fix OCaml 4.12.0 and cmdliner warnings

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -202,7 +202,8 @@ let cmd = {
     | None => "unknown"
     | Some(v) => Build_info.V1.Version.to_string(v)
     };
-  (
+  Cmd.v(
+    Cmd.info(Sys.argv[0], ~version, ~doc),
     Term.(
       ret(
         Grain_utils.Config.with_cli_options(compile_wrapper)
@@ -211,12 +212,11 @@ let cmd = {
         $ output_filename,
       )
     ),
-    Term.info(Sys.argv[0], ~version, ~doc),
   );
 };
 
 let () =
-  switch (Term.eval(cmd)) {
-  | `Error(_) => exit(1)
+  switch (Cmd.eval_value(cmd)) {
+  | Error(_) => exit(1)
   | _ => ()
   };

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -244,7 +244,7 @@ let generate_docs =
   | None => print_bytes(contents)
   };
 
-  `Ok();
+  ();
 };
 
 let graindoc = opts => {
@@ -266,14 +266,14 @@ let cmd = {
     | Some(v) => Build_info.V1.Version.to_string(v)
     };
 
-  (
+  Cmd.v(
+    Cmd.info(Sys.argv[0], ~version, ~doc),
     Grain_utils.Config.with_cli_options(graindoc) $ params_cmdliner_term(),
-    Term.info(Sys.argv[0], ~version, ~doc),
   );
 };
 
 let () =
-  switch (Term.eval(cmd)) {
-  | `Error(_) => exit(1)
+  switch (Cmd.eval_value(cmd)) {
+  | Error(_) => exit(1)
   | _ => ()
   };

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -188,7 +188,8 @@ let cmd = {
     | Some(v) => Build_info.V1.Version.to_string(v)
     };
 
-  (
+  Cmd.v(
+    Cmd.info(Sys.argv[0], ~version, ~doc),
     Term.(
       ret(
         const(grainformat)
@@ -201,12 +202,11 @@ let cmd = {
           ),
       )
     ),
-    Term.info(Sys.argv[0], ~version, ~doc),
   );
 };
 
 let () =
-  switch (Term.eval(cmd)) {
-  | `Error(_) => exit(1)
+  switch (Cmd.eval_value(cmd)) {
+  | Error(_) => exit(1)
   | _ => ()
   };

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -324,7 +324,7 @@ module Top = {
 };
 
 module Val = {
-  let mk = (~loc=?, ~mod_, ~name, ~alias, ~typ, ~prim) => {
+  let mk = (~loc=?, ~mod_, ~name, ~alias, ~typ, ~prim, ()) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
       pval_mod: mod_,

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -260,7 +260,8 @@ module Val: {
       ~name: str,
       ~alias: option(str),
       ~typ: parsed_type,
-      ~prim: list(string)
+      ~prim: list(string),
+      unit
     ) =>
     value_description;
 };

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -676,14 +676,14 @@ export_id_str:
   | type_id_str { ExportExceptData $1 }
 
 foreign_stmt:
-  | FOREIGN WASM id_str colon typ as_prefix(id_str)? FROM file_path { Val.mk ~loc:(to_loc $loc) ~mod_:$8 ~name:$3 ~alias:$6 ~typ:$5 ~prim:[] }
+  | FOREIGN WASM id_str colon typ as_prefix(id_str)? FROM file_path { Val.mk ~loc:(to_loc $loc) ~mod_:$8 ~name:$3 ~alias:$6 ~typ:$5 ~prim:[] () }
 
 prim:
   | primitive_ { Location.mkloc $1 (to_loc $loc) }
 
 primitive_stmt:
-  | PRIMITIVE id_str colon typ equal STRING { Val.mk ~loc:(to_loc $loc) ~mod_:{$2 with txt="primitive"} ~name:$2 ~alias:None ~typ:$4 ~prim:[$6] }
-  | PRIMITIVE prim colon typ equal STRING { Val.mk ~loc:(to_loc $loc) ~mod_:{$2 with txt="primitive"} ~name:$2 ~alias:None ~typ:$4 ~prim:[$6] }
+  | PRIMITIVE id_str colon typ equal STRING { Val.mk ~loc:(to_loc $loc) ~mod_:{$2 with txt="primitive"} ~name:$2 ~alias:None ~typ:$4 ~prim:[$6] () }
+  | PRIMITIVE prim colon typ equal STRING { Val.mk ~loc:(to_loc $loc) ~mod_:{$2 with txt="primitive"} ~name:$2 ~alias:None ~typ:$4 ~prim:[$6] () }
 
 exception_stmt:
   | EXCEPTION type_id_str { Except.singleton ~loc:(to_loc $loc) $2 }

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -821,7 +821,7 @@ module Persistent_signature = {
   };
 
   let load =
-    ref((~loc=Location.dummy_loc, ~unit_name) => {
+    ref((~loc=Location.dummy_loc, unit_name) => {
       switch (Module_resolution.locate_module_file(~loc, unit_name)) {
       | filename =>
         let ret = {filename, cmi: Module_resolution.read_file_cmi(filename)};
@@ -892,7 +892,7 @@ let find_pers_struct = (~loc, check, filepath) => {
     | Cannot_load_modules(_) => raise(Not_found)
     | Can_load_modules =>
       let ps = {
-        switch (Persistent_signature.load^(~loc, ~unit_name=filepath)) {
+        switch (Persistent_signature.load^(~loc, filepath)) {
         | Some(ps) => ps
         | None =>
           Hashtbl.add(persistent_structures, filepath, None);

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -313,7 +313,7 @@ module Persistent_signature: {
       the .cmi file in the load path. This function can be overridden to load
       it from memory, for instance to build a self-contained toplevel. */
 
-  let load: ref((~loc: Location.t=?, ~unit_name: string) => option(t));
+  let load: ref((~loc: Location.t=?, string) => option(t));
 };
 
 /* Summaries -- compact representation of an environment, to be


### PR DESCRIPTION
Following #1151, the build emits a number of warnings related to Cmdliner's [deprecation of the `Term` evaluation interface](https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md#new-cmd-module-and-deprecation-of-the-term-evaluation-interface) and OCaml 4.12's [widening of warning 16](https://github.com/ocaml/ocaml/pull/9783). This PR makes the necessary changes to fix those warnings.