### PR TITLE
chore(compiler): Upgrade reason-native dependencies

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -55,9 +55,9 @@
   "resolutions": {
     "ocaml": "4.12.0",
     "@opam/ocamlfind": "1.8.1",
-    "@opam/fp": "reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87",
-    "@opam/fs": "reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87",
-    "@opam/utf8": "reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87",
+    "@opam/fp": "reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
+    "@opam/fs": "reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
+    "@opam/utf8": "reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
     "@reason-native/cli": "reasonml/reason-native:cli.json#0ed854f986256e52e59aeecfa90e9af60f105b15",
     "@reason-native/rely": "reasonml/reason-native:rely.json#0ed854f986256e52e59aeecfa90e9af60f105b15"
   },

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "adaea30fdc5e7dfac0c30f67e4995aa8",
+  "checksum": "af8b6c623f75208727f18762f4a555aa",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.12.0@d41d8cd9": {
@@ -50,7 +50,7 @@
         "@reason-native/file-context-printer@0.0.3@d41d8cd9",
         "@reason-native/cli@github:reasonml/reason-native:cli.json#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
-        "@opam/reason@opam:3.8.0@0af856e0", "@opam/re@opam:1.10.3@0585c65d",
+        "@opam/reason@opam:3.8.0@0af856e0", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/dune@opam:2.9.3@f57a6d69"
       ],
       "devDependencies": []
@@ -67,7 +67,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/re@opam:1.10.3@0585c65d",
+        "ocaml@4.12.0@d41d8cd9", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/dune@opam:2.9.3@f57a6d69", "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -85,7 +85,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
-        "@opam/re@opam:1.10.3@0585c65d", "@opam/dune@opam:2.9.3@f57a6d69",
+        "@opam/re@opam:1.10.4@c4910ba6", "@opam/dune@opam:2.9.3@f57a6d69",
         "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -105,7 +105,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
-        "@opam/reason@opam:3.8.0@0af856e0", "@opam/re@opam:1.10.3@0585c65d",
+        "@opam/reason@opam:3.8.0@0af856e0", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/dune@opam:2.9.3@f57a6d69"
       ],
       "devDependencies": []
@@ -138,16 +138,16 @@
         "@opam/dune@opam:2.9.3@f57a6d69", "@opam/biniou@opam:1.2.1@420bda02"
       ]
     },
-    "@opam/utf8@github:reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9": {
+    "@opam/utf8@github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9": {
       "id":
-        "@opam/utf8@github:reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/utf8@github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
       "name": "@opam/utf8",
       "version":
-        "github:reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87",
+        "github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
       "source": {
         "type": "install",
         "source": [
-          "github:reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87"
+          "github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15"
         ]
       },
       "overrides": [],
@@ -316,20 +316,20 @@
         "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@f57a6d69"
       ]
     },
-    "@opam/re@opam:1.10.3@0585c65d": {
-      "id": "@opam/re@opam:1.10.3@0585c65d",
+    "@opam/re@opam:1.10.4@c4910ba6": {
+      "id": "@opam/re@opam:1.10.4@c4910ba6",
       "name": "@opam/re",
-      "version": "opam:1.10.3",
+      "version": "opam:1.10.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/84/846546967f3fe31765935dd40a6460a9424337ecce7b12727fcba49480790ebb#sha256:846546967f3fe31765935dd40a6460a9424337ecce7b12727fcba49480790ebb",
-          "archive:https://github.com/ocaml/ocaml-re/releases/download/1.10.3/re-1.10.3.tbz#sha256:846546967f3fe31765935dd40a6460a9424337ecce7b12727fcba49480790ebb"
+          "archive:https://opam.ocaml.org/cache/sha256/83/83eb3e4300aa9b1dc7820749010f4362ea83524742130524d78c20ce99ca747c#sha256:83eb3e4300aa9b1dc7820749010f4362ea83524742130524d78c20ce99ca747c",
+          "archive:https://github.com/ocaml/ocaml-re/releases/download/1.10.4/re-1.10.4.tbz#sha256:83eb3e4300aa9b1dc7820749010f4362ea83524742130524d78c20ce99ca747c"
         ],
         "opam": {
           "name": "re",
-          "version": "1.10.3",
-          "path": "esy.lock/opam/re.1.10.3"
+          "version": "1.10.4",
+          "path": "esy.lock/opam/re.1.10.4"
         }
       },
       "overrides": [],
@@ -705,7 +705,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
-        "@opam/result@opam:1.5@1c6a6533", "@opam/re@opam:1.10.3@0585c65d",
+        "@opam/result@opam:1.5@1c6a6533", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7",
         "@opam/pp@opam:1.1.2@89ad03b5",
         "@opam/ocamlformat-rpc-lib@opam:0.18.0@4bef249f",
@@ -716,7 +716,7 @@
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
-        "@opam/result@opam:1.5@1c6a6533", "@opam/re@opam:1.10.3@0585c65d",
+        "@opam/result@opam:1.5@1c6a6533", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7",
         "@opam/pp@opam:1.1.2@89ad03b5",
         "@opam/ocamlformat-rpc-lib@opam:0.18.0@4bef249f",
@@ -920,40 +920,40 @@
         "@opam/cmdliner@opam:1.1.1@03763729"
       ]
     },
-    "@opam/fs@github:reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9": {
+    "@opam/fs@github:reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9": {
       "id":
-        "@opam/fs@github:reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/fs@github:reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
       "name": "@opam/fs",
       "version":
-        "github:reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87",
+        "github:reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
       "source": {
         "type": "install",
         "source": [
-          "github:reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87"
+          "github:reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15"
         ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.0@0af856e0",
-        "@opam/fp@github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/dune@opam:2.9.3@f57a6d69", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.0@0af856e0",
-        "@opam/fp@github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/dune@opam:2.9.3@f57a6d69"
       ]
     },
-    "@opam/fp@github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9": {
+    "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9": {
       "id":
-        "@opam/fp@github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
       "name": "@opam/fp",
       "version":
-        "github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87",
+        "github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15",
       "source": {
         "type": "install",
         "source": [
-          "github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87"
+          "github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15"
         ]
       },
       "overrides": [],
@@ -1352,7 +1352,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
-        "@opam/utf8@github:reasonml/reason-native:utf8.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/utf8@github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/sexplib@opam:v0.15.0@b6ab7383",
         "@opam/reason@opam:3.8.0@0af856e0",
         "@opam/ppx_sexp_conv@opam:v0.15.0@585f2e4d",
@@ -1360,8 +1360,8 @@
         "@opam/ppx_deriving_cmdliner@opam:0.6.0@07e8c107",
         "@opam/ocamlgraph@opam:2.0.0@929b9eba",
         "@opam/menhir@opam:20211125@3696d253",
-        "@opam/fs@github:reasonml/reason-native:fs.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
-        "@opam/fp@github:reasonml/reason-native:fp.opam#a33f1528a6dd86c67f365e226c81312733181c87@d41d8cd9",
+        "@opam/fs@github:reasonml/reason-native:fs.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
+        "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
         "@opam/dune-build-info@opam:2.9.3@ae518c8c",
         "@opam/dune@opam:2.9.3@f57a6d69",

--- a/compiler/esy.lock/opam/re.1.10.4/opam
+++ b/compiler/esy.lock/opam/re.1.10.4/opam
@@ -8,19 +8,19 @@ authors: [
   "Rudi Grinberg"
   "Gabriel Radanne"
 ]
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.03"}
   "dune" {>= "2.0"}
   "ounit" {with-test}
   "seq"
@@ -37,10 +37,10 @@ Pure OCaml regular expressions with:
 """
 url {
   src:
-    "https://github.com/ocaml/ocaml-re/releases/download/1.10.3/re-1.10.3.tbz"
+    "https://github.com/ocaml/ocaml-re/releases/download/1.10.4/re-1.10.4.tbz"
   checksum: [
-    "sha256=846546967f3fe31765935dd40a6460a9424337ecce7b12727fcba49480790ebb"
-    "sha512=d02103b7b8b8d8bc797341dcc933554745427f3c1b51b54b4ac9ff81badfd68c94726c57548b08e00ca99f3e09741b54b6500e97c19fc0e8fcefd6dfbe71da7f"
+    "sha256=83eb3e4300aa9b1dc7820749010f4362ea83524742130524d78c20ce99ca747c"
+    "sha512=92b05cf92c389fa8c753f2acca837b15dd05a4a2e8e2bec7a269d2e14c35b1a786d394258376648f80b4b99250ba1900cfe68230b8385aeac153149d9ce56099"
   ]
 }
-x-commit-hash: "c5d5df80e128c3d7646b7d8b1322012c5fcc35f3"
+x-commit-hash: "e9a4cecb8294c1839db18b1d0c30e755ec85ed5e"

--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -167,7 +167,7 @@ let input_file_conv = {
   let (prsr, prntr) = non_dir_file;
 
   (
-    filename => prsr(Grain_utils.Files.normalize_separators(filename)),
+    filename => prsr(filename),
     prntr,
   );
 };

--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -166,10 +166,7 @@ let input_file_conv = {
   open Arg;
   let (prsr, prntr) = non_dir_file;
 
-  (
-    filename => prsr(filename),
-    prntr,
-  );
+  (filename => prsr(filename), prntr);
 };
 
 let input_filename = {

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -32,10 +32,7 @@ module Input = {
 
   let (prsr, prntr) = Arg.non_dir_file;
 
-  let cmdliner_converter = (
-    filename => prsr(filename),
-    prntr,
-  );
+  let cmdliner_converter = (filename => prsr(filename), prntr);
 };
 
 module Output = {

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -33,7 +33,7 @@ module Input = {
   let (prsr, prntr) = Arg.non_dir_file;
 
   let cmdliner_converter = (
-    filename => prsr(Grain_utils.Files.normalize_separators(filename)),
+    filename => prsr(filename),
     prntr,
   );
 };
@@ -54,7 +54,7 @@ module Output = {
   };
 
   let cmdliner_converter = (
-    filename => prsr(Grain_utils.Files.normalize_separators(filename)),
+    filename => prsr(filename),
     Format.pp_print_string,
   );
 };

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -133,10 +133,7 @@ let grainformat =
 let input_file_conv = {
   open Arg;
   let (prsr, prntr) = non_dir_file;
-  (
-    filename => prsr(filename),
-    prntr,
-  );
+  (filename => prsr(filename), prntr);
 };
 
 /** Converter which checks that the given output filename is valid */

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -134,7 +134,7 @@ let input_file_conv = {
   open Arg;
   let (prsr, prntr) = non_dir_file;
   (
-    filename => prsr(Grain_utils.Files.normalize_separators(filename)),
+    filename => prsr(filename),
     prntr,
   );
 };


### PR DESCRIPTION
This is a WIP draft of upgrading our reason-native dependencies to drop the Windows path separator hacks.

There's more work to do and a ton more testing (haven't tried it on Windows yet).