### PR TITLE
chore(stdlib): Correct some docs for latest graindoc format

### DIFF
--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -116,8 +116,8 @@ let setSize = (ptr: WasmI32, val: WasmI32) => {
 /**
  * Requests that the heap be grown by the given number of bytes.
  *
- * @param nbytes: WasmI32 - The number of bytes requested
- * @returns WasmI32 - If unsuccessful, -1. Otherwise, the pointer to the beginning of the extended region.
+ * @param nbytes: The number of bytes requested
+ * @returns The pointer to the beginning of the extended region if successful or -1 otherwise
  */
 let growHeap = (nbytes: WasmI32) => {
   let mut reqSize = 0n
@@ -164,7 +164,7 @@ let growHeap = (nbytes: WasmI32) => {
 /**
  * Frees the given allocated pointer.
  *
- * @param ap: WasmI32 - The pointer to free
+ * @param ap: The pointer to free
  */
 export let free = (ap: WasmI32) => {
   let mut blockPtr = ap - 8n // 8 bytes for malloc header
@@ -212,8 +212,8 @@ export let free = (ap: WasmI32) => {
  * (if you can't tell from the fact that the name is reminiscient
  *  of the 1970s, the name of this function is taken from K&R).
  *
- * @param nbytes: WasmI32 - The number of bytes to try to grow the heap by
- * @returns WasmI32 - If successful, a pointer to the start of the free list. If not successful, -1.
+ * @param nbytes: The number of bytes to try to grow the heap by
+ * @returns A pointer to the start of the free list if successful or -1 otherwise
  */
 let morecore = (nbytes: WasmI32) => {
   let origSize = heapSize
@@ -237,8 +237,8 @@ let morecore = (nbytes: WasmI32) => {
 /**
  * Allocates the requested number of bytes, returning a pointer.
  *
- * @param nbytes: WasmI32 - The number of bytes to allocate
- * @returns WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
+ * @param nbytes: The number of bytes to allocate
+ * @returns The pointer to the allocated region (8-byte aligned) or -1 if the allocation failed
  */
 export let malloc = (nb: WasmI32) => {
   let mut nbytes = nb
@@ -302,10 +302,10 @@ export let malloc = (nb: WasmI32) => {
 }
 
 /**
- * Returns the current free list pointer
- * (used for debugging)
+ * Returns the current free list pointer.
+ * Used for debugging.
  *
- * @returns WasmI32 - The free list pointer
+ * @returns The free list pointer
  */
 export let getFreePtr = () => {
   freePtr

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -117,7 +117,7 @@ let setSize = (ptr: WasmI32, val: WasmI32) => {
  * Requests that the heap be grown by the given number of bytes.
  *
  * @param nbytes: WasmI32 - The number of bytes requested
- * @return WasmI32 - If unsuccessful, -1. Otherwise, the pointer to the beginning of the extended region.
+ * @returns WasmI32 - If unsuccessful, -1. Otherwise, the pointer to the beginning of the extended region.
  */
 let growHeap = (nbytes: WasmI32) => {
   let mut reqSize = 0n
@@ -213,7 +213,7 @@ export let free = (ap: WasmI32) => {
  *  of the 1970s, the name of this function is taken from K&R).
  *
  * @param nbytes: WasmI32 - The number of bytes to try to grow the heap by
- * @return WasmI32 - If successful, a pointer to the start of the free list. If not successful, -1.
+ * @returns WasmI32 - If successful, a pointer to the start of the free list. If not successful, -1.
  */
 let morecore = (nbytes: WasmI32) => {
   let origSize = heapSize
@@ -238,7 +238,7 @@ let morecore = (nbytes: WasmI32) => {
  * Allocates the requested number of bytes, returning a pointer.
  *
  * @param nbytes: WasmI32 - The number of bytes to allocate
- * @return WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
+ * @returns WasmI32 - The pointer to the allocated region (8-byte aligned), or -1 if the allocation failed.
  */
 export let malloc = (nb: WasmI32) => {
   let mut nbytes = nb
@@ -305,7 +305,7 @@ export let malloc = (nb: WasmI32) => {
  * Returns the current free list pointer
  * (used for debugging)
  *
- * @return WasmI32 - The free list pointer
+ * @returns WasmI32 - The free list pointer
  */
 export let getFreePtr = () => {
   freePtr

--- a/stdlib/runtime/wasi.gr
+++ b/stdlib/runtime/wasi.gr
@@ -73,7 +73,7 @@ import foreign wasm fd_pread: (
  * @param iovs: The pointer to the array of iovs to write
  * @param iovs_len: The length of the array of iovs
  * @param nwritten: Where to store the number of bytes written
- * @return The number of bytes written
+ * @returns The number of bytes written
  */
 import foreign wasm fd_write: (
   WasmI32,


### PR DESCRIPTION
This updates some docs that don't match the currently supported graindoc format.