### PR TITLE
chore(graindoc): Implement input & output args with a Filepath module

### DIFF
--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -27,27 +27,6 @@ let () =
     }
   );
 
-module Output = {
-  type t = string;
-
-  /** Checks that the given output filename is valid */
-  let prsr = s => {
-    let s_dir = dirname(s);
-    Sys.file_exists(s_dir)
-      ? if (Sys.is_directory(s_dir)) {
-          `Ok(s);
-        } else {
-          `Error(Format.sprintf("`%s' is not a directory", s_dir));
-        }
-      : `Error(Format.sprintf("no `%s' directory", s_dir));
-  };
-
-  let cmdliner_converter = (
-    filename => prsr(filename),
-    Format.pp_print_string,
-  );
-};
-
 [@deriving cmdliner]
 type params = {
   /** Grain source file for which to extract documentation */
@@ -55,7 +34,7 @@ type params = {
   input: Filepath.Args.ExistingFile.t,
   /** Output filename */
   [@name "o"] [@docv "FILE"]
-  output: option(Output.t),
+  output: option(Filepath.Args.MaybeExistingFile.t),
   /**
     The version to use as current when generating markdown for `@since` and `@history` attributes.
     Any future versions will be replace with `next` in the output.
@@ -230,8 +209,15 @@ let generate_docs =
 
   let contents = Buffer.to_bytes(buf);
   switch (output) {
-  | Some(outfile) =>
-    let oc = Fs_access.open_file_for_writing(outfile);
+  | Some(NotExists(outfile)) =>
+    Fs_access.ensure_parent_directory_exists(Filepath.to_string(outfile))
+  | _ => ()
+  };
+
+  switch (output) {
+  | Some(Exists(outfile))
+  | Some(NotExists(outfile)) =>
+    let oc = Fs_access.open_file_for_writing(Filepath.to_string(outfile));
     output_bytes(oc, contents);
     close_out(oc);
   | None => print_bytes(contents)

--- a/compiler/src/utils/filepath.re
+++ b/compiler/src/utils/filepath.re
@@ -183,4 +183,34 @@ module Args = {
 
     let cmdliner_converter = (prsr, prntr);
   };
+
+  module MaybeExistingFile = {
+    type t =
+      | Exists(Fp.t(Fp.absolute))
+      | NotExists(Fp.t(Fp.absolute));
+
+    let prsr = fname => {
+      switch (ExistingFile.query(fname)) {
+      | Ok(path) => `Ok(Exists(path))
+      | Error(NotExists(path)) => `Ok(NotExists(path))
+      | Error(NotFile(path)) =>
+        `Error(
+          Format.sprintf("%s exists but is not a file", to_string(path)),
+        )
+      | Error(InvalidPath(fname)) =>
+        `Error(Format.sprintf("Invalid path: %s", fname))
+      };
+    };
+
+    let prntr = (formatter, value) => {
+      switch (value) {
+      | Exists(path) =>
+        Format.fprintf(formatter, "File: %s", to_string(path))
+      | NotExists(path) =>
+        Format.fprintf(formatter, "Path: %s", to_string(path))
+      };
+    };
+
+    let cmdliner_converter = (prsr, prntr);
+  };
 };

--- a/compiler/src/utils/filepath.re
+++ b/compiler/src/utils/filepath.re
@@ -6,6 +6,8 @@ let from_string = fname => {
   Fp.testForPath(fname);
 };
 
+let dirname = path => Fp.dirName(path);
+
 /**
   Converts the given path to an absolute path. Relative paths will be
   treated as relative to [base], if given; otherwise, they will be


### PR DESCRIPTION
This is a refactor that I wanted to implement to share input/output arguments between our different CLI executables. This is important because I'll be implementing directory support that will be shared between graindoc and grainformat.

What do y'all think of this approach?