### PR TITLE
Refactor suggestions

### DIFF
--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -5,11 +5,6 @@ open Grain_utils;
 open Grain_diagnostics;
 
 module Doc = Res_doc;
-module MiniBuffer = Res_minibuffer;
-
-type eol =
-  | CRLF
-  | LF;
 
 let exception_primitives = [|"throw", "fail", "assert"|];
 
@@ -4140,7 +4135,7 @@ let toplevel_print =
 let format_ast =
     (
       ~original_source: array(string),
-      ~line_end: option(eol),
+      ~eol: Fs_access.eol,
       parsed_program: Parsetree.parsed_program,
     ) => {
   let get_loc = (stmt: Parsetree.toplevel_stmt) => {
@@ -4177,11 +4172,5 @@ let format_ast =
 
   let final_doc = Doc.concat([top_level_stmts, Doc.hardLine]);
 
-  let win_eol =
-    switch (line_end) {
-    | None
-    | Some(LF) => false
-    | Some(CRLF) => true
-    };
-  Doc.toString(~width=80, ~win_eol, final_doc);
+  Doc.toString(~width=80, ~eol, final_doc);
 };

--- a/compiler/grainformat/res_doc.re
+++ b/compiler/grainformat/res_doc.re
@@ -28,6 +28,7 @@
 
 
  */
+open Grain_utils;
 
 module MiniBuffer = Res_minibuffer;
 
@@ -255,9 +256,9 @@ let fits = (w, stack) => {
   calculateAll(stack);
 };
 
-let toString = (~width, ~win_eol, doc) => {
+let toString = (~width, ~eol: Fs_access.eol, doc) => {
   propagateForcedBreaks(doc);
-  let buffer = MiniBuffer.create(1000);
+  let buffer = MiniBuffer.create(~eol, 1000);
 
   let rec process = (~pos, lineSuffices, stack) =>
     switch (stack) {
@@ -288,13 +289,13 @@ let toString = (~width, ~win_eol, doc) => {
           switch (lineSuffices) {
           | [] =>
             if (lineStyle == Literal) {
-              if (win_eol) {
+              if (eol == CRLF) {
                 MiniBuffer.add_char(buffer, '\r');
               };
               MiniBuffer.add_char(buffer, '\n');
               process(~pos=0, [], rest);
             } else {
-              MiniBuffer.flush_newline(buffer, win_eol);
+              MiniBuffer.flush_newline(buffer);
               MiniBuffer.add_string(
                 buffer,
                 [@doesNotRaise] String.make(ind, ' '),
@@ -315,10 +316,10 @@ let toString = (~width, ~win_eol, doc) => {
               MiniBuffer.add_string(buffer, " ");
               pos + 1;
             | Hard =>
-              MiniBuffer.flush_newline(buffer, win_eol);
+              MiniBuffer.flush_newline(buffer);
               0;
             | Literal =>
-              if (win_eol) {
+              if (eol == CRLF) {
                 MiniBuffer.add_char(buffer, '\r');
               };
               MiniBuffer.add_char(buffer, '\n');
@@ -362,7 +363,7 @@ let toString = (~width, ~win_eol, doc) => {
 };
 
 [@live]
-let debug = t => {
+let debug = (~eol, t) => {
   let rec toDoc =
     fun
     | Nil => text("nil")
@@ -454,5 +455,5 @@ let debug = t => {
       );
 
   let doc = toDoc(t);
-  toString(~width=10, ~win_eol=false, doc) |> print_endline;
+  toString(~width=10, ~eol, doc) |> print_endline;
 };

--- a/compiler/grainformat/res_doc.rei
+++ b/compiler/grainformat/res_doc.rei
@@ -118,6 +118,6 @@ let willBreak: t => bool;
 
 let willIndent: t => bool;
 
-let toString: (~width: int, ~win_eol: bool, t) => string;
+let toString: (~width: int, ~eol: Grain_utils.Fs_access.eol, t) => string;
 [@live]
-let debug: t => unit;
+let debug: (~eol: Grain_utils.Fs_access.eol, t) => unit;

--- a/compiler/grainformat/res_minibuffer.re
+++ b/compiler/grainformat/res_minibuffer.re
@@ -33,9 +33,10 @@ type t = {
   mutable buffer: bytes,
   mutable position: int,
   mutable length: int,
+  eol: Grain_utils.Fs_access.eol,
 };
 
-let create = n => {
+let create = (~eol, n) => {
   let n =
     if (n < 1) {
       1;
@@ -43,7 +44,7 @@ let create = n => {
       n;
     };
   let s = ([@doesNotRaise] Bytes.create)(n);
-  {buffer: s, position: 0, length: n};
+  {buffer: s, position: 0, length: n, eol};
 };
 
 let contents = b =>
@@ -89,13 +90,13 @@ let add_string = (b, s) => {
 };
 
 /* adds newline and trims all preceding whitespace */
-let flush_newline = (b, win_eol) => {
+let flush_newline = b => {
   let position = ref(b.position);
   while (Bytes.unsafe_get(b.buffer, position^ - 1) == ' ' && position^ >= 0) {
     position := position^ - 1;
   };
   b.position = position^;
-  if (win_eol) {
+  if (b.eol == CRLF) {
     add_char(b, '\r');
   };
   add_char(b, '\n');

--- a/compiler/grainformat/res_minibuffer.rei
+++ b/compiler/grainformat/res_minibuffer.rei
@@ -33,5 +33,5 @@ type t;
 let add_char: (t, char) => unit;
 let add_string: (t, string) => unit;
 let contents: t => string;
-let create: int => t;
-let flush_newline: (t, bool) => unit;
+let create: (~eol: Grain_utils.Fs_access.eol, int) => t;
+let flush_newline: t => unit;

--- a/compiler/src/utils/fs_access.re
+++ b/compiler/src/utils/fs_access.re
@@ -3,6 +3,27 @@
  various forms of caching.
  */
 
+type eol =
+  | CRLF
+  | LF;
+
+let determine_eol = line => {
+  switch (line) {
+  | Some(line) when String.length(line) > 0 =>
+    // check what the last char was
+    // TODO: Replace with `String.ends_with` in OCaml 4.13
+    let last_char = line.[String.length(line) - 1];
+    if (last_char == '\r') {
+      CRLF;
+    } else {
+      LF;
+    };
+  | _ =>
+    // must use OS default as this file has no newline we can use
+    Sys.win32 ? CRLF : LF
+  };
+};
+
 // TODO: (#598) Should be safe for now, but we should harden this against
 // relative paths by converting everything to absolute paths
 


### PR DESCRIPTION
@marcusroberts These are some refactors that I think we should make to the formatter code. It really cuts down on the different code paths and mutable values. `Grain_utils.Fs_access` isn't the *perfect* place for the EOL utils, but I think it's fine for now.