### PR TITLE
fix(stdlib)!: Add explicit void return type on Map.forEach

### DIFF
--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -223,7 +223,7 @@ let rec forEachBucket = (fn, node) => {
   match (node) {
     None => void,
     Some({ key, value, next }) => {
-      fn(key, value)
+      fn(key, value): Void
       forEachBucket(fn, next)
     },
   }


### PR DESCRIPTION
In #1088, I noticed that `Map.forEach` allowed any return value in the iterator function. This explicitly annotates the return type as `Void` to ensure the signature is correct.