### PR TITLE
chore: Don't raise signals in tests

### DIFF
--- a/compiler/test/stdlib/sys.process.test.gr
+++ b/compiler/test/stdlib/sys.process.test.gr
@@ -4,19 +4,13 @@ import Process from "sys/process"
 // Just a smoke test
 match (Process.argv()) {
   Ok(arr) => assert Array.length(arr) > 0,
-  Err(err) => throw err
+  Err(err) => throw err,
 }
 
 // Just a smoke test
 match (Process.env()) {
   Ok(arr) => assert Array.length(arr) > 0,
-  Err(err) => throw err
-}
-
-// Just a smoke test
-match (Process.sigRaise(Process.VTALRM)) {
-  Ok(a) => assert a == void,
-  Err(err) => throw err
+  Err(err) => throw err,
 }
 
 Process.exit(5)


### PR DESCRIPTION
It's not very cross-platform (crashes on Windows) and we probably shouldn't raise random signals.