### PR TITLE
chore(compiler): Implement JS externals for Windows readdir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Autodetect text files
+* text=auto
+
+# Ensure snapshots always use LF
+*.snapshot text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           npm run compiler test
 
       - name: Run tests (js)
-        if: matrix.os != 'windows-latest'
         run: |
           npm run compiler test:js
 

--- a/compiler/src/utils/hacks.js
+++ b/compiler/src/utils/hacks.js
@@ -17,8 +17,9 @@ function unix_opendir(path) {
 //Requires: caml_string_of_jsstring
 //Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
 function unix_readdir(dir_handle) {
+    var dir;
     try {
-        var dir = dir_handle.readSync();
+        dir = dir_handle.readSync();
     } catch (e) {
         var unix_error = caml_named_value('Unix.Unix_error');
         caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));

--- a/compiler/src/utils/hacks.js
+++ b/compiler/src/utils/hacks.js
@@ -41,3 +41,64 @@ function unix_closedir(dir_handle) {
         caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "closedir", dir_handle.path));
     }
 }
+
+//Provides: win_findfirst
+//Requires: caml_jsstring_of_string, caml_string_of_jsstring
+//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
+//Requires: caml_raise_end_of_file
+function win_findfirst(path) {
+    var fs = require('fs');
+    // The Windows code adds this glob to the path, so we need to remove it
+    var p = caml_jsstring_of_string(path).replace("*.*", "");
+    var dir_handle;
+    try {
+        dir_handle = fs.opendirSync(p);
+    } catch (err) {
+        var unix_error = caml_named_value('Unix.Unix_error');
+        caml_raise_with_args(unix_error, make_unix_err_args(err.code, err.syscall, err.path, err.errno));
+    }
+    var dir;
+    try {
+        dir = dir_handle.readSync();
+    } catch (e) {
+        var unix_error = caml_named_value('Unix.Unix_error');
+        caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));
+    }
+    if (dir === null) {
+        caml_raise_end_of_file();
+    } else {
+        var first_entry = caml_string_of_jsstring(dir.name);
+        // The Windows bindings type dir_handle as an `int` but it's not in JS
+        return [0, first_entry, dir_handle];
+    }
+}
+
+//Provides: win_findnext
+//Requires: caml_raise_end_of_file
+//Requires: caml_string_of_jsstring
+//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
+function win_findnext(dir_handle) {
+    var dir;
+    try {
+        dir = dir_handle.readSync();
+    } catch (e) {
+        var unix_error = caml_named_value('Unix.Unix_error');
+        caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));
+    }
+    if (dir === null) {
+        caml_raise_end_of_file();
+    } else {
+        return caml_string_of_jsstring(dir.name);
+    }
+}
+
+//Provides: win_findclose
+//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
+function win_findclose(dir_handle) {
+    try {
+        dir_handle.closeSync();
+    } catch (e) {
+        var unix_error = caml_named_value('Unix.Unix_error');
+        caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "closedir", dir_handle.path));
+    }
+}


### PR DESCRIPTION
This implements some missing JS externals for Windows related to `Unix.readdir`. I didn't realize they had separate externals when I first implemented them. I also needed to get one fix to the Unix external.

This also enables the JS tests on Windows so we catch things like this before they land. One change that needed to happen to make them work was to ensure our snapshots always have `LF` line endings (because JSOO doesn't actually handle `\r\n` translations for `open_in` on Windows.