### PR TITLE
chore(compiler): Remove depends from dune-project stanzas

### DIFF
--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -16,142 +16,48 @@
 ; These aren't used currently but left in for reference when we generate opam files again
 (package
   (name grain)
-  (synopsis "The core Grain language compiler library")
-  (depends
-    (reason (>= 3.6.0))
-    (conf-openssl (>= 2))
-    (dune-build-info (>= 2.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))
-    (grain_typed (>= 0))
-    (grain_middle_end (>= 0))
-    (grain_diagnostics (>= 0))
-    (grain_codegen (>= 0))))
+  (synopsis "The core Grain language compiler library"))
 
 (package
   (name grainc)
-  (synopsis "The core Grain language compiler CLI")
-  (depends
-    (reason (>= 3.6.0))
-    (js_of_ocaml-compiler (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+  (synopsis "The core Grain language compiler CLI"))
 
 (package
   (name graindoc)
-  (synopsis "Grain documentation generator")
-  (depends
-    (reason (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+  (synopsis "Grain documentation generator"))
 
 (package
   (name grainformat)
-  (synopsis "Grain formatter")
-  (depends
-    (reason (>= 3.6.0))
-    (dune-build-info (>= 2.0))
-    (binaryen (= 0.9.1))
-    (cmdliner (>= 1.0.2))
-    (grain (>= 0))))
+  (synopsis "Grain formatter"))
 
 (package
   (name grain_linking)
-  (synopsis "The Grain linker")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (binaryen (= 0.9.1))
-    (ocamlgraph (>= 2.0.0))
-    (grain_utils (>= 0))
-    (grain_codegen (>= 0))))
+  (synopsis "The Grain linker"))
 
 (package
   (name grain_codegen)
-  (synopsis "Grain WebAssembly code generation")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (binaryen (= 0.9.1))
-    (grain_utils (>= 0))
-    (grain_middle_end (>= 0))))
+  (synopsis "Grain WebAssembly code generation"))
 
 (package
   (name grain_middle_end)
-  (synopsis "Grain itermediate representations")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (cmdliner (>= 1.0.2))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))
-    (grain_typed (>= 0))))
+  (synopsis "Grain itermediate representations"))
 
 (package
   (name grain_parsing)
-  (synopsis "The Grain parser")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (menhir (= 20211125))
-    (cmdliner (>= 1.0.2))
-    (utf8 (>= 0.0.0))
-    (ppx_deriving_yojson (>= 3.5.2))
-    (yojson (>= 1.7.0))
-    (grain_utils (>= 0))))
+  (synopsis "The Grain parser"))
 
 (package
   (name grain_typed)
-  (synopsis "The Grain typechecker")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (ocamlgraph (>= 2.0.0))
-    (cmdliner (>= 1.0.2))
-    (ppx_deriving_yojson (>= 3.5.2))
-    (yojson (>= 1.7.0))
-    (grain_utils (>= 0))
-    (grain_parsing (>= 0))))
+  (synopsis "The Grain typechecker"))
 
 (package
   (name grain_utils)
-  (synopsis "Various Grain utilities")
-  (depends
-    (reason (>= 3.6.0))
-    (ppx_sexp_conv (>= 0.14.0))
-    (sexplib (>= 0.14.0))
-    (fp (>= 0.0.0))
-    (fs (>= 0.0.0))
-    (cmdliner (>= 1.0.2))))
+  (synopsis "Various Grain utilities"))
 
 (package
  (name grain_diagnostics)
- (synopsis "Diagnostics support")
- (depends
-  (reason (>= 3.6.0))
-  (ppx_deriving_yojson (>= 3.5.2))
-  (yojson (>= 1.7.0))
-  (grain_utils (>= 0))
-  (grain_parsing (>= 0))))
+ (synopsis "Diagnostics support"))
 
 (package
   (name grain-tests)
-  (synopsis "Tests")
-  (depends
-    (reason (>= 3.6.0))
-    (rely (>= 3.2.1))))
+  (synopsis "Tests"))


### PR DESCRIPTION
These don't actually do anything since we exclusively use esy, and (for that reason) we are very bad at updating them. We should just delete them. The only thing dune needs for the dune-project stanzas is the name, but a description is nice too.