### PR TITLE
chore(compiler): Move type string printing into Printtyp module

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -38,14 +38,6 @@ let module_name_of_location = (loc: Grain_parsing.Location.t) => {
   );
 };
 
-let string_of_value_description = (~ident, vd) => {
-  Format.asprintf("%a", Printtyp.value_description(ident), vd);
-};
-
-let string_of_type_declaration = (~ident, td) => {
-  Format.asprintf("%a", Printtyp.type_declaration(ident), td);
-};
-
 let title_for_api = (~module_name, ident: Ident.t) => {
   Format.asprintf("%s.**%a**", module_name, Printtyp.ident, ident);
 };
@@ -111,7 +103,7 @@ let for_value_description =
     (~comments, ~ident: Ident.t, vd: Types.value_description) => {
   let module_name = module_name_of_location(vd.val_loc);
   let name = title_for_api(~module_name, ident);
-  let type_sig = string_of_value_description(~ident, vd);
+  let type_sig = Printtyp.string_of_value_description(~ident, vd);
   let comment =
     Comments.Doc.ending_on(~lnum=vd.val_loc.loc_start.pos_lnum - 1, comments);
 
@@ -144,7 +136,7 @@ let for_type_declaration =
     (~comments, ~ident: Ident.t, td: Types.type_declaration) => {
   let module_name = module_name_of_location(td.type_loc);
   let name = title_for_api(~module_name, ident);
-  let type_sig = string_of_type_declaration(~ident, td);
+  let type_sig = Printtyp.string_of_type_declaration(~ident, td);
   let comment =
     Comments.Doc.ending_on(
       ~lnum=td.type_loc.loc_start.pos_lnum - 1,

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -744,6 +744,14 @@ and type_scheme = (ppf, ty) => {
   typexp(true, ppf, ty);
 };
 
+let string_of_type_sch = ty => {
+  asprintf("%a", type_sch, ty);
+};
+
+let string_of_type_scheme = ty => {
+  asprintf("%a", type_scheme, ty);
+};
+
 /* Maxence */
 let type_scheme_max = (~b_reset_names=true, ppf, ty) => {
   if (b_reset_names) {

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -926,6 +926,10 @@ let tree_of_type_declaration = (id, decl, rs) =>
 let type_declaration = (id, ppf, decl) =>
   Oprint.out_sig_item^(ppf, tree_of_type_declaration(id, decl, TRecFirst));
 
+let string_of_type_declaration = (~ident, td) => {
+  asprintf("%a", type_declaration(ident), td);
+};
+
 let constructor_arguments = (ppf, a) => {
   let tys = tree_of_constructor_arguments(a);
   Oprint.out_type^(ppf, Otyp_tuple(tys));
@@ -996,6 +1000,10 @@ let tree_of_value_description = (id, decl) => {
 
 let value_description = (id, ppf, decl) =>
   Oprint.out_sig_item^(ppf, tree_of_value_description(id, decl));
+
+let string_of_value_description = (~ident, vd) => {
+  asprintf("%a", value_description(ident), vd);
+};
 
 /* Print a module type */
 

--- a/compiler/src/typed/printtyp.rei
+++ b/compiler/src/typed/printtyp.rei
@@ -38,8 +38,12 @@ let reset_and_mark_loops_list: list(type_expr) => unit;
 let type_expr: (formatter, type_expr) => unit;
 let constructor_arguments: (formatter, constructor_arguments) => unit;
 let tree_of_type_scheme: type_expr => out_type;
+// The `type_sch` functions avoid resetting the marked variables
 let type_sch: (formatter, type_expr) => unit;
+let string_of_type_sch: type_expr => string;
+// The `type_scheme` functions reset the marked variables
 let type_scheme: (formatter, type_expr) => unit;
+let string_of_type_scheme: type_expr => string;
 /* Maxence */
 let reset_names: unit => unit;
 let type_scheme_max: (~b_reset_names: bool=?, formatter, type_expr) => unit;

--- a/compiler/src/typed/printtyp.rei
+++ b/compiler/src/typed/printtyp.rei
@@ -46,9 +46,12 @@ let type_scheme_max: (~b_reset_names: bool=?, formatter, type_expr) => unit;
 /* End Maxence */
 let tree_of_value_description: (Ident.t, value_description) => out_sig_item;
 let value_description: (Ident.t, formatter, value_description) => unit;
+let string_of_value_description:
+  (~ident: Ident.t, value_description) => string;
 let tree_of_type_declaration:
   (Ident.t, type_declaration, rec_status) => out_sig_item;
 let type_declaration: (Ident.t, formatter, type_declaration) => unit;
+let string_of_type_declaration: (~ident: Ident.t, type_declaration) => string;
 let extension_constructor: (Ident.t, formatter, extension_constructor) => unit;
 let tree_of_module:
   (Ident.t, ~ellipsis: bool=?, module_type, rec_status) => out_sig_item;


### PR DESCRIPTION
This moves the type-to-string utilities that I wrote for graindoc into Printtyp (where they really should be). I noticed that #1131 copy-pasted my utilities. Instead of duplicating this logic, we should be putting them in the correct location.

I also experimented with `string_of_type_sch` and `string_of_type_scheme` and I **think** `string_of_type_sch` does the same thing as my weird `string_of_type_expr` function. I'll have a more thorough testing of that once directory support for graindoc is finished.