### PR TITLE
chore(compiler): Remove Config.base_path entirely

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -94,7 +94,6 @@ let compile_string = name => {
 };
 
 let compile_file = (name, outfile_arg) => {
-  Grain_utils.Config.base_path := dirname(name);
   if (!Printexc.backtrace_status() && Grain_utils.Config.verbose^) {
     Printexc.record_backtrace(true);
   };

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -44,10 +44,6 @@ type params = {
 };
 
 let compile_typed = (opts: params) => {
-  let base_path = Filepath.to_string(Filepath.dirname(opts.input));
-
-  Grain_utils.Config.base_path := base_path;
-
   let input = Filepath.to_string(opts.input);
 
   switch (Compile.compile_file(~hook=stop_after_typed, input)) {

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -573,23 +573,6 @@ let source_map =
 
 let print_warnings = internal_opt(true, NotDigestable);
 
-/* To be filled in by grainc */
-let base_path = internal_opt("", NotDigestable);
-
-let with_base_path = (path, func) => {
-  let old_base_path = base_path^;
-  base_path := path;
-  try({
-    let ret = func();
-    base_path := old_base_path;
-    ret;
-  }) {
-  | e =>
-    base_path := old_base_path;
-    raise(e);
-  };
-};
-
 let stdlib_directory = (): option(string) =>
   Option.map(
     path => Filepath.(to_string(String.derelativize(path))),

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -62,10 +62,6 @@ let include_dirs: ref(list(string));
 
 let stdlib_dir: ref(option(string));
 
-/** The base path where all Grain files for the program reside */
-
-let base_path: ref(string);
-
 /** Whether color output should be enabled */
 
 let color_enabled: ref(bool);
@@ -185,9 +181,6 @@ let preserve_all_configs: (unit => 'a) => 'a;
 /** Wraps the given thunk with extractors for compiler command-line options */
 
 let with_cli_options: 'a => Cmdliner.Term.t('a);
-
-/** Runs the given thunk with the given base_path value */
-let with_base_path: (string, unit => 'a) => 'a;
 
 /** Applies compile flags provided at the start of a file */
 


### PR DESCRIPTION
While doing some Windows debugging, I noticed that we don't actually use `Grain_utils.Config.base_path` anywhere anymore. I believe there was a change where we made things relative to the file being compiled, and this was probably just leftover.