### PR TITLE
Handle more data types and fix printing

### DIFF
--- a/compiler/src/diagnostics/modules.re
+++ b/compiler/src/diagnostics/modules.re
@@ -3,6 +3,9 @@ open Grain_typed;
 type export_kind =
   | Function
   | Record
+  | Variant
+  | AbstractType
+  | Exception
   | Value;
 
 type export = {
@@ -33,10 +36,36 @@ let get_exports = (~path, compiled_code: Typedtree.typed_program) => {
                 kind: Value,
                 signature: Printtyp.string_of_value_description(~ident, vd),
               })
-            | TSigType(ident, td, recstatus) =>
+            | TSigType(
+                ident,
+                {type_kind: TDataRecord(_), _} as td,
+                recstatus,
+              ) =>
               Some({
                 name: ident.name,
                 kind: Record,
+                signature: Printtyp.string_of_type_declaration(~ident, td),
+              })
+            | TSigType(
+                ident,
+                {type_kind: TDataVariant(_), _} as td,
+                recstatus,
+              ) =>
+              Some({
+                name: ident.name,
+                kind: Variant,
+                signature: Printtyp.string_of_type_declaration(~ident, td),
+              })
+            | TSigType(ident, {type_kind: TDataAbstract, _} as td, recstatus) =>
+              Some({
+                name: ident.name,
+                kind: AbstractType,
+                signature: Printtyp.string_of_type_declaration(~ident, td),
+              })
+            | TSigType(ident, {type_kind: TDataOpen, _} as td, recstatus) =>
+              Some({
+                name: ident.name,
+                kind: Exception, // Currently we only use TDataOpen for exceptions
                 signature: Printtyp.string_of_type_declaration(~ident, td),
               })
             | _ => None

--- a/compiler/src/diagnostics/modules.re
+++ b/compiler/src/diagnostics/modules.re
@@ -2,11 +2,11 @@ open Grain_typed;
 
 type export_kind =
   | Function
+  | Value
   | Record
-  | Variant
-  | AbstractType
-  | Exception
-  | Value;
+  | Enum
+  | Abstract
+  | Exception;
 
 type export = {
   name: string,
@@ -53,13 +53,13 @@ let get_exports = (~path, compiled_code: Typedtree.typed_program) => {
               ) =>
               Some({
                 name: ident.name,
-                kind: Variant,
+                kind: Enum,
                 signature: Printtyp.string_of_type_declaration(~ident, td),
               })
             | TSigType(ident, {type_kind: TDataAbstract, _} as td, recstatus) =>
               Some({
                 name: ident.name,
-                kind: AbstractType,
+                kind: Abstract,
                 signature: Printtyp.string_of_type_declaration(~ident, td),
               })
             | TSigType(ident, {type_kind: TDataOpen, _} as td, recstatus) =>

--- a/compiler/src/language_server/completion.re
+++ b/compiler/src/language_server/completion.re
@@ -234,10 +234,10 @@ let process =
                   let kind =
                     switch (m.kind) {
                     | Function => CompletionItemKindFunction
-                    | Record => CompletionItemKindStruct
                     | Value => CompletionItemKindValue
-                    | AbstractType => CompletionItemKindTypeParameter
-                    | Variant => CompletionItemKindEnum
+                    | Record => CompletionItemKindStruct
+                    | Enum => CompletionItemKindEnum
+                    | Abstract => CompletionItemKindTypeParameter
                     | Exception => CompletionItemKindTypeParameter
                     };
 

--- a/compiler/src/language_server/completion.re
+++ b/compiler/src/language_server/completion.re
@@ -236,6 +236,9 @@ let process =
                     | Function => CompletionItemKindFunction
                     | Record => CompletionItemKindStruct
                     | Value => CompletionItemKindValue
+                    | AbstractType => CompletionItemKindTypeParameter
+                    | Variant => CompletionItemKindEnum
+                    | Exception => CompletionItemKindTypeParameter
                     };
 
                   {

--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -522,9 +522,9 @@ let rec expression_lens =
                 | Function
                 | Value => Format.sprintf("let %s", v.signature)
                 | Record
-                | AbstractType
-                | Exception
-                | Variant => v.signature
+                | Enum
+                | Abstract
+                | Exception => v.signature
                 },
               vals,
             );

--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -515,14 +515,20 @@ let rec expression_lens =
             | PExternal(mod_path, name, _) =>
               Modules.get_exports(mod_path, compiled_code)
             };
-          let printed_vals =
-            List.fold_left(
-              (acc, v: Modules.export) =>
-                acc ++ "  let " ++ v.signature ++ "\n",
-              "",
+          let signatures =
+            List.map(
+              (v: Modules.export) =>
+                switch (v.kind) {
+                | Function
+                | Value => Format.sprintf("let %s", v.signature)
+                | Record
+                | AbstractType
+                | Exception
+                | Variant => v.signature
+                },
               vals,
             );
-          printed_vals;
+          String.concat("\n", signatures);
         } else {
           Printtyp.string_of_type_scheme(e.exp_type);
         };


### PR DESCRIPTION
While working on a fix for type printing, I ran into an issue where the LSP wasn't printing types, records, etc as nicely as it could. This applies some fixes to make it nicer.

One thing that I still didn't solve is that `enum` declarations are being printed as `type`. I'm wondering if they are being marked as abstract somehow (cc @ospencer ?)