### PR TITLE
fix(graindoc): Use value_descriptions and type_declarations defined by the module signature

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -140,13 +140,19 @@ let for_type_declaration =
 let for_signature_item =
     (~env: Env.t, ~comments, sig_item: Types.signature_item) => {
   switch (sig_item) {
-  | TSigValue(ident, vd) =>
-    let vd = Env.find_value(vd.val_fullpath, env);
-    let docblock = for_value_description(~comments, ~ident, vd);
+  | TSigValue(ident, ovd) =>
+    // Fetch original location as signatures don't contain real locations
+    let vd = Env.find_value(ovd.val_fullpath, env);
+    let val_loc = vd.val_loc;
+    let docblock =
+      for_value_description(~comments, ~ident, {...ovd, val_loc});
     Some(docblock);
-  | TSigType(ident, td, _rec) =>
-    let td = Env.find_type(td.type_path, env);
-    let docblock = for_type_declaration(~comments, ~ident, td);
+  | TSigType(ident, otd, _rec) =>
+    // Fetch original location as signatures don't contain real locations
+    let td = Env.find_type(otd.type_path, env);
+    let type_loc = td.type_loc;
+    let docblock =
+      for_type_declaration(~comments, ~ident, {...otd, type_loc});
     Some(docblock);
   | _ => None
   };

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -18,6 +18,10 @@ record Bucket<k, v> {
   mut next: Option<Bucket<k, v>>,
 }
 
+/**
+ * @section Types: Type declarations included in the Map module.
+ */
+
 record Map<k, v> {
   mut size: Number,
   mut buckets: Array<Option<Bucket<k, v>>>,
@@ -35,6 +39,7 @@ record Map<k, v> {
  * 
  * @since v0.2.0
  */
+
 // TODO: This could take an `eq` function to custom comparisons
 export let makeSized = size => {
   let buckets = Array.make(size, None)

--- a/stdlib/map.md
+++ b/stdlib/map.md
@@ -13,6 +13,16 @@ No other changes yet.
 import Map from "map"
 ```
 
+## Types
+
+Type declarations included in the Map module.
+
+### Map.**Map**
+
+```grain
+type Map<k, v>
+```
+
 ## Values
 
 Functions for working with Maps.


### PR DESCRIPTION
We previously did a lookup on the types in the module's signature, but that type is the original type rather than what the module is trying to expose. This change uses what's defined in the signature.