### PR TITLE
fix(compiler): Read custom sections in full

### DIFF
--- a/compiler/src/utils/wasm_utils.re
+++ b/compiler/src/utils/wasm_utils.re
@@ -460,11 +460,8 @@ module BinarySection =
           /* Now we're at the start of the section. Time to read */
           let realsize = size - (pos_in(inchan) - offset);
           let bytes = Bytes.create(realsize);
-          if (input(inchan, bytes, 0, realsize) == realsize) {
-            Some(Spec.deserialize(bytes));
-          } else {
-            process(tl);
-          };
+          really_input(inchan, bytes, 0, realsize);
+          Some(Spec.deserialize(bytes));
         | _ => process(tl)
         };
       };


### PR DESCRIPTION
Previously we relied on OCaml's `input` to read the custom section from a module. If all the bytes were not read, we skipped the section entirely. This swaps to `really_input` to ensure we read the entire section.