### PR TITLE
Remove fallible string operations in LSP

### DIFF
--- a/compiler/src/utils/string_utils.re
+++ b/compiler/src/utils/string_utils.re
@@ -17,6 +17,11 @@ let deasterisk_each_line = str => {
   Str.global_replace(Str.regexp("^[ \t]*\\*"), "", str);
 };
 
+let char_at = (str, i) =>
+  try(Some(str.[i])) {
+  | _ => None
+  };
+
 /**
 Slices a string given optional zero-based [~first] and [~last] indexes. The character
 at the [~last] index will not be included in the result.


### PR DESCRIPTION
I found that the LSP was crashing a lot because it was trying to do operations on strings that were outside of the string boundaries. @marcusroberts we have the `String_utils.slice` utility so you should never be using `String.sub`. And I added a `char_at` utility that returns an option.