### PR TITLE
fix(compiler): Report Win32 instead of Cygwin in JS compiler

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3782,7 +3782,7 @@ let compile_wasm_module = (~env=?, ~name=?, prog) => {
     ignore @@
     Module.add_debug_info_filename(
       wasm_mod,
-      Filename.basename(Option.get(name)),
+      Filepath.String.basename(Option.get(name)),
     );
   };
   let default_features = [

--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -22,7 +22,7 @@ let emit_module = ({asm, signature}, outfile) => {
   };
   let source_map_name =
     if (Config.source_map^) {
-      Some(Filename.basename(outfile) ++ ".map");
+      Some(Filepath.String.basename(outfile) ++ ".map");
     } else {
       None;
     };

--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -3,6 +3,7 @@ open Grain_typed;
 open Grain_middle_end;
 open Grain_codegen;
 open Grain_linking;
+open Grain_utils;
 open Optimize;
 
 type input_source =
@@ -39,21 +40,14 @@ type error =
 
 exception InlineFlagsError(Location.t, error);
 
-/** `remove_extension` new enough that we should just use this */
-
-let safe_remove_extension = name =>
-  try(Filename.chop_extension(name)) {
-  | Invalid_argument(_) => name
-  };
-
 let default_output_filename = name =>
-  safe_remove_extension(name) ++ ".gr.wasm";
+  Filepath.String.remove_extension(name) ++ ".gr.wasm";
 
 let default_assembly_filename = name =>
-  safe_remove_extension(name) ++ ".wast";
+  Filepath.String.remove_extension(name) ++ ".wast";
 
 let default_mashtree_filename = name =>
-  safe_remove_extension(name) ++ ".mashtree";
+  Filepath.String.remove_extension(name) ++ ".mashtree";
 
 let compile_prog = p =>
   Compcore.module_to_bytes @@ Compcore.compile_wasm_module(p);

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -47,7 +47,7 @@ let is_grain_module = mod_name => {
 };
 
 let wasi_polyfill_module = () => {
-  Filename.remove_extension(Option.get(Config.wasi_polyfill_path()))
+  Filepath.String.remove_extension(Option.get(Config.wasi_polyfill_path()))
   ++ ".gr.wasm";
 };
 
@@ -59,7 +59,7 @@ let is_wasi_polyfill_module = mod_path => {
   mod_path == wasi_polyfill_module();
 };
 
-let new_base_dir = Filename.dirname;
+let new_base_dir = Filepath.String.dirname;
 
 let rec build_dependency_graph = (~base_dir, mod_path) => {
   let wasm_mod = Hashtbl.find(modules, mod_path);
@@ -591,7 +591,7 @@ let link_modules = ({asm: wasm_mod, signature}) => {
 
   G.add_vertex(dependency_graph, main_module);
   build_dependency_graph(
-    ~base_dir=Filename.dirname(main_module),
+    ~base_dir=Filepath.String.dirname(main_module),
     main_module,
   );
   let dependencies =

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -749,7 +749,7 @@ let check_consistency = ps =>
         | Some(crc) =>
           let resolved_file_name =
             Module_resolution.resolve_unit(
-              ~base_dir=Filename.dirname(ps.ps_filename),
+              ~base_dir=Filepath.String.dirname(ps.ps_filename),
               name,
             );
           Consistbl.check(crc_units, resolved_file_name, crc, ps.ps_filename);

--- a/compiler/src/typed/module_resolution.rei
+++ b/compiler/src/typed/module_resolution.rei
@@ -28,5 +28,3 @@ let current_unit_name: ref(unit => string);
 let current_filename: ref(unit => string);
 
 let dump_dependency_graph: unit => unit;
-
-let is_relpath: string => bool;

--- a/compiler/src/utils/hacks.js
+++ b/compiler/src/utils/hacks.js
@@ -1,3 +1,8 @@
+//Provides: os_type
+var os_type = (globalThis.process &&
+    globalThis.process.platform &&
+    globalThis.process.platform == "win32") ? "Win32" : "Unix";
+
 //Provides: unix_opendir
 //Requires: caml_jsstring_of_string
 //Requires: make_unix_err_args, caml_raise_with_args, caml_named_value

--- a/compiler/test/TestFramework.re
+++ b/compiler/test/TestFramework.re
@@ -35,9 +35,9 @@ let clean_grain_output = stdlib_dir =>
   Array.iter(
     file => {
       let filename = Filepath.to_string(file);
-      if (Filename.check_suffix(filename, ".gr.wasm")
-          || Filename.check_suffix(filename, ".gr.wat")
-          || Filename.check_suffix(filename, ".gr.modsig")) {
+      if (Filepath.String.check_suffix(filename, ".gr.wasm")
+          || Filepath.String.check_suffix(filename, ".gr.wat")
+          || Filepath.String.check_suffix(filename, ".gr.modsig")) {
         Fs.rmExn(file);
       };
     },


### PR DESCRIPTION
The JS version of the compiler kept crashing because it was unable to locate the stdlib. This was due to JSOO reporting itself as "Cygwin" instead of "Win32". We've pushed for a lot of upstream changes in `Fp` so we use the correct separators on Windows, but that doesn't happen if it thinks it is running in Cygwin.

This hack (placed in `Grain_utils` so pretty much everything will get it applied) will swap us back to reporting `Win32` and make the all our tools work.