### PR TITLE
Fix enum serde by providing custom yojson functions

### DIFF
--- a/compiler/src/language_server/completion.re
+++ b/compiler/src/language_server/completion.re
@@ -34,6 +34,16 @@ type completion_item_kind =
   | CompletionItemKindOperator
   | CompletionItemKindTypeParameter;
 
+let completion_item_kind_to_yojson = severity =>
+  completion_item_kind_to_enum(severity) |> [%to_yojson: int];
+let completion_item_kind_of_yojson = json =>
+  Result.bind(json |> [%of_yojson: int], value => {
+    switch (completion_item_kind_of_enum(value)) {
+    | Some(severity) => Ok(severity)
+    | None => Result.Error("Invalid enum value")
+    }
+  });
+
 [@deriving yojson]
 type completion_item = {
   label: string,

--- a/compiler/src/language_server/protocol.re
+++ b/compiler/src/language_server/protocol.re
@@ -37,6 +37,16 @@ type diagnostic_severity =
   | Information
   | Hint;
 
+let diagnostic_severity_to_yojson = severity =>
+  diagnostic_severity_to_enum(severity) |> [%to_yojson: int];
+let diagnostic_severity_of_yojson = json =>
+  Result.bind(json |> [%of_yojson: int], value => {
+    switch (diagnostic_severity_of_enum(value)) {
+    | Some(severity) => Ok(severity)
+    | None => Result.Error("Invalid enum value")
+    }
+  });
+
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic
 [@deriving yojson]
 type diagnostic = {


### PR DESCRIPTION
It turns out that derivers don't know about each other, so we have to override the yojson serde functions if we want to convert to/from integer values.

Good catch @marcusroberts 