### PR TITLE
chore: Use Windows-safe glob strings

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "clean": "del-cli 'bin/*.exe' 'bin/*.bc.js'",
+    "clean": "del-cli \"bin/*.exe\" \"bin/*.bc.js\"",
     "link": "npm link",
     "format": "prettier --write .",
     "check-format": "prettier --check .",

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -27,7 +27,7 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "del-cli '**/*.wasm' '**/*.wat' '**/*.modsig'"
+    "clean": "del-cli \"**/*.wasm\" \"**/*.wat\" \"**/*.modsig\""
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I'm not exactly sure why single-ticks don't work on Windows when inside an npm "script", but they don't. They work when you run the command manually, which is doubly weird.

Anyway, this uses escaped double-tick quotes so deleting files works on Windows.