### PR TITLE
fix(compiler): Refactor WASI polyfill resolution

### DIFF
--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -47,16 +47,17 @@ let is_grain_module = mod_name => {
 };
 
 let wasi_polyfill_module = () => {
-  "GRAIN$MODULE$./"
-  ++ Filename.remove_extension(Option.get(Config.wasi_polyfill^));
+  Filename.remove_extension(Option.get(Config.wasi_polyfill_path()))
+  ++ ".gr.wasm";
 };
 
 let is_wasi_module = mod_name => {
   mod_name == "wasi_snapshot_preview1";
 };
 
-let is_wasi_polyfill_module = mod_path =>
-  mod_path == resolve(wasi_polyfill_module());
+let is_wasi_polyfill_module = mod_path => {
+  mod_path == wasi_polyfill_module();
+};
 
 let new_base_dir = Filename.dirname;
 
@@ -99,15 +100,14 @@ let rec build_dependency_graph = (~base_dir, mod_path) => {
       // Perform any WASI polyfilling. Note that we skip this step if we are compiling the polyfill module itself.
       // If we are importing a foreign from WASI, then add a dependency to the polyfill instead.
       let imported_module = wasi_polyfill_module();
-      let resolved_import = resolve(imported_module);
-      if (!Hashtbl.mem(modules, resolved_import)) {
-        Hashtbl.add(modules, resolved_import, load_module(resolved_import));
+      if (!Hashtbl.mem(modules, imported_module)) {
+        Hashtbl.add(modules, imported_module, load_module(imported_module));
         build_dependency_graph(
-          new_base_dir(resolved_import),
-          resolved_import,
+          new_base_dir(imported_module),
+          imported_module,
         );
       };
-      G.add_edge(dependency_graph, mod_path, resolved_import);
+      G.add_edge(dependency_graph, mod_path, imported_module);
     };
   };
 };
@@ -416,7 +416,7 @@ let link_all = (linked_mod, dependencies, signature) => {
           let wasi_polyfill = wasi_polyfill_module();
           let new_name =
             Hashtbl.find_opt(
-              Hashtbl.find(exported_names, resolve(wasi_polyfill)),
+              Hashtbl.find(exported_names, wasi_polyfill),
               imported_name,
             );
           let new_name =

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -579,6 +579,12 @@ let stdlib_directory = (): option(string) =>
     stdlib_dir^,
   );
 
+let wasi_polyfill_path = (): option(string) =>
+  Option.map(
+    path => Filepath.(to_string(String.derelativize(path))),
+    wasi_polyfill^,
+  );
+
 let module_search_path = () => {
   switch (stdlib_directory()) {
   | Some(x) => include_dirs^ @ [x] /* stdlib goes last */

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -7,6 +7,9 @@ type optimization_level =
 /** The Grain stdlib directory, based on the current configuration */
 let stdlib_directory: unit => option(string);
 
+/** The WASI polyfill path, based on the current configuration */
+let wasi_polyfill_path: unit => option(string);
+
 /** The list of directories to search for modules in, based on the current configuration */
 
 let module_search_path: unit => list(string);


### PR DESCRIPTION
We previously tried to resolve the location of the wasi polyfill relative to the Grain program being compiled, which is incorrect—it's relative to the directory where `grainc` is invoked.

Closes #1257 