### PR TITLE
feat(graindoc): Allow directory input & output

### DIFF
--- a/stdlib/bigint.md
+++ b/stdlib/bigint.md
@@ -5,7 +5,7 @@ title: BigInt
 Utilities for working with the BigInt type.
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -20,7 +20,7 @@ Functions for converting between Numbers and the BigInt type.
 ### Bigint.**fromNumber**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -28,7 +28,7 @@ No other changes yet.
 fromNumber : Number -> BigInt
 ```
 
-Converts a Number to an BigInt.
+Converts a Number to a BigInt.
 
 Parameters:
 
@@ -40,12 +40,12 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`BigInt`|The Number represented as an BigInt|
+|`BigInt`|The Number represented as a BigInt|
 
 ### Bigint.**toNumber**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -53,13 +53,13 @@ No other changes yet.
 toNumber : BigInt -> Number
 ```
 
-Converts an BigInt to a Number.
+Converts a BigInt to a Number.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to convert|
+|`num`|`BigInt`|The value to convert|
 
 Returns:
 
@@ -74,7 +74,7 @@ Mathematical operations for BigInt values.
 ### Bigint.**incr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -88,7 +88,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to increment|
+|`num`|`BigInt`|The value to increment|
 
 Returns:
 
@@ -99,7 +99,7 @@ Returns:
 ### Bigint.**decr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -113,7 +113,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to decrement|
+|`num`|`BigInt`|The value to decrement|
 
 Returns:
 
@@ -124,7 +124,7 @@ Returns:
 ### Bigint.**neg**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -149,7 +149,7 @@ Returns:
 ### Bigint.**abs**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -157,7 +157,7 @@ No other changes yet.
 abs : BigInt -> BigInt
 ```
 
-Returns the absolute value of the given operand
+Returns the absolute value of the given operand.
 
 Parameters:
 
@@ -174,7 +174,7 @@ Returns:
 ### Bigint.**add**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -188,8 +188,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -200,7 +200,7 @@ Returns:
 ### Bigint.**sub**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -214,8 +214,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -226,7 +226,7 @@ Returns:
 ### Bigint.**mul**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -240,8 +240,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -252,7 +252,7 @@ Returns:
 ### Bigint.**div**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -267,8 +267,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -279,7 +279,7 @@ Returns:
 ### Bigint.**rem**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -294,8 +294,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -306,7 +306,7 @@ Returns:
 ### Bigint.**quotRem**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -320,8 +320,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -332,7 +332,7 @@ Returns:
 ### Bigint.**gcd**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -346,8 +346,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -362,7 +362,7 @@ Functions for operating on bits of BigInt values.
 ### Bigint.**shl**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -376,8 +376,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to shift|
-|`amount`|`Int32`|The number of bits to shift by|
+|`num`|`BigInt`|The value to shift|
+|`places`|`Int32`|The number of bits to shift by|
 
 Returns:
 
@@ -388,7 +388,7 @@ Returns:
 ### Bigint.**shr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -402,8 +402,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to shift|
-|`amount`|`Int32`|The amount to shift by|
+|`num`|`BigInt`|The value to shift|
+|`places`|`Int32`|The amount to shift by|
 
 Returns:
 
@@ -418,7 +418,7 @@ Functions for comparing BigInt values.
 ### Bigint.**eqz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -432,7 +432,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to inspect|
+|`num`|`BigInt`|The value to inspect|
 
 Returns:
 
@@ -443,7 +443,7 @@ Returns:
 ### Bigint.**eq**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -457,8 +457,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -469,7 +469,7 @@ Returns:
 ### Bigint.**ne**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -483,8 +483,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -495,7 +495,7 @@ Returns:
 ### Bigint.**lt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -509,8 +509,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -521,7 +521,7 @@ Returns:
 ### Bigint.**lte**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -535,8 +535,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -547,7 +547,7 @@ Returns:
 ### Bigint.**gt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -561,8 +561,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -573,7 +573,7 @@ Returns:
 ### Bigint.**gte**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -587,8 +587,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first value|
-|`y`|`BigInt`|The second value|
+|`num1`|`BigInt`|The first value|
+|`num2`|`BigInt`|The second value|
 
 Returns:
 
@@ -603,7 +603,7 @@ Boolean operations on the bits of BigInt values.
 ### Bigint.**lnot**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -617,7 +617,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The given value|
+|`num`|`BigInt`|The given value|
 
 Returns:
 
@@ -628,7 +628,7 @@ Returns:
 ### Bigint.**land**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -642,8 +642,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -654,7 +654,7 @@ Returns:
 ### Bigint.**lor**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -668,8 +668,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -680,7 +680,7 @@ Returns:
 ### Bigint.**lxor**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -694,8 +694,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`BigInt`|The first operand|
-|`y`|`BigInt`|The second operand|
+|`num1`|`BigInt`|The first operand|
+|`num2`|`BigInt`|The second operand|
 
 Returns:
 
@@ -706,7 +706,7 @@ Returns:
 ### Bigint.**clz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -721,7 +721,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to inspect|
+|`num`|`BigInt`|The value to inspect|
 
 Returns:
 
@@ -732,7 +732,7 @@ Returns:
 ### Bigint.**ctz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -746,7 +746,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to inspect|
+|`num`|`BigInt`|The value to inspect|
 
 Returns:
 
@@ -757,7 +757,7 @@ Returns:
 ### Bigint.**popcnt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 
@@ -772,7 +772,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value`|`BigInt`|The value to inspect|
+|`num`|`BigInt`|The value to inspect|
 
 Returns:
 
@@ -787,7 +787,7 @@ Other functions on BigInts.
 ### Bigint.**toString**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -240,26 +240,6 @@ Returns:
 |----|-----------|
 |`String`|A string made with a subset of data copied from the buffer|
 
-### Buffer.**addChar**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-addChar : (Char, Buffer) -> Void
-```
-
-Appends the bytes of a char to a buffer.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`char`|`Char`|The character to append to the buffer|
-|`buffer`|`Buffer`|The buffer to mutate|
-
 ### Buffer.**addBytes**
 
 <details disabled>
@@ -300,6 +280,26 @@ Parameters:
 |`string`|`String`|The string to append|
 |`buffer`|`Buffer`|The buffer to mutate|
 
+### Buffer.**addChar**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+addChar : (Char, Buffer) -> Void
+```
+
+Appends the bytes of a char to a buffer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`char`|`Char`|The character to append to the buffer|
+|`buffer`|`Buffer`|The buffer to mutate|
+
 ### Buffer.**addStringSlice**
 
 <details disabled>
@@ -318,7 +318,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`start`|`Number`|The char offset into the string|
-|`length`|`Number`|The number of bytes to append|
+|`end`|`Number`|The end offset into the string|
 |`string`|`String`|The string to append|
 |`buffer`|`Buffer`|The buffer to mutate|
 
@@ -333,7 +333,7 @@ No other changes yet.
 addBytesSlice : (Number, Number, Bytes, Buffer) -> Void
 ```
 
-Appends the bytes of a subset of a byte seuqnece to a buffer.
+Appends the bytes of a subset of a byte sequence to a buffer.
 
 Parameters:
 

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -284,7 +284,7 @@ Parameters:
 ### Bytes.**clear**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+<summary tabindex="-1">Added in <code>next</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/exception.md
+++ b/stdlib/exception.md
@@ -1,0 +1,6 @@
+### Exception.**registerPrinter**
+
+```grain
+registerPrinter : (Exception -> Option<String>) -> Void
+```
+

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -1,0 +1,258 @@
+### List.**init**
+
+```grain
+init : (Number, (Number -> a)) -> List<a>
+```
+
+### List.**length**
+
+```grain
+length : List<a> -> Number
+```
+
+### List.**sum**
+
+```grain
+sum : List<Number> -> Number
+```
+
+### List.**reverse**
+
+```grain
+reverse : List<a> -> List<a>
+```
+
+### List.**append**
+
+```grain
+append : (List<a>, List<a>) -> List<a>
+```
+
+### List.**contains**
+
+```grain
+contains : (a, List<a>) -> Bool
+```
+
+### List.**reduce**
+
+```grain
+reduce : (((a, b) -> a), a, List<b>) -> a
+```
+
+### List.**reduceRight**
+
+```grain
+reduceRight : (((a, b) -> b), b, List<a>) -> b
+```
+
+### List.**map**
+
+```grain
+map : ((a -> b), List<a>) -> List<b>
+```
+
+### List.**mapi**
+
+```grain
+mapi : (((a, Number) -> b), List<a>) -> List<b>
+```
+
+### List.**flatMap**
+
+```grain
+flatMap : ((a -> List<b>), List<a>) -> List<b>
+```
+
+### List.**every**
+
+```grain
+every : ((a -> Bool), List<a>) -> Bool
+```
+
+### List.**some**
+
+```grain
+some : ((a -> Bool), List<a>) -> Bool
+```
+
+### List.**forEach**
+
+```grain
+forEach : ((a -> b), List<a>) -> Void
+```
+
+### List.**forEachi**
+
+```grain
+forEachi : (((a, Number) -> b), List<a>) -> Void
+```
+
+### List.**filter**
+
+```grain
+filter : ((a -> Bool), List<a>) -> List<a>
+```
+
+### List.**filteri**
+
+```grain
+filteri : (((a, Number) -> Bool), List<a>) -> List<a>
+```
+
+### List.**reject**
+
+```grain
+reject : ((a -> Bool), List<a>) -> List<a>
+```
+
+### List.**head**
+
+```grain
+head : List<a> -> Option<a>
+```
+
+### List.**tail**
+
+```grain
+tail : List<a> -> Option<List<a>>
+```
+
+### List.**nth**
+
+```grain
+nth : (Number, List<a>) -> Option<a>
+```
+
+### List.**flatten**
+
+```grain
+flatten : List<List<a>> -> List<a>
+```
+
+### List.**insert**
+
+```grain
+insert : (a, Number, List<a>) -> List<a>
+```
+
+### List.**count**
+
+```grain
+count : ((a -> Bool), List<a>) -> Number
+```
+
+### List.**part**
+
+```grain
+part : (Number, List<a>) -> (List<a>, List<a>)
+```
+
+### List.**rotate**
+
+```grain
+rotate : (Number, List<a>) -> List<a>
+```
+
+### List.**unique**
+
+```grain
+unique : List<a> -> List<a>
+```
+
+### List.**drop**
+
+```grain
+drop : (Number, List<a>) -> List<a>
+```
+
+### List.**dropWhile**
+
+```grain
+dropWhile : ((a -> Bool), List<a>) -> List<a>
+```
+
+### List.**take**
+
+```grain
+take : (Number, List<a>) -> List<a>
+```
+
+### List.**takeWhile**
+
+```grain
+takeWhile : ((a -> Bool), List<a>) -> List<a>
+```
+
+### List.**find**
+
+```grain
+find : ((a -> Bool), List<a>) -> Option<a>
+```
+
+### List.**findIndex**
+
+```grain
+findIndex : ((a -> Bool), List<a>) -> Option<Number>
+```
+
+### List.**product**
+
+```grain
+product : (List<a>, List<b>) -> List<(a, b)>
+```
+
+### List.**sub**
+
+```grain
+sub : (Number, Number, List<a>) -> List<a>
+```
+
+### List.**join**
+
+```grain
+join : (String, List<String>) -> String
+```
+
+### List.**revAppend**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
+No other changes yet.
+</details>
+
+```grain
+revAppend : (List<a>, List<a>) -> List<a>
+```
+
+Reverses the first list and appends the second list to the end.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list1`|`List<a>`|The list to reverse|
+|`list2`|`List<a>`|The list to append|
+
+### List.**sort**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.5</code></summary>
+No other changes yet.
+</details>
+
+```grain
+sort : (((a, a) -> Number), List<a>) -> List<a>
+```
+
+Sorts the given list based on a given comparator function. The resulting list is sorted in increasing order.
+
+Ordering is calculated using a comparator function which takes two list elements and must return 0 if both are equal, a positive number if the first is greater, and a negative number if the first is smaller.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`comp`|`(a, a) -> Number`|The comparator function used to indicate sort order|
+|`list`|`List<a>`|The list to be sorted|
+

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -1,0 +1,257 @@
+### Pervasives.**incr**
+
+```grain
+incr : Number -> Number
+```
+
+### Pervasives.**decr**
+
+```grain
+decr : Number -> Number
+```
+
+### Pervasives.**+**
+
+```grain
+( + ) : (Number, Number) -> Number
+```
+
+### Pervasives.**-**
+
+```grain
+( - ) : (Number, Number) -> Number
+```
+
+### Pervasives.*****
+
+```grain
+( * ) : (Number, Number) -> Number
+```
+
+### Pervasives.**/**
+
+```grain
+( / ) : (Number, Number) -> Number
+```
+
+### Pervasives.**%**
+
+```grain
+( % ) : (Number, Number) -> Number
+```
+
+### Pervasives.**<**
+
+```grain
+( < ) : (Number, Number) -> Bool
+```
+
+### Pervasives.**>**
+
+```grain
+( > ) : (Number, Number) -> Bool
+```
+
+### Pervasives.**<=**
+
+```grain
+( <= ) : (Number, Number) -> Bool
+```
+
+### Pervasives.**>=**
+
+```grain
+( >= ) : (Number, Number) -> Bool
+```
+
+### Pervasives.**lnot**
+
+```grain
+lnot : Number -> Number
+```
+
+### Pervasives.**&**
+
+```grain
+( & ) : (Number, Number) -> Number
+```
+
+### Pervasives.**|**
+
+```grain
+( | ) : (Number, Number) -> Number
+```
+
+### Pervasives.**^**
+
+```grain
+( ^ ) : (Number, Number) -> Number
+```
+
+### Pervasives.**<<**
+
+```grain
+( << ) : (Number, Number) -> Number
+```
+
+### Pervasives.**>>>**
+
+```grain
+( >>> ) : (Number, Number) -> Number
+```
+
+### Pervasives.**>>**
+
+```grain
+( >> ) : (Number, Number) -> Number
+```
+
+### Pervasives.**!**
+
+```grain
+( ! ) : Bool -> Bool
+```
+
+### Pervasives.**&&**
+
+```grain
+( && ) : (Bool, Bool) -> Bool
+```
+
+### Pervasives.**||**
+
+```grain
+( || ) : (Bool, Bool) -> Bool
+```
+
+### Pervasives.**box**
+
+```grain
+box : a -> Box<a>
+```
+
+### Pervasives.**unbox**
+
+```grain
+unbox : Box<a> -> a
+```
+
+### Pervasives.**ignore**
+
+```grain
+ignore : a -> Void
+```
+
+### Pervasives.**assert**
+
+```grain
+assert : Bool -> Void
+```
+
+### Pervasives.**throw**
+
+```grain
+throw : Exception -> a
+```
+
+### Pervasives.**fail**
+
+```grain
+fail : String -> a
+```
+
+### Pervasives.**toString**
+
+```grain
+toString : a -> String
+```
+
+### Pervasives.**print**
+
+```grain
+print : a -> Void
+```
+
+### Pervasives.**++**
+
+```grain
+( ++ ) : (String, String) -> String
+```
+
+### Pervasives.**==**
+
+```grain
+( == ) : (a, a) -> Bool
+```
+
+### Pervasives.**!=**
+
+```grain
+( != ) : (a, a) -> Bool
+```
+
+### Pervasives.**is**
+
+```grain
+is : (a, a) -> Bool
+```
+
+### Pervasives.**isnt**
+
+```grain
+isnt : (a, a) -> Bool
+```
+
+### Pervasives.**List**
+
+```grain
+enum List<a> {
+  [],
+  [...](a, List<a>),
+}
+```
+
+### Pervasives.**cons**
+
+> **Deprecated:** This will be removed in a future release of Grain.
+
+```grain
+cons : (a, List<a>) -> List<a>
+```
+
+### Pervasives.**empty**
+
+```grain
+empty : List<a>
+```
+
+### Pervasives.**Option**
+
+```grain
+enum Option<a> {
+  Some(a),
+  None,
+}
+```
+
+### Pervasives.**Result**
+
+```grain
+enum Result<t, e> {
+  Ok(t),
+  Err(e),
+}
+```
+
+### Pervasives.**identity**
+
+```grain
+identity : a -> a
+```
+
+### Pervasives.**setupExceptions**
+
+```grain
+setupExceptions : () -> Void
+```
+

--- a/stdlib/random.md
+++ b/stdlib/random.md
@@ -20,11 +20,7 @@ Type declarations included in the Random module.
 ### Random.**Random**
 
 ```grain
-record Random {
-  seed: Int64,
-  counter: Int64,
-  initialized: Bool,
-}
+type Random
 ```
 
 ## Values

--- a/stdlib/regex.md
+++ b/stdlib/regex.md
@@ -446,3 +446,4 @@ Examples:
 ```grain
 assert Regex.replaceAll(Result.unwrap(Regex.make("o")), "skoot", "r") == "skrrt"
 ```
+

--- a/stdlib/runtime/bigint.md
+++ b/stdlib/runtime/bigint.md
@@ -1,0 +1,326 @@
+### Bigint.**List**
+
+```grain
+type List<a>
+```
+
+### Bigint.**debugDumpNumber**
+
+```grain
+debugDumpNumber : WasmI32 -> Void
+```
+
+### Bigint.**getSize**
+
+```grain
+getSize : WasmI32 -> WasmI32
+```
+
+### Bigint.**getFlags**
+
+```grain
+getFlags : WasmI32 -> WasmI32
+```
+
+### Bigint.**getLimb**
+
+```grain
+getLimb : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Bigint.**makeWrappedInt32**
+
+```grain
+makeWrappedInt32 : WasmI32 -> WasmI32
+```
+
+### Bigint.**makeWrappedUint32**
+
+```grain
+makeWrappedUint32 : WasmI32 -> WasmI32
+```
+
+### Bigint.**makeWrappedInt64**
+
+```grain
+makeWrappedInt64 : WasmI64 -> WasmI32
+```
+
+### Bigint.**makeWrappedUint64**
+
+```grain
+makeWrappedUint64 : WasmI64 -> WasmI32
+```
+
+### Bigint.**isNegative**
+
+```grain
+isNegative : WasmI32 -> Bool
+```
+
+### Bigint.**eqz**
+
+```grain
+eqz : WasmI32 -> Bool
+```
+
+Returns true if the given bigint is equal to zero
+
+### Bigint.**negate**
+
+```grain
+negate : WasmI32 -> WasmI32
+```
+
+### Bigint.**abs**
+
+```grain
+abs : WasmI32 -> WasmI32
+```
+
+### Bigint.**canConvertToInt32**
+
+```grain
+canConvertToInt32 : WasmI32 -> Bool
+```
+
+### Bigint.**toInt32**
+
+```grain
+toInt32 : WasmI32 -> WasmI32
+```
+
+### Bigint.**canConvertToInt64**
+
+```grain
+canConvertToInt64 : WasmI32 -> Bool
+```
+
+### Bigint.**toInt64**
+
+```grain
+toInt64 : WasmI32 -> WasmI64
+```
+
+### Bigint.**toFloat64**
+
+```grain
+toFloat64 : WasmI32 -> WasmF64
+```
+
+### Bigint.**toFloat32**
+
+```grain
+toFloat32 : WasmI32 -> WasmF32
+```
+
+### Bigint.**cmpI64**
+
+```grain
+cmpI64 : (WasmI32, WasmI64) -> WasmI32
+```
+
+### Bigint.**cmpF64**
+
+```grain
+cmpF64 : (WasmI32, WasmF64) -> WasmI32
+```
+
+### Bigint.**cmpF32**
+
+```grain
+cmpF32 : (WasmI32, WasmF32) -> WasmI32
+```
+
+### Bigint.**cmp**
+
+```grain
+cmp : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**eq**
+
+```grain
+eq : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**ne**
+
+```grain
+ne : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**lt**
+
+```grain
+lt : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**lte**
+
+```grain
+lte : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**gt**
+
+```grain
+gt : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**gte**
+
+```grain
+gte : (WasmI32, WasmI32) -> Bool
+```
+
+### Bigint.**bigIntToString**
+
+```grain
+bigIntToString : (WasmI32, WasmI32) -> String
+```
+
+### Bigint.**bigIntToString10**
+
+```grain
+bigIntToString10 : WasmI32 -> String
+```
+
+### Bigint.**add**
+
+```grain
+add : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**addInt**
+
+```grain
+addInt : (WasmI32, WasmI64) -> WasmI32
+```
+
+### Bigint.**sub**
+
+```grain
+sub : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**subInt**
+
+```grain
+subInt : (WasmI32, WasmI64) -> WasmI32
+```
+
+### Bigint.**incr**
+
+```grain
+incr : WasmI32 -> WasmI32
+```
+
+### Bigint.**decr**
+
+```grain
+decr : WasmI32 -> WasmI32
+```
+
+### Bigint.**mul**
+
+```grain
+mul : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**shl**
+
+```grain
+shl : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**shrS**
+
+```grain
+shrS : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**bitwiseNot**
+
+```grain
+bitwiseNot : WasmI32 -> WasmI32
+```
+
+### Bigint.**bitwiseAnd**
+
+```grain
+bitwiseAnd : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**bitwiseOr**
+
+```grain
+bitwiseOr : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**bitwiseXor**
+
+```grain
+bitwiseXor : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**countLeadingZeros**
+
+```grain
+countLeadingZeros : WasmI32 -> WasmI32
+```
+
+### Bigint.**countTrailingZeros**
+
+```grain
+countTrailingZeros : WasmI32 -> WasmI64
+```
+
+### Bigint.**popcnt**
+
+```grain
+popcnt : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Bigint.**gcd**
+
+```grain
+gcd : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**quotRem**
+
+```grain
+quotRem : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Bigint.**divMod**
+
+```grain
+divMod : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Bigint.**quot**
+
+```grain
+quot : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**div**
+
+```grain
+div : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**rem**
+
+```grain
+rem : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Bigint.**mod**
+
+```grain
+mod : (WasmI32, WasmI32) -> WasmI32
+```
+

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -78,20 +78,6 @@ Returns:
 |----|-----------|
 |`WasmI32`|The pointer to the string|
 
-### DataStructures.**allocateChar**
-
-```grain
-allocateChar : () -> WasmI32
-```
-
-Allocates a new Grain char.
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`WasmI32`|The pointer to the char|
-
 ### DataStructures.**allocateInt32**
 
 ```grain
@@ -362,4 +348,44 @@ Returns:
 |type|description|
 |----|-----------|
 |`WasmI32`|The untagged number|
+
+### DataStructures.**tagChar**
+
+```grain
+tagChar : WasmI32 -> Char
+```
+
+Tag a char.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num`|`WasmI32`|The usv to tag|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Char`|The tagged char|
+
+### DataStructures.**untagChar**
+
+```grain
+untagChar : Char -> WasmI32
+```
+
+Untag a char.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num`|`Char`|The char to untag|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The untagged usv|
 

--- a/stdlib/runtime/debug.md
+++ b/stdlib/runtime/debug.md
@@ -1,0 +1,6 @@
+### Debug.**debug**
+
+```grain
+debug : a -> Void
+```
+

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -1,0 +1,6 @@
+### Equal.**equal**
+
+```grain
+equal : (a, a) -> Bool
+```
+

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -1,0 +1,30 @@
+### Exception.**Option**
+
+```grain
+type Option<a>
+```
+
+### Exception.**printers**
+
+```grain
+printers : WasmI32
+```
+
+### Exception.**dangerouslyRegisterBasePrinter**
+
+```grain
+dangerouslyRegisterBasePrinter : a -> Void
+```
+
+### Exception.**dangerouslyRegisterPrinter**
+
+```grain
+dangerouslyRegisterPrinter : a -> Void
+```
+
+### Exception.**printException**
+
+```grain
+printException : Exception -> Void
+```
+

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -1,0 +1,36 @@
+### Gc.**decimalCount32**
+
+```grain
+decimalCount32 : Box<WasmI32 -> WasmI32>
+```
+
+### Gc.**utoa32Buffered**
+
+```grain
+utoa32Buffered : Box<(WasmI32, WasmI32, WasmI32) -> Void>
+```
+
+### Gc.**malloc**
+
+```grain
+malloc : WasmI32 -> WasmI32
+```
+
+### Gc.**free**
+
+```grain
+free : WasmI32 -> Void
+```
+
+### Gc.**incRef**
+
+```grain
+incRef : WasmI32 -> WasmI32
+```
+
+### Gc.**decRef**
+
+```grain
+decRef : WasmI32 -> WasmI32
+```
+

--- a/stdlib/runtime/malloc.md
+++ b/stdlib/runtime/malloc.md
@@ -1,0 +1,55 @@
+### Malloc.**_RESERVED_RUNTIME_SPACE**
+
+```grain
+_RESERVED_RUNTIME_SPACE : WasmI32
+```
+
+### Malloc.**free**
+
+```grain
+free : WasmI32 -> Void
+```
+
+Frees the given allocated pointer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`ap`|`WasmI32`|The pointer to free|
+
+### Malloc.**malloc**
+
+```grain
+malloc : WasmI32 -> WasmI32
+```
+
+Allocates the requested number of bytes, returning a pointer.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`nbytes`|`WasmI32`|The number of bytes to allocate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The pointer to the allocated region (8-byte aligned) or -1 if the allocation failed|
+
+### Malloc.**getFreePtr**
+
+```grain
+getFreePtr : () -> WasmI32
+```
+
+Returns the current free list pointer.
+Used for debugging.
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The free list pointer|
+

--- a/stdlib/runtime/numberUtils.md
+++ b/stdlib/runtime/numberUtils.md
@@ -1,0 +1,54 @@
+### NumberUtils.**_MAX_DOUBLE_LENGTH**
+
+```grain
+_MAX_DOUBLE_LENGTH : WasmI32
+```
+
+### NumberUtils.**get_HEX_DIGITS**
+
+```grain
+get_HEX_DIGITS : () -> WasmI32
+```
+
+### NumberUtils.**decimalCount32**
+
+```grain
+decimalCount32 : WasmI32 -> WasmI32
+```
+
+### NumberUtils.**utoa32Buffered**
+
+```grain
+utoa32Buffered : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### NumberUtils.**utoa32**
+
+```grain
+utoa32 : (WasmI32, WasmI32) -> String
+```
+
+### NumberUtils.**itoa32**
+
+```grain
+itoa32 : (WasmI32, WasmI32) -> String
+```
+
+### NumberUtils.**utoa64**
+
+```grain
+utoa64 : (WasmI64, WasmI32) -> String
+```
+
+### NumberUtils.**itoa64**
+
+```grain
+itoa64 : (WasmI64, WasmI32) -> String
+```
+
+### NumberUtils.**dtoa**
+
+```grain
+dtoa : WasmF64 -> String
+```
+

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -1,0 +1,300 @@
+### Numbers.**isBoxedNumber**
+
+```grain
+isBoxedNumber : WasmI32 -> Bool
+```
+
+### Numbers.**isFloat**
+
+```grain
+isFloat : WasmI32 -> Bool
+```
+
+### Numbers.**isNumber**
+
+```grain
+isNumber : WasmI32 -> Bool
+```
+
+### Numbers.**reducedInteger**
+
+```grain
+reducedInteger : WasmI64 -> WasmI32
+```
+
+### Numbers.**boxedNumberTag**
+
+```grain
+boxedNumberTag : WasmI32 -> WasmI32
+```
+
+### Numbers.**boxedInt32Number**
+
+```grain
+boxedInt32Number : WasmI32 -> WasmI32
+```
+
+### Numbers.**boxedInt64Number**
+
+```grain
+boxedInt64Number : WasmI32 -> WasmI64
+```
+
+### Numbers.**boxedFloat32Number**
+
+```grain
+boxedFloat32Number : WasmI32 -> WasmF32
+```
+
+### Numbers.**boxedFloat64Number**
+
+```grain
+boxedFloat64Number : WasmI32 -> WasmF64
+```
+
+### Numbers.**boxedRationalNumerator**
+
+```grain
+boxedRationalNumerator : WasmI32 -> WasmI32
+```
+
+### Numbers.**boxedRationalDenominator**
+
+```grain
+boxedRationalDenominator : WasmI32 -> WasmI32
+```
+
+### Numbers.**coerceNumberToWasmF32**
+
+```grain
+coerceNumberToWasmF32 : Number -> WasmF32
+```
+
+### Numbers.**coerceNumberToWasmF64**
+
+```grain
+coerceNumberToWasmF64 : Number -> WasmF64
+```
+
+### Numbers.**coerceNumberToWasmI64**
+
+```grain
+coerceNumberToWasmI64 : Number -> WasmI64
+```
+
+### Numbers.**coerceNumberToWasmI32**
+
+```grain
+coerceNumberToWasmI32 : Number -> WasmI32
+```
+
+### Numbers.**numberEqual**
+
+```grain
+numberEqual : (WasmI32, WasmI32) -> Bool
+```
+
+### Numbers.**<**
+
+```grain
+( < ) : (Number, Number) -> Bool
+```
+
+### Numbers.**>**
+
+```grain
+( > ) : (Number, Number) -> Bool
+```
+
+### Numbers.**<=**
+
+```grain
+( <= ) : (Number, Number) -> Bool
+```
+
+### Numbers.**>=**
+
+```grain
+( >= ) : (Number, Number) -> Bool
+```
+
+### Numbers.**numberEq**
+
+```grain
+numberEq : (Number, Number) -> Bool
+```
+
+### Numbers.**lnot**
+
+```grain
+lnot : Number -> Number
+```
+
+### Numbers.**<<**
+
+```grain
+( << ) : (Number, Number) -> Number
+```
+
+### Numbers.**>>>**
+
+```grain
+( >>> ) : (Number, Number) -> Number
+```
+
+### Numbers.**&**
+
+```grain
+( & ) : (Number, Number) -> Number
+```
+
+### Numbers.**|**
+
+```grain
+( | ) : (Number, Number) -> Number
+```
+
+### Numbers.**^**
+
+```grain
+( ^ ) : (Number, Number) -> Number
+```
+
+### Numbers.**>>**
+
+```grain
+( >> ) : (Number, Number) -> Number
+```
+
+### Numbers.**coerceNumberToInt32**
+
+```grain
+coerceNumberToInt32 : Number -> Int32
+```
+
+### Numbers.**coerceNumberToInt64**
+
+```grain
+coerceNumberToInt64 : Number -> Int64
+```
+
+### Numbers.**coerceNumberToBigInt**
+
+```grain
+coerceNumberToBigInt : Number -> BigInt
+```
+
+### Numbers.**coerceNumberToRational**
+
+```grain
+coerceNumberToRational : Number -> Rational
+```
+
+### Numbers.**coerceNumberToFloat32**
+
+```grain
+coerceNumberToFloat32 : Number -> Float32
+```
+
+### Numbers.**coerceNumberToFloat64**
+
+```grain
+coerceNumberToFloat64 : Number -> Float64
+```
+
+### Numbers.**coerceInt32ToNumber**
+
+```grain
+coerceInt32ToNumber : Int32 -> Number
+```
+
+### Numbers.**coerceInt64ToNumber**
+
+```grain
+coerceInt64ToNumber : Int64 -> Number
+```
+
+### Numbers.**coerceBigIntToNumber**
+
+```grain
+coerceBigIntToNumber : BigInt -> Number
+```
+
+### Numbers.**coerceRationalToNumber**
+
+```grain
+coerceRationalToNumber : Rational -> Number
+```
+
+### Numbers.**coerceFloat32ToNumber**
+
+```grain
+coerceFloat32ToNumber : Float32 -> Number
+```
+
+### Numbers.**coerceFloat64ToNumber**
+
+```grain
+coerceFloat64ToNumber : Float64 -> Number
+```
+
+### Numbers.**convertExactToInexact**
+
+```grain
+convertExactToInexact : Number -> Number
+```
+
+### Numbers.**convertInexactToExact**
+
+```grain
+convertInexactToExact : Number -> Number
+```
+
+### Numbers.**+**
+
+```grain
+( + ) : (Number, Number) -> Number
+```
+
+### Numbers.**-**
+
+```grain
+( - ) : (Number, Number) -> Number
+```
+
+### Numbers.*****
+
+```grain
+( * ) : (Number, Number) -> Number
+```
+
+### Numbers.**/**
+
+```grain
+( / ) : (Number, Number) -> Number
+```
+
+### Numbers.**%**
+
+```grain
+( % ) : (Number, Number) -> Number
+```
+
+### Numbers.**incr**
+
+```grain
+incr : Number -> Number
+```
+
+### Numbers.**decr**
+
+```grain
+decr : Number -> Number
+```
+
+### Numbers.**isBigInt**
+
+```grain
+isBigInt : a -> Bool
+```
+

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -1,0 +1,24 @@
+### String.**StringList**
+
+```grain
+type StringList
+```
+
+### String.**concat**
+
+```grain
+concat : (String, String) -> String
+```
+
+### String.**toString**
+
+```grain
+toString : a -> String
+```
+
+### String.**print**
+
+```grain
+print : a -> Void
+```
+

--- a/stdlib/runtime/stringUtils.md
+++ b/stdlib/runtime/stringUtils.md
@@ -1,0 +1,6 @@
+### StringUtils.**parseInt**
+
+```grain
+parseInt : (String, Number) -> Result<Number, String>
+```
+

--- a/stdlib/runtime/unsafe/constants.md
+++ b/stdlib/runtime/unsafe/constants.md
@@ -1,0 +1,72 @@
+### Constants.**_SMIN_I32**
+
+```grain
+_SMIN_I32 : WasmI32
+```
+
+### Constants.**_SMAX_I32**
+
+```grain
+_SMAX_I32 : WasmI32
+```
+
+### Constants.**_UMIN_I32**
+
+```grain
+_UMIN_I32 : WasmI32
+```
+
+### Constants.**_UMAX_I32**
+
+```grain
+_UMAX_I32 : WasmI32
+```
+
+### Constants.**_SMIN_I64**
+
+```grain
+_SMIN_I64 : WasmI64
+```
+
+### Constants.**_SMAX_I64**
+
+```grain
+_SMAX_I64 : WasmI64
+```
+
+### Constants.**_UMIN_I64**
+
+```grain
+_UMIN_I64 : WasmI64
+```
+
+### Constants.**_UMAX_I64**
+
+```grain
+_UMAX_I64 : WasmI64
+```
+
+### Constants.**_SMIN32_I64**
+
+```grain
+_SMIN32_I64 : WasmI64
+```
+
+### Constants.**_SMAX32_I64**
+
+```grain
+_SMAX32_I64 : WasmI64
+```
+
+### Constants.**_UMIN32_I64**
+
+```grain
+_UMIN32_I64 : WasmI64
+```
+
+### Constants.**_UMAX32_I64**
+
+```grain
+_UMAX32_I64 : WasmI64
+```
+

--- a/stdlib/runtime/unsafe/conv.md
+++ b/stdlib/runtime/unsafe/conv.md
@@ -1,0 +1,71 @@
+### Conv.**toInt32**
+
+```grain
+toInt32 : WasmI32 -> Int32
+```
+
+### Conv.**fromInt32**
+
+```grain
+fromInt32 : Int32 -> WasmI32
+```
+
+### Conv.**toInt64**
+
+```grain
+toInt64 : WasmI64 -> Int64
+```
+
+### Conv.**fromInt64**
+
+```grain
+fromInt64 : Int64 -> WasmI64
+```
+
+### Conv.**toFloat32**
+
+```grain
+toFloat32 : WasmF32 -> Float32
+```
+
+### Conv.**fromFloat32**
+
+```grain
+fromFloat32 : Float32 -> WasmF32
+```
+
+### Conv.**toFloat64**
+
+```grain
+toFloat64 : WasmF64 -> Float64
+```
+
+### Conv.**fromFloat64**
+
+```grain
+fromFloat64 : Float64 -> WasmF64
+```
+
+### Conv.**wasmI32ToNumber**
+
+```grain
+wasmI32ToNumber : WasmI32 -> Number
+```
+
+Converts a WasmI32 value to Number.
+
+This function is meant to be called from a `@disableGC` context without
+need to call incRef on the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`n`|`WasmI32`|The WasmI32 to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The value converted to either a simple or a 32 bit heap allocated number.|
+

--- a/stdlib/runtime/unsafe/errors.md
+++ b/stdlib/runtime/unsafe/errors.md
@@ -1,0 +1,204 @@
+### Errors.**_GRAIN_ERR_NOT_NUMBER_COMP**
+
+```grain
+_GRAIN_ERR_NOT_NUMBER_COMP : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_NUMBER_ARITH**
+
+```grain
+_GRAIN_ERR_NOT_NUMBER_ARITH : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_BOOLEAN_LOGIC**
+
+```grain
+_GRAIN_ERR_NOT_BOOLEAN_LOGIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_BOOLEAN_IF**
+
+```grain
+_GRAIN_ERR_NOT_BOOLEAN_IF : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_OVERFLOW**
+
+```grain
+_GRAIN_ERR_OVERFLOW : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_GET_NOT_TUP**
+
+```grain
+_GRAIN_ERR_GET_NOT_TUP : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_GET_ITEM_IDX_NOT_NUMBER**
+
+```grain
+_GRAIN_ERR_GET_ITEM_IDX_NOT_NUMBER : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_GET_ITEM_IDX_TOO_SMALL**
+
+```grain
+_GRAIN_ERR_GET_ITEM_IDX_TOO_SMALL : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_GET_ITEM_IDX_TOO_LARGE**
+
+```grain
+_GRAIN_ERR_GET_ITEM_IDX_TOO_LARGE : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_CALLED_NON_FUNCTION**
+
+```grain
+_GRAIN_ERR_CALLED_NON_FUNCTION : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_ARITY_MISMATCH**
+
+```grain
+_GRAIN_ERR_ARITY_MISMATCH : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_OUT_OF_MEMORY**
+
+```grain
+_GRAIN_ERR_OUT_OF_MEMORY : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_SET_NOT_TUP**
+
+```grain
+_GRAIN_ERR_SET_NOT_TUP : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_SET_ITEM_IDX_NOT_NUMBER**
+
+```grain
+_GRAIN_ERR_SET_ITEM_IDX_NOT_NUMBER : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_SET_ITEM_IDX_TOO_SMALL**
+
+```grain
+_GRAIN_ERR_SET_ITEM_IDX_TOO_SMALL : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_SET_ITEM_IDX_TOO_LARGE**
+
+```grain
+_GRAIN_ERR_SET_ITEM_IDX_TOO_LARGE : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_DIVISION_BY_ZERO**
+
+```grain
+_GRAIN_ERR_DIVISION_BY_ZERO : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_MODULO_BY_ZERO**
+
+```grain
+_GRAIN_ERR_MODULO_BY_ZERO : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_ARRAY_INDEX_OUT_OF_BOUNDS**
+
+```grain
+_GRAIN_ERR_ARRAY_INDEX_OUT_OF_BOUNDS : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_INVALID_ARGUMENT**
+
+```grain
+_GRAIN_ERR_INVALID_ARGUMENT : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_ASSERTION_ERROR**
+
+```grain
+_GRAIN_ERR_ASSERTION_ERROR : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_FAILURE**
+
+```grain
+_GRAIN_ERR_FAILURE : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_SYSTEM**
+
+```grain
+_GRAIN_ERR_SYSTEM : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_INTLIKE**
+
+```grain
+_GRAIN_ERR_NOT_INTLIKE : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_RATIONAL**
+
+```grain
+_GRAIN_ERR_NOT_RATIONAL : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_MALFORMED_UTF8**
+
+```grain
+_GRAIN_ERR_MALFORMED_UTF8 : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_ADT_VAL_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_ADT_VAL_GENERIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_STRING_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_STRING_GENERIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_BOOLEAN_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_BOOLEAN_GENERIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_TUPLE_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_TUPLE_GENERIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_LAMBDA_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_LAMBDA_GENERIC : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_BAD_INPUT**
+
+```grain
+_GRAIN_ERR_BAD_INPUT : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_NONNEG**
+
+```grain
+_GRAIN_ERR_NOT_NONNEG : WasmI32
+```
+
+### Errors.**_GRAIN_ERR_NOT_NUMBER_GENERIC**
+
+```grain
+_GRAIN_ERR_NOT_NUMBER_GENERIC : WasmI32
+```
+

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -1,0 +1,54 @@
+### Memory.**malloc**
+
+```grain
+malloc : WasmI32 -> WasmI32
+```
+
+### Memory.**free**
+
+```grain
+free : WasmI32 -> Void
+```
+
+### Memory.**incRef**
+
+```grain
+incRef : WasmI32 -> WasmI32
+```
+
+### Memory.**decRef**
+
+```grain
+decRef : WasmI32 -> WasmI32
+```
+
+### Memory.**utoa32Buffered**
+
+```grain
+utoa32Buffered : Box<(WasmI32, WasmI32, WasmI32) -> Void>
+```
+
+### Memory.**decimalCount32**
+
+```grain
+decimalCount32 : Box<WasmI32 -> WasmI32>
+```
+
+### Memory.**copy**
+
+```grain
+copy : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Memory.**fill**
+
+```grain
+fill : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Memory.**compare**
+
+```grain
+compare : (WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+

--- a/stdlib/runtime/unsafe/printWasm.md
+++ b/stdlib/runtime/unsafe/printWasm.md
@@ -1,0 +1,24 @@
+### PrintWasm.**printI32**
+
+```grain
+printI32 : WasmI32 -> Void
+```
+
+### PrintWasm.**printI64**
+
+```grain
+printI64 : WasmI64 -> Void
+```
+
+### PrintWasm.**printF32**
+
+```grain
+printF32 : WasmF32 -> Void
+```
+
+### PrintWasm.**printF64**
+
+```grain
+printF64 : WasmF64 -> Void
+```
+

--- a/stdlib/runtime/unsafe/tags.md
+++ b/stdlib/runtime/unsafe/tags.md
@@ -1,0 +1,120 @@
+### Tags.**_GRAIN_NUMBER_TAG_TYPE**
+
+```grain
+_GRAIN_NUMBER_TAG_TYPE : WasmI32
+```
+
+### Tags.**_GRAIN_CHAR_TAG_TYPE**
+
+```grain
+_GRAIN_CHAR_TAG_TYPE : WasmI32
+```
+
+### Tags.**_GRAIN_CONST_TAG_TYPE**
+
+```grain
+_GRAIN_CONST_TAG_TYPE : WasmI32
+```
+
+### Tags.**_GRAIN_GENERIC_HEAP_TAG_TYPE**
+
+```grain
+_GRAIN_GENERIC_HEAP_TAG_TYPE : WasmI32
+```
+
+### Tags.**_GRAIN_NUMBER_TAG_MASK**
+
+```grain
+_GRAIN_NUMBER_TAG_MASK : WasmI32
+```
+
+### Tags.**_GRAIN_GENERIC_TAG_MASK**
+
+```grain
+_GRAIN_GENERIC_TAG_MASK : WasmI32
+```
+
+### Tags.**_GRAIN_STRING_HEAP_TAG**
+
+```grain
+_GRAIN_STRING_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_ADT_HEAP_TAG**
+
+```grain
+_GRAIN_ADT_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_RECORD_HEAP_TAG**
+
+```grain
+_GRAIN_RECORD_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_ARRAY_HEAP_TAG**
+
+```grain
+_GRAIN_ARRAY_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_BOXED_NUM_HEAP_TAG**
+
+```grain
+_GRAIN_BOXED_NUM_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_LAMBDA_HEAP_TAG**
+
+```grain
+_GRAIN_LAMBDA_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_TUPLE_HEAP_TAG**
+
+```grain
+_GRAIN_TUPLE_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_BYTES_HEAP_TAG**
+
+```grain
+_GRAIN_BYTES_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_FLOAT32_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_FLOAT32_BOXED_NUM_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_FLOAT64_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_FLOAT64_BOXED_NUM_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_INT32_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_INT32_BOXED_NUM_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_INT64_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_INT64_BOXED_NUM_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_RATIONAL_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_RATIONAL_BOXED_NUM_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_BIGINT_BOXED_NUM_TAG**
+
+```grain
+_GRAIN_BIGINT_BOXED_NUM_TAG : WasmI32
+```
+

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -1,0 +1,168 @@
+### Wasmf32.**load**
+
+```grain
+load : (WasmI32, WasmI32) -> WasmF32
+```
+
+### Wasmf32.**store**
+
+```grain
+store : (WasmI32, WasmF32, WasmI32) -> Void
+```
+
+### Wasmf32.**neg**
+
+```grain
+neg : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**abs**
+
+```grain
+abs : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**ceil**
+
+```grain
+ceil : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**floor**
+
+```grain
+floor : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**trunc**
+
+```grain
+trunc : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**nearest**
+
+```grain
+nearest : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**sqrt**
+
+```grain
+sqrt : WasmF32 -> WasmF32
+```
+
+### Wasmf32.**add**
+
+```grain
+add : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**sub**
+
+```grain
+sub : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**mul**
+
+```grain
+mul : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**div**
+
+```grain
+div : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**copySign**
+
+```grain
+copySign : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**min**
+
+```grain
+min : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**max**
+
+```grain
+max : (WasmF32, WasmF32) -> WasmF32
+```
+
+### Wasmf32.**eq**
+
+```grain
+eq : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**ne**
+
+```grain
+ne : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**lt**
+
+```grain
+lt : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**le**
+
+```grain
+le : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**gt**
+
+```grain
+gt : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**ge**
+
+```grain
+ge : (WasmF32, WasmF32) -> Bool
+```
+
+### Wasmf32.**reinterpretI32**
+
+```grain
+reinterpretI32 : WasmI32 -> WasmF32
+```
+
+### Wasmf32.**convertI32S**
+
+```grain
+convertI32S : WasmI32 -> WasmF32
+```
+
+### Wasmf32.**convertI32U**
+
+```grain
+convertI32U : WasmI32 -> WasmF32
+```
+
+### Wasmf32.**convertI64S**
+
+```grain
+convertI64S : WasmI64 -> WasmF32
+```
+
+### Wasmf32.**convertI64U**
+
+```grain
+convertI64U : WasmI64 -> WasmF32
+```
+
+### Wasmf32.**demoteF64**
+
+```grain
+demoteF64 : WasmF64 -> WasmF32
+```
+

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -1,0 +1,168 @@
+### Wasmf64.**load**
+
+```grain
+load : (WasmI32, WasmI32) -> WasmF64
+```
+
+### Wasmf64.**store**
+
+```grain
+store : (WasmI32, WasmF64, WasmI32) -> Void
+```
+
+### Wasmf64.**neg**
+
+```grain
+neg : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**abs**
+
+```grain
+abs : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**ceil**
+
+```grain
+ceil : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**floor**
+
+```grain
+floor : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**trunc**
+
+```grain
+trunc : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**nearest**
+
+```grain
+nearest : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**sqrt**
+
+```grain
+sqrt : WasmF64 -> WasmF64
+```
+
+### Wasmf64.**add**
+
+```grain
+add : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**sub**
+
+```grain
+sub : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**mul**
+
+```grain
+mul : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**div**
+
+```grain
+div : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**copySign**
+
+```grain
+copySign : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**min**
+
+```grain
+min : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**max**
+
+```grain
+max : (WasmF64, WasmF64) -> WasmF64
+```
+
+### Wasmf64.**eq**
+
+```grain
+eq : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**ne**
+
+```grain
+ne : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**lt**
+
+```grain
+lt : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**le**
+
+```grain
+le : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**gt**
+
+```grain
+gt : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**ge**
+
+```grain
+ge : (WasmF64, WasmF64) -> Bool
+```
+
+### Wasmf64.**reinterpretI64**
+
+```grain
+reinterpretI64 : WasmI64 -> WasmF64
+```
+
+### Wasmf64.**convertI32S**
+
+```grain
+convertI32S : WasmI32 -> WasmF64
+```
+
+### Wasmf64.**convertI32U**
+
+```grain
+convertI32U : WasmI32 -> WasmF64
+```
+
+### Wasmf64.**convertI64S**
+
+```grain
+convertI64S : WasmI64 -> WasmF64
+```
+
+### Wasmf64.**convertI64U**
+
+```grain
+convertI64U : WasmI64 -> WasmF64
+```
+
+### Wasmf64.**promoteF32**
+
+```grain
+promoteF32 : WasmF32 -> WasmF64
+```
+

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -1,0 +1,282 @@
+### Wasmi32.**load**
+
+```grain
+load : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**load8S**
+
+```grain
+load8S : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**load8U**
+
+```grain
+load8U : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**load16S**
+
+```grain
+load16S : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**load16U**
+
+```grain
+load16U : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**store**
+
+```grain
+store : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Wasmi32.**store8**
+
+```grain
+store8 : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Wasmi32.**store16**
+
+```grain
+store16 : (WasmI32, WasmI32, WasmI32) -> Void
+```
+
+### Wasmi32.**clz**
+
+```grain
+clz : WasmI32 -> WasmI32
+```
+
+### Wasmi32.**ctz**
+
+```grain
+ctz : WasmI32 -> WasmI32
+```
+
+### Wasmi32.**popcnt**
+
+```grain
+popcnt : WasmI32 -> WasmI32
+```
+
+### Wasmi32.**eqz**
+
+```grain
+eqz : WasmI32 -> Bool
+```
+
+### Wasmi32.**add**
+
+```grain
+add : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**sub**
+
+```grain
+sub : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**mul**
+
+```grain
+mul : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**divS**
+
+```grain
+divS : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**divU**
+
+```grain
+divU : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**remS**
+
+```grain
+remS : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**remU**
+
+```grain
+remU : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**and**
+
+```grain
+and : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**or**
+
+```grain
+or : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**xor**
+
+```grain
+xor : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**shl**
+
+```grain
+shl : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**shrS**
+
+```grain
+shrS : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**shrU**
+
+```grain
+shrU : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**rotl**
+
+```grain
+rotl : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**rotr**
+
+```grain
+rotr : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasmi32.**eq**
+
+```grain
+eq : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**ne**
+
+```grain
+ne : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**ltS**
+
+```grain
+ltS : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**ltU**
+
+```grain
+ltU : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**leS**
+
+```grain
+leS : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**leU**
+
+```grain
+leU : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**gtS**
+
+```grain
+gtS : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**gtU**
+
+```grain
+gtU : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**geS**
+
+```grain
+geS : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**geU**
+
+```grain
+geU : (WasmI32, WasmI32) -> Bool
+```
+
+### Wasmi32.**wrapI64**
+
+```grain
+wrapI64 : WasmI64 -> WasmI32
+```
+
+### Wasmi32.**truncF32S**
+
+```grain
+truncF32S : WasmF32 -> WasmI32
+```
+
+### Wasmi32.**truncF32U**
+
+```grain
+truncF32U : WasmF32 -> WasmI32
+```
+
+### Wasmi32.**truncF64S**
+
+```grain
+truncF64S : WasmF64 -> WasmI32
+```
+
+### Wasmi32.**truncF64U**
+
+```grain
+truncF64U : WasmF64 -> WasmI32
+```
+
+### Wasmi32.**reinterpretF32**
+
+```grain
+reinterpretF32 : WasmF32 -> WasmI32
+```
+
+### Wasmi32.**extendS8**
+
+```grain
+extendS8 : WasmI32 -> WasmI32
+```
+
+### Wasmi32.**extendS16**
+
+```grain
+extendS16 : WasmI32 -> WasmI32
+```
+
+### Wasmi32.**fromGrain**
+
+```grain
+fromGrain : a -> WasmI32
+```
+
+### Wasmi32.**toGrain**
+
+```grain
+toGrain : WasmI32 -> a
+```
+

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -1,0 +1,300 @@
+### Wasmi64.**load**
+
+```grain
+load : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load8S**
+
+```grain
+load8S : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load8U**
+
+```grain
+load8U : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load16S**
+
+```grain
+load16S : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load16U**
+
+```grain
+load16U : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load32S**
+
+```grain
+load32S : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**load32U**
+
+```grain
+load32U : (WasmI32, WasmI32) -> WasmI64
+```
+
+### Wasmi64.**store**
+
+```grain
+store : (WasmI32, WasmI64, WasmI32) -> Void
+```
+
+### Wasmi64.**store8**
+
+```grain
+store8 : (WasmI32, WasmI64, WasmI32) -> Void
+```
+
+### Wasmi64.**store16**
+
+```grain
+store16 : (WasmI32, WasmI64, WasmI32) -> Void
+```
+
+### Wasmi64.**store32**
+
+```grain
+store32 : (WasmI32, WasmI64, WasmI32) -> Void
+```
+
+### Wasmi64.**clz**
+
+```grain
+clz : WasmI64 -> WasmI64
+```
+
+### Wasmi64.**ctz**
+
+```grain
+ctz : WasmI64 -> WasmI64
+```
+
+### Wasmi64.**popcnt**
+
+```grain
+popcnt : WasmI64 -> WasmI64
+```
+
+### Wasmi64.**eqz**
+
+```grain
+eqz : WasmI64 -> Bool
+```
+
+### Wasmi64.**add**
+
+```grain
+add : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**sub**
+
+```grain
+sub : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**mul**
+
+```grain
+mul : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**divS**
+
+```grain
+divS : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**divU**
+
+```grain
+divU : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**remS**
+
+```grain
+remS : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**remU**
+
+```grain
+remU : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**and**
+
+```grain
+and : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**or**
+
+```grain
+or : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**xor**
+
+```grain
+xor : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**shl**
+
+```grain
+shl : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**shrU**
+
+```grain
+shrU : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**shrS**
+
+```grain
+shrS : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**rotl**
+
+```grain
+rotl : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**rotr**
+
+```grain
+rotr : (WasmI64, WasmI64) -> WasmI64
+```
+
+### Wasmi64.**eq**
+
+```grain
+eq : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**ne**
+
+```grain
+ne : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**ltS**
+
+```grain
+ltS : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**ltU**
+
+```grain
+ltU : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**leS**
+
+```grain
+leS : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**leU**
+
+```grain
+leU : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**gtS**
+
+```grain
+gtS : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**gtU**
+
+```grain
+gtU : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**geS**
+
+```grain
+geS : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**geU**
+
+```grain
+geU : (WasmI64, WasmI64) -> Bool
+```
+
+### Wasmi64.**extendI32S**
+
+```grain
+extendI32S : WasmI32 -> WasmI64
+```
+
+### Wasmi64.**extendI32U**
+
+```grain
+extendI32U : WasmI32 -> WasmI64
+```
+
+### Wasmi64.**truncF32S**
+
+```grain
+truncF32S : WasmF32 -> WasmI64
+```
+
+### Wasmi64.**truncF32U**
+
+```grain
+truncF32U : WasmF32 -> WasmI64
+```
+
+### Wasmi64.**truncF64S**
+
+```grain
+truncF64S : WasmF64 -> WasmI64
+```
+
+### Wasmi64.**truncF64U**
+
+```grain
+truncF64U : WasmF64 -> WasmI64
+```
+
+### Wasmi64.**reinterpretF64**
+
+```grain
+reinterpretF64 : WasmF64 -> WasmI64
+```
+
+### Wasmi64.**extendS8**
+
+```grain
+extendS8 : WasmI64 -> WasmI64
+```
+
+### Wasmi64.**extendS16**
+
+```grain
+extendS16 : WasmI64 -> WasmI64
+```
+
+### Wasmi64.**extendS32**
+
+```grain
+extendS32 : WasmI64 -> WasmI64
+```
+

--- a/stdlib/runtime/utils/printing.md
+++ b/stdlib/runtime/utils/printing.md
@@ -1,0 +1,18 @@
+### Printing.**numberToString**
+
+```grain
+numberToString : WasmI64 -> String
+```
+
+### Printing.**printNumber**
+
+```grain
+printNumber : WasmI64 -> Void
+```
+
+### Printing.**printString**
+
+```grain
+printString : String -> Void
+```
+

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -1,0 +1,839 @@
+### Wasi.**args_get**
+
+```grain
+args_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**args_sizes_get**
+
+```grain
+args_sizes_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**environ_get**
+
+```grain
+environ_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**environ_sizes_get**
+
+```grain
+environ_sizes_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**proc_exit**
+
+```grain
+proc_exit : WasmI32 -> Void
+```
+
+### Wasi.**proc_raise**
+
+```grain
+proc_raise : WasmI32 -> WasmI32
+```
+
+### Wasi.**sched_yield**
+
+```grain
+sched_yield : () -> WasmI32
+```
+
+### Wasi.**random_get**
+
+```grain
+random_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**clock_time_get**
+
+```grain
+clock_time_get : (WasmI32, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_open**
+
+```grain
+path_open :
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI64, WasmI64, WasmI32,
+   WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_read**
+
+```grain
+fd_read : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_pread**
+
+```grain
+fd_pread : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_write**
+
+```grain
+fd_write : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+Invokes the `fd_write` system call.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`file_descriptor`|`WasmI32`|The file descriptor to write to|
+|`iovs`|`WasmI32`|The pointer to the array of iovs to write|
+|`iovs_len`|`WasmI32`|The length of the array of iovs|
+|`nwritten`|`WasmI32`|Where to store the number of bytes written|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`WasmI32`|The number of bytes written|
+
+### Wasi.**fd_pwrite**
+
+```grain
+fd_pwrite : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_allocate**
+
+```grain
+fd_allocate : (WasmI32, WasmI64, WasmI64) -> WasmI32
+```
+
+### Wasi.**fd_close**
+
+```grain
+fd_close : WasmI32 -> WasmI32
+```
+
+### Wasi.**fd_datasync**
+
+```grain
+fd_datasync : WasmI32 -> WasmI32
+```
+
+### Wasi.**fd_sync**
+
+```grain
+fd_sync : WasmI32 -> WasmI32
+```
+
+### Wasi.**fd_fdstat_get**
+
+```grain
+fd_fdstat_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_fdstat_set_flags**
+
+```grain
+fd_fdstat_set_flags : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_fdstat_set_rights**
+
+```grain
+fd_fdstat_set_rights : (WasmI32, WasmI64, WasmI64) -> WasmI32
+```
+
+### Wasi.**fd_filestat_get**
+
+```grain
+fd_filestat_get : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_filestat_set_size**
+
+```grain
+fd_filestat_set_size : (WasmI32, WasmI64) -> WasmI32
+```
+
+### Wasi.**fd_filestat_set_times**
+
+```grain
+fd_filestat_set_times : (WasmI32, WasmI64, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_readdir**
+
+```grain
+fd_readdir : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_renumber**
+
+```grain
+fd_renumber : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_seek**
+
+```grain
+fd_seek : (WasmI32, WasmI64, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**fd_tell**
+
+```grain
+fd_tell : (WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_create_directory**
+
+```grain
+path_create_directory : (WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_filestat_get**
+
+```grain
+path_filestat_get : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_filestat_set_times**
+
+```grain
+path_filestat_set_times :
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI64, WasmI64, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_link**
+
+```grain
+path_link :
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_symlink**
+
+```grain
+path_symlink : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_unlink_file**
+
+```grain
+path_unlink_file : (WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_readlink**
+
+```grain
+path_readlink :
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_remove_directory**
+
+```grain
+path_remove_directory : (WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**path_rename**
+
+```grain
+path_rename :
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+```
+
+### Wasi.**_CLOCK_REALTIME**
+
+```grain
+_CLOCK_REALTIME : WasmI32
+```
+
+### Wasi.**_CLOCK_MONOTONIC**
+
+```grain
+_CLOCK_MONOTONIC : WasmI32
+```
+
+### Wasi.**_CLOCK_PROCESS_CPUTIME**
+
+```grain
+_CLOCK_PROCESS_CPUTIME : WasmI32
+```
+
+### Wasi.**_CLOCK_THREAD_CPUTIME**
+
+```grain
+_CLOCK_THREAD_CPUTIME : WasmI32
+```
+
+### Wasi.**_TIME_SET_ATIM**
+
+```grain
+_TIME_SET_ATIM : WasmI32
+```
+
+### Wasi.**_TIME_SET_ATIM_NOW**
+
+```grain
+_TIME_SET_ATIM_NOW : WasmI32
+```
+
+### Wasi.**_TIME_SET_MTIM**
+
+```grain
+_TIME_SET_MTIM : WasmI32
+```
+
+### Wasi.**_TIME_SET_MTIM_NOW**
+
+```grain
+_TIME_SET_MTIM_NOW : WasmI32
+```
+
+### Wasi.**_LOOKUP_FLAG_SYMLINK_FOLLOW**
+
+```grain
+_LOOKUP_FLAG_SYMLINK_FOLLOW : WasmI32
+```
+
+### Wasi.**_OPEN_FLAG_CREAT**
+
+```grain
+_OPEN_FLAG_CREAT : WasmI32
+```
+
+### Wasi.**_OPEN_FLAG_DIRECTORY**
+
+```grain
+_OPEN_FLAG_DIRECTORY : WasmI32
+```
+
+### Wasi.**_OPEN_FLAG_EXCL**
+
+```grain
+_OPEN_FLAG_EXCL : WasmI32
+```
+
+### Wasi.**_OPEN_FLAG_TRUNC**
+
+```grain
+_OPEN_FLAG_TRUNC : WasmI32
+```
+
+### Wasi.**_FDFLAG_APPEND**
+
+```grain
+_FDFLAG_APPEND : WasmI32
+```
+
+### Wasi.**_FDFLAG_DSYNC**
+
+```grain
+_FDFLAG_DSYNC : WasmI32
+```
+
+### Wasi.**_FDFLAG_NONBLOCK**
+
+```grain
+_FDFLAG_NONBLOCK : WasmI32
+```
+
+### Wasi.**_FDFLAG_RSYNC**
+
+```grain
+_FDFLAG_RSYNC : WasmI32
+```
+
+### Wasi.**_FDFLAG_SYNC**
+
+```grain
+_FDFLAG_SYNC : WasmI32
+```
+
+### Wasi.**_WHENCE_SET**
+
+```grain
+_WHENCE_SET : WasmI32
+```
+
+### Wasi.**_WHENCE_CUR**
+
+```grain
+_WHENCE_CUR : WasmI32
+```
+
+### Wasi.**_WHENCE_END**
+
+```grain
+_WHENCE_END : WasmI32
+```
+
+### Wasi.**_ESUCCESS**
+
+```grain
+_ESUCCESS : WasmI32
+```
+
+### Wasi.**_ETOOBIG**
+
+```grain
+_ETOOBIG : WasmI32
+```
+
+### Wasi.**_EACCES**
+
+```grain
+_EACCES : WasmI32
+```
+
+### Wasi.**_EADDRINUSE**
+
+```grain
+_EADDRINUSE : WasmI32
+```
+
+### Wasi.**_EADDRNOTAVAIL**
+
+```grain
+_EADDRNOTAVAIL : WasmI32
+```
+
+### Wasi.**_EAFNOSUPPORT**
+
+```grain
+_EAFNOSUPPORT : WasmI32
+```
+
+### Wasi.**_EAGAIN**
+
+```grain
+_EAGAIN : WasmI32
+```
+
+### Wasi.**_EALREADY**
+
+```grain
+_EALREADY : WasmI32
+```
+
+### Wasi.**_EBADF**
+
+```grain
+_EBADF : WasmI32
+```
+
+### Wasi.**_EBADMSG**
+
+```grain
+_EBADMSG : WasmI32
+```
+
+### Wasi.**_EBUSY**
+
+```grain
+_EBUSY : WasmI32
+```
+
+### Wasi.**_ECANCELED**
+
+```grain
+_ECANCELED : WasmI32
+```
+
+### Wasi.**_ECHILD**
+
+```grain
+_ECHILD : WasmI32
+```
+
+### Wasi.**_ECONNABORTED**
+
+```grain
+_ECONNABORTED : WasmI32
+```
+
+### Wasi.**_ECONNREFUSED**
+
+```grain
+_ECONNREFUSED : WasmI32
+```
+
+### Wasi.**_ECONNRESET**
+
+```grain
+_ECONNRESET : WasmI32
+```
+
+### Wasi.**_EDEADLK**
+
+```grain
+_EDEADLK : WasmI32
+```
+
+### Wasi.**_EDESTADDRREQ**
+
+```grain
+_EDESTADDRREQ : WasmI32
+```
+
+### Wasi.**_EDOM**
+
+```grain
+_EDOM : WasmI32
+```
+
+### Wasi.**_EDQUOT**
+
+```grain
+_EDQUOT : WasmI32
+```
+
+### Wasi.**_EEXIST**
+
+```grain
+_EEXIST : WasmI32
+```
+
+### Wasi.**_EFAULT**
+
+```grain
+_EFAULT : WasmI32
+```
+
+### Wasi.**_EFBIG**
+
+```grain
+_EFBIG : WasmI32
+```
+
+### Wasi.**_EHOSTUNREACH**
+
+```grain
+_EHOSTUNREACH : WasmI32
+```
+
+### Wasi.**_EIDRM**
+
+```grain
+_EIDRM : WasmI32
+```
+
+### Wasi.**_EILSEQ**
+
+```grain
+_EILSEQ : WasmI32
+```
+
+### Wasi.**_EINPROGRESS**
+
+```grain
+_EINPROGRESS : WasmI32
+```
+
+### Wasi.**_EINTR**
+
+```grain
+_EINTR : WasmI32
+```
+
+### Wasi.**_EINVAL**
+
+```grain
+_EINVAL : WasmI32
+```
+
+### Wasi.**_EIO**
+
+```grain
+_EIO : WasmI32
+```
+
+### Wasi.**_EISCONN**
+
+```grain
+_EISCONN : WasmI32
+```
+
+### Wasi.**_EISDIR**
+
+```grain
+_EISDIR : WasmI32
+```
+
+### Wasi.**_ELOOP**
+
+```grain
+_ELOOP : WasmI32
+```
+
+### Wasi.**_EMFILE**
+
+```grain
+_EMFILE : WasmI32
+```
+
+### Wasi.**_EMLINK**
+
+```grain
+_EMLINK : WasmI32
+```
+
+### Wasi.**_EMSGSIZE**
+
+```grain
+_EMSGSIZE : WasmI32
+```
+
+### Wasi.**_EMULTIHOP**
+
+```grain
+_EMULTIHOP : WasmI32
+```
+
+### Wasi.**_ENAMETOOLONG**
+
+```grain
+_ENAMETOOLONG : WasmI32
+```
+
+### Wasi.**_ENETDOWN**
+
+```grain
+_ENETDOWN : WasmI32
+```
+
+### Wasi.**_ENETRESET**
+
+```grain
+_ENETRESET : WasmI32
+```
+
+### Wasi.**_ENETUNREACH**
+
+```grain
+_ENETUNREACH : WasmI32
+```
+
+### Wasi.**_ENFILE**
+
+```grain
+_ENFILE : WasmI32
+```
+
+### Wasi.**_ENOBUFS**
+
+```grain
+_ENOBUFS : WasmI32
+```
+
+### Wasi.**_ENODEV**
+
+```grain
+_ENODEV : WasmI32
+```
+
+### Wasi.**_ENOENT**
+
+```grain
+_ENOENT : WasmI32
+```
+
+### Wasi.**_ENOEXEC**
+
+```grain
+_ENOEXEC : WasmI32
+```
+
+### Wasi.**_ENOLCK**
+
+```grain
+_ENOLCK : WasmI32
+```
+
+### Wasi.**_ENOLINK**
+
+```grain
+_ENOLINK : WasmI32
+```
+
+### Wasi.**_ENOMEM**
+
+```grain
+_ENOMEM : WasmI32
+```
+
+### Wasi.**_ENOMSG**
+
+```grain
+_ENOMSG : WasmI32
+```
+
+### Wasi.**_ENOPROTOOPT**
+
+```grain
+_ENOPROTOOPT : WasmI32
+```
+
+### Wasi.**_ENOSPC**
+
+```grain
+_ENOSPC : WasmI32
+```
+
+### Wasi.**_ENOSYS**
+
+```grain
+_ENOSYS : WasmI32
+```
+
+### Wasi.**_ENOTCONN**
+
+```grain
+_ENOTCONN : WasmI32
+```
+
+### Wasi.**_ENOTDIR**
+
+```grain
+_ENOTDIR : WasmI32
+```
+
+### Wasi.**_ENOTEMPTY**
+
+```grain
+_ENOTEMPTY : WasmI32
+```
+
+### Wasi.**_ENOTRECOVERABLE**
+
+```grain
+_ENOTRECOVERABLE : WasmI32
+```
+
+### Wasi.**_ENOTSOCK**
+
+```grain
+_ENOTSOCK : WasmI32
+```
+
+### Wasi.**_ENOTSUP**
+
+```grain
+_ENOTSUP : WasmI32
+```
+
+### Wasi.**_ENOTTY**
+
+```grain
+_ENOTTY : WasmI32
+```
+
+### Wasi.**_ENXIO**
+
+```grain
+_ENXIO : WasmI32
+```
+
+### Wasi.**_EOVERFLOW**
+
+```grain
+_EOVERFLOW : WasmI32
+```
+
+### Wasi.**_EOWNERDEAD**
+
+```grain
+_EOWNERDEAD : WasmI32
+```
+
+### Wasi.**_EPERM**
+
+```grain
+_EPERM : WasmI32
+```
+
+### Wasi.**_EPIPE**
+
+```grain
+_EPIPE : WasmI32
+```
+
+### Wasi.**_EPROTO**
+
+```grain
+_EPROTO : WasmI32
+```
+
+### Wasi.**_EPROTONOSUPPORT**
+
+```grain
+_EPROTONOSUPPORT : WasmI32
+```
+
+### Wasi.**_EPROTOTYPE**
+
+```grain
+_EPROTOTYPE : WasmI32
+```
+
+### Wasi.**_ERANGE**
+
+```grain
+_ERANGE : WasmI32
+```
+
+### Wasi.**_EROFS**
+
+```grain
+_EROFS : WasmI32
+```
+
+### Wasi.**_ESPIPE**
+
+```grain
+_ESPIPE : WasmI32
+```
+
+### Wasi.**_ESRCH**
+
+```grain
+_ESRCH : WasmI32
+```
+
+### Wasi.**_ESTALE**
+
+```grain
+_ESTALE : WasmI32
+```
+
+### Wasi.**_ETIMEDOUT**
+
+```grain
+_ETIMEDOUT : WasmI32
+```
+
+### Wasi.**_ETXTBSY**
+
+```grain
+_ETXTBSY : WasmI32
+```
+
+### Wasi.**_EXDEV**
+
+```grain
+_EXDEV : WasmI32
+```
+
+### Wasi.**_ENOTCAPABLE**
+
+```grain
+_ENOTCAPABLE : WasmI32
+```
+
+### Wasi.**stringOfSystemError**
+
+```grain
+stringOfSystemError : a -> String
+```
+

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -16,19 +16,13 @@ import Set from "set"
 ### Set.**Bucket**
 
 ```grain
-record Bucket<t> {
-  key: t,
-  next: Option<Bucket<t>>,
-}
+type Bucket<t>
 ```
 
 ### Set.**Set**
 
 ```grain
-record Set<k> {
-  size: Number,
-  buckets: Array<Option<Bucket<k>>>,
-}
+type Set<k>
 ```
 
 ### Set.**makeSized**

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -15,9 +15,7 @@ Type declarations included in the Stack module.
 ### Stack.**Stack**
 
 ```grain
-record Stack<a> {
-  data: List<a>,
-}
+type Stack<a>
 ```
 
 Stacks are immutable data structures that store their data in a List.


### PR DESCRIPTION
Closes #972

This adds a first pass at directory support in graindoc. I regenerated the stdlib to show it in action.

I'm guessing we will have some back-and-forth on the error messages (or if those should be error cases), so I wanted to get this open before the weekend.

This logic should be portable to grainformat once we decide it looks good.