### PR TITLE
chore(compiler)!: Refactor HeapAllocated/StackAllocated into Managed/Unmanaged

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -5,11 +5,11 @@ open Grain_utils;
 
 let wasm_type =
   fun
-  | Types.HeapAllocated
-  | Types.StackAllocated(WasmI32) => Type.int32
-  | Types.StackAllocated(WasmI64) => Type.int64
-  | Types.StackAllocated(WasmF32) => Type.float32
-  | Types.StackAllocated(WasmF64) => Type.float64;
+  | Types.Managed
+  | Types.Unmanaged(WasmI32) => Type.int32
+  | Types.Unmanaged(WasmI64) => Type.int64
+  | Types.Unmanaged(WasmF32) => Type.float32
+  | Types.Unmanaged(WasmF64) => Type.float64;
 
 let encoded_int32 = n => n * 2 + 1;
 

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -97,7 +97,7 @@ let required_global_imports = [
     mimp_id: reloc_base,
     mimp_mod: grain_env_mod,
     mimp_name: Ident.name(reloc_base),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), false),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), false),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: true,
@@ -106,7 +106,7 @@ let required_global_imports = [
     mimp_id: module_runtime_id,
     mimp_mod: grain_env_mod,
     mimp_name: Ident.name(module_runtime_id),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), false),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), false),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -115,7 +115,7 @@ let required_global_imports = [
     mimp_id: print_exception_closure_ident,
     mimp_mod: exception_mod,
     mimp_name: Ident.name(print_exception_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -124,7 +124,7 @@ let required_global_imports = [
     mimp_id: assertion_error_closure_ident,
     mimp_mod: exception_mod,
     mimp_name: Ident.name(assertion_error_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -133,7 +133,7 @@ let required_global_imports = [
     mimp_id: index_out_of_bounds_ident,
     mimp_mod: exception_mod,
     mimp_name: Ident.name(index_out_of_bounds_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -142,7 +142,7 @@ let required_global_imports = [
     mimp_id: match_failure_ident,
     mimp_mod: exception_mod,
     mimp_name: Ident.name(match_failure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -154,7 +154,7 @@ let grain_runtime_imports = [
     mimp_id: malloc_closure_ident,
     mimp_mod: gc_mod,
     mimp_name: Ident.name(malloc_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -163,7 +163,7 @@ let grain_runtime_imports = [
     mimp_id: incref_closure_ident,
     mimp_mod: gc_mod,
     mimp_name: Ident.name(incref_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -172,7 +172,7 @@ let grain_runtime_imports = [
     mimp_id: decref_closure_ident,
     mimp_mod: gc_mod,
     mimp_name: Ident.name(decref_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -181,7 +181,7 @@ let grain_runtime_imports = [
     mimp_id: equal_closure_ident,
     mimp_mod: equal_mod,
     mimp_name: Ident.name(equal_closure_ident),
-    mimp_type: MGlobalImport(Types.StackAllocated(WasmI32), true),
+    mimp_type: MGlobalImport(Types.Unmanaged(WasmI32), true),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -198,8 +198,8 @@ let required_function_imports = [
     mimp_name: Ident.name(print_exception_ident),
     mimp_type:
       MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Unmanaged(WasmI32), Types.Unmanaged(WasmI32)],
+        [Types.Unmanaged(WasmI32)],
       ),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -211,8 +211,8 @@ let required_function_imports = [
     mimp_name: Ident.name(assertion_error_ident),
     mimp_type:
       MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Unmanaged(WasmI32), Types.Unmanaged(WasmI32)],
+        [Types.Unmanaged(WasmI32)],
       ),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -227,8 +227,8 @@ let grain_function_imports = [
     mimp_name: Ident.name(malloc_ident),
     mimp_type:
       MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Unmanaged(WasmI32), Types.Unmanaged(WasmI32)],
+        [Types.Unmanaged(WasmI32)],
       ),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -240,8 +240,8 @@ let grain_function_imports = [
     mimp_name: Ident.name(incref_ident),
     mimp_type:
       MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Unmanaged(WasmI32), Types.Unmanaged(WasmI32)],
+        [Types.Unmanaged(WasmI32)],
       ), /* Returns same pointer as argument */
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -253,8 +253,8 @@ let grain_function_imports = [
     mimp_name: Ident.name(decref_ident),
     mimp_type:
       MFuncImport(
-        [Types.StackAllocated(WasmI32), Types.StackAllocated(WasmI32)],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Unmanaged(WasmI32), Types.Unmanaged(WasmI32)],
+        [Types.Unmanaged(WasmI32)],
       ), /* Returns same pointer as argument */
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -264,7 +264,7 @@ let grain_function_imports = [
     mimp_id: tracepoint_ident,
     mimp_mod: console_mod,
     mimp_name: Ident.name(tracepoint_ident),
-    mimp_type: MFuncImport([Types.StackAllocated(WasmI32)], []),
+    mimp_type: MFuncImport([Types.Unmanaged(WasmI32)], []),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
     mimp_used: false,
@@ -275,8 +275,8 @@ let grain_function_imports = [
     mimp_name: Ident.name(equal_ident),
     mimp_type:
       MFuncImport(
-        [Types.HeapAllocated, Types.HeapAllocated, Types.HeapAllocated],
-        [Types.StackAllocated(WasmI32)],
+        [Types.Managed, Types.Managed, Types.Managed],
+        [Types.Unmanaged(WasmI32)],
       ),
     mimp_kind: MImportWasm,
     mimp_setup: MSetupNone,
@@ -507,7 +507,7 @@ let cleanup_local_slot_instructions = (wasm_mod, env: codegen_env, argtypes) => 
         // <arg0> <arg1> <...> <argN> <swap0> <swap1> <...> <swapN> <local1> <local2> <...> <localN>
         // |-----[env.num_args]-----| |----[len(swap_slots)]------|
         switch (arg) {
-        | Types.HeapAllocated =>
+        | Types.Managed =>
           let arg = Expression.Local_get.make(wasm_mod, i, Type.int32);
           Some(
             singleton @@
@@ -536,11 +536,11 @@ let cleanup_local_slot_instructions = (wasm_mod, env: codegen_env, argtypes) => 
 };
 let should_refcount = b =>
   switch (b) {
-  | MArgBind(_, Types.HeapAllocated)
-  | MLocalBind(_, Types.HeapAllocated)
-  | MSwapBind(_, Types.HeapAllocated)
+  | MArgBind(_, Types.Managed)
+  | MLocalBind(_, Types.Managed)
+  | MSwapBind(_, Types.Managed)
   | MClosureBind(_)
-  | MGlobalBind(_, Types.HeapAllocated) => true
+  | MGlobalBind(_, Types.Managed) => true
   | MArgBind(_)
   | MLocalBind(_)
   | MSwapBind(_)
@@ -645,11 +645,11 @@ let compile_bind =
     /* No adjustments are needed for argument bindings */
     let typ =
       switch (alloc) {
-      | Types.HeapAllocated
-      | Types.StackAllocated(WasmI32) => Type.int32
-      | Types.StackAllocated(WasmI64) => Type.int64
-      | Types.StackAllocated(WasmF32) => Type.float32
-      | Types.StackAllocated(WasmF64) => Type.float64
+      | Types.Managed
+      | Types.Unmanaged(WasmI32) => Type.int32
+      | Types.Unmanaged(WasmI64) => Type.int64
+      | Types.Unmanaged(WasmF32) => Type.float32
+      | Types.Unmanaged(WasmF64) => Type.float64
       };
     let slot = Int32.to_int(i);
     switch (action) {
@@ -661,18 +661,18 @@ let compile_bind =
     /* Local bindings need to be offset to account for arguments and swap variables */
     let (typ, slot) =
       switch (alloc) {
-      | Types.HeapAllocated => (
+      | Types.Managed => (
           Type.int32,
           env.num_args + Array.length(swap_slots) + Int32.to_int(i),
         )
-      | Types.StackAllocated(WasmI32) => (
+      | Types.Unmanaged(WasmI32) => (
           Type.int32,
           env.num_args
           + Array.length(swap_slots)
           + env.stack_size.stack_size_ptr
           + Int32.to_int(i),
         )
-      | Types.StackAllocated(WasmI64) => (
+      | Types.Unmanaged(WasmI64) => (
           Type.int64,
           env.num_args
           + Array.length(swap_slots)
@@ -680,7 +680,7 @@ let compile_bind =
           + env.stack_size.stack_size_i32
           + Int32.to_int(i),
         )
-      | Types.StackAllocated(WasmF32) => (
+      | Types.Unmanaged(WasmF32) => (
           Type.float32,
           env.num_args
           + Array.length(swap_slots)
@@ -689,7 +689,7 @@ let compile_bind =
           + env.stack_size.stack_size_i64
           + Int32.to_int(i),
         )
-      | Types.StackAllocated(WasmF64) => (
+      | Types.Unmanaged(WasmF64) => (
           Type.float64,
           env.num_args
           + Array.length(swap_slots)
@@ -791,7 +791,7 @@ let safe_drop = (wasm_mod, env, arg) =>
 
 let get_swap =
     (
-      ~ty as typ=Types.StackAllocated(WasmI32),
+      ~ty as typ=Types.Unmanaged(WasmI32),
       ~skip_incref=true,
       ~skip_decref=true,
       wasm_mod,
@@ -799,8 +799,8 @@ let get_swap =
       idx,
     ) =>
   switch (typ) {
-  | Types.HeapAllocated
-  | Types.StackAllocated(WasmI32) =>
+  | Types.Managed
+  | Types.Unmanaged(WasmI32) =>
     if (idx > Array.length(swap_slots_i32)) {
       raise(Not_found);
     };
@@ -812,7 +812,7 @@ let get_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i32_offset), typ),
     );
-  | Types.StackAllocated(WasmI64) =>
+  | Types.Unmanaged(WasmI64) =>
     if (idx > Array.length(swap_slots_i64)) {
       raise(Not_found);
     };
@@ -824,7 +824,7 @@ let get_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i64_offset), typ),
     );
-  | Types.StackAllocated(WasmF32) =>
+  | Types.Unmanaged(WasmF32) =>
     if (idx > Array.length(swap_slots_f32)) {
       raise(Not_found);
     };
@@ -836,7 +836,7 @@ let get_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_f32_offset), typ),
     );
-  | Types.StackAllocated(WasmF64) =>
+  | Types.Unmanaged(WasmF64) =>
     if (idx > Array.length(swap_slots_f64)) {
       raise(Not_found);
     };
@@ -854,15 +854,15 @@ let set_swap =
     (
       ~skip_incref=true,
       ~skip_decref=true,
-      ~ty as typ=Types.StackAllocated(WasmI32),
+      ~ty as typ=Types.Unmanaged(WasmI32),
       wasm_mod,
       env,
       idx,
       arg,
     ) =>
   switch (typ) {
-  | Types.HeapAllocated
-  | Types.StackAllocated(WasmI32) =>
+  | Types.Managed
+  | Types.Unmanaged(WasmI32) =>
     if (idx > Array.length(swap_slots_i32)) {
       raise(Not_found);
     };
@@ -874,7 +874,7 @@ let set_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i32_offset), typ),
     );
-  | Types.StackAllocated(WasmI64) =>
+  | Types.Unmanaged(WasmI64) =>
     if (idx > Array.length(swap_slots_i64)) {
       raise(Not_found);
     };
@@ -886,7 +886,7 @@ let set_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i64_offset), typ),
     );
-  | Types.StackAllocated(WasmF32) =>
+  | Types.Unmanaged(WasmF32) =>
     if (idx > Array.length(swap_slots_f32)) {
       raise(Not_found);
     };
@@ -898,7 +898,7 @@ let set_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_f32_offset), typ),
     );
-  | Types.StackAllocated(WasmF64) =>
+  | Types.Unmanaged(WasmF64) =>
     if (idx > Array.length(swap_slots_f64)) {
       raise(Not_found);
     };
@@ -914,7 +914,7 @@ let set_swap =
 
 let tee_swap =
     (
-      ~ty as typ=Types.StackAllocated(WasmI32),
+      ~ty as typ=Types.Unmanaged(WasmI32),
       ~skip_incref=true,
       ~skip_decref=true,
       wasm_mod,
@@ -923,8 +923,8 @@ let tee_swap =
       arg,
     ) =>
   switch (typ) {
-  | Types.HeapAllocated
-  | Types.StackAllocated(WasmI32) =>
+  | Types.Managed
+  | Types.Unmanaged(WasmI32) =>
     if (idx > Array.length(swap_slots_i32)) {
       raise(Not_found);
     };
@@ -936,7 +936,7 @@ let tee_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i32_offset), typ),
     );
-  | Types.StackAllocated(WasmI64) =>
+  | Types.Unmanaged(WasmI64) =>
     if (idx > Array.length(swap_slots_i64)) {
       raise(Not_found);
     };
@@ -948,7 +948,7 @@ let tee_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_i64_offset), typ),
     );
-  | Types.StackAllocated(WasmF32) =>
+  | Types.Unmanaged(WasmF32) =>
     if (idx > Array.length(swap_slots_f32)) {
       raise(Not_found);
     };
@@ -960,7 +960,7 @@ let tee_swap =
       env,
       MSwapBind(Int32.of_int(idx + swap_f32_offset), typ),
     );
-  | Types.StackAllocated(WasmF64) =>
+  | Types.Unmanaged(WasmF64) =>
     if (idx > Array.length(swap_slots_f64)) {
       raise(Not_found);
     };
@@ -1619,7 +1619,7 @@ let call_lambda =
           Type.create @@
           Array.map(
             wasm_type,
-            Array.of_list([Types.StackAllocated(WasmI32), ...argsty]),
+            Array.of_list([Types.Unmanaged(WasmI32), ...argsty]),
           ),
           retty,
         ),
@@ -3007,11 +3007,11 @@ and compile_switch = (wasm_mod, env, arg, branches, default, ty) => {
       // This default value is never used, but is necessary to make the wasm types work out
       let default_value =
         switch (ty) {
-        | Types.HeapAllocated
-        | Types.StackAllocated(WasmI32) => const_int32(0)
-        | Types.StackAllocated(WasmI64) => const_int64(0)
-        | Types.StackAllocated(WasmF32) => const_float32(0.)
-        | Types.StackAllocated(WasmF64) => const_float64(0.)
+        | Types.Managed
+        | Types.Unmanaged(WasmI32) => const_int32(0)
+        | Types.Unmanaged(WasmI64) => const_int64(0)
+        | Types.Unmanaged(WasmF32) => const_float32(0.)
+        | Types.Unmanaged(WasmF64) => const_float64(0.)
         };
       let default_value = Expression.Const.make(wasm_mod, default_value);
       let inner_block_body =
@@ -3099,7 +3099,7 @@ and compile_instr = (wasm_mod, env, instr) =>
   switch (instr.instr_desc) {
   | MDrop(arg, ty) =>
     switch (ty) {
-    | HeapAllocated =>
+    | Managed =>
       Expression.Drop.make(
         wasm_mod,
         call_decref(wasm_mod, env, compile_instr(wasm_mod, env, arg)),
@@ -3650,11 +3650,11 @@ let compile_tables = (wasm_mod, env, {function_table_elements}) => {
 let compile_globals = (wasm_mod, env, {globals} as prog) => {
   let initial_value =
     fun
-    | Types.HeapAllocated
-    | Types.StackAllocated(WasmI32) => const_int32(0)
-    | Types.StackAllocated(WasmI64) => const_int64(0)
-    | Types.StackAllocated(WasmF32) => const_float32(0.)
-    | Types.StackAllocated(WasmF64) => const_float64(0.);
+    | Types.Managed
+    | Types.Unmanaged(WasmI32) => const_int32(0)
+    | Types.Unmanaged(WasmI64) => const_int64(0)
+    | Types.Unmanaged(WasmF32) => const_float32(0.)
+    | Types.Unmanaged(WasmF64) => const_float64(0.);
   List.iter(
     ((id, ty)) =>
       ignore @@
@@ -3741,7 +3741,7 @@ let compile_main = (wasm_mod, env, prog) => {
       id: Ident.create(grain_main),
       name: Some(grain_main),
       args: [],
-      return_type: [Types.StackAllocated(WasmI32)],
+      return_type: [Types.Unmanaged(WasmI32)],
       body: prog.main_body,
       stack_size: prog.main_body_stack_size,
       attrs: [],

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -12,7 +12,7 @@ type attributes = Typedtree.attributes;
 let default_loc = Location.dummy_loc;
 let default_env = Env.empty;
 let default_attributes = [];
-let default_allocation_type = HeapAllocated;
+let default_allocation_type = Managed;
 
 let or_default_loc = Option.value(~default=default_loc);
 let or_default_env = Option.value(~default=default_env);
@@ -44,45 +44,15 @@ module Comp = {
   let imm = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, imm) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CImmExpr(imm));
   let number = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CNumber(i),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CNumber(i));
   let int32 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CInt32(i),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CInt32(i));
   let int64 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CInt64(i),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CInt64(i));
   let float32 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CFloat32(i),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CFloat32(i));
   let float64 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CFloat64(i),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CFloat64(i));
   let prim0 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p0) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim0(p0));
   let prim1 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p1, a) =>
@@ -98,21 +68,9 @@ module Comp = {
   let assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CAssign(a1, a2));
   let tuple = (~loc=?, ~attributes=?, ~env=?, elts) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CTuple(elts),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CTuple(elts));
   let array = (~loc=?, ~attributes=?, ~env=?, elts) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CArray(elts),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CArray(elts));
   let array_get = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, arr, i) =>
     mk(~loc?, ~attributes?, ~allocation_type, ~env?, CArrayGet(arr, i));
   let array_set = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, arr, i, a) =>
@@ -121,7 +79,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=HeapAllocated,
+      ~allocation_type=Managed,
       ~env?,
       CRecord(ttag, elts),
     );
@@ -129,7 +87,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=HeapAllocated,
+      ~allocation_type=Managed,
       ~env?,
       CAdt(ttag, vtag, elts),
     );
@@ -162,7 +120,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=StackAllocated(WasmI32),
+      ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CGetAdtTag(value),
     );
@@ -190,7 +148,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=StackAllocated(WasmI32),
+      ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CFor(cond, inc, body),
     );
@@ -198,7 +156,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=StackAllocated(WasmI32),
+      ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CContinue,
     );
@@ -206,7 +164,7 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=StackAllocated(WasmI32),
+      ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CBreak,
     );
@@ -251,28 +209,16 @@ module Comp = {
     mk(
       ~loc?,
       ~attributes?,
-      ~allocation_type=HeapAllocated,
+      ~allocation_type=Managed,
       ~env?,
       CLambda(name, args, body),
     );
   let bytes = (~loc=?, ~attributes=?, ~env=?, b) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CBytes(b),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CBytes(b));
   let string = (~loc=?, ~attributes=?, ~env=?, s) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type=HeapAllocated,
-      ~env?,
-      CString(s),
-    );
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CString(s));
   let char = (~loc=?, ~attributes=?, ~env=?, c) =>
-    mk(~loc?, ~attributes?, ~allocation_type=HeapAllocated, ~env?, CChar(c));
+    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CChar(c));
 };
 
 module AExp = {

--- a/compiler/src/middle_end/anf_utils.re
+++ b/compiler/src/middle_end/anf_utils.re
@@ -187,27 +187,15 @@ let rec anf_count_vars = a =>
     let rec count_binds = (ptr, i32, i64, f32, f64, binds) => {
       switch (global, binds) {
       | (Global, [_, ...rest]) => count_binds(ptr, i32, i64, f32, f64, rest)
-      | (_, [(_, {comp_allocation_type: HeapAllocated}), ...rest]) =>
+      | (_, [(_, {comp_allocation_type: Managed}), ...rest]) =>
         count_binds(ptr + 1, i32, i64, f32, f64, rest)
-      | (
-          _,
-          [(_, {comp_allocation_type: StackAllocated(WasmI32)}), ...rest],
-        ) =>
+      | (_, [(_, {comp_allocation_type: Unmanaged(WasmI32)}), ...rest]) =>
         count_binds(ptr, i32 + 1, i64, f32, f64, rest)
-      | (
-          _,
-          [(_, {comp_allocation_type: StackAllocated(WasmI64)}), ...rest],
-        ) =>
+      | (_, [(_, {comp_allocation_type: Unmanaged(WasmI64)}), ...rest]) =>
         count_binds(ptr, i32, i64 + 1, f32, f64, rest)
-      | (
-          _,
-          [(_, {comp_allocation_type: StackAllocated(WasmF32)}), ...rest],
-        ) =>
+      | (_, [(_, {comp_allocation_type: Unmanaged(WasmF32)}), ...rest]) =>
         count_binds(ptr, i32, i64, f32 + 1, f64, rest)
-      | (
-          _,
-          [(_, {comp_allocation_type: StackAllocated(WasmF64)}), ...rest],
-        ) =>
+      | (_, [(_, {comp_allocation_type: Unmanaged(WasmF64)}), ...rest]) =>
         count_binds(ptr, i32, i64, f32, f64 + 1, rest)
       | (_, []) => (ptr, i32, i64, f32, f64)
       };

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -737,7 +737,7 @@ module MatchTreeCompiler = {
           BSeq(
             Comp.assign(
               ~env,
-              ~allocation_type=HeapAllocated,
+              ~allocation_type=Managed,
               Imm.id(name),
               Imm.id(value),
             ),
@@ -746,7 +746,7 @@ module MatchTreeCompiler = {
           BSeq(
             Comp.local_assign(
               ~env,
-              ~allocation_type=HeapAllocated,
+              ~allocation_type=Managed,
               name,
               Imm.id(value),
             ),
@@ -816,7 +816,7 @@ module MatchTreeCompiler = {
       let env = expr.imm_env;
       (
         Comp.imm(
-          ~allocation_type=StackAllocated(WasmI32),
+          ~allocation_type=Unmanaged(WasmI32),
           Imm.const(Const_number(Const_number_int(Int64.of_int(i)))),
         ),
         get_bindings(~mut_boxing, env, patterns, values, aliases),
@@ -886,7 +886,7 @@ module MatchTreeCompiler = {
         };
       let cond =
         Comp.prim2(
-          ~allocation_type=StackAllocated(WasmI32),
+          ~allocation_type=Unmanaged(WasmI32),
           equality_op,
           cur_value,
           const,
@@ -918,7 +918,7 @@ module MatchTreeCompiler = {
       let alias_binding =
         BLet(
           alias,
-          Comp.imm(~allocation_type=HeapAllocated, cur_value),
+          Comp.imm(~allocation_type=Managed, cur_value),
           Nonglobal,
         );
 
@@ -932,7 +932,7 @@ module MatchTreeCompiler = {
         [alias_binding, ...cond_setup],
       );
     | Fail => (
-        Comp.imm(~allocation_type=StackAllocated(WasmI32), Imm.trap()),
+        Comp.imm(~allocation_type=Unmanaged(WasmI32), Imm.trap()),
         [],
       )
     | Explode(matrix_type, alias, rest) =>
@@ -953,7 +953,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.adt_get(
-                  ~allocation_type=HeapAllocated,
+                  ~allocation_type=Managed,
                   Int32.of_int(idx),
                   cur_value,
                 ),
@@ -971,7 +971,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.tuple_get(
-                  ~allocation_type=HeapAllocated,
+                  ~allocation_type=Managed,
                   Int32.of_int(idx),
                   cur_value,
                 ),
@@ -987,7 +987,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.array_get(
-                  ~allocation_type=HeapAllocated,
+                  ~allocation_type=Managed,
                   Imm.const(
                     Const_number(Const_number_int(Int64.of_int(idx))),
                   ),
@@ -1006,7 +1006,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.record_get(
-                  ~allocation_type=HeapAllocated,
+                  ~allocation_type=Managed,
                   Int32.of_int(label_pos),
                   cur_value,
                 ),
@@ -1035,7 +1035,7 @@ module MatchTreeCompiler = {
       let bindings = [
         BLet(
           alias,
-          Comp.imm(~allocation_type=HeapAllocated, cur_value),
+          Comp.imm(~allocation_type=Managed, cur_value),
           Nonglobal,
         ),
         ...bindings,
@@ -1088,7 +1088,7 @@ module MatchTreeCompiler = {
         | ConstructorSwitch => Comp.adt_get_tag(cur_value)
         | ArraySwitch =>
           Comp.prim1(
-            ~allocation_type=StackAllocated(WasmI32),
+            ~allocation_type=Unmanaged(WasmI32),
             ArrayLength,
             cur_value,
           )
@@ -1106,7 +1106,7 @@ module MatchTreeCompiler = {
               BLet(
                 cmp_id_name,
                 Comp.prim2(
-                  ~allocation_type=StackAllocated(WasmI32),
+                  ~allocation_type=Unmanaged(WasmI32),
                   Is,
                   value_constr_id,
                   Imm.const(
@@ -1156,7 +1156,7 @@ module MatchTreeCompiler = {
         if (mut_boxing) {
           BLet(
             id,
-            Comp.prim1(~allocation_type=HeapAllocated, BoxBind, dummy_value),
+            Comp.prim1(~allocation_type=Managed, BoxBind, dummy_value),
             Nonglobal,
           );
         } else {

--- a/compiler/src/typed/builtin_types.re
+++ b/compiler/src/typed/builtin_types.re
@@ -108,12 +108,12 @@ let decl_abstr = path => {
   type_path: path,
   type_manifest: None,
   type_newtype_level: Some((0, 0)),
-  type_allocation: HeapAllocated,
+  type_allocation: Managed,
 };
 
 let decl_abstr_imm = (repr, path) => {
   ...decl_abstr(path),
-  type_allocation: StackAllocated(repr),
+  type_allocation: Unmanaged(repr),
 };
 
 let cstr = (id, args) => {

--- a/compiler/src/typed/ctype.re
+++ b/compiler/src/typed/ctype.re
@@ -851,7 +851,7 @@ let new_declaration = (newtype, manifest) => {
   type_newtype_level: newtype,
   type_loc: Location.dummy_loc,
   type_path: PIdent({stamp: (-1), name: "", flags: 0}),
-  type_allocation: HeapAllocated,
+  type_allocation: Managed,
 };
 
 let instance_constructor = (~in_pattern=?, cstr) => {
@@ -3304,7 +3304,7 @@ let maybe_pointer_type = (env, typ) =>
   | TTyConstr(p, _args, _abbrev) =>
     try({
       let type_decl = Env.find_type(p, env);
-      type_decl.type_allocation == HeapAllocated;
+      type_decl.type_allocation == Managed;
     }) {
     | Not_found => true
     /* This can happen due to e.g. missing -I options,

--- a/compiler/src/typed/includecore.re
+++ b/compiler/src/typed/includecore.re
@@ -440,8 +440,8 @@ let type_declarations =
            * must be immediate, then we error */
           let err =
             if (abstr
-                && decl1.type_allocation == HeapAllocated
-                && decl2.type_allocation != HeapAllocated) {
+                && decl1.type_allocation == Managed
+                && decl2.type_allocation != Managed) {
               [Immediate];
             } else {
               [];

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -1041,7 +1041,7 @@ let dummy = {
   type_newtype_level: None,
   type_loc: Location.dummy_loc,
   type_path: PIdent({stamp: (-1), name: "", flags: 0}),
-  type_allocation: HeapAllocated,
+  type_allocation: Managed,
 };
 
 let hide_rec_items =

--- a/compiler/src/typed/type_utils.re
+++ b/compiler/src/typed/type_utils.re
@@ -10,7 +10,7 @@ let rec get_allocation_type = (env, ty) => {
   | TTyTuple(_)
   | TTyRecord(_)
   | TTyUniVar(_)
-  | TTyPoly(_) => HeapAllocated
+  | TTyPoly(_) => Managed
   };
 };
 
@@ -78,13 +78,13 @@ let rec returns_void = ty => {
 
 let wasm_repr_of_allocation_type = alloc_type => {
   switch (alloc_type) {
-  | StackAllocated(repr) => repr
-  | HeapAllocated => WasmI32
+  | Unmanaged(repr) => repr
+  | Managed => WasmI32
   };
 };
 
 let allocation_type_of_wasm_repr = repr => {
-  StackAllocated(repr);
+  Unmanaged(repr);
 };
 
 let repr_of_type = (env, ty) =>

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -97,7 +97,7 @@ let enter_type = (rec_flag, env, sdecl, id) => {
       type_newtype_level: None,
       type_loc: sdecl.pdata_loc,
       type_path: PIdent(id),
-      type_allocation: HeapAllocated,
+      type_allocation: Managed,
     };
 
     Env.add_type(~check=true, id, decl, env);
@@ -346,7 +346,7 @@ let transl_declaration = (env, sdecl, id) => {
     type_newtype_level: None,
     type_loc: sdecl.pdata_loc,
     type_path: PIdent(id),
-    type_allocation: HeapAllocated,
+    type_allocation: Managed,
   };
 
   /* Check constraints */

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -115,8 +115,8 @@ type value_kind =
 
 [@deriving (sexp, yojson)]
 type allocation_type =
-  | StackAllocated(wasm_repr)
-  | HeapAllocated
+  | Unmanaged(wasm_repr)
+  | Managed
 
 [@deriving (sexp, yojson)]
 and wasm_repr =

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -116,5 +116,5 @@ enums › adt_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 504
+ ;; custom section \"cmi\", size 498
 )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -565,5 +565,5 @@ enums › enum_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 872
+ ;; custom section \"cmi\", size 860
 )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -298,5 +298,5 @@ functions › func_record_associativity2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 763
+ ;; custom section \"cmi\", size 751
 )

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -215,5 +215,5 @@ functions › func_record_associativity1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 510
+ ;; custom section \"cmi\", size 504
 )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -291,5 +291,5 @@ pattern matching › record_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 498
+ ;; custom section \"cmi\", size 492
 )

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -312,5 +312,5 @@ pattern matching › adt_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 498
+ ;; custom section \"cmi\", size 492
 )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -253,5 +253,5 @@ pattern matching › record_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 498
+ ;; custom section \"cmi\", size 492
 )

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -253,5 +253,5 @@ pattern matching › record_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 498
+ ;; custom section \"cmi\", size 492
 )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -385,5 +385,5 @@ pattern matching › record_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 498
+ ;; custom section \"cmi\", size 492
 )

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -274,5 +274,5 @@ pattern matching › record_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 756
+ ;; custom section \"cmi\", size 744
 )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -199,5 +199,5 @@ records › record_get_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 503
+ ;; custom section \"cmi\", size 497
 )

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -100,5 +100,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 815
+ ;; custom section \"cmi\", size 809
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -100,5 +100,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 799
+ ;; custom section \"cmi\", size 793
 )

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -247,5 +247,5 @@ records › record_destruct_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 501
+ ;; custom section \"cmi\", size 495
 )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -367,5 +367,5 @@ records › record_destruct_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 501
+ ;; custom section \"cmi\", size 495
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -100,5 +100,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 810
+ ;; custom section \"cmi\", size 804
 )

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -279,5 +279,5 @@ records › record_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 768
+ ;; custom section \"cmi\", size 756
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1118
+ ;; custom section \"cmi\", size 1112
 )

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -247,5 +247,5 @@ records › record_destruct_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 501
+ ;; custom section \"cmi\", size 495
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -100,5 +100,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 808
+ ;; custom section \"cmi\", size 802
 )

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -268,5 +268,5 @@ records › record_destruct_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 759
+ ;; custom section \"cmi\", size 747
 )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -279,5 +279,5 @@ records › record_destruct_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 501
+ ;; custom section \"cmi\", size 495
 )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -225,5 +225,5 @@ records › record_get_multilevel
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 762
+ ;; custom section \"cmi\", size 750
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -166,5 +166,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1441
+ ;; custom section \"cmi\", size 1435
 )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -130,5 +130,5 @@ records › record_get_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 496
+ ;; custom section \"cmi\", size 490
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1109
+ ;; custom section \"cmi\", size 1103
 )

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -367,5 +367,5 @@ records › record_destruct_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 508
+ ;; custom section \"cmi\", size 502
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1111
+ ;; custom section \"cmi\", size 1105
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -166,5 +166,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1435
+ ;; custom section \"cmi\", size 1429
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -100,5 +100,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 809
+ ;; custom section \"cmi\", size 803
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1112
+ ;; custom section \"cmi\", size 1106
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1121
+ ;; custom section \"cmi\", size 1115
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -166,5 +166,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1436
+ ;; custom section \"cmi\", size 1430
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -112,5 +112,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1120
+ ;; custom section \"cmi\", size 1114
 )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -294,5 +294,5 @@ stdlib › stdlib_equal_20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 499
+ ;; custom section \"cmi\", size 493
 )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -294,5 +294,5 @@ stdlib › stdlib_equal_19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 499
+ ;; custom section \"cmi\", size 493
 )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -294,5 +294,5 @@ stdlib › stdlib_equal_21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 499
+ ;; custom section \"cmi\", size 493
 )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -294,5 +294,5 @@ stdlib › stdlib_equal_22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 499
+ ;; custom section \"cmi\", size 493
 )

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -76,7 +76,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{ if (true) {4} else {5} }",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(4L))),
       ),
     ),
@@ -86,7 +86,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{ if (false) {4} else {5} }",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(5L))),
       ),
     ),
@@ -96,7 +96,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{ let x = true; if (x) {4} else {5} }",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(4L))),
       ),
     ),
@@ -106,7 +106,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{let x = if (true) {4} else {5}; x}",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(4L))),
       ),
     ),
@@ -121,7 +121,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{\n    let x = 4;\n    let y = x;\n    x}",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(4L))),
       ),
     ),
@@ -135,15 +135,15 @@ describe("optimizations", ({test, testSkip}) => {
       let x = Ident.create("lambda_arg");
       AExp.comp(
         Comp.lambda(
-          [(x, HeapAllocated)],
+          [(x, Managed)],
           (
             AExp.comp(
               Comp.imm(
-                ~allocation_type=HeapAllocated,
+                ~allocation_type=Managed,
                 Imm.const(Const_number(Const_number_int(4L))),
               ),
             ),
-            HeapAllocated,
+            Managed,
           ),
         ),
       );
@@ -155,7 +155,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{\n  let x = 5;\n  let y = 12;\n  let z = y;\n  {\n    let y = x;\n    x\n  }\n  x + y}",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(17L))),
       ),
     ),
@@ -166,7 +166,7 @@ describe("optimizations", ({test, testSkip}) => {
     "{\n    let x = 4 + 5;\n    let y = x * 2;\n    let z = y - x;\n    let a = x + 7;\n    let b = 14;\n    a + b}",
     AExp.comp(
       Comp.imm(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         Imm.const(Const_number(Const_number_int(30L))),
       ),
     ),
@@ -178,14 +178,14 @@ describe("optimizations", ({test, testSkip}) => {
       open Grain_typed;
       let arg = Ident.create("lambda_arg");
       AExp.comp(
-        Comp.lambda([(arg, HeapAllocated)]) @@
+        Comp.lambda([(arg, Managed)]) @@
         (
           AExp.comp @@
           Comp.tuple([
             Imm.id(arg),
             Imm.const(Const_number(Const_number_int(1L))),
           ]),
-          HeapAllocated,
+          Managed,
         ),
       );
     },
@@ -198,15 +198,15 @@ describe("optimizations", ({test, testSkip}) => {
       let x = Ident.create("lambda_arg");
       AExp.comp(
         Comp.lambda(
-          [(x, HeapAllocated)],
+          [(x, Managed)],
           (
             AExp.comp(
               Comp.imm(
-                ~allocation_type=HeapAllocated,
+                ~allocation_type=Managed,
                 Imm.const(Const_number(Const_number_int(1L))),
               ),
             ),
-            HeapAllocated,
+            Managed,
           ),
         ),
       );
@@ -236,7 +236,7 @@ describe("optimizations", ({test, testSkip}) => {
                     (
                       x,
                       Comp.imm(
-                        ~allocation_type=HeapAllocated,
+                        ~allocation_type=Managed,
                         Imm.const(Const_number(Const_number_int(5L))),
                       ),
                     ),
@@ -244,19 +244,19 @@ describe("optimizations", ({test, testSkip}) => {
                 ) @@
                 AExp.comp(
                   Comp.local_assign(
-                    ~allocation_type=StackAllocated(WasmI32),
+                    ~allocation_type=Unmanaged(WasmI32),
                     x,
                     Imm.const(Const_number(Const_number_int(6L))),
                   ),
                 ),
-                StackAllocated(WasmI32),
+                Unmanaged(WasmI32),
               ),
             ),
           ),
         ],
         AExp.comp(
           Comp.imm(
-            ~allocation_type=StackAllocated(WasmI32),
+            ~allocation_type=Unmanaged(WasmI32),
             Imm.const(Const_void),
           ),
         ),
@@ -287,7 +287,7 @@ describe("optimizations", ({test, testSkip}) => {
                     (
                       x,
                       Comp.prim1(
-                        ~allocation_type=HeapAllocated,
+                        ~allocation_type=Managed,
                         BoxBind,
                         Imm.const(Const_number(Const_number_int(5L))),
                       ),
@@ -304,12 +304,12 @@ describe("optimizations", ({test, testSkip}) => {
                         (
                           AExp.comp(
                             Comp.prim1(
-                              ~allocation_type=HeapAllocated,
+                              ~allocation_type=Managed,
                               UnboxBind,
                               Imm.id(x),
                             ),
                           ),
-                          HeapAllocated,
+                          Managed,
                         ),
                       ),
                     ),
@@ -318,19 +318,19 @@ describe("optimizations", ({test, testSkip}) => {
                 AExp.comp(
                   Comp.app(
                     ~tail=true,
-                    ~allocation_type=HeapAllocated,
-                    (Imm.id(foo), ([], HeapAllocated)),
+                    ~allocation_type=Managed,
+                    (Imm.id(foo), ([], Managed)),
                     [],
                   ),
                 ),
-                HeapAllocated,
+                Managed,
               ),
             ),
           ),
         ],
         AExp.comp(
           Comp.imm(
-            ~allocation_type=StackAllocated(WasmI32),
+            ~allocation_type=Unmanaged(WasmI32),
             Imm.const(Const_void),
           ),
         ),
@@ -352,12 +352,10 @@ describe("optimizations", ({test, testSkip}) => {
         [
           (
             foo,
-            Comp.lambda([(arg, HeapAllocated)]) @@
+            Comp.lambda([(arg, Managed)]) @@
             (
-              AExp.comp @@
-              Comp.imm(~allocation_type=HeapAllocated) @@
-              Imm.id(arg),
-              HeapAllocated,
+              AExp.comp @@ Comp.imm(~allocation_type=Managed) @@ Imm.id(arg),
+              Managed,
             ),
           ),
         ],
@@ -368,8 +366,8 @@ describe("optimizations", ({test, testSkip}) => {
           (
             app,
             Comp.app(
-              ~allocation_type=HeapAllocated,
-              (Imm.id(foo), ([HeapAllocated], HeapAllocated)),
+              ~allocation_type=Managed,
+              (Imm.id(foo), ([Managed], Managed)),
               [Imm.const(Const_number(Const_number_int(3L)))],
             ),
           ),
@@ -377,9 +375,9 @@ describe("optimizations", ({test, testSkip}) => {
       ) @@
       AExp.comp @@
       Comp.app(
-        ~allocation_type=HeapAllocated,
+        ~allocation_type=Managed,
         ~tail=true,
-        (Imm.id(plus), ([HeapAllocated, HeapAllocated], HeapAllocated)),
+        (Imm.id(plus), ([Managed, Managed], Managed)),
         [Imm.id(app), Imm.const(Const_number(Const_number_int(5L)))],
       );
     },
@@ -448,11 +446,7 @@ describe("optimizations", ({test, testSkip}) => {
             Comp.lambda(
               ~name=Ident.name(foo),
               ~attributes=[Disable_gc],
-              [
-                (arg, HeapAllocated),
-                (arg, HeapAllocated),
-                (arg, HeapAllocated),
-              ],
+              [(arg, Managed), (arg, Managed), (arg, Managed)],
               (
                 AExp.let_(
                   Nonrecursive,
@@ -460,28 +454,22 @@ describe("optimizations", ({test, testSkip}) => {
                     (
                       app,
                       Comp.app(
-                        ~allocation_type=HeapAllocated,
-                        (
-                          Imm.id(plus),
-                          ([HeapAllocated, HeapAllocated], HeapAllocated),
-                        ),
+                        ~allocation_type=Managed,
+                        (Imm.id(plus), ([Managed, Managed], Managed)),
                         [Imm.id(arg), Imm.id(arg)],
                       ),
                     ),
                   ],
                   AExp.comp(
                     Comp.app(
-                      ~allocation_type=HeapAllocated,
+                      ~allocation_type=Managed,
                       ~tail=true,
-                      (
-                        Imm.id(plus),
-                        ([HeapAllocated, HeapAllocated], HeapAllocated),
-                      ),
+                      (Imm.id(plus), ([Managed, Managed], Managed)),
                       [Imm.id(app), Imm.id(arg)],
                     ),
                   ),
                 ),
-                HeapAllocated,
+                Managed,
               ),
             ),
           ),
@@ -489,7 +477,7 @@ describe("optimizations", ({test, testSkip}) => {
       ) @@
       AExp.comp(
         Comp.imm(
-          ~allocation_type=StackAllocated(WasmI32),
+          ~allocation_type=Unmanaged(WasmI32),
           Imm.const(Const_void),
         ),
       );
@@ -526,16 +514,16 @@ describe("optimizations", ({test, testSkip}) => {
               (
                 AExp.seq(
                   Comp.app(
-                    ~allocation_type=StackAllocated(WasmI32),
+                    ~allocation_type=Unmanaged(WasmI32),
                     (
                       Imm.id(fill),
                       (
                         [
-                          StackAllocated(WasmI32),
-                          StackAllocated(WasmI32),
-                          StackAllocated(WasmI32),
+                          Unmanaged(WasmI32),
+                          Unmanaged(WasmI32),
+                          Unmanaged(WasmI32),
                         ],
-                        StackAllocated(WasmI32),
+                        Unmanaged(WasmI32),
                       ),
                     ),
                     [
@@ -546,16 +534,16 @@ describe("optimizations", ({test, testSkip}) => {
                   ),
                   AExp.comp(
                     Comp.app(
-                      ~allocation_type=StackAllocated(WasmI32),
+                      ~allocation_type=Unmanaged(WasmI32),
                       (
                         Imm.id(copy),
                         (
                           [
-                            StackAllocated(WasmI32),
-                            StackAllocated(WasmI32),
-                            StackAllocated(WasmI32),
+                            Unmanaged(WasmI32),
+                            Unmanaged(WasmI32),
+                            Unmanaged(WasmI32),
                           ],
-                          StackAllocated(WasmI32),
+                          Unmanaged(WasmI32),
                         ),
                       ),
                       [
@@ -566,7 +554,7 @@ describe("optimizations", ({test, testSkip}) => {
                     ),
                   ),
                 ),
-                StackAllocated(WasmI32),
+                Unmanaged(WasmI32),
               ),
             ),
           ),
@@ -574,7 +562,7 @@ describe("optimizations", ({test, testSkip}) => {
       ) @@
       AExp.comp(
         Comp.imm(
-          ~allocation_type=StackAllocated(WasmI32),
+          ~allocation_type=Unmanaged(WasmI32),
           Imm.const(Const_void),
         ),
       );
@@ -607,7 +595,7 @@ describe("optimizations", ({test, testSkip}) => {
               (
                 AExp.seq(
                   Comp.primn(
-                    ~allocation_type=StackAllocated(WasmI32),
+                    ~allocation_type=Unmanaged(WasmI32),
                     WasmMemoryFill,
                     [
                       Imm.const(Const_wasmi32(0l)),
@@ -617,7 +605,7 @@ describe("optimizations", ({test, testSkip}) => {
                   ),
                   AExp.comp(
                     Comp.primn(
-                      ~allocation_type=StackAllocated(WasmI32),
+                      ~allocation_type=Unmanaged(WasmI32),
                       WasmMemoryCopy,
                       [
                         Imm.const(Const_wasmi32(0l)),
@@ -627,7 +615,7 @@ describe("optimizations", ({test, testSkip}) => {
                     ),
                   ),
                 ),
-                StackAllocated(WasmI32),
+                Unmanaged(WasmI32),
               ),
             ),
           ),
@@ -635,7 +623,7 @@ describe("optimizations", ({test, testSkip}) => {
       ) @@
       AExp.comp(
         Comp.imm(
-          ~allocation_type=StackAllocated(WasmI32),
+          ~allocation_type=Unmanaged(WasmI32),
           Imm.const(Const_void),
         ),
       );


### PR DESCRIPTION
Makes CMI size a tad smaller too.

Closes #1154 