### PR TITLE
chore(ci): Allow esy cache import to fail without killing run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Import esy cache
         if: steps.esy-cache.outputs.cache-hit == 'true'
+        # Don't crash the run if esy cache import fails - mostly happens on Windows
+        continue-on-error: true
         run: |
           npm run compiler import-dependencies
           shx rm -rf compiler/_export

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Import esy cache
         if: steps.esy-cache.outputs.cache-hit == 'true'
+        # Don't crash the run if esy cache import fails - mostly happens on Windows
+        continue-on-error: true
         run: |
           npm run compiler import-dependencies
           shx rm -rf compiler/_export


### PR DESCRIPTION
The esy cache import seems to fail on Windows more than I'd like. Let's just make this step fallible in our workflows so it doesn't crash the run (it'll just take longer).