### PR TITLE
chore(cli)!: Remove graceful flag & behavior

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -34,21 +34,6 @@ function graincVersion() {
   return exec.grainc("--version", program).toString().trim();
 }
 
-function wrapAction(action, logError = false) {
-  return (...args) => {
-    try {
-      return action(...args);
-    } catch (e) {
-      if (logError) console.error(e);
-      if (program.opts().graceful) {
-        process.exit();
-      } else {
-        process.exit(1);
-      }
-    }
-  };
-}
-
 class ForwardOption extends program.Option {
   // A ForwardOption is forwarded to the underlying program
   forward = true;
@@ -92,7 +77,6 @@ program
   })
   .description("Compile and run Grain programs. 🌾")
   .addOption(new program.Option("-p, --print-output").hideHelp())
-  .option("-g, --graceful", "return a 0 exit code if the program errors")
   .forwardOption(
     "-I, --include-dirs <dirs>",
     "add additional dependency include directories",
@@ -178,13 +162,11 @@ program
 program
   .command("compile <file>")
   .description("compile a grain program into wasm")
-  .action(
-    wrapAction(function (file) {
-      // The compile subcommand inherits all behaviors/options of the
-      // top level grain command
-      compile(file, program);
-    })
-  );
+  .action(function (file) {
+    // The compile subcommand inherits all behaviors/options of the
+    // top level grain command
+    compile(file, program);
+  });
 
 program
   .command("run <file>")
@@ -198,13 +180,11 @@ program
 program
   .command("lsp <file>")
   .description("check a grain file for LSP")
-  .action(
-    wrapAction(function (file) {
-      // The lsp subcommand inherits all options of the
-      // top level grain command
-      lsp(file, program);
-    })
-  );
+  .action(function (file) {
+    // The lsp subcommand inherits all options of the
+    // top level grain command
+    lsp(file, program);
+  });
 
 program
   .command("doc <file|dir>")
@@ -213,18 +193,14 @@ program
     "--current-version <version>",
     "provide a version to use as current when generating markdown for `@since` and `@history` attributes"
   )
-  .action(
-    wrapAction(function (file, options, program) {
-      doc(file, program);
-    })
-  );
+  .action(function (file, options, program) {
+    doc(file, program);
+  });
 
 program
   .command("format <file|dir>")
   .description("format a grain file")
-  .action(
-    wrapAction(function (file, options, program) {
-      format(file, program);
-    })
-  );
+  .action(function (file, options, program) {
+    format(file, program);
+  });
 program.parse(process.argv);

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -5,27 +5,18 @@ const preparePkg = require("./pkg");
 module.exports = async function run(filename, options) {
   preparePkg();
 
-  try {
-    let basePath = path.dirname(filename);
-    let includeDirs = [basePath, ...options.includeDirs, options.stdlib];
-    let locator = runner.defaultFileLocator(includeDirs);
-    let GrainRunner = runner.buildGrainRunner(locator, {
-      initialMemoryPages: options.initialMemoryPages,
-      maximumMemoryPages: options.maximumMemoryPages,
-    });
-    if (options.printOutput) {
-      let result = await GrainRunner.runFileUnboxed(filename);
-      await GrainRunner.ensureStringModule();
-      console.log(GrainRunner.grainValueToString(result));
-    } else {
-      await GrainRunner.runFile(filename);
-    }
-  } catch (e) {
-    console.error(e);
-    if (options.graceful) {
-      process.exit();
-    } else {
-      process.exit(-1);
-    }
+  let basePath = path.dirname(filename);
+  let includeDirs = [basePath, ...options.includeDirs, options.stdlib];
+  let locator = runner.defaultFileLocator(includeDirs);
+  let GrainRunner = runner.buildGrainRunner(locator, {
+    initialMemoryPages: options.initialMemoryPages,
+    maximumMemoryPages: options.maximumMemoryPages,
+  });
+  if (options.printOutput) {
+    let result = await GrainRunner.runFileUnboxed(filename);
+    await GrainRunner.ensureStringModule();
+    console.log(GrainRunner.grainValueToString(result));
+  } else {
+    await GrainRunner.runFile(filename);
   }
 };

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -173,7 +173,7 @@ let run = (~num_pages=?, file) => {
 
   let cmd =
     Array.concat([
-      [|"grain", "-g"|],
+      [|"grain"|],
       mem_flags,
       [|"-S", stdlib, "-I", Filepath.to_string(test_libs_dir), "run", file|],
     ]);


### PR DESCRIPTION
This removes the `--graceful`/`-g` flag and removes the "graceful" exit behavior. I don't actually think this is necessary/useful and it just makes boilerplate more cluttered.