### PR TITLE
chore(stdlib): Show data type on Queue module docs

### DIFF
--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -5,6 +5,10 @@
  */
 import List from "list"
 
+/**
+ * @section Types: Type declarations included in the Queue module.
+ */
+
 record Queue<a> {
   forwards: List<a>,
   backwards: List<a>,

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -13,6 +13,16 @@ No other changes yet.
 import Queue from "queue"
 ```
 
+## Types
+
+Type declarations included in the Queue module.
+
+### Queue.**Queue**
+
+```grain
+type Queue<a>
+```
+
 ## Values
 
 Functions for working with queues.


### PR DESCRIPTION
Now that we show the abstract type, we should show the data type in the docs.