### PR TITLE
fix(graindoc): Improve location lookup so re-exports do not crash it

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -69,6 +69,8 @@ let enumerate_exports = stmts => {
             },
             decls,
           )
+        | TTopForeign({tvd_id, tvd_loc}) =>
+          id_tbl := Ident.add(tvd_id, tvd_loc, id_tbl^)
         | TTopLet(_, _, vbinds) =>
           List.iter(
             ({vb_pat}: Typedtree.value_binding) => {

--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -91,7 +91,7 @@ let enumerate_exports = stmts => {
   id_tbl^;
 };
 
-let location_for_ident = (~env, ~exports, ident) => {
+let location_for_ident = (~exports, ident) => {
   snd(Ident.find_name(Ident.name(ident), exports));
 };
 
@@ -199,18 +199,17 @@ let for_type_declaration =
 
 let for_signature_item =
     (
-      ~env: Env.t,
       ~comments,
       ~exports: Ident.tbl(Grain_parsing.Location.t),
       sig_item: Types.signature_item,
     ) => {
   switch (sig_item) {
   | TSigValue(ident, vd) =>
-    let loc = location_for_ident(~env, ~exports, ident);
+    let loc = location_for_ident(~exports, ident);
     let docblock = for_value_description(~comments, ~ident, ~loc, vd);
     Some(docblock);
   | TSigType(ident, td, _rec) =>
-    let loc = location_for_ident(~env, ~exports, ident);
+    let loc = location_for_ident(~exports, ident);
     let docblock = for_type_declaration(~comments, ~ident, ~loc, td);
     Some(docblock);
   | _ => None
@@ -219,17 +218,16 @@ let for_signature_item =
 
 let signature_item_in_range =
     (
-      ~env: Env.t,
       ~exports: Ident.tbl(Grain_parsing.Location.t),
       sig_item: Types.signature_item,
       range: Grain_utils.Range.t,
     ) => {
   switch (sig_item) {
   | TSigValue(ident, vd) =>
-    let loc = location_for_ident(~env, ~exports, ident);
+    let loc = location_for_ident(~exports, ident);
     Grain_utils.Range.inRange(loc.loc_start.pos_lnum, range);
   | TSigType(ident, td, _rec) =>
-    let loc = location_for_ident(~env, ~exports, ident);
+    let loc = location_for_ident(~exports, ident);
     Grain_utils.Range.inRange(loc.loc_start.pos_lnum, range);
   | _ => false
   };

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -78,6 +78,8 @@ let generate_docs =
     (~current_version, ~output=?, program: Typedtree.typed_program) => {
   let comments = Comments.to_ordered(program.comments);
 
+  let exports = Docblock.enumerate_exports(program.statements);
+
   let env = program.env;
   let signature_items = program.signature.cmi_sign;
 
@@ -156,7 +158,8 @@ let generate_docs =
   };
 
   let add_docblock = sig_item => {
-    let docblock = Docblock.for_signature_item(~env, ~comments, sig_item);
+    let docblock =
+      Docblock.for_signature_item(~env, ~comments, ~exports, sig_item);
     switch (docblock) {
     | Some(docblock) =>
       Buffer.add_buffer(
@@ -197,7 +200,12 @@ let generate_docs =
         );
         List.iter(
           sig_item =>
-            if (Docblock.signature_item_in_range(~env, sig_item, range)) {
+            if (Docblock.signature_item_in_range(
+                  ~env,
+                  ~exports,
+                  sig_item,
+                  range,
+                )) {
               add_docblock(sig_item);
             },
           signature_items,

--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -80,7 +80,6 @@ let generate_docs =
 
   let exports = Docblock.enumerate_exports(program.statements);
 
-  let env = program.env;
   let signature_items = program.signature.cmi_sign;
 
   let buf = Buffer.create(0);
@@ -158,8 +157,7 @@ let generate_docs =
   };
 
   let add_docblock = sig_item => {
-    let docblock =
-      Docblock.for_signature_item(~env, ~comments, ~exports, sig_item);
+    let docblock = Docblock.for_signature_item(~comments, ~exports, sig_item);
     switch (docblock) {
     | Some(docblock) =>
       Buffer.add_buffer(
@@ -200,12 +198,7 @@ let generate_docs =
         );
         List.iter(
           sig_item =>
-            if (Docblock.signature_item_in_range(
-                  ~env,
-                  ~exports,
-                  sig_item,
-                  range,
-                )) {
+            if (Docblock.signature_item_in_range(~exports, sig_item, range)) {
               add_docblock(sig_item);
             },
           signature_items,

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -509,6 +509,7 @@ type import_declaration = {
 
 [@deriving sexp]
 type export_declaration = {
+  tex_id: Ident.t,
   tex_path: Path.t,
   [@sexp_drop_if sexp_locs_disabled]
   tex_loc: Location.t,

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -472,6 +472,7 @@ type import_declaration = {
 
 [@deriving sexp]
 type export_declaration = {
+  tex_id: Ident.t,
   tex_path: Path.t,
   [@sexp_drop_if sexp_locs_disabled]
   tex_loc: Location.t,

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -602,7 +602,10 @@ let type_module = (~toplevel=false, funct_body, anchor, env, sstr /*scope*/) => 
             };
           let name = Identifier.IdentName(name);
           let (p, {val_fullpath} as desc) = Env.lookup_value(name, env);
-          (TSigValue(id, desc), {tex_path: val_fullpath, tex_loc: loc});
+          (
+            TSigValue(id, desc),
+            {tex_id: id, tex_path: val_fullpath, tex_loc: loc},
+          );
         },
         exports,
       );


### PR DESCRIPTION
The exports refactor & bug fixes caused some of my bad code to break in graindoc. Since no new bindings are created in scope for re-exports, I can't use `Env.find_value` to find the locations anymore. @ospencer walked me through the better way to do this, but I need help to finish the value lookup (see TODO in diff).