### PR TITLE
fix(compiler): fix formatter multiple data bug

### DIFF
--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -3723,13 +3723,17 @@ let data_print =
     Doc.concat([Doc.comma, Doc.hardLine]),
     List.map(
       data => {
-        let (expt, decl) = data;
+        let (expt, decl:Parsetree.data_declaration) = data;
+        // localise the comments
+
+       let data_comments=Comment_utils.get_comments_inside_location(~location=decl.pdata_loc,comments);
+
         Doc.concat([
           switch ((expt: Asttypes.export_flag)) {
           | Nonexported => Doc.nil
           | Exported => Doc.text("export ")
           },
-          print_data(~original_source, ~comments, decl),
+          print_data(~original_source, ~comments=data_comments, decl),
         ]);
       },
       datas,

--- a/compiler/grainformat/format.re
+++ b/compiler/grainformat/format.re
@@ -3723,10 +3723,13 @@ let data_print =
     Doc.concat([Doc.comma, Doc.hardLine]),
     List.map(
       data => {
-        let (expt, decl:Parsetree.data_declaration) = data;
-        // localise the comments
+        let (expt, decl: Parsetree.data_declaration) = data;
 
-       let data_comments=Comment_utils.get_comments_inside_location(~location=decl.pdata_loc,comments);
+        let data_comments =
+          Comment_utils.get_comments_inside_location(
+            ~location=decl.pdata_loc,
+            comments,
+          );
 
         Doc.concat([
           switch ((expt: Asttypes.export_flag)) {

--- a/compiler/test/formatter_inputs/enum_long.gr
+++ b/compiler/test/formatter_inputs/enum_long.gr
@@ -6,3 +6,15 @@ export enum Test {
   Test( Shape< 
   String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String > ),
 }
+
+enum EvenNumber {
+  Zero, // comment 0
+  OddPlusOne(OddNumber), // comment 1
+  // comment 2
+  // comment 3
+},
+enum OddNumber {
+  // comment 4
+  // comment 5
+  EvenPlusOne(EvenNumber),
+} // comment 6

--- a/compiler/test/formatter_outputs/enum_long.gr
+++ b/compiler/test/formatter_outputs/enum_long.gr
@@ -94,3 +94,15 @@ export enum Test {
     >
   ),
 }
+
+enum EvenNumber {
+  Zero, // comment 0
+  OddPlusOne(OddNumber), // comment 1
+  // comment 2
+  // comment 3
+},
+enum OddNumber {
+  // comment 4
+  // comment 5
+  EvenPlusOne(EvenNumber),
+} // comment 6


### PR DESCRIPTION
Fixes the problems with comments when we had multiple data declarations in a top level statement