### PR TITLE
fix(compiler): Iterate over guard clauses in typedTreeIter/typedTreeMap

### DIFF
--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -89,9 +89,10 @@ module MakeIterator =
     Iter.leave_bindings(rec_flag, mut_flag);
   }
 
-  and iter_match_branch = ({mb_pat, mb_body}) => {
+  and iter_match_branch = ({mb_pat, mb_body, mb_guard}) => {
     iter_pattern(mb_pat);
     iter_expression(mb_body);
+    Option.iter(iter_expression, mb_guard);
   }
 
   and iter_match_branches = branches => List.iter(iter_match_branch, branches)

--- a/compiler/src/typed/typedtreeMap.re
+++ b/compiler/src/typed/typedtreeMap.re
@@ -82,10 +82,11 @@ module MakeMap =
   and map_bindings = (rec_flag, mut_flag, binds) =>
     List.map(map_binding, binds)
 
-  and map_match_branch = ({mb_pat, mb_body} as mb) => {
+  and map_match_branch = ({mb_pat, mb_body, mb_guard} as mb) => {
     let mb_pat = map_pattern(mb_pat);
     let mb_body = map_expression(mb_body);
-    {...mb, mb_pat, mb_body};
+    let mb_guard = Option.map(map_expression, mb_guard);
+    {...mb, mb_pat, mb_body, mb_guard};
   }
 
   and map_match_branches = branches => List.map(map_match_branch, branches)


### PR DESCRIPTION
Found that we were missing these while smoke testing the new LSP version.