### PR TITLE
fix(lsp): Report non-instanced type for identifiers

### DIFF
--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -90,6 +90,10 @@ let module_lens = (~program: Typedtree.typed_program, p: Path.t) => {
   grain_code_block(String.concat("\n", signatures));
 };
 
+let value_lens = (desc: Types.value_description) => {
+  grain_type_code_block(Printtyp.string_of_type_scheme(desc.val_type));
+};
+
 let expression_lens = (e: Typedtree.expression) => {
   switch (e.exp_desc) {
   | TExpRecord(fields) =>
@@ -128,6 +132,8 @@ let process =
   | Some({program, sourcetree}) =>
     let results = Sourcetree.query(params.position, sourcetree);
     switch (results) {
+    | [Value(loc, desc), ..._] =>
+      send_hover(~id, ~range=loc_to_range(loc), value_lens(desc))
     | [Expression(exp), ..._] =>
       send_hover(
         ~id,

--- a/compiler/src/language_server/lenses.re
+++ b/compiler/src/language_server/lenses.re
@@ -50,7 +50,11 @@ let get_signature_from_statement = (stmt: Typedtree.toplevel_stmt) =>
 
     Some(String.concat(", ", bindings));
   | TTopExpr(expression) =>
-    Some(Printtyp.string_of_type_scheme(expression.exp_type))
+    switch (expression.exp_desc) {
+    | TExpIdent(_, _, desc) =>
+      Some(Printtyp.string_of_type_scheme(desc.val_type))
+    | _ => Some(Printtyp.string_of_type_scheme(expression.exp_type))
+    }
   | TTopException(type_exception) => None
   | TTopExport(export_declarations) => None
   };


### PR DESCRIPTION
This reports the original type of an identifier rather than the instanced type. For example, before this change, the LSP would report the type of `print` as `_weak -> Void`, and if hovering `print` in `print(5)`, `Number -> Void`, when it should show `a -> Void` as the instanced is a bit misleading.

The instanced type is correct for other expressions.

A good example of this is `Map.make`. Creating one without setting any values should show the instanced type as being weak as you haven't set any values to define some concrete types:

<img width="276" alt="image" src="https://user-images.githubusercontent.com/7244034/170890774-aa5db9d4-f1a2-4d90-9183-fbf2b55ef469.png">

But hovering over just `make` should show the original type, since hey, you're probably going to make another map some day and you'd be pretty confused if the tool told you it only makes weak maps.

<img width="281" alt="image" src="https://user-images.githubusercontent.com/7244034/170891076-11f40d3a-a2e4-4f22-bdad-4f49400c5ef7.png">

And the same deal for non-weak maps:

<img width="312" alt="image" src="https://user-images.githubusercontent.com/7244034/170891140-247f4fc9-7d27-4d95-9f86-01992694944f.png">

<img width="309" alt="image" src="https://user-images.githubusercontent.com/7244034/170891148-20fedc82-3195-4ef8-bc08-1ac890c16069.png">
