### PR TITLE
fix(cli)!: Show all global options within help for every command

### DIFF
--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -2,6 +2,16 @@ const path = require("path");
 const { execSync } = require("child_process");
 const fs = require("fs");
 
+function flagsFromOptions(program, options) {
+  const flags = [];
+  program.options.forEach((option) => {
+    if (!option.forward) return;
+    const flag = option.toFlag(options);
+    if (flag) flags.push(flag);
+  });
+  return flags;
+}
+
 function getGrainc() {
   const grainc = path.join(__dirname, "grainc.exe");
 
@@ -19,16 +29,11 @@ const grainc = getGrainc();
 
 function execGrainc(
   commandOrFile = "",
+  options,
   program,
   execOpts = { stdio: "inherit" }
 ) {
-  const flags = [];
-  const options = program.opts();
-  program.options.forEach((option) => {
-    if (!option.forward) return;
-    const flag = option.toFlag(options);
-    if (flag) flags.push(flag);
-  });
+  const flags = flagsFromOptions(program, options);
 
   return execSync(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
@@ -50,18 +55,11 @@ const graindoc = getGraindoc();
 
 function execGraindoc(
   commandOrFile = "",
+  options,
   program,
   execOpts = { stdio: "inherit" }
 ) {
-  const flags = [];
-  // Inherit compiler flags passed to the parent
-  const options = program.parent.options.concat(program.options);
-  const opts = { ...program.parent.opts(), ...program.opts() };
-  options.forEach((option) => {
-    if (!option.forward) return;
-    const flag = option.toFlag(opts);
-    if (flag) flags.push(flag);
-  });
+  const flags = flagsFromOptions(program, options);
 
   return execSync(`${graindoc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
@@ -83,18 +81,11 @@ const grainformat = getGrainformat();
 
 function execGrainformat(
   commandOrFile = "",
+  options,
   program,
   execOpts = { stdio: "inherit" }
 ) {
-  const flags = [];
-  // Inherit compiler flags passed to the parent
-  const options = program.parent.options.concat(program.options);
-  const opts = { ...program.parent.opts(), ...program.opts() };
-  options.forEach((option) => {
-    if (!option.forward) return;
-    const flag = option.toFlag(opts);
-    if (flag) flags.push(flag);
-  });
+  const flags = flagsFromOptions(program, options);
 
   return execSync(
     `${grainformat} ${flags.join(" ")} ${commandOrFile}`,

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -12,7 +12,7 @@ const v8 = require("v8");
  */
 v8.setFlagsFromString("--experimental-wasm-return-call");
 
-const program = require("commander");
+const commander = require("commander");
 const exec = require("./exec.js");
 const run = require("./run.js");
 
@@ -26,11 +26,7 @@ function num(val) {
   return Number.parseInt(val, 10);
 }
 
-function graincVersion() {
-  return exec.grainc("--version", program, { stdio: "pipe" }).toString().trim();
-}
-
-class ForwardOption extends program.Option {
+class ForwardOption extends commander.Option {
   // A ForwardOption is forwarded to the underlying program
   forward = true;
 
@@ -50,7 +46,7 @@ class ForwardOption extends program.Option {
   }
 }
 
-class ProfileOption extends program.Option {
+class ProfileOption extends commander.Option {
   // Like ForwardOption, ProfileOption is forwarded to the underlying program
   // but we convert the flag into a profile flag, i.e. `--release` becomes `--profile=release`
   forward = true;
@@ -63,6 +59,18 @@ class ProfileOption extends program.Option {
   }
 }
 
+class GrainHelp extends commander.Help {
+  visibleOptions(cmd) {
+    // If we are running `--help` at the root, we want to list options for `compile-and-run`
+    if (cmd.name() === "grain") {
+      return super.visibleOptions(
+        cmd.commands.find((command) => command.name() === "compile-and-run")
+      );
+    }
+    return super.visibleOptions(cmd);
+  }
+}
+
 const optionApplicator = (Option) =>
   function (flags, description, parser, defaultValue) {
     const option = new Option(flags, description);
@@ -71,136 +79,159 @@ const optionApplicator = (Option) =>
     return this.addOption(option);
   };
 
-// Adds .forwardOption to commands. Similar to Commander's native .option,
-// but will forward the flag to the underlying program.
-program.Command.prototype.forwardOption = optionApplicator(ForwardOption);
+class GrainCommand extends commander.Command {
+  // Adds .forwardOption to commands. Similar to Commander's native .option,
+  // but will forward the flag to the underlying program.
+  forwardOption = optionApplicator(ForwardOption);
 
-// Adds .profileOption to commands. Similar to Commander's native .option,
-// but will convert the flag from the shorthand to the full form.
-program.Command.prototype.profileOption = optionApplicator(ProfileOption);
+  // Adds .profileOption to commands. Similar to Commander's native .option,
+  // but will convert the flag from the shorthand to the full form.
+  profileOption = optionApplicator(ProfileOption);
+
+  createHelp() {
+    return new GrainHelp();
+  }
+
+  createCommand(name) {
+    const cmd = new GrainCommand(name);
+    // Add global options to command
+    cmd.forwardOption(
+      "-I, --include-dirs <dirs>",
+      "add additional dependency include directories",
+      list,
+      []
+    );
+    cmd.forwardOption(
+      "-S, --stdlib <path>",
+      "override the standard libary with your own",
+      null,
+      stdlibPath
+    );
+    cmd.forwardOption(
+      "--initial-memory-pages <size>",
+      "initial number of WebAssembly memory pages",
+      num
+    );
+    cmd.forwardOption(
+      "--maximum-memory-pages <size>",
+      "maximum number of WebAssembly memory pages",
+      num
+    );
+    cmd.forwardOption(
+      "--compilation-mode <mode>",
+      "compilation mode (advanced use only)"
+    );
+    cmd.forwardOption(
+      "--elide-type-info",
+      "don't include runtime type information used by toString/print"
+    );
+    cmd.profileOption(
+      "--release",
+      "compile using the release profile (production mode)"
+    );
+    cmd.forwardOption(
+      "--experimental-wasm-tail-call",
+      "enables tail-call optimization"
+    );
+    cmd.forwardOption("--debug", "compile with debugging information");
+    cmd.forwardOption(
+      "--wat",
+      "additionally produce a WebAssembly Text (.wat) file"
+    );
+    cmd.forwardOption(
+      "--hide-locs",
+      "hide locations from intermediate trees. Only has an effect with `--verbose`"
+    );
+    cmd.forwardOption("--no-color", "disable colored output");
+    cmd.forwardOption(
+      "--no-gc",
+      "turn off reference counting garbage collection"
+    );
+    cmd.forwardOption(
+      "--no-bulk-memory",
+      "polyfill WebAssembly bulk memory instructions"
+    );
+    cmd.forwardOption(
+      "--wasi-polyfill <filename>",
+      "path to custom WASI implementation"
+    );
+    cmd.forwardOption(
+      "--use-start-section",
+      "replaces the _start export with a start section during linking"
+    );
+    cmd.forwardOption("--no-link", "disable static linking");
+    cmd.forwardOption(
+      "--no-pervasives",
+      "don't automatically import the Grain Pervasives module"
+    );
+    // TODO: Remove this
+    cmd.forwardOption("-O <level>", "set the optimization level");
+    cmd.forwardOption(
+      "--parser-debug-level <level>",
+      "debugging level for parser output"
+    );
+    cmd.forwardOption(
+      "--memory-base <addr>",
+      "set the base address for the Grain heap"
+    );
+    cmd.forwardOption("--source-map", "generate source maps");
+    cmd.forwardOption("--strict-sequence", "enable strict sequencing");
+    cmd.forwardOption(
+      "--verbose",
+      "print critical information at various stages of compilation"
+    );
+    return cmd;
+  }
+}
+
+const program = new GrainCommand();
 
 program
+  .description("Compile and run Grain programs. 🌾")
+  // Show the default usage without "compile-and-run"
+  .usage("[options] <file>")
+  .addHelpCommand(false)
+  // The default command that compiles & runs
+  .command("compile-and-run <file>", { isDefault: true, hidden: true })
+  // `--version` should only be available on the default command
   .option("-v, --version", "output CLI and compiler versions")
-  .on("option:version", () => {
+  .on("option:version", function () {
+    const program = this;
     console.log(`Grain cli ${require("../package.json").version}`);
-    console.log(`Grain compiler ${graincVersion()}`);
+    const graincVersion = exec
+      .grainc("--version", program.opts(), program, { stdio: "pipe" })
+      .toString()
+      .trim();
+    console.log(`Grain compiler ${graincVersion}`);
     process.exit(0);
   })
-  .description("Compile and run Grain programs. 🌾")
-  .addOption(new program.Option("-p, --print-output").hideHelp())
-  .forwardOption(
-    "-I, --include-dirs <dirs>",
-    "add additional dependency include directories",
-    list,
-    []
-  )
-  .forwardOption(
-    "-S, --stdlib <path>",
-    "override the standard libary with your own",
-    null,
-    stdlibPath
-  )
-  .forwardOption(
-    "--initial-memory-pages <size>",
-    "initial number of WebAssembly memory pages",
-    num
-  )
-  .forwardOption(
-    "--maximum-memory-pages <size>",
-    "maximum number of WebAssembly memory pages",
-    num
-  )
-  .forwardOption(
-    "--compilation-mode <mode>",
-    "compilation mode (advanced use only)"
-  )
-  .forwardOption(
-    "--elide-type-info",
-    "don't include runtime type information used by toString/print"
-  )
-  .profileOption(
-    "--release",
-    "compile using the release profile (production mode)"
-  )
-  .forwardOption(
-    "--experimental-wasm-tail-call",
-    "enables tail-call optimization"
-  )
-  .forwardOption("--debug", "compile with debugging information")
-  .forwardOption("--wat", "additionally produce a WebAssembly Text (.wat) file")
-  .forwardOption(
-    "--hide-locs",
-    "hide locations from intermediate trees. Only has an effect with `--verbose`"
-  )
-  .forwardOption("--lsp", "generate lsp errors and warnings only")
-  .forwardOption("--no-color", "disable colored output")
-  .forwardOption("--no-gc", "turn off reference counting garbage collection")
-  .forwardOption(
-    "--no-bulk-memory",
-    "polyfill WebAssembly bulk memory instructions"
-  )
-  .forwardOption(
-    "--wasi-polyfill <filename>",
-    "path to custom WASI implementation"
-  )
-  .forwardOption(
-    "--use-start-section",
-    "replaces the _start export with a start section during linking"
-  )
-  .forwardOption("--no-link", "disable static linking")
-  .forwardOption(
-    "--no-pervasives",
-    "don't automatically import the Grain Pervasives module"
-  )
+  .addOption(new commander.Option("-p, --print-output").hideHelp())
   .forwardOption("-o <filename>", "output filename")
-  .forwardOption("-O <level>", "set the optimization level")
-  .forwardOption(
-    "--parser-debug-level <level>",
-    "debugging level for parser output"
-  )
-  .forwardOption(
-    "--memory-base <addr>",
-    "set the base address for the Grain heap"
-  )
-  .forwardOption("--source-map", "generate source maps")
-  .forwardOption("--strict-sequence", "enable strict sequencing")
-  .forwardOption(
-    "--verbose",
-    "print critical information at various stages of compilation"
-  )
-  // The root command that compiles & runs
-  .arguments("<file>")
   .action(function (file, options, program) {
-    exec.grainc(file, program);
+    exec.grainc(file, options, program);
     if (options.o) {
-      run(options.o, program.opts());
+      run(options.o, options);
     } else {
-      run(file.replace(/\.gr$/, ".gr.wasm"), program.opts());
+      run(file.replace(/\.gr$/, ".gr.wasm"), options);
     }
   });
 
 program
   .command("compile <file>")
   .description("compile a grain program into wasm")
-  .action(function (file) {
-    // The compile subcommand inherits all behaviors/options of the
-    // top level grain command
-    exec.grainc(file, program);
-  });
+  .forwardOption("-o <filename>", "output filename")
+  .action(exec.grainc);
 
 program
   .command("run <file>")
   .description("run a wasm file with grain's javascript runner")
-  .action(function (wasmFile) {
-    // The run subcommand inherits all options of the
-    // top level grain command
-    run(wasmFile, program.opts());
-  });
+  .addOption(new commander.Option("-p, --print-output").hideHelp())
+  .action(run);
 
 program
   .command("lsp <file>")
   .description("check a grain file for LSP")
-  .action(function (file) {
+  .action(function (file, options, program) {
     // The lsp subcommand inherits all options of the
     // top level grain command
 
@@ -208,7 +239,7 @@ program
     // and we get the compiler output in stdout
     // we still take the file name so we have it available
 
-    exec.grainc(`--lsp ${file}`, program);
+    exec.grainc(`--lsp ${file}`, options, program);
   });
 
 program
@@ -218,14 +249,13 @@ program
     "--current-version <version>",
     "provide a version to use as current when generating markdown for `@since` and `@history` attributes"
   )
-  .action(function (file, options, program) {
-    exec.graindoc(file, program);
-  });
+  .forwardOption("-o <file|dir>", "output file or directory")
+  .action(exec.graindoc);
 
 program
   .command("format <file|dir>")
   .description("format a grain file")
-  .action(function (file, options, program) {
-    exec.grainformat(file, program);
-  });
+  .forwardOption("-o <file|dir>", "output file or directory")
+  .action(exec.grainformat);
+
 program.parse(process.argv);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -164,8 +164,6 @@ class GrainCommand extends commander.Command {
       "--no-pervasives",
       "don't automatically import the Grain Pervasives module"
     );
-    // TODO: Remove this
-    cmd.forwardOption("-O <level>", "set the optimization level");
     cmd.forwardOption(
       "--parser-debug-level <level>",
       "debugging level for parser output"

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -173,9 +173,10 @@ let run = (~num_pages=?, file) => {
 
   let cmd =
     Array.concat([
-      [|"grain"|],
+      [|"grain", "run"|],
       mem_flags,
-      [|"-S", stdlib, "-I", Filepath.to_string(test_libs_dir), "run", file|],
+      [|"-S", stdlib, "-I", Filepath.to_string(test_libs_dir)|],
+      [|file|],
     ]);
 
   let (code, out, err) = open_process(cmd);


### PR DESCRIPTION
Closes #1080

This PR reworks our commander stuff in the CLI so we show all global options for the root/default command **and** all subcommands. It also allows subcommands to specify specific options they need, which you'll notice with the different `-o` options throughout the CLI (some that require only files and some that allow directories or files).

This is a pretty hefty PR, so I hope I didn't miss anything. Please give it a thorough review and test combinations of flags with various commands. I tested with `--release` and `--no-link` during development.

This PR is marked as breaking because the changes caused the tests to fail, which made me realize we were generating this command `grain -S /path/to/stdlib -I /path/to/test/includes run test-file.gr`. We no longer allow options before the subcommands because otherwise our CLI thinks you are running the root command and that `run` is supposed to be a file.

Here are what some of the `--help` usages output:
<img width="876" alt="Screen Shot 2022-05-29 at 4 38 39 PM" src="https://user-images.githubusercontent.com/992373/170895881-6817f44b-0486-48f7-8510-b7552a3d935e.png">

<img width="941" alt="Screen Shot 2022-05-29 at 4 38 27 PM" src="https://user-images.githubusercontent.com/992373/170895893-6059c069-544e-4e43-b741-2f6f2a55c501.png">
