### PR TITLE
chore(compiler): Add boxed number overflow regression test

### DIFF
--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -51,6 +51,7 @@ describe("numbers", ({test, testSkip}) => {
     "print(987654321987654321987654321t)",
     "987654321987654321987654321\n",
   );
+  assertRun("number_syntax13", "print(17179869184 - 1024)", "17179868160\n");
   // equality checks
   assertRun(
     "nan_equality1",


### PR DESCRIPTION
Closes #1081

I believe this was fixed with the thiccnum implementation, but this adds a direct regression test from the issue.