### PR TITLE
fix(ci): Add a last-release-sha to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "last-release-sha": "af86344e778187659e80753b2ea847f5dea13908",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "plugins": [


### PR DESCRIPTION
I was writing docs for the List stdlib module, and I found a really old issue number linked into our release notes. I believe the new version of release-please isn't finding the correct release PR, so we should try to force it with this.