### PR TITLE
chore(stdlib): Add docs to List module

### DIFF
--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -96,8 +96,8 @@ export let reverse = list => {
 }
 
 /**
- * Creates a new list with the elements the first list, followed by
- * the elements of the second list. This does not modify the arguments.
+ * Creates a new list with the elements of the first list followed by
+ * the elements of the second list.
  *
  * @param list1: The list containing elements to appear first
  * @param list2: The list containing elements to appear second
@@ -290,7 +290,7 @@ export let rec forEach = (fn, list) => {
 }
 
 /**
- * Iterates a list, calling an iterator function with each element.
+ * Iterates a list, calling an iterator function on each element.
  * Also passes the index as the second argument to the function.
  *
  * @param fn: The iterator function to call with each element
@@ -523,10 +523,10 @@ export let part = (count, list) => {
 }
 
 /**
- * Rotates list elements by the specified amount to the right.
+ * Rotates list elements by the specified amount to the left.
  *
  * If value is negative, list elements will be rotated by the
- * specified amount to the left. See examples.
+ * specified amount to the right. See examples.
  *
  * Fails if the input list doesn't contain at least the required amount of elements.
  *
@@ -568,7 +568,7 @@ export let unique = list => {
 }
 
 /**
- * Produces a new list with the specified amount elements removed from
+ * Produces a new list with the specified number of elements removed from
  * the beginning of the input list.
  *
  * Fails if the specified amount is a negative number.

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -1,8 +1,6 @@
 // Standard library for list functionality
 
-export *
-
-let init = (length, fn) => {
+export let init = (length, fn) => {
   // This method can be further improved by checking the length against a specific size
   // and determining if it can be made tail-recursive, then use List.reverse on it.
   // Which would be the same as OCaml does it in https://github.com/ocaml/ocaml/blob/03839754f46319aa36d9dad56940a6f3c3bcb48a/stdlib/list.ml#L79
@@ -16,7 +14,7 @@ let init = (length, fn) => {
   iter(0, length)
 }
 
-let length = list => {
+export let length = list => {
   let rec iter = (len, list) => {
     match (list) {
       [] => len,
@@ -26,7 +24,7 @@ let length = list => {
   iter(0, list)
 }
 
-let sum = list => {
+export let sum = list => {
   let rec iter = (n, list) => {
     match (list) {
       [] => n,
@@ -36,7 +34,7 @@ let sum = list => {
   iter(0, list)
 }
 
-let reverse = list => {
+export let reverse = list => {
   let rec iter = (list, acc) => {
     match (list) {
       [] => acc,
@@ -46,42 +44,42 @@ let reverse = list => {
   iter(list, [])
 }
 
-let rec append = (list1, list2) => {
+export let rec append = (list1, list2) => {
   match (list1) {
     [] => list2,
     [first, ...rest] => [first, ...append(rest, list2)],
   }
 }
 
-let rec contains = (value, list) => {
+export let rec contains = (value, list) => {
   match (list) {
     [] => false,
     [first, ...rest] => first == value || contains(value, rest),
   }
 }
 
-let rec reduce = (fn, acc, list) => {
+export let rec reduce = (fn, acc, list) => {
   match (list) {
     [] => acc,
     [first, ...rest] => reduce(fn, fn(acc, first), rest),
   }
 }
 
-let rec reduceRight = (fn, acc, list) => {
+export let rec reduceRight = (fn, acc, list) => {
   match (list) {
     [] => acc,
     [first, ...rest] => fn(first, reduceRight(fn, acc, rest)),
   }
 }
 
-let rec map = (fn, list) => {
+export let rec map = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] => [fn(first), ...map(fn, rest)],
   }
 }
 
-let mapi = (fn, list) => {
+export let mapi = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
       [] => [],
@@ -91,26 +89,26 @@ let mapi = (fn, list) => {
   iter(fn, list, 0)
 }
 
-let rec flatMap = (fn, list) => {
+export let rec flatMap = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] => append(fn(first), flatMap(fn, rest)),
   }
 }
 
-let every = (fn, list) => {
+export let every = (fn, list) => {
   reduce((acc, value) => {
     acc && fn(value)
   }, true, list)
 }
 
-let some = (fn, list) => {
+export let some = (fn, list) => {
   reduce((acc, value) => {
     acc || fn(value)
   }, false, list)
 }
 
-let rec forEach = (fn, list) => {
+export let rec forEach = (fn, list) => {
   match (list) {
     [] => void,
     [first, ...rest] => {
@@ -120,7 +118,7 @@ let rec forEach = (fn, list) => {
   }
 }
 
-let forEachi = (fn, list) => {
+export let forEachi = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
       [] => void,
@@ -133,7 +131,7 @@ let forEachi = (fn, list) => {
   iter(fn, list, 0)
 }
 
-let rec filter = (fn, list) => {
+export let rec filter = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] =>
@@ -141,7 +139,7 @@ let rec filter = (fn, list) => {
   }
 }
 
-let filteri = (fn, list) => {
+export let filteri = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
       [] => [],
@@ -153,7 +151,7 @@ let filteri = (fn, list) => {
   iter(fn, list, 0)
 }
 
-let rec reject = (fn, list) => {
+export let rec reject = (fn, list) => {
   match (list) {
     [] => [],
     [first, ...rest] =>
@@ -161,21 +159,21 @@ let rec reject = (fn, list) => {
   }
 }
 
-let head = list => {
+export let head = list => {
   match (list) {
     [] => None,
     [first, ..._] => Some(first),
   }
 }
 
-let tail = list => {
+export let tail = list => {
   match (list) {
     [] => None,
     [_, ...rest] => Some(rest),
   }
 }
 
-let rec nth = (index, list) => {
+export let rec nth = (index, list) => {
   if (index < 0) {
     None
   } else {
@@ -186,14 +184,14 @@ let rec nth = (index, list) => {
   }
 }
 
-let rec flatten = list => {
+export let rec flatten = list => {
   match (list) {
     [] => [],
     [first, ...rest] => append(first, flatten(rest)),
   }
 }
 
-let rec insert = (value, index, list) => {
+export let rec insert = (value, index, list) => {
   if (index < 0) {
     fail "insert index cannot be a negative number"
   } else {
@@ -206,7 +204,7 @@ let rec insert = (value, index, list) => {
   }
 }
 
-let count = (fn, list) => {
+export let count = (fn, list) => {
   let rec iter = (n, list) => {
     match (list) {
       [] => n,
@@ -216,7 +214,7 @@ let count = (fn, list) => {
   iter(0, list)
 }
 
-let part = (count, list) => {
+export let part = (count, list) => {
   if (count < 0) {
     fail "part count cannot be a negative number"
   } else {
@@ -234,13 +232,13 @@ let part = (count, list) => {
   }
 }
 
-let rotate = (count, list) => {
+export let rotate = (count, list) => {
   let (beginning, end) = if (count >= 0) part(count, list)
     else part(length(list) + count, list)
   append(end, beginning)
 }
 
-let unique = list => {
+export let unique = list => {
   let rec iter = (list, acc) => {
     match (list) {
       [] => reverse(acc),
@@ -252,7 +250,7 @@ let unique = list => {
   iter(list, [])
 }
 
-let rec drop = (n, list) => {
+export let rec drop = (n, list) => {
   if (n < 0) {
     fail "number of items to drop cannot be a negative number"
   } else {
@@ -264,14 +262,14 @@ let rec drop = (n, list) => {
   }
 }
 
-let rec dropWhile = (fn, list) => {
+export let rec dropWhile = (fn, list) => {
   match (list) {
     [] => list,
     [first, ...rest] => if (fn(first)) dropWhile(fn, rest) else list,
   }
 }
 
-let rec take = (n, list) => {
+export let rec take = (n, list) => {
   if (n < 0) {
     fail "number of items to take cannot be a negative number"
   } else {
@@ -283,21 +281,21 @@ let rec take = (n, list) => {
   }
 }
 
-let rec takeWhile = (p, list) => {
+export let rec takeWhile = (p, list) => {
   match (list) {
     [] => [],
     [first, ...rest] => if (p(first)) [first, ...takeWhile(p, rest)] else [],
   }
 }
 
-let rec find = (fn, list) => {
+export let rec find = (fn, list) => {
   match (list) {
     [] => None,
     [first, ...rest] => if (fn(first)) Some(first) else find(fn, rest),
   }
 }
 
-let findIndex = (fn, list) => {
+export let findIndex = (fn, list) => {
   let rec findItemIndex = (l, index) => {
     match (l) {
       [] => None,
@@ -308,7 +306,7 @@ let findIndex = (fn, list) => {
   findItemIndex(list, 0)
 }
 
-let product = (a, b) => {
+export let product = (a, b) => {
   let mut list = []
   forEach(aItem => {
     forEach(bItem => {
@@ -318,7 +316,7 @@ let product = (a, b) => {
   reverse(list)
 }
 
-let sub = (start, length, list) => {
+export let sub = (start, length, list) => {
   take(length, drop(start, list))
 }
 
@@ -326,7 +324,7 @@ let sub = (start, length, list) => {
 // @param separator: String - The separator to insert between items in the string
 // @param items: List<String> - The input strings
 // @returns String
-let join = (separator: String, items: List<String>) => {
+export let join = (separator: String, items: List<String>) => {
   let rec iter = (sep, acc, rem) => {
     match (rem) {
       [] => acc,
@@ -354,7 +352,7 @@ let join = (separator: String, items: List<String>) => {
  * @param list2: The list to append
  * @since v0.4.5
  */
-let rec revAppend = (list1, list2) => {
+export let rec revAppend = (list1, list2) => {
   match (list1) {
     [hd, ...tl] => revAppend(tl, [hd, ...list2]),
     [] => list2,
@@ -369,7 +367,7 @@ let rec revAppend = (list1, list2) => {
  * @param list: The list to be sorted
  * @since v0.4.5
  */
-let sort = (comp, list) => {
+export let sort = (comp, list) => {
   let rec merge = (left, right, list) => {
     match ((left, right)) {
       (_, []) => {

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -1,5 +1,30 @@
-// Standard library for list functionality
+/**
+ * @module List: Utilities for working with lists.
+ *
+ * @example import List from "list"
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `lists`
+ * @history v0.2.0: Renamed to `list`
+ */
 
+/**
+ * @section Values: Functions for working with the List data type.
+ */
+
+/**
+ * Creates a new list of the specified length where each element is
+ * initialized with the result of an initializer function. The initializer
+ * is called with the index of each list element.
+ *
+ * @param length: The length of the new list
+ * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
+ * @returns The new list
+ *
+ * @example List.init(5, n => n + 3) // [3, 4, 5, 6, 7]
+ *
+ * @since v0.3.0
+ */
 export let init = (length, fn) => {
   // This method can be further improved by checking the length against a specific size
   // and determining if it can be made tail-recursive, then use List.reverse on it.
@@ -14,6 +39,15 @@ export let init = (length, fn) => {
   iter(0, length)
 }
 
+/**
+ * Computes the length of the input list.
+ *
+ * @param list: The list to inspect
+ * @returns The number of elements in the list
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Made the function tail-recursive
+ */
 export let length = list => {
   let rec iter = (len, list) => {
     match (list) {
@@ -24,6 +58,15 @@ export let length = list => {
   iter(0, list)
 }
 
+/**
+ * Adds all numbers in the input list.
+ *
+ * @param list: The input list
+ * @returns The combined sum of all values
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Made the function tail-recursive
+ */
 export let sum = list => {
   let rec iter = (n, list) => {
     match (list) {
@@ -34,6 +77,14 @@ export let sum = list => {
   iter(0, list)
 }
 
+/**
+ * Creates a new list with all elements in reverse order.
+ *
+ * @param list: The list to reverse
+ * @returns The new list
+ *
+ * @since v0.1.0
+ */
 export let reverse = list => {
   let rec iter = (list, acc) => {
     match (list) {
@@ -44,6 +95,16 @@ export let reverse = list => {
   iter(list, [])
 }
 
+/**
+ * Creates a new list with the elements the first list, followed by
+ * the elements of the second list. This does not modify the arguments.
+ *
+ * @param list1: The list containing elements to appear first
+ * @param list2: The list containing elements to appear second
+ * @returns The new list containing elements from `list1` followed by elements from `list2`
+ *
+ * @since v0.1.0
+ */
 export let rec append = (list1, list2) => {
   match (list1) {
     [] => list2,
@@ -51,27 +112,87 @@ export let rec append = (list1, list2) => {
   }
 }
 
-export let rec contains = (value, list) => {
+/**
+ * Checks if the value is an element of the input list.
+ * Uses the generic `==` structural equality operator.
+ *
+ * @param search: The value to compare
+ * @param list: The list to inspect
+ * @returns `true` if the value exists in the list or `false` otherwise
+ *
+ * @since v0.1.0
+ */
+export let rec contains = (search, list) => {
   match (list) {
     [] => false,
-    [first, ...rest] => first == value || contains(value, rest),
+    [first, ...rest] => first == search || contains(search, rest),
   }
 }
 
-export let rec reduce = (fn, acc, list) => {
+/**
+ * Combines all elements of a list using a reducer function,
+ * starting from the "head", or left side, of the list.
+ *
+ * In `List.reduce(fn, initial, list)`, `fn` is called with
+ * an accumulator and each element of the list, and returns
+ * a new accumulator. The final value is the last accumulator
+ * returned. The accumulator starts with value `initial`.
+ *
+ * @param fn: The reducer function to call on each element, where the value returned will be the next accumulator value
+ * @param initial: The initial value to use for the accumulator on the first iteration
+ * @param list: The list to iterate
+ * @returns The final accumulator returned from `fn`
+ *
+ * @example List.reduce((a, b) => a + b, 0, [1, 2, 3]) // 6
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `foldLeft`
+ * @history v0.2.0: Renamed to `reduce`
+ */
+export let rec reduce = (fn, initial, list) => {
   match (list) {
-    [] => acc,
-    [first, ...rest] => reduce(fn, fn(acc, first), rest),
+    [] => initial,
+    [first, ...rest] => reduce(fn, fn(initial, first), rest),
   }
 }
 
-export let rec reduceRight = (fn, acc, list) => {
+/**
+ * Combines all elements of a list using a reducer function,
+ * starting from the "end", or right side, of the list.
+ *
+ * In `List.reduceRight(fn, initial, list)`, `fn` is called with
+ * each element of the list and an accumulator, and returns
+ * a new accumulator. The final value is the last accumulator
+ * returned. The accumulator starts with value `initial`.
+ *
+ * @param fn: The reducer function to call on each element, where the value returned will be the next accumulator value
+ * @param initial: The initial value to use for the accumulator on the first iteration
+ * @param list: The list to iterate
+ * @returns The final accumulator returned from `fn`
+ *
+ * @example List.reduceRight((a, b) => b ++ a, "", ["baz", "bar", "foo"]) // "foobarbaz"
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `foldRight`
+ * @history v0.2.0: Renamed to `reduceRight`
+ */
+export let rec reduceRight = (fn, initial, list) => {
   match (list) {
-    [] => acc,
-    [first, ...rest] => fn(first, reduceRight(fn, acc, rest)),
+    [] => initial,
+    [first, ...rest] => fn(first, reduceRight(fn, initial, rest)),
   }
 }
 
+/**
+ * Produces a new list initialized with the results of a mapper function
+ * called on each element of the input list.
+ *
+ * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new list
+ * @param list: The list to iterate
+ * @returns The new list with mapped values
+ *
+ * @since v0.1.0
+ */
 export let rec map = (fn, list) => {
   match (list) {
     [] => [],
@@ -79,6 +200,16 @@ export let rec map = (fn, list) => {
   }
 }
 
+/**
+ * Produces a new list initialized with the results of a mapper function
+ * called on each element of the input list and its index.
+ *
+ * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new list
+ * @param list: The list to iterate
+ * @returns The new list with mapped values
+ *
+ * @since v0.1.0
+ */
 export let mapi = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
@@ -89,6 +220,18 @@ export let mapi = (fn, list) => {
   iter(fn, list, 0)
 }
 
+/**
+ * Produces a new list by calling a function on each element
+ * of the input list. Each iteration produces an intermediate
+ * list, which are all appended to produce a "flattened" list
+ * of all results.
+ *
+ * @param fn: The function to be called on each element, where the value returned will be a list that gets appended to the new list
+ * @param list: The list to iterate
+ * @returns The new list
+ *
+ * @since v0.2.0
+ */
 export let rec flatMap = (fn, list) => {
   match (list) {
     [] => [],
@@ -96,18 +239,46 @@ export let rec flatMap = (fn, list) => {
   }
 }
 
+/**
+ * Checks that the given condition is satisfied for all
+ * elements in the input list.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to check
+ * @returns `true` if all elements satify the condition or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 export let every = (fn, list) => {
   reduce((acc, value) => {
     acc && fn(value)
   }, true, list)
 }
 
+/**
+ * Checks that the given condition is satisfied **at least
+ * once** by an element in the input list.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to iterate
+ * @returns `true` if one or more elements satify the condition or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 export let some = (fn, list) => {
   reduce((acc, value) => {
     acc || fn(value)
   }, false, list)
 }
 
+/**
+ * Iterates a list, calling an iterator function on each element.
+ *
+ * @param fn: The iterator function to call with each element
+ * @param list: The list to iterate
+ *
+ * @since v0.1.0
+ */
 export let rec forEach = (fn, list) => {
   match (list) {
     [] => void,
@@ -118,6 +289,15 @@ export let rec forEach = (fn, list) => {
   }
 }
 
+/**
+ * Iterates a list, calling an iterator function with each element.
+ * Also passes the index as the second argument to the function.
+ *
+ * @param fn: The iterator function to call with each element
+ * @param list: The list to iterate
+ *
+ * @since v0.1.0
+ */
 export let forEachi = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
@@ -131,6 +311,17 @@ export let forEachi = (fn, list) => {
   iter(fn, list, 0)
 }
 
+/**
+ * Produces a new list by calling a function on each element of
+ * the input list and only including it in the result list if the element satisfies
+ * the condition.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to iterate
+ * @returns The new list containing elements where `fn` returned `true`
+ *
+ * @since v0.1.0
+ */
 export let rec filter = (fn, list) => {
   match (list) {
     [] => [],
@@ -139,6 +330,17 @@ export let rec filter = (fn, list) => {
   }
 }
 
+/**
+ * Produces a new list by calling a function on each element of
+ * the input list and only including it in the result list if the element satisfies
+ * the condition. Also passes the index to the function.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to iterate
+ * @returns The new list containing elements where `fn` returned `true`
+ *
+ * @since v0.3.0
+ */
 export let filteri = (fn, list) => {
   let rec iter = (fn, list, index) => {
     match (list) {
@@ -151,6 +353,17 @@ export let filteri = (fn, list) => {
   iter(fn, list, 0)
 }
 
+/**
+ * Produces a new list by calling a function on each element of
+ * the input list and excluding it from the result list if the element satisfies
+ * the condition.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to iterate
+ * @returns The new list containing elements where `fn` returned `false`
+ *
+ * @since v0.1.0
+ */
 export let rec reject = (fn, list) => {
   match (list) {
     [] => [],
@@ -159,6 +372,18 @@ export let rec reject = (fn, list) => {
   }
 }
 
+/**
+ * Provides `Some(element)` containing the first element, or "head", of
+ * the input list or `None` if the list is empty.
+ *
+ * @param list: The list to access
+ * @returns `Some(firstElement)` if the list has elements or `None` otherwise
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `hd`
+ * @history v0.2.0: Renamed to `head`
+ * @history v0.3.0: Return type converted to `Option` type
+ */
 export let head = list => {
   match (list) {
     [] => None,
@@ -166,6 +391,18 @@ export let head = list => {
   }
 }
 
+/**
+ * Provides `Some(tail)` containing all list items except the first element, or "tail", of
+ * the input list or `None` if the list is empty.
+ *
+ * @param list: The list to access
+ * @returns `Some(tail)` if the list has elements or `None` otherwise
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `tl`
+ * @history v0.2.0: Renamed to `tail`
+ * @history v0.3.0: Return type converted to `Option` type
+ */
 export let tail = list => {
   match (list) {
     [] => None,
@@ -173,6 +410,18 @@ export let tail = list => {
   }
 }
 
+/**
+ * Provides `Some(element)` containing the element in the list at the specified index
+ * or `None` if the index is out-of-bounds or the list is empty.
+ *
+ * @param index: The index to access
+ * @param list: The list to access
+ * @returns `Some(element)` if the list contains an element at the index or `None` otherwise
+ *
+ * @since v0.1.0
+ * @history v0.1.0: Originally failed for index out-of-bounds or list empty
+ * @history v0.3.0: Return type converted to `Option` type
+ */
 export let rec nth = (index, list) => {
   if (index < 0) {
     None
@@ -184,6 +433,16 @@ export let rec nth = (index, list) => {
   }
 }
 
+/**
+ * Flattens nested lists.
+ *
+ * @param list: The list to flatten
+ * @returns A new list containing all nested list elements combined
+ *
+ * @example List.flatten([[1, 2], [3, 4]]) // [1, 2, 3, 4]
+ *
+ * @since v0.1.0
+ */
 export let rec flatten = list => {
   match (list) {
     [] => [],
@@ -191,6 +450,17 @@ export let rec flatten = list => {
   }
 }
 
+/**
+ * Inserts a new value into a list at the specified index.
+ * Fails if the index is out-of-bounds.
+ *
+ * @param value: The value to insert
+ * @param index: The index to update
+ * @param list: The list to update
+ * @returns The new list
+ *
+ * @since v0.1.0
+ */
 export let rec insert = (value, index, list) => {
   if (index < 0) {
     fail "insert index cannot be a negative number"
@@ -204,6 +474,16 @@ export let rec insert = (value, index, list) => {
   }
 }
 
+/**
+ * Counts the number of elements in a list that satisfy the given condition.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to iterate
+ * @returns The total number of elements that satisfy the condition
+ *
+ * @since v0.1.0
+ * @history v0.2.0: Made the function tail-recursive
+ */
 export let count = (fn, list) => {
   let rec iter = (n, list) => {
     match (list) {
@@ -214,6 +494,16 @@ export let count = (fn, list) => {
   iter(0, list)
 }
 
+/**
+ * Split a list into two, with the first list containing the required number of elements.
+ * Fails if the input list doesn't contain at least the required amount of elements.
+ *
+ * @param count: The number of elements required
+ * @param list: The list to split
+ * @returns Two lists where the first contains exactly the required amount of elements and the second contains any remaining elements
+ *
+ * @since v0.1.0
+ */
 export let part = (count, list) => {
   if (count < 0) {
     fail "part count cannot be a negative number"
@@ -232,12 +522,39 @@ export let part = (count, list) => {
   }
 }
 
+/**
+ * Rotates list elements by the specified amount to the right.
+ *
+ * If value is negative, list elements will be rotated by the
+ * specified amount to the left. See examples.
+ *
+ * Fails if the input list doesn't contain at least the required amount of elements.
+ *
+ * @param count: The number of elements to rotate by
+ * @param list: The list to be rotated
+ *
+ * @example List.rotate(2, [1, 2, 3, 4, 5]) // [3, 4, 5, 1, 2]
+ * @example List.rotate(-1, [1, 2, 3, 4, 5]) // [5, 1, 2, 3, 4]
+ *
+ * @since v0.1.0
+ */
 export let rotate = (count, list) => {
   let (beginning, end) = if (count >= 0) part(count, list)
     else part(length(list) + count, list)
   append(end, beginning)
 }
 
+/**
+ * Produces a new list with any duplicates removed.
+ * Uses the generic `==` structural equality operator.
+ *
+ * @param list: The list to filter
+ * @returns The new list with only unique values
+ *
+ * @since v0.2.0
+ * @history v0.1.0: Originally named `uniq`
+ * @history v0.2.0: Renamed to `unique`
+ */
 export let unique = list => {
   let rec iter = (list, acc) => {
     match (list) {
@@ -250,11 +567,23 @@ export let unique = list => {
   iter(list, [])
 }
 
-export let rec drop = (n, list) => {
-  if (n < 0) {
+/**
+ * Produces a new list with the specified amount elements removed from
+ * the beginning of the input list.
+ *
+ * Fails if the specified amount is a negative number.
+ *
+ * @param count: The amount of elements to remove
+ * @param list: The input list
+ * @returns The new list without the dropped elements
+ *
+ * @since v0.2.0
+ */
+export let rec drop = (count, list) => {
+  if (count < 0) {
     fail "number of items to drop cannot be a negative number"
   } else {
-    match ((n, list)) {
+    match ((count, list)) {
       (_, []) => [],
       (n, _) when n == 0 => list,
       (n, [first, ...rest]) => drop(n - 1, rest),
@@ -262,6 +591,17 @@ export let rec drop = (n, list) => {
   }
 }
 
+/**
+ * Produces a new list with the elements removed from the beginning
+ * of the input list until they no longer satisfy the given condition.
+ * Stops when the predicate function returns `false`.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The input list
+ * @returns The new list without the dropped elements
+ *
+ * @since v0.2.0
+ */
 export let rec dropWhile = (fn, list) => {
   match (list) {
     [] => list,
@@ -269,11 +609,23 @@ export let rec dropWhile = (fn, list) => {
   }
 }
 
-export let rec take = (n, list) => {
-  if (n < 0) {
+/**
+ * Produces a new list with–at most—the specified amount elements from
+ * the beginning of the input list.
+ *
+ * Fails if the specified amount is a negative number.
+ *
+ * @param count: The amount of elements to keep
+ * @param list: The input list
+ * @returns The new list containing the taken elements
+ *
+ * @since v0.2.0
+ */
+export let rec take = (count, list) => {
+  if (count < 0) {
     fail "number of items to take cannot be a negative number"
   } else {
-    match ((n, list)) {
+    match ((count, list)) {
       (_, []) => list,
       (n, _) when n == 0 => [],
       (n, [first, ...rest]) => [first, ...take(n - 1, rest)],
@@ -281,13 +633,35 @@ export let rec take = (n, list) => {
   }
 }
 
-export let rec takeWhile = (p, list) => {
+/**
+ * Produces a new list with elements from the beginning of the input list
+ * as long as they satisfy the given condition.
+ * Stops when the predicate function returns `false`.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The input list
+ * @returns The new list containing the taken elements
+ *
+ * @since v0.2.0
+ */
+export let rec takeWhile = (fn, list) => {
   match (list) {
     [] => [],
-    [first, ...rest] => if (p(first)) [first, ...takeWhile(p, rest)] else [],
+    [first, ...rest] => if (fn(first)) [first, ...takeWhile(fn, rest)] else [],
   }
 }
 
+/**
+ * Finds the first element in a list that satifies the given condition.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to search
+ * @returns `Some(element)` containing the first value found or `None` otherwise
+ *
+ * @since v0.2.0
+ * @history v0.2.0: Originally failed if the list was empty
+ * @history v0.3.0: Return type converted to `Option` type
+ */
 export let rec find = (fn, list) => {
   match (list) {
     [] => None,
@@ -295,6 +669,17 @@ export let rec find = (fn, list) => {
   }
 }
 
+/**
+ * Finds the first index in a list where the element satifies the given condition.
+ *
+ * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
+ * @param list: The list to search
+ * @returns `Some(index)` containing the index of the first element found or `None` otherwise
+ *
+ * @since v0.2.0
+ * @history v0.2.0: Originally failed if the list was empty
+ * @history v0.3.0: Return type converted to `Option` type
+ */
 export let findIndex = (fn, list) => {
   let rec findItemIndex = (l, index) => {
     match (l) {
@@ -306,25 +691,54 @@ export let findIndex = (fn, list) => {
   findItemIndex(list, 0)
 }
 
-export let product = (a, b) => {
+/**
+ * Combines two lists into a Cartesian product of tuples containing
+ * all ordered pairs `(a, b)`.
+ *
+ * @param list1: The list to provide values for the first tuple element
+ * @param list2: The list to provide values for the second tuple element
+ * @returns The new list containing all pairs of `(a, b)`
+ *
+ * @since v0.2.0
+ */
+export let product = (list1, list2) => {
   let mut list = []
   forEach(aItem => {
     forEach(bItem => {
       list = [(aItem, bItem), ...list]
-    }, b)
-  }, a)
+    }, list2)
+  }, list1)
   reverse(list)
 }
 
+/**
+ * Provides the subset of a list given zero-based start index and amount of elements
+ * to include.
+ *
+ * Fails if the start index or amount of elements are negative numbers.
+ *
+ * @param start: The index of the list where the subset will begin (inclusive)
+ * @param length: The amount of elements to be included in the subset
+ * @param list: The input list
+ * @returns The subset of the list
+ *
+ * @since v0.2.0
+ */
 export let sub = (start, length, list) => {
   take(length, drop(start, list))
 }
 
-// Join the given list of strings with the given separator
-// @param separator: String - The separator to insert between items in the string
-// @param items: List<String> - The input strings
-// @returns String
-export let join = (separator: String, items: List<String>) => {
+/**
+ * Combine the given list of strings into one string with the specified
+ * separator inserted between each item.
+ *
+ * @param separator: The separator to insert between elements
+ * @param list: The list to combine
+ * @returns The combined elements with the separator between each
+ *
+ * @since v0.4.0
+ */
+export let join = (separator: String, list: List<String>) => {
   let rec iter = (sep, acc, rem) => {
     match (rem) {
       [] => acc,
@@ -339,7 +753,7 @@ export let join = (separator: String, items: List<String>) => {
   }
 
   // Reverse and reduce to take advantage of TCE
-  match (iter(separator, None, reverse(items))) {
+  match (iter(separator, None, reverse(list))) {
     None => "",
     Some(s) => s,
   }
@@ -347,7 +761,7 @@ export let join = (separator: String, items: List<String>) => {
 
 /**
  * Reverses the first list and appends the second list to the end.
- * 
+ *
  * @param list1: The list to reverse
  * @param list2: The list to append
  * @since v0.4.5
@@ -361,7 +775,7 @@ export let rec revAppend = (list1, list2) => {
 
 /**
  * Sorts the given list based on a given comparator function. The resulting list is sorted in increasing order.
- * 
+ *
  * Ordering is calculated using a comparator function which takes two list elements and must return 0 if both are equal, a positive number if the first is greater, and a negative number if the first is smaller.
  * @param comp: The comparator function used to indicate sort order
  * @param list: The list to be sorted

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -159,8 +159,8 @@ No other changes yet.
 append : (List<a>, List<a>) -> List<a>
 ```
 
-Creates a new list with the elements the first list, followed by
-the elements of the second list. This does not modify the arguments.
+Creates a new list with the elements of the first list followed by
+the elements of the second list.
 
 Parameters:
 
@@ -464,7 +464,7 @@ No other changes yet.
 forEachi : (((a, Number) -> b), List<a>) -> Void
 ```
 
-Iterates a list, calling an iterator function with each element.
+Iterates a list, calling an iterator function on each element.
 Also passes the index as the second argument to the function.
 
 Parameters:
@@ -793,10 +793,10 @@ No other changes yet.
 rotate : (Number, List<a>) -> List<a>
 ```
 
-Rotates list elements by the specified amount to the right.
+Rotates list elements by the specified amount to the left.
 
 If value is negative, list elements will be rotated by the
-specified amount to the left. See examples.
+specified amount to the right. See examples.
 
 Fails if the input list doesn't contain at least the required amount of elements.
 
@@ -862,7 +862,7 @@ No other changes yet.
 drop : (Number, List<a>) -> List<a>
 ```
 
-Produces a new list with the specified amount elements removed from
+Produces a new list with the specified number of elements removed from
 the beginning of the input list.
 
 Fails if the specified amount is a negative number.

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -1,218 +1,1121 @@
+---
+title: List
+---
+
+Utilities for working with lists.
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `lists`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `list`</td></tr>
+</tbody>
+</table>
+</details>
+
+```grain
+import List from "list"
+```
+
+## Values
+
+Functions for working with the List data type.
+
 ### List.**init**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 init : (Number, (Number -> a)) -> List<a>
 ```
 
+Creates a new list of the specified length where each element is
+initialized with the result of an initializer function. The initializer
+is called with the index of each list element.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The length of the new list|
+|`fn`|`Number -> a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list|
+
+Examples:
+
+```grain
+List.init(5, n => n + 3) // [3, 4, 5, 6, 7]
+```
+
 ### List.**length**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Made the function tail-recursive</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 length : List<a> -> Number
 ```
 
+Computes the length of the input list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The number of elements in the list|
+
 ### List.**sum**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Made the function tail-recursive</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 sum : List<Number> -> Number
 ```
 
+Adds all numbers in the input list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<Number>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The combined sum of all values|
+
 ### List.**reverse**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 reverse : List<a> -> List<a>
 ```
 
+Creates a new list with all elements in reverse order.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to reverse|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list|
+
 ### List.**append**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 append : (List<a>, List<a>) -> List<a>
 ```
 
+Creates a new list with the elements the first list, followed by
+the elements of the second list. This does not modify the arguments.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list1`|`List<a>`|The list containing elements to appear first|
+|`list2`|`List<a>`|The list containing elements to appear second|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing elements from `list1` followed by elements from `list2`|
+
 ### List.**contains**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 contains : (a, List<a>) -> Bool
 ```
 
+Checks if the value is an element of the input list.
+Uses the generic `==` structural equality operator.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`search`|`a`|The value to compare|
+|`list`|`List<a>`|The list to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the value exists in the list or `false` otherwise|
+
 ### List.**reduce**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `foldLeft`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `reduce`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 reduce : (((a, b) -> a), a, List<b>) -> a
 ```
 
+Combines all elements of a list using a reducer function,
+starting from the "head", or left side, of the list.
+
+In `List.reduce(fn, initial, list)`, `fn` is called with
+an accumulator and each element of the list, and returns
+a new accumulator. The final value is the last accumulator
+returned. The accumulator starts with value `initial`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`initial`|`a`|The initial value to use for the accumulator on the first iteration|
+|`list`|`List<b>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`a`|The final accumulator returned from `fn`|
+
+Examples:
+
+```grain
+List.reduce((a, b) => a + b, 0, [1, 2, 3]) // 6
+```
+
 ### List.**reduceRight**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `foldRight`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `reduceRight`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 reduceRight : (((a, b) -> b), b, List<a>) -> b
 ```
 
+Combines all elements of a list using a reducer function,
+starting from the "end", or right side, of the list.
+
+In `List.reduceRight(fn, initial, list)`, `fn` is called with
+each element of the list and an accumulator, and returns
+a new accumulator. The final value is the last accumulator
+returned. The accumulator starts with value `initial`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, b) -> b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`initial`|`b`|The initial value to use for the accumulator on the first iteration|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`b`|The final accumulator returned from `fn`|
+
+Examples:
+
+```grain
+List.reduceRight((a, b) => b ++ a, "", ["baz", "bar", "foo"]) // "foobarbaz"
+```
+
 ### List.**map**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 map : ((a -> b), List<a>) -> List<b>
 ```
 
+Produces a new list initialized with the results of a mapper function
+called on each element of the input list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<b>`|The new list with mapped values|
+
 ### List.**mapi**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 mapi : (((a, Number) -> b), List<a>) -> List<b>
 ```
 
+Produces a new list initialized with the results of a mapper function
+called on each element of the input list and its index.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<b>`|The new list with mapped values|
+
 ### List.**flatMap**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 flatMap : ((a -> List<b>), List<a>) -> List<b>
 ```
 
+Produces a new list by calling a function on each element
+of the input list. Each iteration produces an intermediate
+list, which are all appended to produce a "flattened" list
+of all results.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> List<b>`|The function to be called on each element, where the value returned will be a list that gets appended to the new list|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<b>`|The new list|
+
 ### List.**every**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 every : ((a -> Bool), List<a>) -> Bool
 ```
 
+Checks that the given condition is satisfied for all
+elements in the input list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to check|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if all elements satify the condition or `false` otherwise|
+
 ### List.**some**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 some : ((a -> Bool), List<a>) -> Bool
 ```
 
+Checks that the given condition is satisfied **at least
+once** by an element in the input list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if one or more elements satify the condition or `false` otherwise|
+
 ### List.**forEach**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 forEach : ((a -> b), List<a>) -> Void
 ```
 
+Iterates a list, calling an iterator function on each element.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> b`|The iterator function to call with each element|
+|`list`|`List<a>`|The list to iterate|
+
 ### List.**forEachi**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 forEachi : (((a, Number) -> b), List<a>) -> Void
 ```
 
+Iterates a list, calling an iterator function with each element.
+Also passes the index as the second argument to the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> b`|The iterator function to call with each element|
+|`list`|`List<a>`|The list to iterate|
+
 ### List.**filter**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 filter : ((a -> Bool), List<a>) -> List<a>
 ```
 
+Produces a new list by calling a function on each element of
+the input list and only including it in the result list if the element satisfies
+the condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing elements where `fn` returned `true`|
+
 ### List.**filteri**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.3.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 filteri : (((a, Number) -> Bool), List<a>) -> List<a>
 ```
 
+Produces a new list by calling a function on each element of
+the input list and only including it in the result list if the element satisfies
+the condition. Also passes the index to the function.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing elements where `fn` returned `true`|
+
 ### List.**reject**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 reject : ((a -> Bool), List<a>) -> List<a>
 ```
 
+Produces a new list by calling a function on each element of
+the input list and excluding it from the result list if the element satisfies
+the condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing elements where `fn` returned `false`|
+
 ### List.**head**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `hd`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `head`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Return type converted to `Option` type</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 head : List<a> -> Option<a>
 ```
 
+Provides `Some(element)` containing the first element, or "head", of
+the input list or `None` if the list is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to access|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|`Some(firstElement)` if the list has elements or `None` otherwise|
+
 ### List.**tail**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `tl`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `tail`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Return type converted to `Option` type</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 tail : List<a> -> Option<List<a>>
 ```
 
+Provides `Some(tail)` containing all list items except the first element, or "tail", of
+the input list or `None` if the list is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to access|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<List<a>>`|`Some(tail)` if the list has elements or `None` otherwise|
+
 ### List.**nth**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally failed for index out-of-bounds or list empty</td></tr>
+<tr><td><code>0.3.0</code></td><td>Return type converted to `Option` type</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 nth : (Number, List<a>) -> Option<a>
 ```
 
+Provides `Some(element)` containing the element in the list at the specified index
+or `None` if the index is out-of-bounds or the list is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`index`|`Number`|The index to access|
+|`list`|`List<a>`|The list to access|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|`Some(element)` if the list contains an element at the index or `None` otherwise|
+
 ### List.**flatten**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 flatten : List<List<a>> -> List<a>
 ```
 
+Flattens nested lists.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<List<a>>`|The list to flatten|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A new list containing all nested list elements combined|
+
+Examples:
+
+```grain
+List.flatten([[1, 2], [3, 4]]) // [1, 2, 3, 4]
+```
+
 ### List.**insert**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 insert : (a, Number, List<a>) -> List<a>
 ```
 
+Inserts a new value into a list at the specified index.
+Fails if the index is out-of-bounds.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`a`|The value to insert|
+|`index`|`Number`|The index to update|
+|`list`|`List<a>`|The list to update|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list|
+
 ### List.**count**
+
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Made the function tail-recursive</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 count : ((a -> Bool), List<a>) -> Number
 ```
 
+Counts the number of elements in a list that satisfy the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to iterate|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The total number of elements that satisfy the condition|
+
 ### List.**part**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 part : (Number, List<a>) -> (List<a>, List<a>)
 ```
 
+Split a list into two, with the first list containing the required number of elements.
+Fails if the input list doesn't contain at least the required amount of elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`count`|`Number`|The number of elements required|
+|`list`|`List<a>`|The list to split|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`(List<a>, List<a>)`|Two lists where the first contains exactly the required amount of elements and the second contains any remaining elements|
+
 ### List.**rotate**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 rotate : (Number, List<a>) -> List<a>
 ```
 
+Rotates list elements by the specified amount to the right.
+
+If value is negative, list elements will be rotated by the
+specified amount to the left. See examples.
+
+Fails if the input list doesn't contain at least the required amount of elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`count`|`Number`|The number of elements to rotate by|
+|`list`|`List<a>`|The list to be rotated|
+
+Examples:
+
+```grain
+List.rotate(2, [1, 2, 3, 4, 5]) // [3, 4, 5, 1, 2]
+```
+
+```grain
+List.rotate(-1, [1, 2, 3, 4, 5]) // [5, 1, 2, 3, 4]
+```
+
 ### List.**unique**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>Originally named `uniq`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Renamed to `unique`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 unique : List<a> -> List<a>
 ```
 
+Produces a new list with any duplicates removed.
+Uses the generic `==` structural equality operator.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to filter|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list with only unique values|
+
 ### List.**drop**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 drop : (Number, List<a>) -> List<a>
 ```
 
+Produces a new list with the specified amount elements removed from
+the beginning of the input list.
+
+Fails if the specified amount is a negative number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`count`|`Number`|The amount of elements to remove|
+|`list`|`List<a>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list without the dropped elements|
+
 ### List.**dropWhile**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 dropWhile : ((a -> Bool), List<a>) -> List<a>
 ```
 
+Produces a new list with the elements removed from the beginning
+of the input list until they no longer satisfy the given condition.
+Stops when the predicate function returns `false`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list without the dropped elements|
+
 ### List.**take**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 take : (Number, List<a>) -> List<a>
 ```
 
+Produces a new list with–at most—the specified amount elements from
+the beginning of the input list.
+
+Fails if the specified amount is a negative number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`count`|`Number`|The amount of elements to keep|
+|`list`|`List<a>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing the taken elements|
+
 ### List.**takeWhile**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 takeWhile : ((a -> Bool), List<a>) -> List<a>
 ```
 
+Produces a new list with elements from the beginning of the input list
+as long as they satisfy the given condition.
+Stops when the predicate function returns `false`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The new list containing the taken elements|
+
 ### List.**find**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally failed if the list was empty</td></tr>
+<tr><td><code>0.3.0</code></td><td>Return type converted to `Option` type</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 find : ((a -> Bool), List<a>) -> Option<a>
 ```
 
+Finds the first element in a list that satifies the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to search|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|`Some(element)` containing the first value found or `None` otherwise|
+
 ### List.**findIndex**
+
+<details>
+<summary>Added in <code>0.2.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally failed if the list was empty</td></tr>
+<tr><td><code>0.3.0</code></td><td>Return type converted to `Option` type</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 findIndex : ((a -> Bool), List<a>) -> Option<Number>
 ```
 
+Finds the first index in a list where the element satifies the given condition.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`list`|`List<a>`|The list to search|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<Number>`|`Some(index)` containing the index of the first element found or `None` otherwise|
+
 ### List.**product**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 product : (List<a>, List<b>) -> List<(a, b)>
 ```
 
+Combines two lists into a Cartesian product of tuples containing
+all ordered pairs `(a, b)`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list1`|`List<a>`|The list to provide values for the first tuple element|
+|`list2`|`List<b>`|The list to provide values for the second tuple element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<(a, b)>`|The new list containing all pairs of `(a, b)`|
+
 ### List.**sub**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 sub : (Number, Number, List<a>) -> List<a>
 ```
 
+Provides the subset of a list given zero-based start index and amount of elements
+to include.
+
+Fails if the start index or amount of elements are negative numbers.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`start`|`Number`|The index of the list where the subset will begin (inclusive)|
+|`length`|`Number`|The amount of elements to be included in the subset|
+|`list`|`List<a>`|The input list|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|The subset of the list|
+
 ### List.**join**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 join : (String, List<String>) -> String
 ```
+
+Combine the given list of strings into one string with the specified
+separator inserted between each item.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`separator`|`String`|The separator to insert between elements|
+|`list`|`List<String>`|The list to combine|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|The combined elements with the separator between each|
 
 ### List.**revAppend**
 


### PR DESCRIPTION
While prepping for release, I noticed that the List module didn't have any graindoc added to it. With the automated docs updates on the website, this would wipe out our List documentation.

I took most of this from the Array module and updated it for the differences. I also noticed some inconsistencies in Array that I'll PR after this.

Please thoroughly review the docs for clarity and consistency (especially with our other docs).