### PR TITLE
fix(graindoc): Remove spaces between parens and infix idents

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -50,7 +50,7 @@ let parenthesized_ident = name =>
 
 let value_ident = (ppf, name) =>
   if (parenthesized_ident(name)) {
-    fprintf(ppf, "( %s )", name);
+    fprintf(ppf, "(%s)", name);
   } else {
     pp_print_string(ppf, name);
   };

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -13,55 +13,55 @@ decr : Number -> Number
 ### Pervasives.**+**
 
 ```grain
-( + ) : (Number, Number) -> Number
+(+) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**-**
 
 ```grain
-( - ) : (Number, Number) -> Number
+(-) : (Number, Number) -> Number
 ```
 
 ### Pervasives.*****
 
 ```grain
-( * ) : (Number, Number) -> Number
+(*) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**/**
 
 ```grain
-( / ) : (Number, Number) -> Number
+(/) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**%**
 
 ```grain
-( % ) : (Number, Number) -> Number
+(%) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**<**
 
 ```grain
-( < ) : (Number, Number) -> Bool
+(<) : (Number, Number) -> Bool
 ```
 
 ### Pervasives.**>**
 
 ```grain
-( > ) : (Number, Number) -> Bool
+(>) : (Number, Number) -> Bool
 ```
 
 ### Pervasives.**<=**
 
 ```grain
-( <= ) : (Number, Number) -> Bool
+(<=) : (Number, Number) -> Bool
 ```
 
 ### Pervasives.**>=**
 
 ```grain
-( >= ) : (Number, Number) -> Bool
+(>=) : (Number, Number) -> Bool
 ```
 
 ### Pervasives.**lnot**
@@ -73,55 +73,55 @@ lnot : Number -> Number
 ### Pervasives.**&**
 
 ```grain
-( & ) : (Number, Number) -> Number
+(&) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**|**
 
 ```grain
-( | ) : (Number, Number) -> Number
+(|) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**^**
 
 ```grain
-( ^ ) : (Number, Number) -> Number
+(^) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**<<**
 
 ```grain
-( << ) : (Number, Number) -> Number
+(<<) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**>>>**
 
 ```grain
-( >>> ) : (Number, Number) -> Number
+(>>>) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**>>**
 
 ```grain
-( >> ) : (Number, Number) -> Number
+(>>) : (Number, Number) -> Number
 ```
 
 ### Pervasives.**!**
 
 ```grain
-( ! ) : Bool -> Bool
+(!) : Bool -> Bool
 ```
 
 ### Pervasives.**&&**
 
 ```grain
-( && ) : (Bool, Bool) -> Bool
+(&&) : (Bool, Bool) -> Bool
 ```
 
 ### Pervasives.**||**
 
 ```grain
-( || ) : (Bool, Bool) -> Bool
+(||) : (Bool, Bool) -> Bool
 ```
 
 ### Pervasives.**box**
@@ -175,19 +175,19 @@ print : a -> Void
 ### Pervasives.**++**
 
 ```grain
-( ++ ) : (String, String) -> String
+(++) : (String, String) -> String
 ```
 
 ### Pervasives.**==**
 
 ```grain
-( == ) : (a, a) -> Bool
+(==) : (a, a) -> Bool
 ```
 
 ### Pervasives.**!=**
 
 ```grain
-( != ) : (a, a) -> Bool
+(!=) : (a, a) -> Bool
 ```
 
 ### Pervasives.**is**

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -97,25 +97,25 @@ numberEqual : (WasmI32, WasmI32) -> Bool
 ### Numbers.**<**
 
 ```grain
-( < ) : (Number, Number) -> Bool
+(<) : (Number, Number) -> Bool
 ```
 
 ### Numbers.**>**
 
 ```grain
-( > ) : (Number, Number) -> Bool
+(>) : (Number, Number) -> Bool
 ```
 
 ### Numbers.**<=**
 
 ```grain
-( <= ) : (Number, Number) -> Bool
+(<=) : (Number, Number) -> Bool
 ```
 
 ### Numbers.**>=**
 
 ```grain
-( >= ) : (Number, Number) -> Bool
+(>=) : (Number, Number) -> Bool
 ```
 
 ### Numbers.**numberEq**
@@ -133,37 +133,37 @@ lnot : Number -> Number
 ### Numbers.**<<**
 
 ```grain
-( << ) : (Number, Number) -> Number
+(<<) : (Number, Number) -> Number
 ```
 
 ### Numbers.**>>>**
 
 ```grain
-( >>> ) : (Number, Number) -> Number
+(>>>) : (Number, Number) -> Number
 ```
 
 ### Numbers.**&**
 
 ```grain
-( & ) : (Number, Number) -> Number
+(&) : (Number, Number) -> Number
 ```
 
 ### Numbers.**|**
 
 ```grain
-( | ) : (Number, Number) -> Number
+(|) : (Number, Number) -> Number
 ```
 
 ### Numbers.**^**
 
 ```grain
-( ^ ) : (Number, Number) -> Number
+(^) : (Number, Number) -> Number
 ```
 
 ### Numbers.**>>**
 
 ```grain
-( >> ) : (Number, Number) -> Number
+(>>) : (Number, Number) -> Number
 ```
 
 ### Numbers.**coerceNumberToInt32**
@@ -253,31 +253,31 @@ convertInexactToExact : Number -> Number
 ### Numbers.**+**
 
 ```grain
-( + ) : (Number, Number) -> Number
+(+) : (Number, Number) -> Number
 ```
 
 ### Numbers.**-**
 
 ```grain
-( - ) : (Number, Number) -> Number
+(-) : (Number, Number) -> Number
 ```
 
 ### Numbers.*****
 
 ```grain
-( * ) : (Number, Number) -> Number
+(*) : (Number, Number) -> Number
 ```
 
 ### Numbers.**/**
 
 ```grain
-( / ) : (Number, Number) -> Number
+(/) : (Number, Number) -> Number
 ```
 
 ### Numbers.**%**
 
 ```grain
-( % ) : (Number, Number) -> Number
+(%) : (Number, Number) -> Number
 ```
 
 ### Numbers.**incr**


### PR DESCRIPTION
While working on the Pervasives docs, I noticed that we printed infix operators like `( + )` but all our website docs were written as `(+)`. So this removes the extra spaces around it.