### PR TITLE
fix(graindoc): Add parens around infix operators in titles

### DIFF
--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -23,7 +23,13 @@ let unique_names = ref(Ident.empty);
 
 let ident_name = id =>
   try(Ident.find_same(id, unique_names^)) {
-  | Not_found => Ident.name(id)
+  | Not_found =>
+    let name = Ident.name(id);
+    if (Oprint.parenthesized_ident(name)) {
+      "(" ++ name ++ ")";
+    } else {
+      name;
+    };
   };
 
 let add_unique = id =>

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -23,13 +23,7 @@ let unique_names = ref(Ident.empty);
 
 let ident_name = id =>
   try(Ident.find_same(id, unique_names^)) {
-  | Not_found =>
-    let name = Ident.name(id);
-    if (Oprint.parenthesized_ident(name)) {
-      "(" ++ name ++ ")";
-    } else {
-      name;
-    };
+  | Not_found => Ident.name(id)
   };
 
 let add_unique = id =>
@@ -39,7 +33,14 @@ let add_unique = id =>
       Ident.add(id, Ident.unique_toplevel_name(id), unique_names^)
   };
 
-let ident = (ppf, id) => pp_print_string(ppf, ident_name(id));
+let ident = (ppf, id) => {
+  let name = ident_name(id);
+  if (Oprint.parenthesized_ident(name)) {
+    fprintf(ppf, "(%s)", name);
+  } else {
+    pp_print_string(ppf, name);
+  };
+};
 
 /* Print a path */
 

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -10,55 +10,55 @@ incr : Number -> Number
 decr : Number -> Number
 ```
 
-### Pervasives.**+**
+### Pervasives.**(+)**
 
 ```grain
 ( + ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**-**
+### Pervasives.**(-)**
 
 ```grain
 ( - ) : (Number, Number) -> Number
 ```
 
-### Pervasives.*****
+### Pervasives.**(*)**
 
 ```grain
 ( * ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**/**
+### Pervasives.**(/)**
 
 ```grain
 ( / ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**%**
+### Pervasives.**(%)**
 
 ```grain
 ( % ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**<**
+### Pervasives.**(<)**
 
 ```grain
 ( < ) : (Number, Number) -> Bool
 ```
 
-### Pervasives.**>**
+### Pervasives.**(>)**
 
 ```grain
 ( > ) : (Number, Number) -> Bool
 ```
 
-### Pervasives.**<=**
+### Pervasives.**(<=)**
 
 ```grain
 ( <= ) : (Number, Number) -> Bool
 ```
 
-### Pervasives.**>=**
+### Pervasives.**(>=)**
 
 ```grain
 ( >= ) : (Number, Number) -> Bool
@@ -70,55 +70,55 @@ decr : Number -> Number
 lnot : Number -> Number
 ```
 
-### Pervasives.**&**
+### Pervasives.**(&)**
 
 ```grain
 ( & ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**|**
+### Pervasives.**(|)**
 
 ```grain
 ( | ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**^**
+### Pervasives.**(^)**
 
 ```grain
 ( ^ ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**<<**
+### Pervasives.**(<<)**
 
 ```grain
 ( << ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**>>>**
+### Pervasives.**(>>>)**
 
 ```grain
 ( >>> ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**>>**
+### Pervasives.**(>>)**
 
 ```grain
 ( >> ) : (Number, Number) -> Number
 ```
 
-### Pervasives.**!**
+### Pervasives.**(!)**
 
 ```grain
 ( ! ) : Bool -> Bool
 ```
 
-### Pervasives.**&&**
+### Pervasives.**(&&)**
 
 ```grain
 ( && ) : (Bool, Bool) -> Bool
 ```
 
-### Pervasives.**||**
+### Pervasives.**(||)**
 
 ```grain
 ( || ) : (Bool, Bool) -> Bool
@@ -172,19 +172,19 @@ toString : a -> String
 print : a -> Void
 ```
 
-### Pervasives.**++**
+### Pervasives.**(++)**
 
 ```grain
 ( ++ ) : (String, String) -> String
 ```
 
-### Pervasives.**==**
+### Pervasives.**(==)**
 
 ```grain
 ( == ) : (a, a) -> Bool
 ```
 
-### Pervasives.**!=**
+### Pervasives.**(!=)**
 
 ```grain
 ( != ) : (a, a) -> Bool

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -94,25 +94,25 @@ coerceNumberToWasmI32 : Number -> WasmI32
 numberEqual : (WasmI32, WasmI32) -> Bool
 ```
 
-### Numbers.**<**
+### Numbers.**(<)**
 
 ```grain
 ( < ) : (Number, Number) -> Bool
 ```
 
-### Numbers.**>**
+### Numbers.**(>)**
 
 ```grain
 ( > ) : (Number, Number) -> Bool
 ```
 
-### Numbers.**<=**
+### Numbers.**(<=)**
 
 ```grain
 ( <= ) : (Number, Number) -> Bool
 ```
 
-### Numbers.**>=**
+### Numbers.**(>=)**
 
 ```grain
 ( >= ) : (Number, Number) -> Bool
@@ -130,37 +130,37 @@ numberEq : (Number, Number) -> Bool
 lnot : Number -> Number
 ```
 
-### Numbers.**<<**
+### Numbers.**(<<)**
 
 ```grain
 ( << ) : (Number, Number) -> Number
 ```
 
-### Numbers.**>>>**
+### Numbers.**(>>>)**
 
 ```grain
 ( >>> ) : (Number, Number) -> Number
 ```
 
-### Numbers.**&**
+### Numbers.**(&)**
 
 ```grain
 ( & ) : (Number, Number) -> Number
 ```
 
-### Numbers.**|**
+### Numbers.**(|)**
 
 ```grain
 ( | ) : (Number, Number) -> Number
 ```
 
-### Numbers.**^**
+### Numbers.**(^)**
 
 ```grain
 ( ^ ) : (Number, Number) -> Number
 ```
 
-### Numbers.**>>**
+### Numbers.**(>>)**
 
 ```grain
 ( >> ) : (Number, Number) -> Number
@@ -250,31 +250,31 @@ convertExactToInexact : Number -> Number
 convertInexactToExact : Number -> Number
 ```
 
-### Numbers.**+**
+### Numbers.**(+)**
 
 ```grain
 ( + ) : (Number, Number) -> Number
 ```
 
-### Numbers.**-**
+### Numbers.**(-)**
 
 ```grain
 ( - ) : (Number, Number) -> Number
 ```
 
-### Numbers.*****
+### Numbers.**(*)**
 
 ```grain
 ( * ) : (Number, Number) -> Number
 ```
 
-### Numbers.**/**
+### Numbers.**(/)**
 
 ```grain
 ( / ) : (Number, Number) -> Number
 ```
 
-### Numbers.**%**
+### Numbers.**(%)**
 
 ```grain
 ( % ) : (Number, Number) -> Number


### PR DESCRIPTION
While working on the Pervasives docs, I noticed that infix operator idents weren't being printed with parens. This adds similar logic to `Oprint.value_ident` for handling these idents.