### PR TITLE
chore(cli): Always run NEAR smoketest in release mode

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "build-pkg": "pkg ./package.json --no-bytecode --compress Brotli --output ../pkg/grain",
-    "build:test": "grain compile --wasi-polyfill __test__/wasi.gr --use-start-section __test__/index.gr",
+    "build:test": "grain compile --release --wasi-polyfill __test__/wasi.gr --use-start-section __test__/index.gr",
     "pretest": "npm run build:test",
     "test": "jest --detectOpenHandles"
   },


### PR DESCRIPTION
This makes it so our NEAR smoketest always runs in release mode. We need to do this because the smoketest is testing that binaryen optimizations don't produce wasm that is unsupported by NEAR.