### PR TITLE
fix(stdlib)!: Ensure Void return for forEach functions in List module

### DIFF
--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -283,7 +283,7 @@ export let rec forEach = (fn, list) => {
   match (list) {
     [] => void,
     [first, ...rest] => {
-      fn(first)
+      fn(first): Void
       forEach(fn, rest)
     },
   }
@@ -303,7 +303,7 @@ export let forEachi = (fn, list) => {
     match (list) {
       [] => void,
       [first, ...rest] => {
-        fn(first, index)
+        fn(first, index): Void
         iter(fn, rest, index + 1)
       },
     }

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -441,7 +441,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : ((a -> b), List<a>) -> Void
+forEach : ((a -> Void), List<a>) -> Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -450,7 +450,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The iterator function to call with each element|
+|`fn`|`a -> Void`|The iterator function to call with each element|
 |`list`|`List<a>`|The list to iterate|
 
 ### List.**forEachi**
@@ -461,7 +461,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachi : (((a, Number) -> b), List<a>) -> Void
+forEachi : (((a, Number) -> Void), List<a>) -> Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -471,7 +471,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> b`|The iterator function to call with each element|
+|`fn`|`(a, Number) -> Void`|The iterator function to call with each element|
 |`list`|`List<a>`|The list to iterate|
 
 ### List.**filter**


### PR DESCRIPTION
Found this while reviewing doc changes against the website. `List.forEach` and `List.forEachi` signatures were wrong.