### PR TITLE
chore(ci): Remove the last-release-sha from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "last-release-sha": "af86344e778187659e80753b2ea847f5dea13908",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "plugins": [


### PR DESCRIPTION
This was used to get us through the upgrade of release-please, but it should be removed now that 0.5.0 is released.