### PR TITLE
fix(compiler): Properly handle corrupted CMIs

### DIFF
--- a/compiler/src/typed/cmi_format.re
+++ b/compiler/src/typed/cmi_format.re
@@ -127,6 +127,7 @@ let read_cmi = filename => {
     cmi;
   | None
   | exception End_of_file
+  | exception (Invalid_argument(_))
   | exception (Failure(_)) =>
     close_in(ic);
     raise(Error(Corrupted_interface(filename)));


### PR DESCRIPTION
I was able to reproduce with a hex editor, and with this change the file is recompiled as expected.