### PR TITLE
fix(grainfmt): Support PPatOr and PPatAlias

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1308,7 +1308,9 @@ and print_pattern =
     | PPatOr(pattern1, pattern2) => (
         Doc.group(
           Doc.concat([
-            print_pattern(~original_source, ~comments, ~next_loc, pattern1),
+            Doc.group(
+              print_pattern(~original_source, ~comments, ~next_loc, pattern1),
+            ),
             Doc.space,
             Doc.text("|"),
             Doc.line,

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1312,7 +1312,9 @@ and print_pattern =
             Doc.space,
             Doc.text("|"),
             Doc.line,
-            print_pattern(~original_source, ~comments, ~next_loc, pattern2),
+            Doc.group(
+              print_pattern(~original_source, ~comments, ~next_loc, pattern2),
+            ),
           ]),
         ),
         false,

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1309,7 +1309,9 @@ and print_pattern =
         Doc.group(
           Doc.concat([
             print_pattern(~original_source, ~comments, ~next_loc, pattern1),
-            Doc.text(" | "),
+            Doc.space,
+            Doc.text("|"),
+            Doc.line,
             print_pattern(~original_source, ~comments, ~next_loc, pattern2),
           ]),
         ),
@@ -1320,7 +1322,9 @@ and print_pattern =
         Doc.group(
           Doc.concat([
             print_pattern(~original_source, ~comments, ~next_loc, pattern),
-            Doc.text(" as "),
+            Doc.space,
+            Doc.text("as"),
+            Doc.space,
             Doc.text(loc.txt),
           ]),
         ),

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1305,16 +1305,27 @@ and print_pattern =
         );
       };
 
-    | PPatOr(pattern1, pattern2) =>
-      /* currently unsupported so just replace with the original source */
-      let original_code = get_original_code(pat.ppat_loc, original_source);
+    | PPatOr(pattern1, pattern2) => (
+        Doc.group(
+          Doc.concat([
+            print_pattern(~original_source, ~comments, ~next_loc, pattern1),
+            Doc.text(" | "),
+            print_pattern(~original_source, ~comments, ~next_loc, pattern2),
+          ]),
+        ),
+        false,
+      )
 
-      (Doc.text(original_code), false);
-    | PPatAlias(pattern, loc) =>
-      /* currently unsupported so just replace with the original source */
-      let original_code = get_original_code(pat.ppat_loc, original_source);
-
-      (Doc.text(original_code), false);
+    | PPatAlias(pattern, loc) => (
+        Doc.group(
+          Doc.concat([
+            print_pattern(~original_source, ~comments, ~next_loc, pattern),
+            Doc.text(" as "),
+            Doc.text(loc.txt),
+          ]),
+        ),
+        false,
+      )
     };
 
   let (pattern, parens) = printed_pattern;

--- a/compiler/test/formatter_inputs/patterns.gr
+++ b/compiler/test/formatter_inputs/patterns.gr
@@ -1,0 +1,23 @@
+import Option from "option"
+import List from "list"
+
+let user = Some("Bob")
+
+match (user) {
+  Some("Bob" |   "Sally" as name) =>   "VIP " ++ name,
+
+  
+  Some(name) =>     "Valued guest " ++ name,
+    None => "Member",
+}
+
+let list = [1, 2, 3]
+match (list) {
+
+
+  [_, mid,    _] |
+  [_, _, mid, _, _] => Some(mid),
+  _ => None,
+
+
+}

--- a/compiler/test/formatter_inputs/patterns.gr
+++ b/compiler/test/formatter_inputs/patterns.gr
@@ -23,6 +23,6 @@ match (list) {
 }
 
 match (list) {
-  [_, alongidentalongident, _] | [_, _, alongidentalongident, _, _] => Some(alongidentalongident),
+  [_, alongidentalongident123456, _] | [_, _, alongidentalongident123456, _, _] => Some(alongidentalongident123456),
   _ => None,
 }

--- a/compiler/test/formatter_inputs/patterns.gr
+++ b/compiler/test/formatter_inputs/patterns.gr
@@ -21,3 +21,8 @@ match (list) {
 
 
 }
+
+match (list) {
+  [_, alongidentalongident, _] | [_, _, alongidentalongident, _, _] => Some(alongidentalongident),
+  _ => None,
+}

--- a/compiler/test/formatter_outputs/patterns.gr
+++ b/compiler/test/formatter_outputs/patterns.gr
@@ -1,0 +1,16 @@
+import Option from "option"
+import List from "list"
+
+let user = Some("Bob")
+
+match (user) {
+  Some("Bob" | "Sally" as name) => "VIP " ++ name,
+  Some(name) => "Valued guest " ++ name,
+  None => "Member",
+}
+
+let list = [1, 2, 3]
+match (list) {
+  [_, mid, _] | [_, _, mid, _, _] => Some(mid),
+  _ => None,
+}

--- a/compiler/test/formatter_outputs/patterns.gr
+++ b/compiler/test/formatter_outputs/patterns.gr
@@ -16,7 +16,8 @@ match (list) {
 }
 
 match (list) {
-  [_, alongidentalongident, _] | [_, _, alongidentalongident, _, _] =>
-    Some(alongidentalongident),
+  [_, alongidentalongident123456, _] |
+  [_, _, alongidentalongident123456, _, _] =>
+    Some(alongidentalongident123456),
   _ => None,
 }

--- a/compiler/test/formatter_outputs/patterns.gr
+++ b/compiler/test/formatter_outputs/patterns.gr
@@ -14,3 +14,9 @@ match (list) {
   [_, mid, _] | [_, _, mid, _, _] => Some(mid),
   _ => None,
 }
+
+match (list) {
+  [_, alongidentalongident, _] | [_, _, alongidentalongident, _, _] =>
+    Some(alongidentalongident),
+  _ => None,
+}

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -44,4 +44,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("while_loops", "while_loops");
   assertFormatOutput("parens", "parens");
   assertFormatOutput("windows", "windows");
+  assertFormatOutput("patterns", "patterns");
 });


### PR DESCRIPTION
The formatter now correctly formats Or and Alias patterns.

@ospencer and @phated  notice the second example from the blog has the OR formatted onto a single line as it fits.  
This follows the formatter rules, but may not be best style.   We could look to force a new line for an Or operator applied to lists?