### PR TITLE
feat(compiler): Allow newline in or-patterns

### DIFF
--- a/compiler/src/parsing/wrapped_lexer.re
+++ b/compiler/src/parsing/wrapped_lexer.re
@@ -351,7 +351,7 @@ let restore_lexer_positions = state => {
 };
 
 let token = state => {
-  // if-else hack
+  // if-else and or-patterns hack
   let (tok, _, _) as triple = token(state);
   if (tok == EOL) {
     let fst = ((a, _, _)) => a;
@@ -363,7 +363,8 @@ let token = state => {
     };
 
     switch (fst(next_triple^)) {
-    | ELSE => next_triple^
+    | ELSE
+    | PIPE => next_triple^
     | _ =>
       state.queued_tokens =
         List.tl(

--- a/compiler/test/__snapshots__/pattern_matching.e17bcd61.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e17bcd61.0.snapshot
@@ -1,0 +1,130 @@
+pattern matching › or_match_4
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
+ (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
+ (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
+ (elem $elem (global.get $relocBase_0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
+ (func $_gmain (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 i32)
+  (return
+   (block $cleanup_locals.15 (result i32)
+    (local.set $0
+     (block $compile_block.14 (result i32)
+      (block $compile_store.2
+       (local.set $6
+        (i32.or
+         (i32.shl
+          (i32.eq
+           (i32.const -2)
+           (i32.const 2147483646)
+          )
+          (i32.const 31)
+         )
+         (i32.const 2147483646)
+        )
+       )
+       (block $do_backpatches.1
+       )
+      )
+      (block $compile_store.10
+       (local.set $7
+        (if (result i32)
+         (i32.shr_u
+          (local.get $6)
+          (i32.const 31)
+         )
+         (block $compile_block.3 (result i32)
+          (i32.const 1)
+         )
+         (block $compile_block.8 (result i32)
+          (block $compile_store.5
+           (local.set $7
+            (i32.or
+             (i32.shl
+              (i32.eq
+               (i32.const -2)
+               (i32.const -2)
+              )
+              (i32.const 31)
+             )
+             (i32.const 2147483646)
+            )
+           )
+           (block $do_backpatches.4
+           )
+          )
+          (if (result i32)
+           (i32.shr_u
+            (local.get $7)
+            (i32.const 31)
+           )
+           (block $compile_block.6 (result i32)
+            (i32.const 1)
+           )
+           (block $compile_block.7
+            (unreachable)
+           )
+          )
+         )
+        )
+       )
+       (block $do_backpatches.9
+       )
+      )
+      (block $switch.11_outer (result i32)
+       (block $switch.11_branch_0 (result i32)
+        (drop
+         (block $switch.11_branch_1 (result i32)
+          (drop
+           (block $switch.11_default (result i32)
+            (br_table $switch.11_branch_1 $switch.11_default $switch.11_default
+             (i32.const 0)
+             (i32.shr_s
+              (local.get $7)
+              (i32.const 1)
+             )
+            )
+           )
+          )
+          (br $switch.11_outer
+           (block $compile_block.13 (result i32)
+            (unreachable)
+           )
+          )
+         )
+        )
+        (br $switch.11_outer
+         (block $compile_block.12 (result i32)
+          (i32.const 7)
+         )
+        )
+       )
+      )
+     )
+    )
+    (local.get $0)
+   )
+  )
+ )
+ (func $_start
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 242
+)

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -225,6 +225,8 @@ describe("pattern matching", ({test, testSkip}) => {
     "or_match_3",
     "match ([5]) { [a, _] | [_, a, _] | [a] => true, _ => false }",
   );
+  assertSnapshot("or_match_4", {|match (true) { true
+  | false => 3 }|});
   // Aliases
   assertSnapshot("alias_match_1", "match (true) { _ as p => p }");
   assertSnapshot("alias_match_2", "match (true) { a as b => a && b }");


### PR DESCRIPTION
This PR allows
```
match (true) {
  true
  | false => print("ok")
}
```
in addition to
```
match (true) {
  true |
  false => print("ok")
}
```