### PR TITLE
fix(lsp): Always respond to hover request

### DIFF
--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -159,7 +159,7 @@ let process =
       params: RequestParams.t,
     ) => {
   switch (Hashtbl.find_opt(compiled_code, params.text_document.uri)) {
-  | None => ()
+  | None => send_no_result(~id)
   | Some({program, sourcetree}) =>
     let results = Sourcetree.query(params.position, sourcetree);
     switch (results) {


### PR DESCRIPTION
When we don't have a successful compilation to check, this will tell vscode "I heard you but I don't have an answer for you" so it doesn't think it's waiting on us and display a "Loading..." message.