### PR TITLE
chore(ci): Add phase for checking stdlib docs & formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           grain -v
 
       # If we have a working grain CLI, we can run grainfmt and graindoc on stdlib
-      - name: Run formatting lint
+      - name: Check stdlib docs and formatting
         if: matrix.os != 'windows-latest'
         run: |
           grain doc stdlib -o stdlib --current-version=$(grain -v)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
         run: |
           grain -v
 
+      # If we have a working grain CLI, we can run grainfmt and graindoc on stdlib
+      - name: Run formatting lint
+        if: matrix.os != 'windows-latest'
+        run: |
+          grain doc stdlib -o stdlib --current-version=$(grain -v)
+          grain format stdlib -o stdlib
+          git diff --exit-code --name-only
+
       # This is to test that we didn't actually introduce multivalue
       # which might happen through a binaryen optimization
       - name: Run NEAR smoketest

--- a/stdlib/bigint.md
+++ b/stdlib/bigint.md
@@ -5,7 +5,7 @@ title: BigInt
 Utilities for working with the BigInt type.
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -20,7 +20,7 @@ Functions for converting between Numbers and the BigInt type.
 ### Bigint.**fromNumber**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -45,7 +45,7 @@ Returns:
 ### Bigint.**toNumber**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -74,7 +74,7 @@ Mathematical operations for BigInt values.
 ### Bigint.**incr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -99,7 +99,7 @@ Returns:
 ### Bigint.**decr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -124,7 +124,7 @@ Returns:
 ### Bigint.**neg**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -149,7 +149,7 @@ Returns:
 ### Bigint.**abs**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -174,7 +174,7 @@ Returns:
 ### Bigint.**add**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -200,7 +200,7 @@ Returns:
 ### Bigint.**sub**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -226,7 +226,7 @@ Returns:
 ### Bigint.**mul**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -252,7 +252,7 @@ Returns:
 ### Bigint.**div**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -279,7 +279,7 @@ Returns:
 ### Bigint.**rem**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -306,7 +306,7 @@ Returns:
 ### Bigint.**quotRem**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -332,7 +332,7 @@ Returns:
 ### Bigint.**gcd**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -362,7 +362,7 @@ Functions for operating on bits of BigInt values.
 ### Bigint.**shl**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -388,7 +388,7 @@ Returns:
 ### Bigint.**shr**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -418,7 +418,7 @@ Functions for comparing BigInt values.
 ### Bigint.**eqz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -443,7 +443,7 @@ Returns:
 ### Bigint.**eq**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -469,7 +469,7 @@ Returns:
 ### Bigint.**ne**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -495,7 +495,7 @@ Returns:
 ### Bigint.**lt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -521,7 +521,7 @@ Returns:
 ### Bigint.**lte**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -547,7 +547,7 @@ Returns:
 ### Bigint.**gt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -573,7 +573,7 @@ Returns:
 ### Bigint.**gte**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -603,7 +603,7 @@ Boolean operations on the bits of BigInt values.
 ### Bigint.**lnot**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -628,7 +628,7 @@ Returns:
 ### Bigint.**land**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -654,7 +654,7 @@ Returns:
 ### Bigint.**lor**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -680,7 +680,7 @@ Returns:
 ### Bigint.**lxor**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -706,7 +706,7 @@ Returns:
 ### Bigint.**clz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -732,7 +732,7 @@ Returns:
 ### Bigint.**ctz**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -757,7 +757,7 @@ Returns:
 ### Bigint.**popcnt**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -787,7 +787,7 @@ Other functions on BigInts.
 ### Bigint.**toString**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -83,21 +83,21 @@ let checkIsIndexInBounds = (i, len, buf) => {
 let addInt8help = (value, buffer) => {
   autogrow(_8BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _8BIT_LEN
+  buffer.len += _8BIT_LEN
   Bytes.setInt8(index, value, buffer.data)
 }
 
 let addInt16help = (value, buffer) => {
   autogrow(_16BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _16BIT_LEN
+  buffer.len += _16BIT_LEN
   Bytes.setInt16(index, value, buffer.data)
 }
 
 let addInt32help = (value, buffer) => {
   autogrow(_32BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _32BIT_LEN
+  buffer.len += _32BIT_LEN
   Bytes.setInt32(index, value, buffer.data)
 }
 
@@ -255,7 +255,7 @@ export let addBytes = (bytes, buffer) => {
   let dst = WasmI32.fromGrain(buffer.data)
   appendBytes(0n, off, len, src, dst)
 
-  buffer.len = buffer.len + bytelen
+  buffer.len += bytelen
 }
 
 /**
@@ -278,7 +278,7 @@ export let addString = (string, buffer) => {
   let dst = WasmI32.fromGrain(buffer.data)
   appendBytes(0n, off, len, src, dst)
 
-  buffer.len = buffer.len + bytelen
+  buffer.len += bytelen
 }
 
 /**
@@ -318,7 +318,7 @@ export let addStringSlice = (start: Number, end, string, buffer) => {
   let dst = WasmI32.fromGrain(buffer.data)
   appendBytes(srcOff, dstOff, coerceNumberToWasmI32(bytelen), src, dst)
 
-  buffer.len = buffer.len + bytelen
+  buffer.len += bytelen
 }
 
 /**
@@ -364,7 +364,7 @@ export let addBytesSlice =
   let dst = WasmI32.fromGrain(buffer.data)
   appendBytes(srcOff, dstOff, len, src, dst)
 
-  buffer.len = buffer.len + length
+  buffer.len += length
 }
 
 /**
@@ -588,7 +588,7 @@ export let setFloat32 = (index, value, buffer) => {
 export let addFloat32 = (value, buffer) => {
   autogrow(_32BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _32BIT_LEN
+  buffer.len += _32BIT_LEN
   setFloat32(index, value, buffer)
 }
 
@@ -631,7 +631,7 @@ export let setInt64 = (index, value, buffer) => {
 export let addInt64 = (value, buffer) => {
   autogrow(_64BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _64BIT_LEN
+  buffer.len += _64BIT_LEN
   setInt64(index, value, buffer)
 }
 
@@ -674,6 +674,6 @@ export let setFloat64 = (index, value, buffer) => {
 export let addFloat64 = (value, buffer) => {
   autogrow(_64BIT_LEN, buffer)
   let index = buffer.len
-  buffer.len = buffer.len + _64BIT_LEN
+  buffer.len += _64BIT_LEN
   setFloat64(index, value, buffer)
 }

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -309,7 +309,7 @@ Parameters:
 <tr><th>version</th><th>changes</th></tr>
 </thead>
 <tbody>
-<tr><td><code>next</code></td><td>Now takes the end offset instead of length</td></tr>
+<tr><td><code>0.5.0</code></td><td>Now takes the end offset instead of length</td></tr>
 </tbody>
 </table>
 </details>

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -284,7 +284,7 @@ Parameters:
 ### Bytes.**clear**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -574,7 +574,7 @@ Returns:
 ### Int32.**ltU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -626,7 +626,7 @@ Returns:
 ### Int32.**gtU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -678,7 +678,7 @@ Returns:
 ### Int32.**lteU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -730,7 +730,7 @@ Returns:
 ### Int32.**gteU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -574,7 +574,7 @@ Returns:
 ### Int64.**ltU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -626,7 +626,7 @@ Returns:
 ### Int64.**gtU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -678,7 +678,7 @@ Returns:
 ### Int64.**lteU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -730,7 +730,7 @@ Returns:
 ### Int64.**gteU**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/map.md
+++ b/stdlib/map.md
@@ -263,7 +263,7 @@ Parameters:
 <tr><th>version</th><th>changes</th></tr>
 </thead>
 <tbody>
-<tr><td><code>next</code></td><td>Ensured the iterator function return type is always `Void`</td></tr>
+<tr><td><code>0.5.0</code></td><td>Ensured the iterator function return type is always `Void`</td></tr>
 </tbody>
 </table>
 </details>

--- a/stdlib/random.md
+++ b/stdlib/random.md
@@ -5,7 +5,7 @@ title: Random
 Pseudo-random number generation.
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -30,7 +30,7 @@ Functions for working with pseudo-random number generators.
 ### Random.**make**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -55,7 +55,7 @@ Returns:
 ### Random.**makeUnseeded**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -74,7 +74,7 @@ Returns:
 ### Random.**nextInt32**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -99,7 +99,7 @@ Returns:
 ### Random.**nextInt64**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -124,7 +124,7 @@ Returns:
 ### Random.**nextInt32InRange**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -152,7 +152,7 @@ Returns:
 ### Random.**nextInt64InRange**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -215,7 +215,7 @@ Parameters:
 <tr><th>version</th><th>changes</th></tr>
 </thead>
 <tbody>
-<tr><td><code>next</code></td><td>Ensured the iterator function return type is always `Void`</td></tr>
+<tr><td><code>0.5.0</code></td><td>Ensured the iterator function return type is always `Void`</td></tr>
 </tbody>
 </table>
 </details>

--- a/stdlib/sys/random.md
+++ b/stdlib/sys/random.md
@@ -15,7 +15,7 @@ Functions and constants included in the Sys/Random module.
 ### Random.**randomInt32**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 
@@ -34,7 +34,7 @@ Returns:
 ### Random.**randomInt64**
 
 <details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
 No other changes yet.
 </details>
 


### PR DESCRIPTION
This adds a step to the CI workflow that runs graindoc and grainformat against the stdlib. This is really just another linting step but it needs to happen after we know we have a working grain binary.

As you can see in the following commits, we are very bad at updating things 😛 

I have been planning to add this, but #1337 reminded me we needed it when @ospencer accepted my change but didn't regen the docs. 