### PR TITLE
fix(compiler): Allow defining _start when using --use-start-section

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3624,7 +3624,9 @@ let compile_exports = (wasm_mod, env, {imports, exports, globals}) => {
   };
   List.iteri(compile_export, exports);
   ignore @@ Export.add_function_export(wasm_mod, grain_main, grain_main);
-  ignore @@ Export.add_function_export(wasm_mod, grain_start, grain_start);
+  if (! Config.use_start_section^) {
+    ignore @@ Export.add_function_export(wasm_mod, grain_start, grain_start);
+  };
   ignore @@
   Export.add_global_export(
     wasm_mod,
@@ -3748,17 +3750,20 @@ let compile_main = (wasm_mod, env, prog) => {
       func_loc: Grain_parsing.Location.dummy_loc,
     },
   );
-  Function.add_function(
-    wasm_mod,
-    grain_start,
-    Type.none,
-    Type.none,
-    [||],
-    Expression.Drop.make(
+  if (! Config.use_start_section^) {
+    ignore @@
+    Function.add_function(
       wasm_mod,
-      Expression.Call.make(wasm_mod, grain_main, [], Type.int32),
-    ),
-  );
+      grain_start,
+      Type.none,
+      Type.none,
+      [||],
+      Expression.Drop.make(
+        wasm_mod,
+        Expression.Call.make(wasm_mod, grain_main, [], Type.int32),
+      ),
+    );
+  };
 };
 
 let compile_functions = (wasm_mod, env, {functions} as prog) => {

--- a/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
+++ b/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
@@ -1,0 +1,217 @@
+exports › export_start_function
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
+ (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
+ (global $_start_1128 (mut i32) (i32.const 0))
+ (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
+ (elem $elem (global.get $relocBase_0))
+ (export \"memory\" (memory $0))
+ (export \"_start\" (func $_start_1128))
+ (export \"GRAIN$EXPORT$_start\" (global $_start_1128))
+ (export \"_gmain\" (func $_gmain))
+ (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
+ (func $_start_1128 (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f32)
+  (local $6 f64)
+  (local $7 i32)
+  (return
+   (block $cleanup_locals.5 (result i32)
+    (local.set $1
+     (block $compile_block.4 (result i32)
+      (block $compile_store.3
+       (local.set $7
+        (tuple.extract 0
+         (tuple.make
+          (block $allocate_string.1 (result i32)
+           (i32.store
+            (local.tee $1
+             (call $malloc_0
+              (global.get $GRAIN$EXPORT$malloc_0)
+              (i32.const 24)
+             )
+            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
+            (local.get $1)
+            (i32.const 11)
+           )
+           (i64.store offset=8
+            (local.get $1)
+            (i64.const 7453010382200861811)
+           )
+           (i64.store offset=16
+            (local.get $1)
+            (i64.const 7370016)
+           )
+           (local.get $1)
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (local.get $7)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.2
+       )
+      )
+      (call $print_1132
+       (call $incRef_0
+        (global.get $GRAIN$EXPORT$incRef_0)
+        (global.get $print_1132)
+       )
+       (call $incRef_0
+        (global.get $GRAIN$EXPORT$incRef_0)
+        (local.get $7)
+       )
+      )
+     )
+    )
+    (drop
+     (call $decRef_0
+      (global.get $GRAIN$EXPORT$decRef_0)
+      (local.get $0)
+     )
+    )
+    (drop
+     (call $decRef_0
+      (global.get $GRAIN$EXPORT$decRef_0)
+      (local.get $7)
+     )
+    )
+    (local.get $1)
+   )
+  )
+ )
+ (func $_gmain (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 f64)
+  (local $6 i32)
+  (return
+   (block $cleanup_locals.13 (result i32)
+    (local.set $0
+     (block $compile_block.12 (result i32)
+      (block $compile_store.8
+       (local.set $6
+        (tuple.extract 0
+         (tuple.make
+          (block $allocate_string.6 (result i32)
+           (i32.store
+            (local.tee $0
+             (call $malloc_0
+              (global.get $GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+            )
+            (i32.const 1)
+           )
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 4)
+           )
+           (i64.store offset=8
+            (local.get $0)
+            (i64.const 1953066601)
+           )
+           (local.get $0)
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (local.get $6)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.7
+       )
+      )
+      (drop
+       (call $print_1132
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (global.get $print_1132)
+        )
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (local.get $6)
+        )
+       )
+      )
+      (block $compile_store.11
+       (global.set $_start_1128
+        (tuple.extract 0
+         (tuple.make
+          (block $allocate_closure.9 (result i32)
+           (i32.store
+            (local.tee $0
+             (call $malloc_0
+              (global.get $GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+            )
+            (i32.const 6)
+           )
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 1)
+           )
+           (i32.store offset=8
+            (local.get $0)
+            (i32.const -1)
+           )
+           (i32.store offset=12
+            (local.get $0)
+            (i32.const 0)
+           )
+           (local.get $0)
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (global.get $_start_1128)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.10
+        (local.set $0
+         (global.get $_start_1128)
+        )
+       )
+      )
+      (i32.const 1879048190)
+     )
+    )
+    (drop
+     (call $decRef_0
+      (global.get $GRAIN$EXPORT$decRef_0)
+      (local.get $6)
+     )
+    )
+    (local.get $0)
+   )
+  )
+ )
+ ;; custom section \"cmi\", size 707
+)

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -192,14 +192,14 @@ let format = file => {
   (out ++ err, code);
 };
 
-let makeSnapshotRunner = (test, name, prog) => {
-  test(
-    name,
-    ({expect}) => {
-      ignore @@ compile(~hook=stop_after_object_file_emitted, name, prog);
+let makeSnapshotRunner = (~config_fn=?, test, name, prog) => {
+  test(name, ({expect}) => {
+    Config.preserve_all_configs(() => {
+      ignore @@
+      compile(~hook=stop_after_object_file_emitted, ~config_fn?, name, prog);
       expect.file(watfile(name)).toMatchSnapshot();
-    },
-  );
+    })
+  });
 };
 
 let makeSnapshotFileRunner = (test, name, filename) => {

--- a/compiler/test/suites/exports.re
+++ b/compiler/test/suites/exports.re
@@ -1,8 +1,13 @@
 open Grain_tests.TestFramework;
 open Grain_tests.Runner;
 
-describe("exports", ({test}) => {
+describe("exports", ({test, testSkip}) => {
   let assertSnapshot = makeSnapshotRunner(test);
+  let assertStartSectionSnapshot =
+    makeSnapshotRunner(
+      ~config_fn=() => {Grain_utils.Config.use_start_section := true},
+      test,
+    );
   let assertCompileError = makeCompileErrorRunner(test);
   let assertHasExport = (name, prog, export) => {
     test(
@@ -84,6 +89,17 @@ describe("exports", ({test}) => {
   );
 
   assertSnapshot("let_rec_export", "export let rec foo = () => 5");
+
+  assertStartSectionSnapshot(
+    "export_start_function",
+    {|
+      print("init")
+      export let _start = () => {
+        print("starting up")
+      }
+    |},
+  );
+
   assertHasExport(
     "issue_918_annotated_func_export",
     "export let foo: () -> Number = () => 5",


### PR DESCRIPTION
This PR allows you to manually define a function called `_start` when using the `--use-start-section` flag.