### PR TITLE
fix(stdlib): Correctly promote numbers to bigints when left-shifting

### DIFF
--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -41,6 +41,7 @@ describe("numbers", ({test, testSkip}) => {
   assertRun("number_syntax8", "print(1.2e2)", "120.0\n");
   assertRun("number_syntax9", "print(1l)", "1\n");
   assertRun("number_syntax10", "print(1L)", "1\n");
+  assertRun("number_shift_promote", "print(5 << 64)", "92233720368547758080\n");
   assertRun(
     "number_syntax11",
     "print(987654321987654321987654321)",

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -41,7 +41,11 @@ describe("numbers", ({test, testSkip}) => {
   assertRun("number_syntax8", "print(1.2e2)", "120.0\n");
   assertRun("number_syntax9", "print(1l)", "1\n");
   assertRun("number_syntax10", "print(1L)", "1\n");
-  assertRun("number_shift_promote", "print(5 << 64)", "92233720368547758080\n");
+  assertRun(
+    "number_shift_promote",
+    "print(5 << 64)",
+    "92233720368547758080\n",
+  );
   assertRun(
     "number_syntax11",
     "print(987654321987654321987654321)",

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1833,7 +1833,13 @@ export let (<<) = (x: Number, y: Number) => {
   } else {
     let xval = coerceNumberToWasmI64(x)
     let yval = coerceNumberToWasmI64(y)
-    WasmI32.toGrain(reducedInteger(WasmI64.shl(xval, yval))): Number
+    if (WasmI64.leU(WasmI64.clz(xval), yval)) {
+      let xbi = coerceNumberToBigInt(x)
+      let yval = coerceNumberToWasmI32(y)
+      WasmI32.toGrain(reducedBigInteger(BI.shl(xbi, yval))): Number
+    } else {
+      WasmI32.toGrain(reducedInteger(WasmI64.shl(xval, yval))): Number
+    }
   }
 }
 

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1835,14 +1835,7 @@ export let (<<) = (x: Number, y: Number) => {
     let yval = coerceNumberToWasmI64(y)
     // if the number will be shifted beyond the end of the i64 range, promote to BigInt
     // (note that we subtract one leading zero, since the leading bit is the sign bit)
-    if (
-      // positive number; just count leading zeros
-      WasmI64.geS(xval, 0N) &&
-      WasmI64.leU(WasmI64.sub(WasmI64.clz(xval), 1N), yval) ||
-      // negative number; negate and count leading zeros (clz of a negative is always 0)
-      WasmI64.ltS(xval, 0N) &&
-      WasmI64.leU(WasmI64.sub(WasmI64.clz(i64neg(xval)), 1N), yval)
-    ) {
+    if (WasmI64.leU(WasmI64.sub(WasmI64.clz(i64abs(xval)), 1N), yval)) {
       let xbi = coerceNumberToBigInt(x)
       let yval = coerceNumberToWasmI32(y)
       WasmI32.toGrain(reducedBigInteger(BI.shl(xbi, yval))): Number

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1833,7 +1833,16 @@ export let (<<) = (x: Number, y: Number) => {
   } else {
     let xval = coerceNumberToWasmI64(x)
     let yval = coerceNumberToWasmI64(y)
-    if (WasmI64.leU(WasmI64.clz(xval), yval)) {
+    // if the number will be shifted beyond the end of the i64 range, promote to BigInt
+    // (note that we subtract one leading zero, since the leading bit is the sign bit)
+    if (
+      // positive number; just count leading zeros
+      WasmI64.geS(xval, 0N) &&
+      WasmI64.leU(WasmI64.sub(WasmI64.clz(xval), 1N), yval) ||
+      // negative number; negate and count leading zeros (clz of a negative is always 0)
+      WasmI64.ltS(xval, 0N) &&
+      WasmI64.leU(WasmI64.sub(WasmI64.clz(i64neg(xval)), 1N), yval)
+    ) {
       let xbi = coerceNumberToBigInt(x)
       let yval = coerceNumberToWasmI32(y)
       WasmI32.toGrain(reducedBigInteger(BI.shl(xbi, yval))): Number


### PR DESCRIPTION
Closes #1350.