### PR TITLE
chore(compiler): Remove deprecated use of Streams

### DIFF
--- a/compiler/src/utils/wasm_utils.re
+++ b/compiler/src/utils/wasm_utils.re
@@ -139,26 +139,18 @@ let read_leb128_i32 = (bytesrc): int32 =>
   read_leb128(~signed=true, ~maxbits=32, ~conv=i32_of_u64, bytesrc);
 let read_leb128_i32_input = inchan =>
   read_leb128_i32(() => input_byte(inchan));
-let read_leb128_i32_stream = stream =>
-  read_leb128_i32(() => Stream.next(stream));
 let read_leb128_u32 = (bytesrc): int32 =>
   read_leb128(~signed=false, ~maxbits=32, ~conv=i32_of_u64, bytesrc);
 let read_leb128_u32_input = inchan =>
   read_leb128_u32(() => input_byte(inchan));
-let read_leb128_u32_stream = stream =>
-  read_leb128_u32(() => Stream.next(stream));
 let read_leb128_i64 = (bytesrc): int64 =>
   read_leb128(~signed=true, ~maxbits=64, ~conv=identity, bytesrc);
 let read_leb128_i64_input = inchan =>
   read_leb128_i64(() => input_byte(inchan));
-let read_leb128_i64_stream = stream =>
-  read_leb128_i64(() => Stream.next(stream));
 let read_leb128_u64 = (bytesrc): int64 =>
   read_leb128(~signed=false, ~maxbits=64, ~conv=identity, bytesrc);
 let read_leb128_u64_input = inchan =>
   read_leb128_u64(() => input_byte(inchan));
-let read_leb128_u64_stream = stream =>
-  read_leb128_u64(() => Stream.next(stream));
 
 let read_int32 = inchan => {
   let bytes = Bytes.create(4);

--- a/compiler/src/utils/wasm_utils.rei
+++ b/compiler/src/utils/wasm_utils.rei
@@ -40,19 +40,15 @@ let latest_abi: abi_version;
 
 let read_leb128_i32: (unit => int) => int32;
 let read_leb128_i32_input: in_channel => int32;
-let read_leb128_i32_stream: Stream.t(int) => int32;
 
 let read_leb128_u32: (unit => int) => int32;
 let read_leb128_u32_input: in_channel => int32;
-let read_leb128_u32_stream: Stream.t(int) => int32;
 
 let read_leb128_i64: (unit => int) => int64;
 let read_leb128_i64_input: in_channel => int64;
-let read_leb128_i64_stream: Stream.t(int) => int64;
 
 let read_leb128_u64: (unit => int) => int64;
 let read_leb128_u64_input: in_channel => int64;
-let read_leb128_u64_stream: Stream.t(int) => int64;
 
 let get_wasm_sections: (~reset: bool=?, in_channel) => list(wasm_bin_section);
 


### PR DESCRIPTION
Streams in OCaml have been deprecated. This also cleans up a long-time comment about an issue with streams, so that's a plus.