### PR TITLE
chore(compiler): Port Anf_utils.anf_count_vars to use record

### DIFF
--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -619,13 +619,13 @@ let compile_lambda =
     };
   let args = List.map(((_, ty)) => ty, new_args);
   let arity = List.length(args);
-  let (
+  let {
     stack_size_ptr,
     stack_size_i32,
     stack_size_i64,
     stack_size_f32,
     stack_size_f64,
-  ) =
+  }: Anf_utils.stack_size =
     Anf_utils.anf_count_vars(body);
   let lam_env = {
     ce_binds: arg_binds,
@@ -1441,13 +1441,13 @@ let transl_anf_program =
 
   set_global_imports(env.ce_binds);
 
-  let (
+  let {
     stack_size_ptr,
     stack_size_i32,
     stack_size_i64,
     stack_size_f32,
     stack_size_f64,
-  ) =
+  }: Anf_utils.stack_size =
     Anf_utils.anf_count_vars(anf_prog.body);
   let main_body_stack_size = {
     stack_size_ptr,

--- a/compiler/src/middle_end/anf_utils.rei
+++ b/compiler/src/middle_end/anf_utils.rei
@@ -5,7 +5,15 @@ let anf_free_vars: anf_expression => Ident.Set.t;
 let comp_free_vars: comp_expression => Ident.Set.t;
 let imm_free_vars: imm_expression => Ident.Set.t;
 
-let anf_count_vars: anf_expression => (int, int, int, int, int);
-let comp_count_vars: comp_expression => (int, int, int, int, int);
+type stack_size = {
+  stack_size_ptr: int,
+  stack_size_i32: int,
+  stack_size_i64: int,
+  stack_size_f32: int,
+  stack_size_f64: int,
+};
+
+let anf_count_vars: anf_expression => stack_size;
+let comp_count_vars: comp_expression => stack_size;
 
 let clear_locations: anf_program => anf_program;


### PR DESCRIPTION
- Adds a new record type, stack_size to anf_utils.re && rei
- Gets unpacked + ported to a Mashtree.stack_size in codegen
  - decided to not have Mashtree.stack_size use Anf_utils.stack_size due to not wanting to use `[@derive sexp]` in the middle end

I don't know if there is a better convention for testing small things/unit testing here, but `npm run compiler test` gave me the good ol' thumbs up.

Closes #1155 