### PR TITLE
fix(graindoc): Enable printing of arrow types

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -651,8 +651,8 @@ and print_out_sig_item = ppf =>
           failwith("NYI: Otyp_variant pretty-printer")
         | Otyp_open => failwith("NYI: Otyp_open pretty-printer")
         | Otyp_alias(_, _) => failwith("NYI: Otyp_alias pretty-printer")
-        | Otyp_arrow(_, _) => failwith("NYI: Otyp_arrow pretty-printer")
         | Otyp_class(_, _, _) => failwith("NYI: Otyp_class pretty-printer")
+        | Otyp_arrow(_, _)
         | Otyp_abstract
         | Otyp_tuple(_)
         | Otyp_constr(_, _) => "type"


### PR DESCRIPTION
Fixes #1366 

Also fixes the LSP problem (and this shows the output of the printer):
<img width="376" alt="image" src="https://user-images.githubusercontent.com/7244034/180341415-618ceff9-2abb-47c1-9d0e-650370637732.png">

@phated we don't have any graindoc tests right?