### PR TITLE
feat: Arm64 docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ permissions:
   id-token: write # Required to auth to AWS
   contents: read # Required for actions/checkout
   packages: write # Required to upload to ghcr
+env:
+  AWS_EC2_INSTANCE_ID: i-0960f9b8de8285aed
+  AWS_REGION: us-east-1
 jobs:
   push_base_image:
     name: Push base Docker image to multiple registries
@@ -30,14 +33,14 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::881972110175:role/github-actions-openid
           role-session-name: cisession
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Start AWS EC2 arm64 instance
         id: instance
         run: |
-          aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
-          aws ec2 wait instance-running --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
-          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ secrets.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
+          aws ec2 start-instances --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-running --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ env.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
 
       - name: Bring in SSH keys
         uses: grain-lang/ssh-agent@v0.5.4
@@ -110,14 +113,14 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::881972110175:role/github-actions-openid
           role-session-name: cisession
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Start AWS EC2 arm64 instance
         id: instance
         run: |
-          aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
-          aws ec2 wait instance-running --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
-          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ secrets.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
+          aws ec2 start-instances --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-running --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ env.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
 
       - name: Bring in SSH keys
         uses: grain-lang/ssh-agent@v0.5.4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,10 @@ on:
       tag:
         description: "The tag of release"
         required: true
+permissions:
+  id-token: write # Required to auth to AWS
+  contents: read # Required for actions/checkout
+  packages: write # Required to upload to ghcr
 jobs:
   push_base_image:
     name: Push base Docker image to multiple registries
@@ -21,6 +25,37 @@ jobs:
         if: ${{ github.event.inputs.tag }}
         run: GITHUB_TAG=${{ github.event.inputs.tag }}; echo ::set-output name=tag::${GITHUB_TAG#grain-}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          role-to-assume: arn:aws:iam::881972110175:role/github-actions-openid
+          role-session-name: cisession
+          aws-region: us-east-1
+
+      - name: Start AWS EC2 arm64 instance
+        id: instance
+        run: |
+          aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-running --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
+          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ secrets.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
+
+      - name: Bring in SSH keys
+        uses: grain-lang/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+
+      - name: Set up remote builder
+        run: |
+          ssh-keyscan -H ${{ steps.instance.outputs.ip }} >> ~/.ssh/known_hosts
+          docker context create node-amd64 --docker host=unix:///var/run/docker.sock
+          docker context create node-arm64 --docker host=ssh://ubuntu@${{ steps.instance.outputs.ip }}
+          docker buildx create --use --name multiarch-builder --platform linux/amd64 node-amd64
+          docker buildx create --append --name multiarch-builder --platform linux/arm64 node-arm64
+          docker buildx inspect --bootstrap
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3.6.0
@@ -34,13 +69,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -52,6 +87,8 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          builder: multiarch-builder
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -68,6 +105,37 @@ jobs:
         if: ${{ github.event.inputs.tag }}
         run: GITHUB_TAG=${{ github.event.inputs.tag }}; echo ::set-output name=tag::${GITHUB_TAG#grain-}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          role-to-assume: arn:aws:iam::881972110175:role/github-actions-openid
+          role-session-name: cisession
+          aws-region: us-east-1
+
+      - name: Start AWS EC2 arm64 instance
+        id: instance
+        run: |
+          aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-running --instance-ids ${{ secrets.AWS_EC2_INSTANCE_ID }}
+          echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ secrets.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
+
+      - name: Bring in SSH keys
+        uses: grain-lang/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+
+      - name: Set up remote builder
+        run: |
+          ssh-keyscan -H ${{ steps.instance.outputs.ip }} >> ~/.ssh/known_hosts
+          docker context create node-amd64 --docker host=unix:///var/run/docker.sock
+          docker context create node-arm64 --docker host=ssh://ubuntu@${{ steps.instance.outputs.ip }}
+          docker buildx create --use --name multiarch-builder --platform linux/amd64 node-amd64
+          docker buildx create --append --name multiarch-builder --platform linux/arm64 node-arm64
+          docker buildx inspect --bootstrap
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3.6.0
@@ -83,13 +151,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.vars.outputs.tag }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -101,5 +169,7 @@ jobs:
           context: .
           file: Dockerfile-slim
           push: true
+          builder: multiarch-builder
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # This Dockerfile constructs an environment in which the Grain compiler can be built and used.
 
+FROM ospencer/esy:alpine as esy
 FROM node:16
 
 LABEL name="Grain"
@@ -11,9 +12,21 @@ COPY . /grain
 
 WORKDIR /grain
 
+# esy does not currently ship linux/arm64 binaries, so we manually patch it in
+
+# Install dependencies but don't allow esy's postinstall script to run
+RUN npm ci --ignore-scripts
+# This line is technically incorrect on amd64, but docker does not support
+# conditional copies and the arm64 folder is ignored on amd64 anyway
+COPY --from=esy /app/_release /grain/node_modules/esy/platform-linux-arm64
+# Manually run esy's postinstall script
+RUN cd node_modules/esy && npm run postinstall
+
+# Necessary because we disabled scripts during the original install
+RUN npm run prepare
+
 # Build the compiler and CLI
-RUN npm ci && \
-    npm run compiler build
+RUN npm run compiler build
 
 # Set up container environment
 WORKDIR /

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,7 @@
 # This Dockerfile constructs a minimal environment in which Grain programs can be compiled.
 # The environment is only meant to build Grain programs, not develop the compiler.
 
+FROM ospencer/esy:alpine as esy
 FROM node:16 as builder
 
 LABEL name="Grain"
@@ -12,9 +13,21 @@ COPY . /grain
 
 WORKDIR /grain
 
+# esy does not currently ship linux/arm64 binaries, so we manually patch it in
+
+# Install dependencies but don't allow esy's postinstall script to run
+RUN npm ci --ignore-scripts
+# This line is technically incorrect on amd64, but docker does not support
+# conditional copies and the arm64 folder is ignored on amd64 anyway
+COPY --from=esy /app/_release /grain/node_modules/esy/platform-linux-arm64
+# Manually run esy's postinstall script
+RUN cd node_modules/esy && npm run postinstall
+
+# Necessary because we disabled scripts during the original install
+RUN npm run prepare
+
 # Build the compiler and CLI
-RUN npm ci && \
-    npm run compiler build
+RUN npm run compiler build
 
 # Remove build files
 RUN rm -rf compiler/_esy


### PR DESCRIPTION
This PR adds support for the linux/arm64 arch in our published Docker images. Since GitHub actions doesn't yet support ARM, this is done by booting up an AWS Graviton instance and using it as a remote builder to handle the arm64 part of the image build. The Graviton instance is set to automatically stop when it detects that builds are complete.

Additionally, `esy` does not yet have linux/arm64 binaries, so we use a workaround in the Dockerfiles to use one that I built. When `esy` ships a release with linux/arm64 binaries, we can remove the workaround.

If you have an arm64 linux machine (or a Mac with an M1 processor) you can try out the image with
```sh
docker run -it ghcr.io/grain-lang/grain:oscar-docker-arm64
```
or
```sh
docker run -it ghcr.io/grain-lang/grain:oscar-docker-arm64-slim
```
and try compiling and running a Grain program. (If you're not on an arm64 machine you can also do this, but you won't be testing out the new stuff 🙂)

You can see that both arches are contained in the image:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/7244034/180574776-7d55f4ac-09b0-49c3-a886-afd7ebb166c7.png">

The successful CI run can be found here: https://github.com/grain-lang/grain/runs/7566595877?check_suite_focus=true