### PR TITLE
fix(grainfmt): Use only the correct comments for constraints

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -2970,7 +2970,15 @@ and print_expression =
           ),
           Doc.text(":"),
           Doc.space,
-          print_type(~original_source, ~comments, parsed_type),
+          print_type(
+            ~original_source,
+            ~comments=
+              Comment_utils.get_comments_inside_location(
+                ~location=parsed_type.ptyp_loc,
+                comments,
+              ),
+            parsed_type,
+          ),
         ]),
       );
     | PExpLambda(patterns, expression) =>

--- a/compiler/test/formatter_inputs/constraints.gr
+++ b/compiler/test/formatter_inputs/constraints.gr
@@ -1,0 +1,8 @@
+import List from "list"
+let test = test => {
+  // Comments
+  List.forEach(i => {
+    // Comment In ForEach
+    print(i)
+  }, test: List<Number>)
+}

--- a/compiler/test/formatter_outputs/constraints.gr
+++ b/compiler/test/formatter_outputs/constraints.gr
@@ -1,0 +1,8 @@
+import List from "list"
+let test = test => {
+  // Comments
+  List.forEach(i => {
+    // Comment In ForEach
+    print(i)
+  }, test: List<Number>)
+}

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -45,4 +45,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("parens", "parens");
   assertFormatOutput("windows", "windows");
   assertFormatOutput("patterns", "patterns");
+  assertFormatOutput("constraints", "constraints");
 });


### PR DESCRIPTION
Use only the comments applicable for the constraint not the whole expression

Fixes #1378 