### PR TITLE
feat(stdlib): Implement mutable/immutable priority queues

### DIFF
--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -63,7 +63,7 @@ for (let mut i = 0; i < numVals; i += 1) {
 
   let newPq = ImmutablePriorityQueue.pop(pq)
   let newMaxPq = ImmutablePriorityQueue.pop(maxPq)
-  let expectedSize = (numVals - i)
+  let expectedSize = numVals - i
   assert ImmutablePriorityQueue.size(pq) == expectedSize
   assert ImmutablePriorityQueue.size(maxPq) == expectedSize
   assert ImmutablePriorityQueue.size(newPq) == expectedSize - 1
@@ -82,7 +82,9 @@ assert ImmutablePriorityQueue.drain(pqWithAll) == sortedList
 assert ImmutablePriorityQueue.drain(maxPqWithAll) == List.reverse(sortedList)
 assert ImmutablePriorityQueue.drain(
   ImmutablePriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => a - b)
-) == sortedList
+) ==
+sortedList
 assert ImmutablePriorityQueue.drain(
   ImmutablePriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => b - a)
-) == List.reverse(sortedList)
+) ==
+List.reverse(sortedList)

--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -1,0 +1,87 @@
+import ImmutablePriorityQueue from "immutablepriorityqueue"
+import List from "list"
+import Array from "array"
+
+let lotsOfVals = [>
+  3, 2, 1, 5, 3, 2, 2, 10, 6, 5,
+  6, 4, 9, 10, 10, 5, 9, 6, 1, 3,
+  3, 6, 6, 1, 3, 9, 6, 7, 4, 6,
+  5, 4, 4, 8, 6, 4, 1, 2, 3, 8,
+  8, 8, 10, 9, 6, 8, 4, 1, 1, 2,
+  10, 2, 8, 10, 8, 7, 4, 8, 10, 1,
+  3, 10, 4, 1, 6, 9, 6, 7, 8, 7,
+  10, 4, 5, 10, 3, 2, 4, 5, 9, 5,
+  3, 5, 10, 8, 7, 1, 6, 1, 4, 8,
+  3, 5, 7, 2, 4, 2, 4, 5, 10, 6,
+  7, 7, 7, 1, 10, 4, 9, 9, 10, 10,
+  2, 5, 2, 4, 3, 10, 9, 8, 3, 5,
+  7, 10, 9, 7, 8, 9, 3, 7, 7, 1,
+  7, 7, 6, 3, 3, 5, 1, 8, 9, 10,
+  7, 5, 9, 2, 9, 1, 6, 3, 10, 6,
+  10, 2, 6, 2, 9, 3, 3, 2, 4, 1,
+  9, 4, 9, 2, 9, 4, 8, 5, 6, 7,
+  4, 6, 5, 4, 3, 4, 2, 9, 10, 1,
+  10, 4, 4, 6, 3, 1, 9, 10, 2, 2,
+  5, 5, 3, 4, 5, 8, 3, 8, 4, 10
+]
+let numVals = Array.length(lotsOfVals)
+
+let sortedVals = Array.copy(lotsOfVals)
+Array.sort((a, b) => a - b, sortedVals)
+
+let mut pq = ImmutablePriorityQueue.make((a, b) => a - b)
+let mut maxPq = ImmutablePriorityQueue.make((a, b) => b - a)
+
+assert ImmutablePriorityQueue.size(pq) == 0
+assert ImmutablePriorityQueue.isEmpty(pq)
+assert ImmutablePriorityQueue.peek(pq) == None
+assert ImmutablePriorityQueue.drain(pq) == []
+
+pq = ImmutablePriorityQueue.pop(pq)
+assert ImmutablePriorityQueue.size(pq) == 0
+
+for (let mut i = 0; i < numVals; i += 1) {
+  let newPq = ImmutablePriorityQueue.push(lotsOfVals[i], pq)
+  let newMaxPq = ImmutablePriorityQueue.push(lotsOfVals[i], maxPq)
+  assert ImmutablePriorityQueue.size(pq) == i
+  assert ImmutablePriorityQueue.size(maxPq) == i
+  assert ImmutablePriorityQueue.size(newPq) == i + 1
+  assert ImmutablePriorityQueue.size(newMaxPq) == i + 1
+  pq = newPq
+  maxPq = newMaxPq
+}
+
+let pqWithAll = pq
+let maxPqWithAll = maxPq
+
+for (let mut i = 0; i < numVals; i += 1) {
+  let val = ImmutablePriorityQueue.peek(pq)
+  assert val == Some(sortedVals[i])
+  let maxVal = ImmutablePriorityQueue.peek(maxPq)
+  assert maxVal == Some(sortedVals[numVals - i - 1])
+
+  let newPq = ImmutablePriorityQueue.pop(pq)
+  let newMaxPq = ImmutablePriorityQueue.pop(maxPq)
+  let expectedSize = (numVals - i)
+  assert ImmutablePriorityQueue.size(pq) == expectedSize
+  assert ImmutablePriorityQueue.size(maxPq) == expectedSize
+  assert ImmutablePriorityQueue.size(newPq) == expectedSize - 1
+  assert ImmutablePriorityQueue.size(newMaxPq) == expectedSize - 1
+  pq = newPq
+  maxPq = newMaxPq
+}
+
+assert ImmutablePriorityQueue.size(pq) == 0
+assert ImmutablePriorityQueue.size(pqWithAll) == numVals
+assert !ImmutablePriorityQueue.isEmpty(pqWithAll)
+assert ImmutablePriorityQueue.peek(pq) == None
+
+let sortedList = Array.toList(sortedVals)
+assert ImmutablePriorityQueue.drain(pqWithAll) == sortedList
+assert ImmutablePriorityQueue.drain(maxPqWithAll) == List.reverse(sortedList)
+assert ImmutablePriorityQueue.drain(
+  ImmutablePriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => a - b)
+) == sortedList
+assert ImmutablePriorityQueue.drain(
+  ImmutablePriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => b - a)
+) == List.reverse(sortedList)

--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -2,6 +2,7 @@ import ImmutablePriorityQueue from "immutablepriorityqueue"
 import List from "list"
 import Array from "array"
 
+// formatter-ignore
 let lotsOfVals = [>
   3, 2, 1, 5, 3, 2, 2, 10, 6, 5,
   6, 4, 9, 10, 10, 5, 9, 6, 1, 3,

--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -28,7 +28,7 @@ let lotsOfVals = [>
 let numVals = Array.length(lotsOfVals)
 
 let sortedVals = Array.copy(lotsOfVals)
-Array.sort((a, b) => a - b, sortedVals)
+Array.sort(compare, sortedVals)
 
 let mut pq = ImmutablePriorityQueue.make((a, b) => a - b)
 let mut maxPq = ImmutablePriorityQueue.make((a, b) => b - a)

--- a/compiler/test/stdlib/priorityqueue.test.gr
+++ b/compiler/test/stdlib/priorityqueue.test.gr
@@ -2,6 +2,7 @@ import PriorityQueue from "priorityqueue"
 import List from "list"
 import Array from "array"
 
+// formatter-ignore
 let lotsOfVals = [>
   3, 2, 1, 5, 3, 2, 2, 10, 6, 5,
   6, 4, 9, 10, 10, 5, 9, 6, 1, 3,

--- a/compiler/test/stdlib/priorityqueue.test.gr
+++ b/compiler/test/stdlib/priorityqueue.test.gr
@@ -1,0 +1,77 @@
+import PriorityQueue from "priorityqueue"
+import List from "list"
+import Array from "array"
+
+let lotsOfVals = [>
+  3, 2, 1, 5, 3, 2, 2, 10, 6, 5,
+  6, 4, 9, 10, 10, 5, 9, 6, 1, 3,
+  3, 6, 6, 1, 3, 9, 6, 7, 4, 6,
+  5, 4, 4, 8, 6, 4, 1, 2, 3, 8,
+  8, 8, 10, 9, 6, 8, 4, 1, 1, 2,
+  10, 2, 8, 10, 8, 7, 4, 8, 10, 1,
+  3, 10, 4, 1, 6, 9, 6, 7, 8, 7,
+  10, 4, 5, 10, 3, 2, 4, 5, 9, 5,
+  3, 5, 10, 8, 7, 1, 6, 1, 4, 8,
+  3, 5, 7, 2, 4, 2, 4, 5, 10, 6,
+  7, 7, 7, 1, 10, 4, 9, 9, 10, 10,
+  2, 5, 2, 4, 3, 10, 9, 8, 3, 5,
+  7, 10, 9, 7, 8, 9, 3, 7, 7, 1,
+  7, 7, 6, 3, 3, 5, 1, 8, 9, 10,
+  7, 5, 9, 2, 9, 1, 6, 3, 10, 6,
+  10, 2, 6, 2, 9, 3, 3, 2, 4, 1,
+  9, 4, 9, 2, 9, 4, 8, 5, 6, 7,
+  4, 6, 5, 4, 3, 4, 2, 9, 10, 1,
+  10, 4, 4, 6, 3, 1, 9, 10, 2, 2,
+  5, 5, 3, 4, 5, 8, 3, 8, 4, 10
+]
+let numVals = Array.length(lotsOfVals)
+
+let sortedVals = Array.copy(lotsOfVals)
+Array.sort((a, b) => a - b, sortedVals)
+
+let mut pq = PriorityQueue.make((a, b) => a - b)
+let mut maxPq = PriorityQueue.make((a, b) => b - a)
+
+assert PriorityQueue.size(pq) == 0
+assert PriorityQueue.isEmpty(pq)
+assert PriorityQueue.peek(pq) == None
+assert PriorityQueue.drain(pq) == []
+
+assert PriorityQueue.pop(pq) == None
+assert PriorityQueue.size(pq) == 0
+
+for (let mut i = 0; i < numVals; i += 1) {
+  PriorityQueue.push(lotsOfVals[i], pq)
+  PriorityQueue.push(lotsOfVals[i], maxPq)
+  assert PriorityQueue.size(pq) == i + 1
+  assert PriorityQueue.size(maxPq) == i + 1
+}
+
+assert PriorityQueue.size(pq) == numVals
+assert PriorityQueue.size(maxPq) == numVals
+
+for (let mut i = 0; i < numVals; i += 1) {
+  let val = PriorityQueue.peek(pq)
+  assert val == Some(sortedVals[i])
+  let maxVal = PriorityQueue.peek(maxPq)
+  assert maxVal == Some(sortedVals[numVals - i - 1])
+
+  let val = PriorityQueue.pop(pq)
+  assert val == Some(sortedVals[i])
+  let maxVal = PriorityQueue.pop(maxPq)
+  assert maxVal == Some(sortedVals[numVals - i - 1])
+
+  assert PriorityQueue.size(pq) == numVals - i - 1
+  assert PriorityQueue.size(maxPq) == numVals - i - 1
+}
+
+assert PriorityQueue.size(pq) == 0
+assert PriorityQueue.peek(pq) == None
+
+let sortedList = Array.toList(sortedVals)
+assert PriorityQueue.drain(
+  PriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => a - b)
+) == sortedList
+assert PriorityQueue.drain(
+  PriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => b - a)
+) == List.reverse(sortedList)

--- a/compiler/test/stdlib/priorityqueue.test.gr
+++ b/compiler/test/stdlib/priorityqueue.test.gr
@@ -72,7 +72,9 @@ assert PriorityQueue.peek(pq) == None
 let sortedList = Array.toList(sortedVals)
 assert PriorityQueue.drain(
   PriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => a - b)
-) == sortedList
+) ==
+sortedList
 assert PriorityQueue.drain(
   PriorityQueue.fromList(Array.toList(lotsOfVals), (a, b) => b - a)
-) == List.reverse(sortedList)
+) ==
+List.reverse(sortedList)

--- a/compiler/test/stdlib/priorityqueue.test.gr
+++ b/compiler/test/stdlib/priorityqueue.test.gr
@@ -28,7 +28,7 @@ let lotsOfVals = [>
 let numVals = Array.length(lotsOfVals)
 
 let sortedVals = Array.copy(lotsOfVals)
-Array.sort((a, b) => a - b, sortedVals)
+Array.sort(compare, sortedVals)
 
 let mut pq = PriorityQueue.make((a, b) => a - b)
 let mut maxPq = PriorityQueue.make((a, b) => b - a)

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -110,6 +110,8 @@ describe("stdlib", ({test, testSkip}) => {
   assertStdlib("set.test");
   assertStdlib("regex.test");
   assertStdlib("stack.test");
+  assertStdlib("priorityqueue.test")
+  assertStdlib("immutablepriorityqueue.test")
   assertStdlib("string.test");
   assertStdlib("sys.file.test");
   assertStdlib(~code=5, "sys.process.test");

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -110,8 +110,8 @@ describe("stdlib", ({test, testSkip}) => {
   assertStdlib("set.test");
   assertStdlib("regex.test");
   assertStdlib("stack.test");
-  assertStdlib("priorityqueue.test")
-  assertStdlib("immutablepriorityqueue.test")
+  assertStdlib("priorityqueue.test");
+  assertStdlib("immutablepriorityqueue.test");
   assertStdlib("string.test");
   assertStdlib("sys.file.test");
   assertStdlib(~code=5, "sys.process.test");

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -62,9 +62,9 @@ export let make = comp => {
 }
 
 /**
- * Returns the number of elements in the priority queue.
+ * Gets the number of elements in a priority queue.
  * 
- * @param pq: The priority queue to get the size of
+ * @param pq: The priority queue to inspect
  * @returns The number of elements in the priority queue
  *
  * @since v0.5.3
@@ -74,10 +74,10 @@ export let size = pq => {
 }
 
 /**
- * Returns whether or not the priority queue is empty.
+ * Determines if the priority queue contains no elements.
  * 
  * @param pq: The priority queue to check
- * @returns `true` if the priority queue has no elements and `false` otherwise
+ * @returns `true` if the priority queue is empty and `false` otherwise
  *
  * @since v0.5.3
  */
@@ -119,11 +119,11 @@ let skewInsert = (comp, val, pq) => {
 }
 
 /**
- * Returns a new priority queue with the given element inserted into the given priority queue.
+ * Produces a new priority queue by inserting the given element into the given priority queue.
  * 
  * @param val: The value to add into the priority queue
  * @param pq: The priority queue
- * @returns A new priority queue with the given element inserted into the given priority queue
+ * @returns A new priority queue with the given element inserted
  */
 export let push = (val, pq) => {
   let { comp, size, root } = pq
@@ -143,11 +143,11 @@ export let push = (val, pq) => {
 }
 
 /**
- * Returns the highest priority element in the priority queue in a `Some`
- * variant, or `None` if the priority queue is empty.
+ * Retrieves the highest priority element in the priority queue. It is not
+ * removed from the queue.
  * 
- * @param pq: The priority queue to get the highest priority element of
- * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ * @param pq: The priority queue to inspect
+ * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
  * @since v0.5.3
  */
@@ -192,8 +192,8 @@ let uniquify = (comp, pq) => {
   }
 }
 
-// step through the trees of two priority queues in increasing rank order, perform-
-// ing a simple link whenever we find two trees of equal rank
+// step through the trees of two priority queues in increasing rank order,
+// performing a simple link whenever we find two trees of equal rank
 let rec mergeUniq = (comp, pq1, pq2) => {
   match ((pq1, pq2)) {
     ([], ts) | (ts, []) => ts,
@@ -266,12 +266,12 @@ let rec findHighestPriority = (comp, pq) => {
 }
 
 /**
- * Returns a new priority queue without the highest priority element in the
+ * Produces a new priority queue without the highest priority element in the
  * given priority queue. If the input priority queue is empty, this function will
  * return it.
  * 
  * @param pq: The priority queue
- * @returns A new priority queue without the highest priority element in the input priority queue
+ * @returns A new priority queue without the highest priority element
  *
  * @since v0.5.3
  */
@@ -297,7 +297,7 @@ export let pop = pq => {
 }
 
 /**
- * Returns all of the elements in the priority queue in priority order.
+ * Produces a list of all elements in the priority queue in priority order.
  * 
  * @param pq: The priority queue to drain
  * @returns A list of all elements in the priority in priority order
@@ -321,9 +321,9 @@ export let drain = pq => {
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
  * 
- * @param list: A list of values to initialize the priority queue with
+ * @param list: A list of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
- * @returns A priority queue containing the elements in the list
+ * @returns A priority queue containing the elements from the list
  *
  * @since v0.5.3
  */

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -1,0 +1,324 @@
+/**
+ * @module ImmutablePriorityQueue: An immutable priority queue implemented as a skew binomial queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ *
+ * @example import ImmutablePriorityQueue from "immutablepriorityqueue"
+ *
+ * @since v0.5.3
+ */
+
+import List from "list"
+
+// implementation based on immutable skew binomial queue with global root optimization
+// as described in the paper "Optimal Purely Functional Priority Queues" by Chris Okasaki.
+
+// rank is a stand-in for height of this skew binomial tree
+record Node<a> {
+  val: a,
+  rank: Number,
+  children: List<Node<a>>,
+}
+
+// an optimization over binomial queue that allows keeping track of the root value
+
+// a skew binomial queue is defined as a forest of heap-ordered skew binomial trees
+record PQRoot<a> {
+  rootVal: a,
+  pq: List<Node<a>>,
+}
+
+/**
+ * @section Types: Type declarations included in the ImmutablePriorityQueue module.
+ */
+
+/**
+ * Immutable data structure which maintains a priority order for its elements.
+ */
+record ImmutablePriorityQueue<a> {
+  comp: (a, a) -> Number,
+  size: Number,
+  root: Option<PQRoot<a>>,
+}
+
+/**
+ * @section Values: Functions for working with ImmutablePriorityQueues.
+ */
+
+/**
+ * Creates a new priority queue with a comparator to use for determining element priority.
+ * 
+ * @param comp: The comparator function used to indicate priority order
+ * @returns An empty priority queue
+ * 
+ * @example ImmutablePriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+ *
+ * @since v0.5.3
+ */
+export let make = comp => {
+  { comp, size: 0, root: None }
+}
+
+/**
+ * Returns the number of elements currently in the priority queue.
+ * 
+ * @param pq: The priority queue to get the size of
+ * @returns The number of elements in the priority queue
+ *
+ * @since v0.5.3
+ */
+export let size = pq => {
+  pq.size
+}
+
+/**
+ * Returns whether or not the priority queue is empty.
+ * 
+ * @param pq: The priority queue to find the emptiness of
+ * @returns `true` if the priority queue has no elements and `false` otherwise
+ *
+ * @since v0.5.3
+ */
+export let isEmpty = pq => {
+  pq.size == 0
+}
+
+let skewLinkNodes = (comp, newNode, node1, node2) => {
+  // make the two nodes with larger values children of the node with the smallest value
+  if (comp(node1.val, newNode.val) <= 0 && comp(node1.val, node2.val) <= 0) {
+    {
+      val: node1.val,
+      rank: node1.rank + 1,
+      children: [newNode, node2, ...node1.children],
+    }
+  } else if (
+    comp(node2.val, newNode.val) <= 0 && comp(node2.val, node1.val) <= 0
+  ) {
+    {
+      val: node2.val,
+      rank: node2.rank + 1,
+      children: [newNode, node1, ...node2.children],
+    }
+  } else {
+    { val: newNode.val, rank: node1.rank + 1, children: [node1, node2] }
+  }
+}
+
+let skewInsert = (comp, val, pq) => {
+  let newNode = { val, rank: 0, children: [] }
+  match (pq) {
+    // the only time two trees will have the same rank is if they are the
+    // smallest-ranked trees in the queue, in which case we should link
+    // them with the new node
+    [node1, node2, ...rest] when node1.rank == node2.rank =>
+      [skewLinkNodes(comp, newNode, node1, node2), ...rest],
+    _ => [newNode, ...pq],
+  }
+}
+
+/**
+ * Returns a new priority queue with the given element inserted into the given priority queue.
+ * 
+ * @param val: The value to add into the priority queue
+ * @param pq: The priority queue
+ * @returns A new priority queue with the given element inserted into the given priority queue
+ */
+export let push = (val, pq) => {
+  let { comp, size, root } = pq
+  match (root) {
+    None => { comp, size: 1, root: Some({ rootVal: val, pq: [] }) },
+    Some({ rootVal, pq }) => {
+      // make the new value the root if it has higher priority than the highest priority value
+      let (morePriorityVal, lessPriorityVal) = if (comp(val, rootVal) <= 0)
+          (val, rootVal) else (rootVal, val)
+
+      let newRoot = Some(
+        { rootVal: morePriorityVal, pq: skewInsert(comp, lessPriorityVal, pq) }
+      )
+      { comp, size: size + 1, root: newRoot }
+    },
+  }
+}
+
+/**
+ * Returns the highest-priority element in the priority queue in a `Some`
+ * variant, or `None` if the priority queue is empty.
+ * 
+ * @param pq: The priority queue to get the highest-priority element of
+ * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ *
+ * @since v0.5.3
+ */
+export let peek = pq => {
+  match (pq.root) {
+    None => None,
+    Some({ rootVal, _ }) => Some(rootVal),
+  }
+}
+
+let linkNodes = (comp, node1, node2) => {
+  // make the node with higher priority the parent of the node with smaller
+  // priority to presere heap-ordering
+  let (morePriority, lessPriority) = if (comp(node1.val, node2.val) <= 0)
+      (node1, node2) else (node2, node1)
+  {
+    val: morePriority.val,
+    rank: morePriority.rank + 1,
+    children: [lessPriority, ...morePriority.children],
+  }
+}
+
+// step through the trees in the priority queue in increasing rank order until we
+// find a missing rank, linking trees of equal rank as we go
+let rec ins = (comp, node, pq) => {
+  match (pq) {
+    [] => [node],
+    [firstNode, ...rest] => {
+      if (node.rank < firstNode.rank) {
+        [node, firstNode, ...rest]
+      } else {
+        ins(comp, linkNodes(comp, node, firstNode), rest)
+      }
+    },
+  }
+}
+
+let uniquify = (comp, pq) => {
+  match (pq) {
+    [] => [],
+    [node, ...rest] => ins(comp, node, rest),
+  }
+}
+
+// step through the trees of two priority queues in increasing rank order, perform-
+// ing a simple link whenever we find two trees of equal rank
+let rec mergeUniq = (comp, pq1, pq2) => {
+  match ((pq1, pq2)) {
+    ([], ts) | (ts, []) => ts,
+    ([node1, ...rest1], [node2, ...rest2]) => {
+      if (node1.rank < node2.rank) {
+        [node1, ...mergeUniq(comp, rest1, pq2)]
+      } else if (node2.rank < node1.rank) {
+        [node2, ...mergeUniq(comp, pq1, rest2)]
+      } else {
+        ins(comp, linkNodes(comp, node1, node2), mergeUniq(comp, rest1, rest2))
+      }
+    },
+  }
+}
+
+let merge = (comp, pq1, pq2) =>
+  mergeUniq(comp, uniquify(comp, pq1), uniquify(comp, pq2))
+
+// splits the node with the minimum value out from the rest of the nodes
+let rec separateHighestPriority = (comp, pq) => {
+  match (pq) {
+    // empty list case should never happen; this is here just to satisfy compiler
+    [] => fail "getHighestPriority called with empty PQ",
+    [node] => (node, []),
+    [node, ...rest] => {
+      let (currMinNode, currNonMinNodes) = separateHighestPriority(comp, rest)
+      if (comp(node.val, currMinNode.val) <= 0) {
+        (node, rest)
+      } else {
+        (currMinNode, [node, ...currNonMinNodes])
+      }
+    },
+  }
+}
+
+// splits the nodes of rank 0 out from the other nodes
+let rec splitRankZero = (rankZeroVals, nonRankZeroNodes, pq) => {
+  match (pq) {
+    [] => (rankZeroVals, nonRankZeroNodes),
+    [node, ...rest] => {
+      if (node.rank == 0) {
+        splitRankZero([node.val, ...rankZeroVals], nonRankZeroNodes, rest)
+      } else {
+        splitRankZero(rankZeroVals, [node, ...nonRankZeroNodes], rest)
+      }
+    },
+  }
+}
+
+let withoutHighestPriority = (comp, pq) => {
+  // split out the node with the highest priority
+  let (hpNode, nonHpNodes) = separateHighestPriority(comp, pq)
+  // split out the values with nodes of rank 0, which will all be singleton nodes
+  let (rankZeroVals, nonRankZeroNodes) = splitRankZero([], [], hpNode.children)
+
+  let mergedPq = merge(comp, nonHpNodes, nonRankZeroNodes)
+  List.reduce((pq, val) => skewInsert(comp, val, pq), mergedPq, rankZeroVals)
+}
+
+let rec findHighestPriority = (comp, pq) => {
+  match (pq) {
+    // empty list case should never happen; this is here just to satisfy compiler
+    [] => fail "findHighestPriority with empty PQ",
+    [node] => node.val,
+    [node, ...rest] => {
+      let currMin = findHighestPriority(comp, rest)
+      if (comp(node.val, currMin) <= 0) node.val else currMin
+    },
+  }
+}
+
+/**
+ * Returns a new priority queue without the highest-priority element in the given priority queue
+ * in a `Some` variant, or `None` if the priority queue is empty.
+ * 
+ * @param pq: The priority queue
+ * @returns A new priority queue without the highest-priority element in the input priority queue
+ *
+ * @since v0.5.3
+ */
+export let pop = pq => {
+  let pqWithRoot = pq
+  let { comp, size, root } = pq
+  match (root) {
+    None => pq,
+    Some({ pq, rootVal }) => {
+      let newRoot = if (pq == []) {
+        None
+      } else {
+        Some(
+          {
+            rootVal: findHighestPriority(comp, pq),
+            pq: withoutHighestPriority(comp, pq),
+          }
+        )
+      }
+      { comp, size: size - 1, root: newRoot }
+    },
+  }
+}
+
+/**
+ * Returns all of the elements in the priority queue in priority order.
+ * 
+ * @param pq: The priority queue to drain
+ * @returns A list of all elements in the priority in priority order
+ *
+ * @since v0.5.3
+ */
+export let drain = pq => {
+  let rec drainRec = (acc, pq) => {
+    match (pq.root) {
+      None => acc,
+      Some(root) => drainRec([root.rootVal, ...acc], pop(pq)),
+    }
+  }
+  List.reverse(drainRec([], pq))
+}
+
+/**
+ * Constructs a new priority queue initialized with the elements in the list, and
+ * with a custom comparator function used to assign priority.
+ * 
+ * @param list: A list of values to initialize the priority queue with
+ * @param comp: A comparator function used to assign priority to elements
+ * @returns A priority queue containing the elements in the list
+ *
+ * @since v0.5.3
+ */
+export let fromList = (list, comp) => {
+  List.reduce((pq, val) => push(val, pq), make(comp), list)
+}

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -1,5 +1,5 @@
 /**
- * @module ImmutablePriorityQueue: An immutable priority queue implemented as a skew binomial queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ * @module ImmutablePriorityQueue: An immutable priority queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
  *
  * @example import ImmutablePriorityQueue from "immutablepriorityqueue"
  *
@@ -44,12 +44,16 @@ record ImmutablePriorityQueue<a> {
  */
 
 /**
- * Creates a new priority queue with a comparator to use for determining element priority.
+ * Creates a new priority queue with a comparator function, which is used to
+ * determine priority of elements. The comparator function takes two elements
+ * and must return 0 if both share priority, a positive number if the first
+ * has greater priority, and a negative number if the first has less priority.
  * 
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
  * 
- * @example ImmutablePriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+ * @example ImmutablePriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
+ * @example ImmutablePriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
  *
  * @since v0.5.3
  */
@@ -58,7 +62,7 @@ export let make = comp => {
 }
 
 /**
- * Returns the number of elements currently in the priority queue.
+ * Returns the number of elements in the priority queue.
  * 
  * @param pq: The priority queue to get the size of
  * @returns The number of elements in the priority queue
@@ -72,7 +76,7 @@ export let size = pq => {
 /**
  * Returns whether or not the priority queue is empty.
  * 
- * @param pq: The priority queue to find the emptiness of
+ * @param pq: The priority queue to check
  * @returns `true` if the priority queue has no elements and `false` otherwise
  *
  * @since v0.5.3
@@ -139,10 +143,10 @@ export let push = (val, pq) => {
 }
 
 /**
- * Returns the highest-priority element in the priority queue in a `Some`
+ * Returns the highest priority element in the priority queue in a `Some`
  * variant, or `None` if the priority queue is empty.
  * 
- * @param pq: The priority queue to get the highest-priority element of
+ * @param pq: The priority queue to get the highest priority element of
  * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
  *
  * @since v0.5.3
@@ -211,7 +215,7 @@ let merge = (comp, pq1, pq2) =>
 // splits the node with the minimum value out from the rest of the nodes
 let rec separateHighestPriority = (comp, pq) => {
   match (pq) {
-    // empty list case should never happen; this is here just to satisfy compiler
+    // empty list case should never happen; this is here just to satisfy the compiler
     [] => fail "getHighestPriority called with empty PQ",
     [node] => (node, []),
     [node, ...rest] => {
@@ -251,7 +255,7 @@ let withoutHighestPriority = (comp, pq) => {
 
 let rec findHighestPriority = (comp, pq) => {
   match (pq) {
-    // empty list case should never happen; this is here just to satisfy compiler
+    // empty list case should never happen; this is here just to satisfy the compiler
     [] => fail "findHighestPriority with empty PQ",
     [node] => node.val,
     [node, ...rest] => {
@@ -262,11 +266,12 @@ let rec findHighestPriority = (comp, pq) => {
 }
 
 /**
- * Returns a new priority queue without the highest-priority element in the given priority queue
- * in a `Some` variant, or `None` if the priority queue is empty.
+ * Returns a new priority queue without the highest priority element in the
+ * given priority queue. If the input priority queue is empty, this function will
+ * return it.
  * 
  * @param pq: The priority queue
- * @returns A new priority queue without the highest-priority element in the input priority queue
+ * @returns A new priority queue without the highest priority element in the input priority queue
  *
  * @since v0.5.3
  */
@@ -310,8 +315,11 @@ export let drain = pq => {
 }
 
 /**
- * Constructs a new priority queue initialized with the elements in the list, and
- * with a custom comparator function used to assign priority.
+ * Constructs a new priority queue initialized with the elements in the list
+ * using a custom comparator function, which is used to determine priority of
+ * elements. The comparator function takes two elements and must return 0 if
+ * both share priority, a positive number if the first has greater priority,
+ * and a negative number if the first has less priority.
  * 
  * @param list: A list of values to initialize the priority queue with
  * @param comp: A comparator function used to assign priority to elements

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -2,7 +2,7 @@
 title: ImmutablePriorityQueue
 ---
 
-An immutable priority queue implemented as a skew binomial queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+An immutable priority queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -40,7 +40,10 @@ No other changes yet.
 make : ((a, a) -> Number) -> ImmutablePriorityQueue<a>
 ```
 
-Creates a new priority queue with a comparator to use for determining element priority.
+Creates a new priority queue with a comparator function, which is used to
+determine priority of elements. The comparator function takes two elements
+and must return 0 if both share priority, a positive number if the first
+has greater priority, and a negative number if the first has less priority.
 
 Parameters:
 
@@ -57,7 +60,11 @@ Returns:
 Examples:
 
 ```grain
-ImmutablePriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+ImmutablePriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
+```
+
+```grain
+ImmutablePriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
 ```
 
 ### Immutablepriorityqueue.**size**
@@ -71,7 +78,7 @@ No other changes yet.
 size : ImmutablePriorityQueue<a> -> Number
 ```
 
-Returns the number of elements currently in the priority queue.
+Returns the number of elements in the priority queue.
 
 Parameters:
 
@@ -102,7 +109,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to find the emptiness of|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to check|
 
 Returns:
 
@@ -142,14 +149,14 @@ No other changes yet.
 peek : ImmutablePriorityQueue<a> -> Option<a>
 ```
 
-Returns the highest-priority element in the priority queue in a `Some`
+Returns the highest priority element in the priority queue in a `Some`
 variant, or `None` if the priority queue is empty.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the highest-priority element of|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the highest priority element of|
 
 Returns:
 
@@ -168,8 +175,9 @@ No other changes yet.
 pop : ImmutablePriorityQueue<a> -> ImmutablePriorityQueue<a>
 ```
 
-Returns a new priority queue without the highest-priority element in the given priority queue
-in a `Some` variant, or `None` if the priority queue is empty.
+Returns a new priority queue without the highest priority element in the
+given priority queue. If the input priority queue is empty, this function will
+return it.
 
 Parameters:
 
@@ -181,7 +189,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`ImmutablePriorityQueue<a>`|A new priority queue without the highest-priority element in the input priority queue|
+|`ImmutablePriorityQueue<a>`|A new priority queue without the highest priority element in the input priority queue|
 
 ### Immutablepriorityqueue.**drain**
 
@@ -219,8 +227,11 @@ No other changes yet.
 fromList : (List<a>, ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
 ```
 
-Constructs a new priority queue initialized with the elements in the list, and
-with a custom comparator function used to assign priority.
+Constructs a new priority queue initialized with the elements in the list
+using a custom comparator function, which is used to determine priority of
+elements. The comparator function takes two elements and must return 0 if
+both share priority, a positive number if the first has greater priority,
+and a negative number if the first has less priority.
 
 Parameters:
 

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -78,13 +78,13 @@ No other changes yet.
 size : ImmutablePriorityQueue<a> -> Number
 ```
 
-Returns the number of elements in the priority queue.
+Gets the number of elements in a priority queue.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the size of|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to inspect|
 
 Returns:
 
@@ -103,7 +103,7 @@ No other changes yet.
 isEmpty : ImmutablePriorityQueue<a> -> Bool
 ```
 
-Returns whether or not the priority queue is empty.
+Determines if the priority queue contains no elements.
 
 Parameters:
 
@@ -115,7 +115,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the priority queue has no elements and `false` otherwise|
+|`Bool`|`true` if the priority queue is empty and `false` otherwise|
 
 ### Immutablepriorityqueue.**push**
 
@@ -123,7 +123,7 @@ Returns:
 push : (a, ImmutablePriorityQueue<a>) -> ImmutablePriorityQueue<a>
 ```
 
-Returns a new priority queue with the given element inserted into the given priority queue.
+Produces a new priority queue by inserting the given element into the given priority queue.
 
 Parameters:
 
@@ -136,7 +136,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`ImmutablePriorityQueue<a>`|A new priority queue with the given element inserted into the given priority queue|
+|`ImmutablePriorityQueue<a>`|A new priority queue with the given element inserted|
 
 ### Immutablepriorityqueue.**peek**
 
@@ -149,20 +149,20 @@ No other changes yet.
 peek : ImmutablePriorityQueue<a> -> Option<a>
 ```
 
-Returns the highest priority element in the priority queue in a `Some`
-variant, or `None` if the priority queue is empty.
+Retrieves the highest priority element in the priority queue. It is not
+removed from the queue.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the highest priority element of|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to inspect|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+|`Option<a>`|`Some(value)` containing the highest priority element or `None` if the priority queue is empty|
 
 ### Immutablepriorityqueue.**pop**
 
@@ -175,7 +175,7 @@ No other changes yet.
 pop : ImmutablePriorityQueue<a> -> ImmutablePriorityQueue<a>
 ```
 
-Returns a new priority queue without the highest priority element in the
+Produces a new priority queue without the highest priority element in the
 given priority queue. If the input priority queue is empty, this function will
 return it.
 
@@ -189,7 +189,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`ImmutablePriorityQueue<a>`|A new priority queue without the highest priority element in the input priority queue|
+|`ImmutablePriorityQueue<a>`|A new priority queue without the highest priority element|
 
 ### Immutablepriorityqueue.**drain**
 
@@ -202,7 +202,7 @@ No other changes yet.
 drain : ImmutablePriorityQueue<a> -> List<a>
 ```
 
-Returns all of the elements in the priority queue in priority order.
+Produces a list of all elements in the priority queue in priority order.
 
 Parameters:
 
@@ -237,12 +237,12 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`list`|`List<a>`|A list of values to initialize the priority queue with|
+|`list`|`List<a>`|A list of values used to initialize the priority queue|
 |`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`ImmutablePriorityQueue<a>`|A priority queue containing the elements in the list|
+|`ImmutablePriorityQueue<a>`|A priority queue containing the elements from the list|
 

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -1,0 +1,237 @@
+---
+title: ImmutablePriorityQueue
+---
+
+An immutable priority queue implemented as a skew binomial queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+import ImmutablePriorityQueue from "immutablepriorityqueue"
+```
+
+## Types
+
+Type declarations included in the ImmutablePriorityQueue module.
+
+### Immutablepriorityqueue.**ImmutablePriorityQueue**
+
+```grain
+type ImmutablePriorityQueue<a>
+```
+
+Immutable data structure which maintains a priority order for its elements.
+
+## Values
+
+Functions for working with ImmutablePriorityQueues.
+
+### Immutablepriorityqueue.**make**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+make : ((a, a) -> Number) -> ImmutablePriorityQueue<a>
+```
+
+Creates a new priority queue with a comparator to use for determining element priority.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`ImmutablePriorityQueue<a>`|An empty priority queue|
+
+Examples:
+
+```grain
+ImmutablePriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+```
+
+### Immutablepriorityqueue.**size**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+size : ImmutablePriorityQueue<a> -> Number
+```
+
+Returns the number of elements currently in the priority queue.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the size of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The number of elements in the priority queue|
+
+### Immutablepriorityqueue.**isEmpty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isEmpty : ImmutablePriorityQueue<a> -> Bool
+```
+
+Returns whether or not the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to find the emptiness of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the priority queue has no elements and `false` otherwise|
+
+### Immutablepriorityqueue.**push**
+
+```grain
+push : (a, ImmutablePriorityQueue<a>) -> ImmutablePriorityQueue<a>
+```
+
+Returns a new priority queue with the given element inserted into the given priority queue.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`val`|`a`|The value to add into the priority queue|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`ImmutablePriorityQueue<a>`|A new priority queue with the given element inserted into the given priority queue|
+
+### Immutablepriorityqueue.**peek**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+peek : ImmutablePriorityQueue<a> -> Option<a>
+```
+
+Returns the highest-priority element in the priority queue in a `Some`
+variant, or `None` if the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to get the highest-priority element of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+
+### Immutablepriorityqueue.**pop**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+pop : ImmutablePriorityQueue<a> -> ImmutablePriorityQueue<a>
+```
+
+Returns a new priority queue without the highest-priority element in the given priority queue
+in a `Some` variant, or `None` if the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`ImmutablePriorityQueue<a>`|A new priority queue without the highest-priority element in the input priority queue|
+
+### Immutablepriorityqueue.**drain**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+drain : ImmutablePriorityQueue<a> -> List<a>
+```
+
+Returns all of the elements in the priority queue in priority order.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`ImmutablePriorityQueue<a>`|The priority queue to drain|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A list of all elements in the priority in priority order|
+
+### Immutablepriorityqueue.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : (List<a>, ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
+```
+
+Constructs a new priority queue initialized with the elements in the list, and
+with a custom comparator function used to assign priority.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|A list of values to initialize the priority queue with|
+|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`ImmutablePriorityQueue<a>`|A priority queue containing the elements in the list|
+

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -34,7 +34,13 @@ let swap = (i1, i2, array) => {
   array[i1] = t
 }
 
-let get = (array, i) => Option.unwrap(array[i])
+let get = (array, i) =>
+  Option.expect(
+    "Failure to retrieve element at index " ++
+    toString(i) ++
+    " in PriorityQueue's inner storage array",
+    array[i]
+  )
 
 let rec siftDown = (i, pq) => {
   let leftI = 2 * i + 1
@@ -73,7 +79,10 @@ let rec siftUp = (i, pq) => {
  * priority, a positive number if the first has greater priority, and a
  * negative number if the first has less priority.
  * 
- * @param size: The number of elements to initialize the internal storage array with
+ * Generally, you won't need to care about the storage size of your priority
+ * queue and can use `PriorityQueue.make()` instead.
+ * 
+ * @param size: The initial storage size of the priority queue
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
  *
@@ -102,9 +111,9 @@ export let make = comp => {
 }
 
 /**
- * Returns the number of elements currently in the priority queue.
+ * Gets the number of elements in a priority queue.
  * 
- * @param pq: The priority queue to get the size of
+ * @param pq: The priority queue to inspect
  * @returns The number of elements in the priority queue
  *
  * @since v0.5.3
@@ -114,10 +123,10 @@ export let size = pq => {
 }
 
 /**
- * Returns whether or not the priority queue is empty.
+ * Determines if the priority queue contains no elements.
  * 
  * @param pq: The priority queue to check
- * @returns `true` if the priority queue has no elements and `false` otherwise
+ * @returns `true` if the priority queue is empty and `false` otherwise
  *
  * @since v0.5.3
  */
@@ -129,7 +138,7 @@ export let isEmpty = pq => {
  * Adds a new element to the priority queue.
  * 
  * @param val: The value to add into the priority queue
- * @param pq: The priority queue to add a new element to
+ * @param pq: The priority queue to update
  *
  * @since v0.5.3
  */
@@ -151,11 +160,11 @@ export let push = (val, pq) => {
 }
 
 /**
- * Returns the highest priority element in the priority queue in a `Some`
- * variant, or `None` if the priority queue is empty.
+ * Retrieves the highest priority element in the priority queue. It is not
+ * removed from the queue.
  * 
- * @param pq: The priority queue to get the highest priority element of
- * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ * @param pq: The priority queue to inspect
+ * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
  * @since v0.5.3
  */
@@ -168,11 +177,10 @@ export let peek = pq => {
 }
 
 /**
- * Removes and returns the highest priority element in the priority queue in a `Some`
- * variant, or `None` if the priority queue is empty.
+ * Removes and retrieves the highest priority element in the priority queue.
  * 
- * @param pq: The priority queue to remove and get the highest priority element of
- * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ * @param pq: The priority queue to inspect
+ * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
  * @since v0.5.3
  */
@@ -193,7 +201,7 @@ export let pop = pq => {
 }
 
 /**
- * Clears the priority queue and returns all of the elements in the priority
+ * Clears the priority queue and produces a list of all of the elements in the priority
  * queue in priority order.
  * 
  * @param pq: The priority queue to drain
@@ -218,9 +226,9 @@ export let drain = pq => {
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
  * 
- * @param list: A list of values to initialize the priority queue with
+ * @param list: A list of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
- * @returns A priority queue containing the elements in the list
+ * @returns A priority queue containing the elements from the list
  *
  * @since v0.5.3
  */

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -1,5 +1,5 @@
 /**
- * @module PriorityQueue: A mutable binary heap priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ * @module PriorityQueue: A mutable priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
  *
  * @example import PriorityQueue from "priorityqueue"
  *
@@ -68,7 +68,10 @@ let rec siftUp = (i, pq) => {
 
 /**
  * Creates a new priority queue with a given internal storage size and a
- * comparator to use for determining element priority.
+ * comparator function, which is used to determine priority of elements. The
+ * comparator function takes two elements and must return 0 if both share
+ * priority, a positive number if the first has greater priority, and a
+ * negative number if the first has less priority.
  * 
  * @param size: The number of elements to initialize the internal storage array with
  * @param comp: The comparator function used to indicate priority order
@@ -81,12 +84,16 @@ export let makeSized = (size, comp) => {
 }
 
 /**
- * Creates a new priority queue with a comparator to use for determining element priority.
+ * Creates a new priority queue with a comparator function, which is used to
+ * determine priority of elements. The comparator function takes two elements
+ * and must return 0 if both share priority, a positive number if the first
+ * has greater priority, and a negative number if the first has less priority.
  * 
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
  * 
- * @example PriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+ * @example PriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
+ * @example PriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
  *
  * @since v0.5.3
  */
@@ -109,7 +116,7 @@ export let size = pq => {
 /**
  * Returns whether or not the priority queue is empty.
  * 
- * @param pq: The priority queue to find the emptiness of
+ * @param pq: The priority queue to check
  * @returns `true` if the priority queue has no elements and `false` otherwise
  *
  * @since v0.5.3
@@ -144,10 +151,10 @@ export let push = (val, pq) => {
 }
 
 /**
- * Returns the highest-priority element in the priority queue in a `Some`
+ * Returns the highest priority element in the priority queue in a `Some`
  * variant, or `None` if the priority queue is empty.
  * 
- * @param pq: The priority queue to get the highest-priority element of
+ * @param pq: The priority queue to get the highest priority element of
  * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
  *
  * @since v0.5.3
@@ -161,10 +168,10 @@ export let peek = pq => {
 }
 
 /**
- * Removes and returns the highest-priority element in the priority queue in a `Some`
+ * Removes and returns the highest priority element in the priority queue in a `Some`
  * variant, or `None` if the priority queue is empty.
  * 
- * @param pq: The priority queue to remove and get the highest-priority element of
+ * @param pq: The priority queue to remove and get the highest priority element of
  * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
  *
  * @since v0.5.3
@@ -186,7 +193,7 @@ export let pop = pq => {
 }
 
 /**
- * Clears the priority queue, and returns all of the elements in the priority
+ * Clears the priority queue and returns all of the elements in the priority
  * queue in priority order.
  * 
  * @param pq: The priority queue to drain
@@ -205,8 +212,11 @@ export let drain = pq => {
 }
 
 /**
- * Constructs a new priority queue initialized with the elements in the list, and
- * a custom comparator function used to assign priority.
+ * Constructs a new priority queue initialized with the elements in the list
+ * using a custom comparator function, which is used to determine priority of
+ * elements. The comparator function takes two elements and must return 0 if
+ * both share priority, a positive number if the first has greater priority,
+ * and a negative number if the first has less priority.
  * 
  * @param list: A list of values to initialize the priority queue with
  * @param comp: A comparator function used to assign priority to elements

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -1,0 +1,223 @@
+/**
+ * @module PriorityQueue: A mutable binary heap priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ *
+ * @example import PriorityQueue from "priorityqueue"
+ *
+ * @since v0.5.3
+ */
+
+import Array from "array"
+import List from "list"
+import Number from "number"
+import Option from "option"
+
+/**
+ * @section Types: Type declarations included in the PriorityQueue module.
+ */
+
+/**
+ * Mutable data structure which maintains a priority order for its elements.
+ */
+record PriorityQueue<a> {
+  mut size: Number,
+  mut array: Array<Option<a>>,
+  comp: (a, a) -> Number,
+}
+
+/**
+ * @section Values: Functions for working with PriorityQueues.
+ */
+
+let swap = (i1, i2, array) => {
+  let t = array[i2]
+  array[i2] = array[i1]
+  array[i1] = t
+}
+
+let get = (array, i) => Option.unwrap(array[i])
+
+let rec siftDown = (i, pq) => {
+  let leftI = 2 * i + 1
+  let rightI = 2 * i + 2
+
+  // we want to find the smaller child from the current tree node to sift down to
+  let mut swapWithI = i
+  if (leftI < pq.size && pq.comp(get(pq.array, leftI), get(pq.array, i)) < 0) {
+    swapWithI = leftI
+  }
+  if (
+    rightI < pq.size &&
+    pq.comp(get(pq.array, rightI), get(pq.array, swapWithI)) < 0
+  ) {
+    swapWithI = rightI
+  }
+  if (swapWithI != i) {
+    swap(i, swapWithI, pq.array)
+    siftDown(swapWithI, pq)
+  }
+}
+
+let rec siftUp = (i, pq) => {
+  let parentI = Number.trunc((i - 1) / 2)
+  // we should only sift up if the element is smaller than its parent
+  if (i > 0 && pq.comp(get(pq.array, i), get(pq.array, parentI)) < 0) {
+    swap(i, parentI, pq.array)
+    siftUp(parentI, pq)
+  }
+}
+
+/**
+ * Creates a new priority queue with a given internal storage size and a
+ * comparator to use for determining element priority.
+ * 
+ * @param size: The number of elements to initialize the internal storage array with
+ * @param comp: The comparator function used to indicate priority order
+ * @returns An empty priority queue
+ *
+ * @since v0.5.3
+ */
+export let makeSized = (size, comp) => {
+  { size: 0, array: Array.make(size, None), comp }
+}
+
+/**
+ * Creates a new priority queue with a comparator to use for determining element priority.
+ * 
+ * @param comp: The comparator function used to indicate priority order
+ * @returns An empty priority queue
+ * 
+ * @example PriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+ *
+ * @since v0.5.3
+ */
+export let make = comp => {
+  makeSized(16, comp)
+}
+
+/**
+ * Returns the number of elements currently in the priority queue.
+ * 
+ * @param pq: The priority queue to get the size of
+ * @returns The number of elements in the priority queue
+ *
+ * @since v0.5.3
+ */
+export let size = pq => {
+  pq.size
+}
+
+/**
+ * Returns whether or not the priority queue is empty.
+ * 
+ * @param pq: The priority queue to find the emptiness of
+ * @returns `true` if the priority queue has no elements and `false` otherwise
+ *
+ * @since v0.5.3
+ */
+export let isEmpty = pq => {
+  pq.size == 0
+}
+
+/**
+ * Adds a new element to the priority queue.
+ * 
+ * @param val: The value to add into the priority queue
+ * @param pq: The priority queue to add a new element to
+ *
+ * @since v0.5.3
+ */
+export let push = (val, pq) => {
+  let arrLen = Array.length(pq.array)
+  // double size of internal array if out of space
+  if (pq.size == arrLen) {
+    let oldArr = pq.array
+    pq.array = Array.make(arrLen * 2, None)
+    Array.forEachi((val, i) => {
+      pq.array[i] = val
+    }, oldArr)
+  }
+  pq.array[pq.size] = Some(val)
+  pq.size += 1
+  // reorder heap to ensure that binary heap property of parent nodes having
+  // larger values than their children is upheld
+  siftUp(pq.size - 1, pq)
+}
+
+/**
+ * Returns the highest-priority element in the priority queue in a `Some`
+ * variant, or `None` if the priority queue is empty.
+ * 
+ * @param pq: The priority queue to get the highest-priority element of
+ * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ *
+ * @since v0.5.3
+ */
+export let peek = pq => {
+  if (pq.size == 0) {
+    None
+  } else {
+    pq.array[0]
+  }
+}
+
+/**
+ * Removes and returns the highest-priority element in the priority queue in a `Some`
+ * variant, or `None` if the priority queue is empty.
+ * 
+ * @param pq: The priority queue to remove and get the highest-priority element of
+ * @returns The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty
+ *
+ * @since v0.5.3
+ */
+export let pop = pq => {
+  if (pq.size == 0) {
+    None
+  } else {
+    let root = pq.array[0]
+
+    pq.array[0] = pq.array[pq.size - 1]
+    pq.array[pq.size - 1] = None
+    pq.size -= 1
+    // reorder heap to ensure that binary heap property of parent nodes having
+    // larger values than their children is upheld
+    siftDown(0, pq)
+    root
+  }
+}
+
+/**
+ * Clears the priority queue, and returns all of the elements in the priority
+ * queue in priority order.
+ * 
+ * @param pq: The priority queue to drain
+ * @returns A list of all elements in the priority in priority order
+ *
+ * @since v0.5.3
+ */
+export let drain = pq => {
+  let rec drainRec = acc => {
+    match (pop(pq)) {
+      Some(val) => drainRec([val, ...acc]),
+      None => acc,
+    }
+  }
+  List.reverse(drainRec([]))
+}
+
+/**
+ * Constructs a new priority queue initialized with the elements in the list, and
+ * a custom comparator function used to assign priority.
+ * 
+ * @param list: A list of values to initialize the priority queue with
+ * @param comp: A comparator function used to assign priority to elements
+ * @returns A priority queue containing the elements in the list
+ *
+ * @since v0.5.3
+ */
+export let fromList = (list, comp) => {
+  let heap = makeSized(List.length(list), comp)
+  List.forEach(val => {
+    push(val, heap)
+  }, list)
+  heap
+}

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -36,9 +36,9 @@ let swap = (i1, i2, array) => {
 
 let get = (array, i) =>
   Option.expect(
-    "Failure to retrieve element at index " ++
+    "Impossible: " ++
     toString(i) ++
-    " in PriorityQueue's inner storage array",
+    " in PriorityQueue's inner storage array is None",
     array[i]
   )
 

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -1,0 +1,264 @@
+---
+title: PriorityQueue
+---
+
+A mutable binary heap priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+import PriorityQueue from "priorityqueue"
+```
+
+## Types
+
+Type declarations included in the PriorityQueue module.
+
+### Priorityqueue.**PriorityQueue**
+
+```grain
+type PriorityQueue<a>
+```
+
+Mutable data structure which maintains a priority order for its elements.
+
+## Values
+
+Functions for working with PriorityQueues.
+
+### Priorityqueue.**makeSized**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+makeSized : (Number, ((a, a) -> Number)) -> PriorityQueue<a>
+```
+
+Creates a new priority queue with a given internal storage size and a
+comparator to use for determining element priority.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`size`|`Number`|The number of elements to initialize the internal storage array with|
+|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`PriorityQueue<a>`|An empty priority queue|
+
+### Priorityqueue.**make**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+make : ((a, a) -> Number) -> PriorityQueue<a>
+```
+
+Creates a new priority queue with a comparator to use for determining element priority.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`PriorityQueue<a>`|An empty priority queue|
+
+Examples:
+
+```grain
+PriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+```
+
+### Priorityqueue.**size**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+size : PriorityQueue<a> -> Number
+```
+
+Returns the number of elements currently in the priority queue.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`PriorityQueue<a>`|The priority queue to get the size of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The number of elements in the priority queue|
+
+### Priorityqueue.**isEmpty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isEmpty : PriorityQueue<a> -> Bool
+```
+
+Returns whether or not the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`PriorityQueue<a>`|The priority queue to find the emptiness of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the priority queue has no elements and `false` otherwise|
+
+### Priorityqueue.**push**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+push : (a, PriorityQueue<a>) -> Void
+```
+
+Adds a new element to the priority queue.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`val`|`a`|The value to add into the priority queue|
+|`pq`|`PriorityQueue<a>`|The priority queue to add a new element to|
+
+### Priorityqueue.**peek**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+peek : PriorityQueue<a> -> Option<a>
+```
+
+Returns the highest-priority element in the priority queue in a `Some`
+variant, or `None` if the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`PriorityQueue<a>`|The priority queue to get the highest-priority element of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+
+### Priorityqueue.**pop**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+pop : PriorityQueue<a> -> Option<a>
+```
+
+Removes and returns the highest-priority element in the priority queue in a `Some`
+variant, or `None` if the priority queue is empty.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`PriorityQueue<a>`|The priority queue to remove and get the highest-priority element of|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+
+### Priorityqueue.**drain**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+drain : PriorityQueue<a> -> List<a>
+```
+
+Clears the priority queue, and returns all of the elements in the priority
+queue in priority order.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`pq`|`PriorityQueue<a>`|The priority queue to drain|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A list of all elements in the priority in priority order|
+
+### Priorityqueue.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : (List<a>, ((a, a) -> Number)) -> PriorityQueue<a>
+```
+
+Constructs a new priority queue initialized with the elements in the list, and
+a custom comparator function used to assign priority.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|A list of values to initialize the priority queue with|
+|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`PriorityQueue<a>`|A priority queue containing the elements in the list|
+

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -2,7 +2,7 @@
 title: PriorityQueue
 ---
 
-A mutable binary heap priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+A mutable priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -41,7 +41,10 @@ makeSized : (Number, ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
 Creates a new priority queue with a given internal storage size and a
-comparator to use for determining element priority.
+comparator function, which is used to determine priority of elements. The
+comparator function takes two elements and must return 0 if both share
+priority, a positive number if the first has greater priority, and a
+negative number if the first has less priority.
 
 Parameters:
 
@@ -67,7 +70,10 @@ No other changes yet.
 make : ((a, a) -> Number) -> PriorityQueue<a>
 ```
 
-Creates a new priority queue with a comparator to use for determining element priority.
+Creates a new priority queue with a comparator function, which is used to
+determine priority of elements. The comparator function takes two elements
+and must return 0 if both share priority, a positive number if the first
+has greater priority, and a negative number if the first has less priority.
 
 Parameters:
 
@@ -84,7 +90,11 @@ Returns:
 Examples:
 
 ```grain
-PriorityQueue.make((a, b) => a - b) // creates a min priority queue of numbers
+PriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
+```
+
+```grain
+PriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
 ```
 
 ### Priorityqueue.**size**
@@ -129,7 +139,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to find the emptiness of|
+|`pq`|`PriorityQueue<a>`|The priority queue to check|
 
 Returns:
 
@@ -168,14 +178,14 @@ No other changes yet.
 peek : PriorityQueue<a> -> Option<a>
 ```
 
-Returns the highest-priority element in the priority queue in a `Some`
+Returns the highest priority element in the priority queue in a `Some`
 variant, or `None` if the priority queue is empty.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to get the highest-priority element of|
+|`pq`|`PriorityQueue<a>`|The priority queue to get the highest priority element of|
 
 Returns:
 
@@ -194,14 +204,14 @@ No other changes yet.
 pop : PriorityQueue<a> -> Option<a>
 ```
 
-Removes and returns the highest-priority element in the priority queue in a `Some`
+Removes and returns the highest priority element in the priority queue in a `Some`
 variant, or `None` if the priority queue is empty.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to remove and get the highest-priority element of|
+|`pq`|`PriorityQueue<a>`|The priority queue to remove and get the highest priority element of|
 
 Returns:
 
@@ -220,7 +230,7 @@ No other changes yet.
 drain : PriorityQueue<a> -> List<a>
 ```
 
-Clears the priority queue, and returns all of the elements in the priority
+Clears the priority queue and returns all of the elements in the priority
 queue in priority order.
 
 Parameters:
@@ -246,8 +256,11 @@ No other changes yet.
 fromList : (List<a>, ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
-Constructs a new priority queue initialized with the elements in the list, and
-a custom comparator function used to assign priority.
+Constructs a new priority queue initialized with the elements in the list
+using a custom comparator function, which is used to determine priority of
+elements. The comparator function takes two elements and must return 0 if
+both share priority, a positive number if the first has greater priority,
+and a negative number if the first has less priority.
 
 Parameters:
 

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -46,11 +46,14 @@ comparator function takes two elements and must return 0 if both share
 priority, a positive number if the first has greater priority, and a
 negative number if the first has less priority.
 
+Generally, you won't need to care about the storage size of your priority
+queue and can use `PriorityQueue.make()` instead.
+
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`size`|`Number`|The number of elements to initialize the internal storage array with|
+|`size`|`Number`|The initial storage size of the priority queue|
 |`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
 
 Returns:
@@ -108,13 +111,13 @@ No other changes yet.
 size : PriorityQueue<a> -> Number
 ```
 
-Returns the number of elements currently in the priority queue.
+Gets the number of elements in a priority queue.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to get the size of|
+|`pq`|`PriorityQueue<a>`|The priority queue to inspect|
 
 Returns:
 
@@ -133,7 +136,7 @@ No other changes yet.
 isEmpty : PriorityQueue<a> -> Bool
 ```
 
-Returns whether or not the priority queue is empty.
+Determines if the priority queue contains no elements.
 
 Parameters:
 
@@ -145,7 +148,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the priority queue has no elements and `false` otherwise|
+|`Bool`|`true` if the priority queue is empty and `false` otherwise|
 
 ### Priorityqueue.**push**
 
@@ -165,7 +168,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`val`|`a`|The value to add into the priority queue|
-|`pq`|`PriorityQueue<a>`|The priority queue to add a new element to|
+|`pq`|`PriorityQueue<a>`|The priority queue to update|
 
 ### Priorityqueue.**peek**
 
@@ -178,20 +181,20 @@ No other changes yet.
 peek : PriorityQueue<a> -> Option<a>
 ```
 
-Returns the highest priority element in the priority queue in a `Some`
-variant, or `None` if the priority queue is empty.
+Retrieves the highest priority element in the priority queue. It is not
+removed from the queue.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to get the highest priority element of|
+|`pq`|`PriorityQueue<a>`|The priority queue to inspect|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+|`Option<a>`|`Some(value)` containing the highest priority element or `None` if the priority queue is empty|
 
 ### Priorityqueue.**pop**
 
@@ -204,20 +207,19 @@ No other changes yet.
 pop : PriorityQueue<a> -> Option<a>
 ```
 
-Removes and returns the highest priority element in the priority queue in a `Some`
-variant, or `None` if the priority queue is empty.
+Removes and retrieves the highest priority element in the priority queue.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`pq`|`PriorityQueue<a>`|The priority queue to remove and get the highest priority element of|
+|`pq`|`PriorityQueue<a>`|The priority queue to inspect|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Option<a>`|The element with the highest priority wrapped in a `Some` variant, or `None` if the priority queue is empty|
+|`Option<a>`|`Some(value)` containing the highest priority element or `None` if the priority queue is empty|
 
 ### Priorityqueue.**drain**
 
@@ -230,7 +232,7 @@ No other changes yet.
 drain : PriorityQueue<a> -> List<a>
 ```
 
-Clears the priority queue and returns all of the elements in the priority
+Clears the priority queue and produces a list of all of the elements in the priority
 queue in priority order.
 
 Parameters:
@@ -266,12 +268,12 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`list`|`List<a>`|A list of values to initialize the priority queue with|
+|`list`|`List<a>`|A list of values used to initialize the priority queue|
 |`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`PriorityQueue<a>`|A priority queue containing the elements in the list|
+|`PriorityQueue<a>`|A priority queue containing the elements from the list|
 


### PR DESCRIPTION
As the name suggests, this PR is for implementation of both mutable and immutable priority queues. The mutable priority queue is implemented as a binary heap, and the immutable priority queue is implemented as a skew binomial queue as described in the paper "Optimal Purely Functional Priority Queues" by Chris Okasaki. (O(1) insertions and peeking, O(log(n)) deletions)

This closes #1383 . The API for an immutable priority queue was not really discussed in this issue, but I made one that seemed reasonable to me; let me know if something should be changed:

- `make(comp: (a, a) -> Number) -> ImmutablePriorityQueue<a>`: creates a new PQ with a comparator for determining priority
- `size(pq) -> Number`
- `isEmpty(pq) -> Bool`
- `push(val: a, pq) -> ImmutablePriorityQueue<a>`: creates a new immutable PQ with new element added
- `peek(pq) -> Option<a>`: returns highest priority val wrapped in Some, or None if the PQ is empty
- `pop(pq) -> ImmutablePriorityQueue<a>`: returns an immutable PQ without the highest priority element in the original PQ (if the original PQ is empty it just returns it)
- `drain(pq) -> List<a>`: returns a list of all of the elements in the PQ in priority order; the name of this one I was the least sure about since it's not really "draining" the PQ since it is immutable, but I just went with this name for now for consistency with the mutable PQ
- `fromList(list: List<a>, comp: (a, a) -> Number)`: creates a new PQ containing all of the elements in the list in the priority determined by the comparator