### PR TITLE
feat: Implement Pervasives.compare

### DIFF
--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -16,7 +16,7 @@ arrays › array_access
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,7 +35,7 @@ arrays › array_access
     (local.set $0
      (block $compile_block.7 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -68,7 +68,7 @@ arrays › array_access
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -84,7 +84,7 @@ arrays › array_access
         )
        )
        (local.set $2
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (if
         (i32.gt_s

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -16,7 +16,7 @@ arrays › array_access4
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,7 +35,7 @@ arrays › array_access4
     (local.set $0
      (block $compile_block.7 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -68,7 +68,7 @@ arrays › array_access4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -84,7 +84,7 @@ arrays › array_access4
         )
        )
        (local.set $2
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (if
         (i32.gt_s

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -16,7 +16,7 @@ arrays › array_access2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,7 +35,7 @@ arrays › array_access2
     (local.set $0
      (block $compile_block.7 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -68,7 +68,7 @@ arrays › array_access2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -84,7 +84,7 @@ arrays › array_access2
         )
        )
        (local.set $2
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (if
         (i32.gt_s

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -16,7 +16,7 @@ arrays › array_access3
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,7 +35,7 @@ arrays › array_access3
     (local.set $0
      (block $compile_block.7 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -68,7 +68,7 @@ arrays › array_access3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -84,7 +84,7 @@ arrays › array_access3
         )
        )
        (local.set $2
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (if
         (i32.gt_s

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -16,7 +16,7 @@ arrays › array_access5
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,7 +35,7 @@ arrays › array_access5
     (local.set $0
      (block $compile_block.7 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -68,7 +68,7 @@ arrays › array_access5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -84,7 +84,7 @@ arrays › array_access5
         )
        )
        (local.set $2
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (if
         (i32.gt_s

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const -33)
        (i32.const 35)

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › land4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1128
+      (call $&_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1128)
+        (global.get $&_1131)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lxor1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1128
+      (call $^_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1128)
+        (global.get $^_1131)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lor1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1128
+      (call $|_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1128)
+        (global.get $|_1131)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo6
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo6
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const 35)
        (i32.const 35)

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -10,12 +10,12 @@ basic functionality › precedence3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1134 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › precedence3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $%_1131
+          (call $%_1134
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $%_1131)
+            (global.get $%_1134)
            )
            (i32.const 9)
            (i32.const 13)
@@ -56,10 +56,10 @@ basic functionality › precedence3
        (block $do_backpatches.1
        )
       )
-      (call $+_1128
+      (call $+_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1128)
+        (global.get $+_1131)
        )
        (i32.const 7)
        (call $incRef_0

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsl1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lsl1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $<<_1128
+      (call $<<_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $<<_1128)
+        (global.get $<<_1131)
        )
        (i32.const 15)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -11,18 +11,18 @@ basic functionality › unsafe_wasm_globals
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F64_VAL\" (global $_F64_VAL_1159 (mut f64)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printF64\" (global $printF64_1158 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F32_VAL\" (global $_F32_VAL_1157 (mut f32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printF32\" (global $printF32_1156 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I64_VAL\" (global $_I64_VAL_1155 (mut i64)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI64\" (global $printI64_1154 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I32_VAL\" (global $_I32_VAL_1153 (mut i32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI32\" (global $printI32_1152 (mut i32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF64\" (func $printF64_1158 (param i32 f64) (result i32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF32\" (func $printF32_1156 (param i32 f32) (result i32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI64\" (func $printI64_1154 (param i32 i64) (result i32)))
- (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI32\" (func $printI32_1152 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F64_VAL\" (global $_F64_VAL_1162 (mut f64)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printF64\" (global $printF64_1161 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F32_VAL\" (global $_F32_VAL_1160 (mut f32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printF32\" (global $printF32_1159 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I64_VAL\" (global $_I64_VAL_1158 (mut i64)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI64\" (global $printI64_1157 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I32_VAL\" (global $_I32_VAL_1156 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"GRAIN$EXPORT$printI32\" (global $printI32_1155 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF64\" (func $printF64_1161 (param i32 f64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printF32\" (func $printF32_1159 (param i32 f32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI64\" (func $printI64_1157 (param i32 i64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/unsafe/printWasm\" \"printI32\" (func $printI32_1155 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,26 +39,26 @@ basic functionality › unsafe_wasm_globals
   (return
    (block $compile_block.1 (result i32)
     (drop
-     (call $printI32_1152
-      (global.get $printI32_1152)
-      (global.get $_I32_VAL_1153)
+     (call $printI32_1155
+      (global.get $printI32_1155)
+      (global.get $_I32_VAL_1156)
      )
     )
     (drop
-     (call $printI64_1154
-      (global.get $printI64_1154)
-      (global.get $_I64_VAL_1155)
+     (call $printI64_1157
+      (global.get $printI64_1157)
+      (global.get $_I64_VAL_1158)
      )
     )
     (drop
-     (call $printF32_1156
-      (global.get $printF32_1156)
-      (global.get $_F32_VAL_1157)
+     (call $printF32_1159
+      (global.get $printF32_1159)
+      (global.get $_F32_VAL_1160)
      )
     )
-    (call $printF64_1158
-     (global.get $printF64_1158)
-     (global.get $_F64_VAL_1159)
+    (call $printF64_1161
+     (global.get $printF64_1161)
+     (global.get $_F64_VAL_1162)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -11,14 +11,14 @@ basic functionality › comp22
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1133 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1130 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1130 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -78,10 +78,10 @@ basic functionality › comp22
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -89,7 +89,7 @@ basic functionality › comp22
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1133)
+            (global.get $[]_1136)
            )
           )
           (call $decRef_0
@@ -140,10 +140,10 @@ basic functionality › comp22
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -151,7 +151,7 @@ basic functionality › comp22
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1133)
+            (global.get $[]_1136)
            )
           )
           (call $decRef_0
@@ -164,10 +164,10 @@ basic functionality › comp22
        (block $do_backpatches.9
        )
       )
-      (call $isnt_1128
+      (call $isnt_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1128)
+        (global.get $isnt_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › land1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1128
+      (call $&_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1128)
+        (global.get $&_1131)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › orshort2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › orshort2
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1128
+       (call $print_1131
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1128)
+         (global.get $print_1131)
         )
         (i32.const 3)
        )

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -10,12 +10,12 @@ basic functionality › precedence4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1130 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1130 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › precedence4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $%_1130
+          (call $%_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $%_1130)
+            (global.get $%_1133)
            )
            (i32.const 9)
            (i32.const 13)
@@ -56,10 +56,10 @@ basic functionality › precedence4
        (block $do_backpatches.1
        )
       )
-      (call $+_1128
+      (call $+_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1128)
+        (global.get $+_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsl2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lsl2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $<<_1128
+      (call $<<_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $<<_1128)
+        (global.get $<<_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › comp17
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › comp17
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $isnt_1128
+      (call $isnt_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1128)
+        (global.get $isnt_1131)
        )
        (i32.const 2147483646)
        (i32.const -2)

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › complex2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › complex2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $print_1128
+      (call $print_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1128)
+        (global.get $print_1131)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -10,13 +10,13 @@ basic functionality › comp20
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1130 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1130 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -42,15 +42,15 @@ basic functionality › comp20
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0
@@ -67,10 +67,10 @@ basic functionality › comp20
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (i32.const 3)
            (call $incRef_0
@@ -92,15 +92,15 @@ basic functionality › comp20
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0
@@ -117,10 +117,10 @@ basic functionality › comp20
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1130
+          (call $[...]_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1130)
+            (global.get $[...]_1133)
            )
            (i32.const 3)
            (call $incRef_0
@@ -138,10 +138,10 @@ basic functionality › comp20
        (block $do_backpatches.7
        )
       )
-      (call $isnt_1128
+      (call $isnt_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1128)
+        (global.get $isnt_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lor3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1128
+      (call $|_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1128)
+        (global.get $|_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › decr_3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1128
+      (call $decr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1128)
+        (global.get $decr_1131)
        )
        (i32.const 1)
       )

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -11,20 +11,20 @@ basic functionality › func_shadow
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1133 (param i32 i32) (result i32)))
- (global $foo_1130 (mut i32) (i32.const 0))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1136 (param i32 i32) (result i32)))
+ (global $foo_1133 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -72,7 +72,7 @@ basic functionality › func_shadow
    )
   )
  )
- (func $foo_1130 (param $0 i32) (result i32)
+ (func $foo_1133 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -134,7 +134,7 @@ basic functionality › func_shadow
     (local.set $0
      (block $compile_block.17 (result i32)
       (block $compile_store.9
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.7 (result i32)
@@ -163,14 +163,14 @@ basic functionality › func_shadow
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.8
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -178,10 +178,10 @@ basic functionality › func_shadow
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $foo_1128
+          (call $foo_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1128)
+            (global.get $foo_1131)
            )
           )
           (call $decRef_0
@@ -195,10 +195,10 @@ basic functionality › func_shadow
        )
       )
       (drop
-       (call $print_1133
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1133)
+         (global.get $print_1136)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -207,7 +207,7 @@ basic functionality › func_shadow
        )
       )
       (block $compile_store.14
-       (global.set $foo_1130
+       (global.set $foo_1133
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.12 (result i32)
@@ -236,14 +236,14 @@ basic functionality › func_shadow
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1130)
+           (global.get $foo_1133)
           )
          )
         )
        )
        (block $do_backpatches.13
         (local.set $0
-         (global.get $foo_1130)
+         (global.get $foo_1133)
         )
        )
       )
@@ -251,10 +251,10 @@ basic functionality › func_shadow
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $foo_1130
+          (call $foo_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1130)
+            (global.get $foo_1133)
            )
           )
           (call $decRef_0
@@ -267,10 +267,10 @@ basic functionality › func_shadow
        (block $do_backpatches.15
        )
       )
-      (call $print_1133
+      (call $print_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1133)
+        (global.get $print_1136)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo5
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo5
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const 35)
        (i32.const -33)

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -11,7 +11,7 @@ basic functionality › if_one_sided6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,13 +30,13 @@ basic functionality › if_one_sided6
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -52,13 +52,13 @@ basic functionality › if_one_sided6
         )
         (block $compile_block.4 (result i32)
          (block $compile_set.3 (result i32)
-          (global.set $x_1128
+          (global.set $x_1131
            (tuple.extract 0
             (tuple.make
              (i32.const 11)
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $x_1128)
+              (global.get $x_1131)
              )
             )
            )
@@ -73,7 +73,7 @@ basic functionality › if_one_sided6
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1128)
+       (global.get $x_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › binop6
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › binop6
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const 19)
        (i32.const 11)

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -14,14 +14,14 @@ basic functionality › block_no_expression
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $f_1128 (mut i32) (i32.const 0))
+ (global $f_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $f_1128 (param $0 i32) (result i32)
+ (func $f_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -57,7 +57,7 @@ basic functionality › block_no_expression
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $f_1128
+       (global.set $f_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -86,21 +86,21 @@ basic functionality › block_no_expression
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $f_1128)
+           (global.get $f_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $f_1128)
+         (global.get $f_1131)
         )
        )
       )
-      (call $f_1128
+      (call $f_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $f_1128)
+        (global.get $f_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -9,7 +9,7 @@ basic functionality › if_one_sided5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,13 +28,13 @@ basic functionality › if_one_sided5
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.2
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -43,13 +43,13 @@ basic functionality › if_one_sided5
        )
       )
       (block $compile_set.3 (result i32)
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 11)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lor2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1128
+      (call $|_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1128)
+        (global.get $|_1131)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › land2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1128
+      (call $&_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1128)
+        (global.get $&_1131)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -11,19 +11,19 @@ basic functionality › pattern_match_unsafe_wasm
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1140 (param i32 i32) (result i32)))
- (global $test_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1143 (param i32 i32) (result i32)))
+ (global $test_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $test_1128 (param $0 i32) (result i32)
+ (func $test_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -72,37 +72,37 @@ basic functionality › pattern_match_unsafe_wasm
      )
     )
     (drop
-     (call $foo_1129
+     (call $foo_1132
       (local.get $7)
       (i32.const 0)
      )
     )
     (drop
-     (call $foo_1129
+     (call $foo_1132
       (local.get $7)
       (i32.const 1)
      )
     )
     (drop
-     (call $foo_1129
+     (call $foo_1132
       (local.get $7)
       (i32.const 5)
      )
     )
     (drop
-     (call $foo_1129
+     (call $foo_1132
       (local.get $7)
       (i32.const 8)
      )
     )
-    (call $foo_1129
+    (call $foo_1132
      (local.get $7)
      (i32.const 42)
     )
    )
   )
  )
- (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1132 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -354,8 +354,8 @@ basic functionality › pattern_match_unsafe_wasm
                      (block $do_backpatches.39
                      )
                     )
-                    (call $print_1140
-                     (global.get $print_1140)
+                    (call $print_1143
+                     (global.get $print_1143)
                      (local.get $8)
                     )
                    )
@@ -364,8 +364,8 @@ basic functionality › pattern_match_unsafe_wasm
                 )
                 (br $switch.31_outer
                  (block $compile_block.37 (result i32)
-                  (call $print_1140
-                   (global.get $print_1140)
+                  (call $print_1143
+                   (global.get $print_1143)
                    (i32.const 13)
                   )
                  )
@@ -374,8 +374,8 @@ basic functionality › pattern_match_unsafe_wasm
               )
               (br $switch.31_outer
                (block $compile_block.36 (result i32)
-                (call $print_1140
-                 (global.get $print_1140)
+                (call $print_1143
+                 (global.get $print_1143)
                  (i32.const 11)
                 )
                )
@@ -384,8 +384,8 @@ basic functionality › pattern_match_unsafe_wasm
             )
             (br $switch.31_outer
              (block $compile_block.35 (result i32)
-              (call $print_1140
-               (global.get $print_1140)
+              (call $print_1143
+               (global.get $print_1143)
                (i32.const 9)
               )
              )
@@ -394,8 +394,8 @@ basic functionality › pattern_match_unsafe_wasm
           )
           (br $switch.31_outer
            (block $compile_block.34 (result i32)
-            (call $print_1140
-             (global.get $print_1140)
+            (call $print_1143
+             (global.get $print_1143)
              (i32.const 7)
             )
            )
@@ -404,8 +404,8 @@ basic functionality › pattern_match_unsafe_wasm
         )
         (br $switch.31_outer
          (block $compile_block.33 (result i32)
-          (call $print_1140
-           (global.get $print_1140)
+          (call $print_1143
+           (global.get $print_1143)
            (i32.const 5)
           )
          )
@@ -414,8 +414,8 @@ basic functionality › pattern_match_unsafe_wasm
       )
       (br $switch.31_outer
        (block $compile_block.32 (result i32)
-        (call $print_1140
-         (global.get $print_1140)
+        (call $print_1143
+         (global.get $print_1143)
          (i32.const 3)
         )
        )
@@ -437,7 +437,7 @@ basic functionality › pattern_match_unsafe_wasm
     (local.set $0
      (block $compile_block.47 (result i32)
       (block $compile_store.46
-       (global.set $test_1128
+       (global.set $test_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.44 (result i32)
@@ -466,21 +466,21 @@ basic functionality › pattern_match_unsafe_wasm
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $test_1128)
+           (global.get $test_1131)
           )
          )
         )
        )
        (block $do_backpatches.45
         (local.set $0
-         (global.get $test_1128)
+         (global.get $test_1131)
         )
        )
       )
-      (call $test_1128
+      (call $test_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $test_1128)
+        (global.get $test_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › asr1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › asr1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>_1128
+      (call $>>_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>_1128)
+        (global.get $>>_1131)
        )
        (i32.const 359)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -11,12 +11,12 @@ basic functionality › comp21
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1132 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1129 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1129 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1132 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -76,10 +76,10 @@ basic functionality › comp21
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -87,7 +87,7 @@ basic functionality › comp21
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1132)
+            (global.get $[]_1135)
            )
           )
           (call $decRef_0
@@ -138,10 +138,10 @@ basic functionality › comp21
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -149,7 +149,7 @@ basic functionality › comp21
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1132)
+            (global.get $[]_1135)
            )
           )
           (call $decRef_0

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lxor3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1128
+      (call $^_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1128)
+        (global.get $^_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › incr_3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1128
+      (call $incr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1128)
+        (global.get $incr_1131)
        )
        (i32.const -1)
       )

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -9,7 +9,7 @@ basic functionality › if_one_sided3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,13 +28,13 @@ basic functionality › if_one_sided3
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.2
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -43,13 +43,13 @@ basic functionality › if_one_sided3
        )
       )
       (block $compile_set.3 (result i32)
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 5)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
@@ -11,11 +11,11 @@ basic functionality › bigint_1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -68,10 +68,10 @@ basic functionality › bigint_1
        (block $do_backpatches.2
        )
       )
-      (call $+_1128
+      (call $+_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1128)
+        (global.get $+_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lxor2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1128
+      (call $^_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1128)
+        (global.get $^_1131)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › if_one_sided
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › if_one_sided
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $print_1132
+      (call $print_1135
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1132)
+        (global.get $print_1135)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lxor4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1128
+      (call $^_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1128)
+        (global.get $^_1131)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › complex1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › complex1
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 7)
        )

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsr2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lsr2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>>_1128
+      (call $>>>_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>>_1128)
+        (global.get $>>>_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -9,10 +9,10 @@ basic functionality › toplevel_statements
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -31,46 +31,46 @@ basic functionality › toplevel_statements
     (local.set $0
      (block $compile_block.2 (result i32)
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 3)
        )
       )
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 5)
        )
       )
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 7)
        )
       )
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 9)
        )
       )
       (drop
-       (call $print_1135
+       (call $print_1138
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1138)
         )
         (i32.const 11)
        )

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsr1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lsr1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>>_1128
+      (call $>>>_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>>_1128)
+        (global.get $>>>_1131)
        )
        (i32.const 15)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › incr_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1128
+      (call $incr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1128)
+        (global.get $incr_1131)
        )
        (i32.const 5)
       )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › incr_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1128
+      (call $incr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1128)
+        (global.get $incr_1131)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const -33)
        (i32.const -7)

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › lor4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1128
+      (call $|_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1128)
+        (global.get $|_1131)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › int64_pun_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › int64_pun_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $*_1128
+      (call $*_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $*_1128)
+        (global.get $*_1131)
        )
        (i32.const 19999999)
        (i32.const 199999999)

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › decr_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1128
+      (call $decr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1128)
+        (global.get $decr_1131)
        )
        (i32.const 5)
       )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › andshort1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › andshort1
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1128
+       (call $print_1131
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1128)
+         (global.get $print_1131)
         )
         (i32.const 3)
        )

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const -33)
        (i32.const 9)

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › land3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1128
+      (call $&_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1128)
+        (global.get $&_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › comp18
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › comp18
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $isnt_1128
+      (call $isnt_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1128)
+        (global.get $isnt_1131)
        )
        (i32.const 9)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -11,7 +11,7 @@ basic functionality › if_one_sided4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,13 +30,13 @@ basic functionality › if_one_sided4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -52,13 +52,13 @@ basic functionality › if_one_sided4
         )
         (block $compile_block.4 (result i32)
          (block $compile_set.3 (result i32)
-          (global.set $x_1128
+          (global.set $x_1131
            (tuple.extract 0
             (tuple.make
              (i32.const 5)
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $x_1128)
+              (global.get $x_1131)
              )
             )
            )
@@ -73,7 +73,7 @@ basic functionality › if_one_sided4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1128)
+       (global.get $x_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › asr2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › asr2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>_1128
+      (call $>>_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>_1128)
+        (global.get $>>_1131)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › modulo2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1128
+      (call $%_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1128)
+        (global.get $%_1131)
        )
        (i32.const 35)
        (i32.const -7)

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -28,10 +28,10 @@ basic functionality › decr_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1128
+      (call $decr_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1128)
+        (global.get $decr_1131)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -10,11 +10,11 @@ basic functionality › comp19
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1133 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1129 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1129 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1132 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -40,15 +40,15 @@ basic functionality › comp19
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1133)
+            (global.get $[]_1136)
            )
           )
           (call $decRef_0
@@ -65,10 +65,10 @@ basic functionality › comp19
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 3)
            (call $incRef_0
@@ -90,15 +90,15 @@ basic functionality › comp19
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1133)
+            (global.get $[]_1136)
            )
           )
           (call $decRef_0
@@ -115,10 +115,10 @@ basic functionality › comp19
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 3)
            (call $incRef_0

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › int64_pun_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ basic functionality › int64_pun_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $-_1128
+      (call $-_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $-_1128)
+        (global.get $-_1131)
        )
        (i32.const -199999997)
        (i32.const 1999999999)

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -11,22 +11,22 @@ basic functionality › func_shadow_and_indirect_call
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1139 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1136 (param i32 i32) (result i32)))
- (global $foo_1134 (mut i32) (i32.const 0))
- (global $foo_1132 (mut i32) (i32.const 0))
- (global $foo_1130 (mut i32) (i32.const 0))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1139 (param i32 i32) (result i32)))
+ (global $foo_1137 (mut i32) (i32.const 0))
+ (global $foo_1135 (mut i32) (i32.const 0))
+ (global $foo_1133 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1145)
+ (elem $elem (global.get $relocBase_0) $func_1148)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -74,7 +74,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $foo_1130 (param $0 i32) (result i32)
+ (func $foo_1133 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -122,7 +122,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $foo_1132 (param $0 i32) (result i32)
+ (func $foo_1135 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -177,7 +177,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $func_1145 (param $0 i32) (result i32)
+ (func $func_1148 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -240,7 +240,7 @@ basic functionality › func_shadow_and_indirect_call
     (local.set $0
      (block $compile_block.31 (result i32)
       (block $compile_store.15
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.13 (result i32)
@@ -269,14 +269,14 @@ basic functionality › func_shadow_and_indirect_call
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.14
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -284,10 +284,10 @@ basic functionality › func_shadow_and_indirect_call
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $foo_1128
+          (call $foo_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1128)
+            (global.get $foo_1131)
            )
           )
           (call $decRef_0
@@ -301,10 +301,10 @@ basic functionality › func_shadow_and_indirect_call
        )
       )
       (drop
-       (call $print_1136
+       (call $print_1139
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1136)
+         (global.get $print_1139)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -313,7 +313,7 @@ basic functionality › func_shadow_and_indirect_call
        )
       )
       (block $compile_store.20
-       (global.set $foo_1130
+       (global.set $foo_1133
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.18 (result i32)
@@ -342,14 +342,14 @@ basic functionality › func_shadow_and_indirect_call
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1130)
+           (global.get $foo_1133)
           )
          )
         )
        )
        (block $do_backpatches.19
         (local.set $0
-         (global.get $foo_1130)
+         (global.get $foo_1133)
         )
        )
       )
@@ -357,10 +357,10 @@ basic functionality › func_shadow_and_indirect_call
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $foo_1130
+          (call $foo_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1130)
+            (global.get $foo_1133)
            )
           )
           (call $decRef_0
@@ -374,10 +374,10 @@ basic functionality › func_shadow_and_indirect_call
        )
       )
       (drop
-       (call $print_1136
+       (call $print_1139
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1136)
+         (global.get $print_1139)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -386,7 +386,7 @@ basic functionality › func_shadow_and_indirect_call
        )
       )
       (block $compile_store.25
-       (global.set $foo_1132
+       (global.set $foo_1135
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.23 (result i32)
@@ -415,30 +415,30 @@ basic functionality › func_shadow_and_indirect_call
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1135)
           )
          )
         )
        )
        (block $do_backpatches.24
         (local.set $0
-         (global.get $foo_1132)
+         (global.get $foo_1135)
         )
        )
       )
       (block $compile_store.27
-       (global.set $foo_1134
+       (global.set $foo_1137
         (tuple.extract 0
          (tuple.make
-          (call $foo_1132
+          (call $foo_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1132)
+            (global.get $foo_1135)
            )
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1134)
+           (global.get $foo_1137)
           )
          )
         )
@@ -454,7 +454,7 @@ basic functionality › func_shadow_and_indirect_call
            (local.set $0
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $foo_1134)
+             (global.get $foo_1137)
             )
            )
            (call_indirect (type $i32_=>_i32)
@@ -474,10 +474,10 @@ basic functionality › func_shadow_and_indirect_call
        (block $do_backpatches.29
        )
       )
-      (call $print_1136
+      (call $print_1139
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1136)
+        (global.get $print_1139)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_subtraction1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,7 +37,7 @@ boxes › box_subtraction1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -62,7 +62,7 @@ boxes › box_subtraction1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -77,7 +77,7 @@ boxes › box_subtraction1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -94,10 +94,10 @@ boxes › box_subtraction1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -117,7 +117,7 @@ boxes › box_subtraction1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -127,7 +127,7 @@ boxes › box_subtraction1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_multiplication2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,7 +38,7 @@ boxes › box_multiplication2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -63,7 +63,7 @@ boxes › box_multiplication2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -78,7 +78,7 @@ boxes › box_multiplication2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -95,10 +95,10 @@ boxes › box_multiplication2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $*_1132
+          (call $*_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1132)
+            (global.get $*_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -120,7 +120,7 @@ boxes › box_multiplication2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1128)
+          (global.get $b_1131)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -130,7 +130,7 @@ boxes › box_multiplication2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1128)
+              (global.get $b_1131)
              )
             )
            )
@@ -145,7 +145,7 @@ boxes › box_multiplication2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_division2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,7 +38,7 @@ boxes › box_division2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -63,7 +63,7 @@ boxes › box_division2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -78,7 +78,7 @@ boxes › box_division2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -95,10 +95,10 @@ boxes › box_division2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $/_1132
+          (call $/_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1132)
+            (global.get $/_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -120,7 +120,7 @@ boxes › box_division2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1128)
+          (global.get $b_1131)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -130,7 +130,7 @@ boxes › box_division2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1128)
+              (global.get $b_1131)
              )
             )
            )
@@ -145,7 +145,7 @@ boxes › box_division2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_addition2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,7 +38,7 @@ boxes › box_addition2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -63,7 +63,7 @@ boxes › box_addition2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -78,7 +78,7 @@ boxes › box_addition2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -95,10 +95,10 @@ boxes › box_addition2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $+_1132
+          (call $+_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1132)
+            (global.get $+_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -120,7 +120,7 @@ boxes › box_addition2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1128)
+          (global.get $b_1131)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -130,7 +130,7 @@ boxes › box_addition2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1128)
+              (global.get $b_1131)
              )
             )
            )
@@ -145,7 +145,7 @@ boxes › box_addition2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_division1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,7 +37,7 @@ boxes › box_division1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -62,7 +62,7 @@ boxes › box_division1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -77,7 +77,7 @@ boxes › box_division1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -94,10 +94,10 @@ boxes › box_division1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $/_1132
+          (call $/_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1132)
+            (global.get $/_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -117,7 +117,7 @@ boxes › box_division1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -127,7 +127,7 @@ boxes › box_division1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_subtraction2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,7 +38,7 @@ boxes › box_subtraction2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -63,7 +63,7 @@ boxes › box_subtraction2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -78,7 +78,7 @@ boxes › box_subtraction2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -95,10 +95,10 @@ boxes › box_subtraction2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -120,7 +120,7 @@ boxes › box_subtraction2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1128)
+          (global.get $b_1131)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -130,7 +130,7 @@ boxes › box_subtraction2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1128)
+              (global.get $b_1131)
              )
             )
            )
@@ -145,7 +145,7 @@ boxes › box_subtraction2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_addition1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,7 +37,7 @@ boxes › box_addition1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -62,7 +62,7 @@ boxes › box_addition1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -77,7 +77,7 @@ boxes › box_addition1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -94,10 +94,10 @@ boxes › box_addition1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $+_1132
+          (call $+_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1132)
+            (global.get $+_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -117,7 +117,7 @@ boxes › box_addition1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -127,7 +127,7 @@ boxes › box_addition1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_multiplication1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,7 +37,7 @@ boxes › box_multiplication1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -62,7 +62,7 @@ boxes › box_multiplication1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -77,7 +77,7 @@ boxes › box_multiplication1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
           (call $decRef_0
@@ -94,10 +94,10 @@ boxes › box_multiplication1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $*_1132
+          (call $*_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1132)
+            (global.get $*_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -117,7 +117,7 @@ boxes › box_multiplication1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -127,7 +127,7 @@ boxes › box_multiplication1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
           )
          )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -53,7 +53,7 @@ enums › adt_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 85899347048)
+           (i64.const 85899347051)
           )
           (i64.store offset=32
            (local.get $0)
@@ -119,7 +119,7 @@ enums › adt_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -11,22 +11,22 @@ enums › enum_recursive_data_definition
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1154 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1157 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1154 (param i32 i32) (result i32)))
- (global $Cons_1133 (mut i32) (i32.const 0))
- (global $forest_1142 (mut i32) (i32.const 0))
- (global $Node_1131 (mut i32) (i32.const 0))
- (global $Nil_1132 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1157 (param i32 i32) (result i32)))
+ (global $Cons_1136 (mut i32) (i32.const 0))
+ (global $forest_1145 (mut i32) (i32.const 0))
+ (global $Node_1134 (mut i32) (i32.const 0))
+ (global $Nil_1135 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $Node_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Node_1134 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -58,7 +58,7 @@ enums › enum_recursive_data_definition
          )
          (i32.store offset=8
           (local.get $3)
-          (i32.const 2257)
+          (i32.const 2263)
          )
          (i32.store offset=12
           (local.get $3)
@@ -111,7 +111,7 @@ enums › enum_recursive_data_definition
    )
   )
  )
- (func $Cons_1133 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Cons_1136 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -143,7 +143,7 @@ enums › enum_recursive_data_definition
          )
          (i32.store offset=8
           (local.get $3)
-          (i32.const 2259)
+          (i32.const 2265)
          )
          (i32.store offset=12
           (local.get $3)
@@ -239,7 +239,7 @@ enums › enum_recursive_data_definition
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 85899347049)
+           (i64.const 85899347052)
           )
           (i64.store offset=32
            (local.get $0)
@@ -263,7 +263,7 @@ enums › enum_recursive_data_definition
           )
           (i64.store offset=72
            (local.get $0)
-           (i64.const 85899347048)
+           (i64.const 85899347051)
           )
           (i64.store offset=80
            (local.get $0)
@@ -307,7 +307,7 @@ enums › enum_recursive_data_definition
       )
       (block $compile_block.32 (result i32)
        (block $compile_store.11
-        (global.set $Node_1131
+        (global.set $Node_1134
          (tuple.extract 0
           (tuple.make
            (block $allocate_closure.9 (result i32)
@@ -336,19 +336,19 @@ enums › enum_recursive_data_definition
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Node_1131)
+            (global.get $Node_1134)
            )
           )
          )
         )
         (block $do_backpatches.10
          (local.set $0
-          (global.get $Node_1131)
+          (global.get $Node_1134)
          )
         )
        )
        (block $compile_store.14
-        (global.set $Nil_1132
+        (global.set $Nil_1135
          (tuple.extract 0
           (tuple.make
            (block $allocate_adt.12 (result i32)
@@ -370,7 +370,7 @@ enums › enum_recursive_data_definition
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)
@@ -384,7 +384,7 @@ enums › enum_recursive_data_definition
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Nil_1132)
+            (global.get $Nil_1135)
            )
           )
          )
@@ -393,7 +393,7 @@ enums › enum_recursive_data_definition
         )
        )
        (block $compile_store.17
-        (global.set $Cons_1133
+        (global.set $Cons_1136
          (tuple.extract 0
           (tuple.make
            (block $allocate_closure.15 (result i32)
@@ -422,14 +422,14 @@ enums › enum_recursive_data_definition
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Cons_1133)
+            (global.get $Cons_1136)
            )
           )
          )
         )
         (block $do_backpatches.16
          (local.set $0
-          (global.get $Cons_1133)
+          (global.get $Cons_1136)
          )
         )
        )
@@ -505,10 +505,10 @@ enums › enum_recursive_data_definition
         (local.set $8
          (tuple.extract 0
           (tuple.make
-           (call $Node_1131
+           (call $Node_1134
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Node_1131)
+             (global.get $Node_1134)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -516,7 +516,7 @@ enums › enum_recursive_data_definition
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Nil_1132)
+             (global.get $Nil_1135)
             )
            )
            (call $decRef_0
@@ -533,10 +533,10 @@ enums › enum_recursive_data_definition
         (local.set $9
          (tuple.extract 0
           (tuple.make
-           (call $Cons_1133
+           (call $Cons_1136
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Cons_1133)
+             (global.get $Cons_1136)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -544,7 +544,7 @@ enums › enum_recursive_data_definition
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Nil_1132)
+             (global.get $Nil_1135)
             )
            )
            (call $decRef_0
@@ -561,10 +561,10 @@ enums › enum_recursive_data_definition
         (local.set $10
          (tuple.extract 0
           (tuple.make
-           (call $Node_1131
+           (call $Node_1134
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Node_1131)
+             (global.get $Node_1134)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -586,13 +586,13 @@ enums › enum_recursive_data_definition
         )
        )
        (block $compile_store.31
-        (global.set $forest_1142
+        (global.set $forest_1145
          (tuple.extract 0
           (tuple.make
-           (call $Cons_1133
+           (call $Cons_1136
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Cons_1133)
+             (global.get $Cons_1136)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -600,12 +600,12 @@ enums › enum_recursive_data_definition
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Nil_1132)
+             (global.get $Nil_1135)
             )
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $forest_1142)
+            (global.get $forest_1145)
            )
           )
          )
@@ -613,14 +613,14 @@ enums › enum_recursive_data_definition
         (block $do_backpatches.30
         )
        )
-       (call $print_1154
+       (call $print_1157
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1154)
+         (global.get $print_1157)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $forest_1142)
+         (global.get $forest_1145)
         )
        )
       )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -14,18 +14,18 @@ exceptions › exception_4
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $Bar_1130 (mut i32) (i32.const 0))
- (global $Foo_1128 (mut i32) (i32.const 0))
+ (global $Bar_1133 (mut i32) (i32.const 0))
+ (global $Foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"GRAIN$EXPORT$Bar\" (global $Bar_1130))
- (export \"Foo\" (func $Foo_1128))
- (export \"GRAIN$EXPORT$Foo\" (global $Foo_1128))
+ (export \"GRAIN$EXPORT$Bar\" (global $Bar_1133))
+ (export \"Foo\" (func $Foo_1131))
+ (export \"GRAIN$EXPORT$Foo\" (global $Foo_1131))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $Foo_1128 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $Foo_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -61,7 +61,7 @@ exceptions › exception_4
          )
          (i32.store offset=12
           (local.get $3)
-          (i32.const 2257)
+          (i32.const 2263)
          )
          (i32.store offset=16
           (local.get $3)
@@ -143,7 +143,7 @@ exceptions › exception_4
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903016)
+           (i64.const 12884903019)
           )
           (i64.store offset=40
            (local.get $0)
@@ -151,7 +151,7 @@ exceptions › exception_4
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 4853313044500)
+           (i64.const 4866197946388)
           )
           (i64.store offset=56
            (local.get $0)
@@ -183,7 +183,7 @@ exceptions › exception_4
       )
       (block $compile_block.12 (result i32)
        (block $compile_store.8
-        (global.set $Foo_1128
+        (global.set $Foo_1131
          (tuple.extract 0
           (tuple.make
            (block $allocate_closure.6 (result i32)
@@ -212,19 +212,19 @@ exceptions › exception_4
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Foo_1128)
+            (global.get $Foo_1131)
            )
           )
          )
         )
         (block $do_backpatches.7
          (local.set $0
-          (global.get $Foo_1128)
+          (global.get $Foo_1131)
          )
         )
        )
        (block $compile_store.11
-        (global.set $Bar_1130
+        (global.set $Bar_1133
          (tuple.extract 0
           (tuple.make
            (block $allocate_adt.9 (result i32)
@@ -250,7 +250,7 @@ exceptions › exception_4
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 2261)
+             (i32.const 2267)
             )
             (i32.store offset=16
              (local.get $0)
@@ -260,7 +260,7 @@ exceptions › exception_4
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Bar_1130)
+            (global.get $Bar_1133)
            )
           )
          )
@@ -270,7 +270,7 @@ exceptions › exception_4
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Bar_1130)
+        (global.get $Bar_1133)
        )
       )
      )

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -13,11 +13,11 @@ exceptions › exception_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $Foo_1128 (mut i32) (i32.const 0))
+ (global $Foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"GRAIN$EXPORT$Foo\" (global $Foo_1128))
+ (export \"GRAIN$EXPORT$Foo\" (global $Foo_1131))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
@@ -63,7 +63,7 @@ exceptions › exception_2
           )
           (i64.store offset=32
            (local.get $0)
-           (i64.const 12884903016)
+           (i64.const 12884903019)
           )
           (i64.store offset=40
            (local.get $0)
@@ -91,7 +91,7 @@ exceptions › exception_2
       )
       (block $compile_block.6 (result i32)
        (block $compile_store.5
-        (global.set $Foo_1128
+        (global.set $Foo_1131
          (tuple.extract 0
           (tuple.make
            (block $allocate_adt.3 (result i32)
@@ -117,7 +117,7 @@ exceptions › exception_2
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=16
              (local.get $0)
@@ -127,7 +127,7 @@ exceptions › exception_2
            )
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $Foo_1128)
+            (global.get $Foo_1131)
            )
           )
          )
@@ -137,7 +137,7 @@ exceptions › exception_2
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Foo_1128)
+        (global.get $Foo_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
+++ b/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
@@ -10,20 +10,20 @@ exports › export_start_function
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
- (global $_start_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
+ (global $_start_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"_start\" (func $_start_1128))
- (export \"GRAIN$EXPORT$_start\" (global $_start_1128))
+ (export \"_start\" (func $_start_1131))
+ (export \"GRAIN$EXPORT$_start\" (global $_start_1131))
  (export \"_gmain\" (func $_gmain))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $_start_1128 (param $0 i32) (result i32)
+ (func $_start_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -73,10 +73,10 @@ exports › export_start_function
        (block $do_backpatches.2
        )
       )
-      (call $print_1132
+      (call $print_1135
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1132)
+        (global.get $print_1135)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -148,10 +148,10 @@ exports › export_start_function
        )
       )
       (drop
-       (call $print_1132
+       (call $print_1135
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1132)
+         (global.get $print_1135)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -160,7 +160,7 @@ exports › export_start_function
        )
       )
       (block $compile_store.11
-       (global.set $_start_1128
+       (global.set $_start_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.9 (result i32)
@@ -189,14 +189,14 @@ exports › export_start_function
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $_start_1128)
+           (global.get $_start_1131)
           )
          )
         )
        )
        (block $do_backpatches.10
         (local.set $0
-         (global.get $_start_1128)
+         (global.get $_start_1131)
         )
        )
       )

--- a/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
+++ b/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
@@ -8,7 +8,7 @@ exports › export7
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ exports › export7
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1137)
+       (global.get $x_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -12,16 +12,16 @@ exports › let_rec_export
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"foo\" (func $foo_1128))
- (export \"GRAIN$EXPORT$foo\" (global $foo_1128))
+ (export \"foo\" (func $foo_1131))
+ (export \"GRAIN$EXPORT$foo\" (global $foo_1131))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -62,7 +62,7 @@ exports › let_rec_export
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -91,14 +91,14 @@ exports › let_rec_export
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )

--- a/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
@@ -8,7 +8,7 @@ exports › export4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$onlyXExported\" \"GRAIN$EXPORT$x\" (global $x_1131 (mut i32)))
+ (import \"GRAIN$MODULE$onlyXExported\" \"GRAIN$EXPORT$x\" (global $x_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ exports › export4
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1131)
+       (global.get $x_1134)
       )
      )
     )

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -8,10 +8,10 @@ exports › export9
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ exports › export9
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1137
+      (call $y_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1137)
+        (global.get $y_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $z_1138)
+        (global.get $z_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/exports.d19c8510.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d19c8510.0.snapshot
@@ -10,20 +10,20 @@ exports › export12
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1177 (mut i32)))
- (import \"GRAIN$MODULE$exposedType\" \"GRAIN$EXPORT$apply\" (global $apply_1175 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1180 (mut i32)))
+ (import \"GRAIN$MODULE$exposedType\" \"GRAIN$EXPORT$apply\" (global $apply_1178 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1177 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exposedType\" \"apply\" (func $apply_1175 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1180 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exposedType\" \"apply\" (func $apply_1178 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1176)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1179)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1176 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1179 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -69,10 +69,10 @@ exports › export12
        (block $do_backpatches.2
        )
       )
-      (call $print_1177
+      (call $print_1180
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1177)
+        (global.get $print_1180)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -159,10 +159,10 @@ exports › export12
         )
        )
       )
-      (call $apply_1175
+      (call $apply_1178
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $apply_1175)
+        (global.get $apply_1178)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -10,13 +10,13 @@ exports › export8
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1143 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1143 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1140 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ exports › export8
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $y_1140
+          (call $y_1143
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $y_1140)
+            (global.get $y_1143)
            )
            (i32.const 9)
           )
@@ -56,14 +56,14 @@ exports › export8
        (block $do_backpatches.1
        )
       )
-      (call $+_1137
+      (call $+_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1137)
+        (global.get $+_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1138)
+        (global.get $x_1141)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -14,14 +14,14 @@ functions › dup_func
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1132 (mut i32) (i32.const 0))
+ (global $foo_1135 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1132 (param $0 i32) (result i32)
+ (func $foo_1135 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -62,7 +62,7 @@ functions › dup_func
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1132
+       (global.set $foo_1135
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -91,21 +91,21 @@ functions › dup_func
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1135)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1132)
+         (global.get $foo_1135)
         )
        )
       )
-      (call $foo_1132
+      (call $foo_1135
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1132)
+        (global.get $foo_1135)
        )
       )
      )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -11,19 +11,19 @@ functions › shorthand_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1130 (param i32 i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -36,10 +36,10 @@ functions › shorthand_4
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1130
+        (call $+_1133
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1130)
+          (global.get $+_1133)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -80,7 +80,7 @@ functions › shorthand_4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -109,21 +109,21 @@ functions › shorthand_4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -13,14 +13,14 @@ functions › shorthand_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -70,7 +70,7 @@ functions › shorthand_1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -99,21 +99,21 @@ functions › shorthand_1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -11,18 +11,18 @@ functions › lam_destructure_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1133 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $lam_lambda_1136 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -337,10 +337,10 @@ functions › lam_destructure_5
          (local.set $19
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -365,10 +365,10 @@ functions › lam_destructure_5
          (local.set $20
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -393,10 +393,10 @@ functions › lam_destructure_5
          (local.set $21
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -417,10 +417,10 @@ functions › lam_destructure_5
          (block $do_backpatches.30
          )
         )
-        (call $+_1134
+        (call $+_1137
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1134)
+          (global.get $+_1137)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -671,7 +671,7 @@ functions › lam_destructure_5
        (block $do_backpatches.41
        )
       )
-      (call $lam_lambda_1133
+      (call $lam_lambda_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -13,14 +13,14 @@ functions › lambda_pat_any
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $x_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $x_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -68,7 +68,7 @@ functions › lambda_pat_any
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.5
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -97,14 +97,14 @@ functions › lambda_pat_any
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $x_1128)
+         (global.get $x_1131)
         )
        )
       )
@@ -142,10 +142,10 @@ functions › lambda_pat_any
        (block $do_backpatches.7
        )
       )
-      (call $x_1128
+      (call $x_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1128)
+        (global.get $x_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -11,19 +11,19 @@ functions › curried_func
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
- (global $add_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
+ (global $add_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1138)
+ (elem $elem (global.get $relocBase_0) $func_1141)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $add_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $add_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -91,7 +91,7 @@ functions › curried_func
    )
   )
  )
- (func $func_1138 (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1141 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -104,10 +104,10 @@ functions › curried_func
      (tuple.extract 0
       (tuple.make
        (block $compile_block.4 (result i32)
-        (call $+_1131
+        (call $+_1134
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1131)
+          (global.get $+_1134)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -154,7 +154,7 @@ functions › curried_func
     (local.set $0
      (block $compile_block.12 (result i32)
       (block $compile_store.8
-       (global.set $add_1128
+       (global.set $add_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.6 (result i32)
@@ -183,14 +183,14 @@ functions › curried_func
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $add_1128)
+           (global.get $add_1131)
           )
          )
         )
        )
        (block $do_backpatches.7
         (local.set $0
-         (global.get $add_1128)
+         (global.get $add_1131)
         )
        )
       )
@@ -198,10 +198,10 @@ functions › curried_func
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $add_1128
+          (call $add_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $add_1128)
+            (global.get $add_1131)
            )
            (i32.const 5)
           )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -12,26 +12,26 @@ functions › func_recursive_closure
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1154 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1149 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1139 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1157 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1152 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1154 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1149 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1139 (param i32 i32 i32) (result i32)))
- (global $truc_1131 (mut i32) (i32.const 0))
- (global $makeAdder_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1157 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1152 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
+ (global $truc_1134 (mut i32) (i32.const 0))
+ (global $makeAdder_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1162)
+ (elem $elem (global.get $relocBase_0) $func_1165)
  (export \"memory\" (memory $0))
- (export \"truc\" (func $truc_1131))
- (export \"GRAIN$EXPORT$truc\" (global $truc_1131))
+ (export \"truc\" (func $truc_1134))
+ (export \"GRAIN$EXPORT$truc\" (global $truc_1134))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $makeAdder_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $makeAdder_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -99,7 +99,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $truc_1131 (param $0 i32) (result i32)
+ (func $truc_1134 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -154,7 +154,7 @@ functions › func_recursive_closure
           )
          )
         )
-        (call $foo_1132
+        (call $foo_1135
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
           (local.get $7)
@@ -182,7 +182,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $func_1162 (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1165 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -195,10 +195,10 @@ functions › func_recursive_closure
      (tuple.extract 0
       (tuple.make
        (block $compile_block.9 (result i32)
-        (call $+_1139
+        (call $+_1142
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1139)
+          (global.get $+_1142)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -232,7 +232,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $foo_1132 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1135 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -254,10 +254,10 @@ functions › func_recursive_closure
          (local.set $8
           (tuple.extract 0
            (tuple.make
-            (call $makeAdder_1128
+            (call $makeAdder_1131
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $makeAdder_1128)
+              (global.get $makeAdder_1131)
              )
              (i32.const 3)
             )
@@ -328,10 +328,10 @@ functions › func_recursive_closure
         )
         (block $compile_store.17
          (local.set $11
-          (call $==_1149
+          (call $==_1152
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1149)
+            (global.get $==_1152)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -354,10 +354,10 @@ functions › func_recursive_closure
          (block $compile_block.25 (result i32)
           (block $compile_store.20
            (local.set $12
-            (call $==_1149
+            (call $==_1152
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $==_1149)
+              (global.get $==_1152)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -375,7 +375,7 @@ functions › func_recursive_closure
             (i32.const 31)
            )
            (block $compile_block.21 (result i32)
-            (call $bar_1135
+            (call $bar_1138
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (local.get $9)
@@ -388,10 +388,10 @@ functions › func_recursive_closure
              (local.set $10
               (tuple.extract 0
                (tuple.make
-                (call $-_1154
+                (call $-_1157
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $-_1154)
+                  (global.get $-_1157)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -409,7 +409,7 @@ functions › func_recursive_closure
              (block $do_backpatches.22
              )
             )
-            (call $foo_1132
+            (call $foo_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (local.get $0)
@@ -462,7 +462,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $bar_1135 (param $0 i32) (param $1 i32) (result i32)
+ (func $bar_1138 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -481,7 +481,7 @@ functions › func_recursive_closure
          (local.set $8
           (tuple.extract 0
            (tuple.make
-            (call $foo_1132
+            (call $foo_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (i32.load offset=16
@@ -531,10 +531,10 @@ functions › func_recursive_closure
          (block $do_backpatches.31
          )
         )
-        (call $+_1139
+        (call $+_1142
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1139)
+          (global.get $+_1142)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -590,7 +590,7 @@ functions › func_recursive_closure
     (local.set $0
      (block $compile_block.41 (result i32)
       (block $compile_store.37
-       (global.set $makeAdder_1128
+       (global.set $makeAdder_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.35 (result i32)
@@ -619,19 +619,19 @@ functions › func_recursive_closure
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $makeAdder_1128)
+           (global.get $makeAdder_1131)
           )
          )
         )
        )
        (block $do_backpatches.36
         (local.set $0
-         (global.get $makeAdder_1128)
+         (global.get $makeAdder_1131)
         )
        )
       )
       (block $compile_store.40
-       (global.set $truc_1131
+       (global.set $truc_1134
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.38 (result i32)
@@ -660,21 +660,21 @@ functions › func_recursive_closure
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $truc_1131)
+           (global.get $truc_1134)
           )
          )
         )
        )
        (block $do_backpatches.39
         (local.set $0
-         (global.get $truc_1131)
+         (global.get $truc_1134)
         )
        )
       )
-      (call $truc_1131
+      (call $truc_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $truc_1131)
+        (global.get $truc_1134)
        )
       )
      )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -19,7 +19,7 @@ functions › app_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1129 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1132 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -110,7 +110,7 @@ functions › app_1
         )
        )
       )
-      (call $lam_lambda_1129
+      (call $lam_lambda_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -13,14 +13,14 @@ functions › shorthand_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -70,7 +70,7 @@ functions › shorthand_3
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -99,21 +99,21 @@ functions › shorthand_3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -11,18 +11,18 @@ functions › lam_destructure_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1134 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -217,10 +217,10 @@ functions › lam_destructure_3
          (local.set $14
           (tuple.extract 0
            (tuple.make
-            (call $+_1132
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1132)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -241,10 +241,10 @@ functions › lam_destructure_3
          (block $do_backpatches.16
          )
         )
-        (call $+_1132
+        (call $+_1135
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1132)
+          (global.get $+_1135)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -414,7 +414,7 @@ functions › lam_destructure_3
        (block $do_backpatches.24
        )
       )
-      (call $lam_lambda_1131
+      (call $lam_lambda_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -11,18 +11,18 @@ functions › lam_destructure_7
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1136 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1132 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1135 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -298,10 +298,10 @@ functions › lam_destructure_7
          (local.set $17
           (tuple.extract 0
            (tuple.make
-            (call $+_1133
+            (call $+_1136
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1133)
+              (global.get $+_1136)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -326,10 +326,10 @@ functions › lam_destructure_7
          (local.set $18
           (tuple.extract 0
            (tuple.make
-            (call $+_1133
+            (call $+_1136
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1133)
+              (global.get $+_1136)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -350,10 +350,10 @@ functions › lam_destructure_7
          (block $do_backpatches.25
          )
         )
-        (call $+_1133
+        (call $+_1136
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1133)
+          (global.get $+_1136)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -589,7 +589,7 @@ functions › lam_destructure_7
        (block $do_backpatches.36
        )
       )
-      (call $lam_lambda_1132
+      (call $lam_lambda_1135
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -11,19 +11,19 @@ functions › shorthand_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1130 (param i32 i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -36,10 +36,10 @@ functions › shorthand_2
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1130
+        (call $+_1133
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1130)
+          (global.get $+_1133)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -80,7 +80,7 @@ functions › shorthand_2
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -109,21 +109,21 @@ functions › shorthand_2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -11,19 +11,19 @@ functions › lam_destructure_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -218,10 +218,10 @@ functions › lam_destructure_4
          (local.set $14
           (tuple.extract 0
            (tuple.make
-            (call $+_1132
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1132)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -242,10 +242,10 @@ functions › lam_destructure_4
          (block $do_backpatches.16
          )
         )
-        (call $+_1132
+        (call $+_1135
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1132)
+          (global.get $+_1135)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -332,7 +332,7 @@ functions › lam_destructure_4
     (local.set $0
      (block $compile_block.26 (result i32)
       (block $compile_store.22
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.20 (result i32)
@@ -361,14 +361,14 @@ functions › lam_destructure_4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.21
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -414,10 +414,10 @@ functions › lam_destructure_4
        (block $do_backpatches.24
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -11,19 +11,19 @@ functions › lam_destructure_8
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1136 (param i32 i32 i32) (result i32)))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -299,10 +299,10 @@ functions › lam_destructure_8
          (local.set $17
           (tuple.extract 0
            (tuple.make
-            (call $+_1133
+            (call $+_1136
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1133)
+              (global.get $+_1136)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -327,10 +327,10 @@ functions › lam_destructure_8
          (local.set $18
           (tuple.extract 0
            (tuple.make
-            (call $+_1133
+            (call $+_1136
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1133)
+              (global.get $+_1136)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -351,10 +351,10 @@ functions › lam_destructure_8
          (block $do_backpatches.25
          )
         )
-        (call $+_1133
+        (call $+_1136
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1133)
+          (global.get $+_1136)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -466,7 +466,7 @@ functions › lam_destructure_8
     (local.set $0
      (block $compile_block.38 (result i32)
       (block $compile_store.31
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.29 (result i32)
@@ -495,14 +495,14 @@ functions › lam_destructure_8
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.30
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -589,10 +589,10 @@ functions › lam_destructure_8
        (block $do_backpatches.36
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -19,7 +19,7 @@ functions › lam_destructure_1
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -142,7 +142,7 @@ functions › lam_destructure_1
        (block $do_backpatches.7
        )
       )
-      (call $lam_lambda_1128
+      (call $lam_lambda_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -13,14 +13,14 @@ functions › lam_destructure_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -68,7 +68,7 @@ functions › lam_destructure_2
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.5
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -97,14 +97,14 @@ functions › lam_destructure_2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -142,10 +142,10 @@ functions › lam_destructure_2
        (block $do_backpatches.7
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -15,12 +15,12 @@ functions › func_record_associativity2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1138)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1141)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1138 (param $0 i32) (result i32)
+ (func $lam_lambda_1141 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -88,7 +88,7 @@ functions › func_record_associativity2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -100,7 +100,7 @@ functions › func_record_associativity2
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 68719477865)
+           (i64.const 68719477868)
           )
           (i64.store offset=56
            (local.get $0)
@@ -198,7 +198,7 @@ functions › func_record_associativity2
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -246,7 +246,7 @@ functions › func_record_associativity2
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -11,19 +11,19 @@ functions › fn_trailing_comma
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
- (global $testFn_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
+ (global $testFn_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $testFn_1128 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $testFn_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36,10 +36,10 @@ functions › fn_trailing_comma
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1131
+        (call $+_1134
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1131)
+          (global.get $+_1134)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -89,7 +89,7 @@ functions › fn_trailing_comma
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $testFn_1128
+       (global.set $testFn_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -118,21 +118,21 @@ functions › fn_trailing_comma
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $testFn_1128)
+           (global.get $testFn_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $testFn_1128)
+         (global.get $testFn_1131)
         )
        )
       )
-      (call $testFn_1128
+      (call $testFn_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $testFn_1128)
+        (global.get $testFn_1131)
        )
        (i32.const 5)
        (i32.const 7)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -11,19 +11,19 @@ functions › lam_destructure_6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
- (global $foo_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1128 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -338,10 +338,10 @@ functions › lam_destructure_6
          (local.set $19
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -366,10 +366,10 @@ functions › lam_destructure_6
          (local.set $20
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -394,10 +394,10 @@ functions › lam_destructure_6
          (local.set $21
           (tuple.extract 0
            (tuple.make
-            (call $+_1134
+            (call $+_1137
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1134)
+              (global.get $+_1137)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -418,10 +418,10 @@ functions › lam_destructure_6
          (block $do_backpatches.30
          )
         )
-        (call $+_1134
+        (call $+_1137
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1134)
+          (global.get $+_1137)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -551,7 +551,7 @@ functions › lam_destructure_6
     (local.set $0
      (block $compile_block.43 (result i32)
       (block $compile_store.36
-       (global.set $foo_1128
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.34 (result i32)
@@ -580,14 +580,14 @@ functions › lam_destructure_6
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1128)
+           (global.get $foo_1131)
           )
          )
         )
        )
        (block $do_backpatches.35
         (local.set $0
-         (global.get $foo_1128)
+         (global.get $foo_1131)
         )
        )
       )
@@ -671,10 +671,10 @@ functions › lam_destructure_6
        (block $do_backpatches.41
        )
       )
-      (call $foo_1128
+      (call $foo_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1128)
+        (global.get $foo_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -15,12 +15,12 @@ functions › func_record_associativity1
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1134)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1137)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1134 (param $0 i32) (result i32)
+ (func $lam_lambda_1137 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -86,7 +86,7 @@ functions › func_record_associativity1
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -184,7 +184,7 @@ functions › func_record_associativity1
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
@@ -9,10 +9,10 @@ imports › import_all_constructor
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1137 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1140 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,15 +30,15 @@ imports › import_all_constructor
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $Cons_1135
+      (call $Cons_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Cons_1135)
+        (global.get $Cons_1138)
        )
        (i32.const 5)
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1137)
+        (global.get $Empty_1140)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
@@ -8,7 +8,7 @@ imports › import_some
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_some
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1137)
+       (global.get $x_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
@@ -8,7 +8,7 @@ imports › import_all_except_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_all_except_multiple
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $z_1137)
+       (global.get $z_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.259f419e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.259f419e.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$../test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$../test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_relative_path1
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1137)
+       (global.get $x_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -10,13 +10,13 @@ imports › import_alias_multiple_constructor
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $None_1139 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Add_1137 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $None_1142 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Add_1140 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Add_1137 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Add_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,15 +39,15 @@ imports › import_alias_multiple_constructor
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $Add_1137
+          (call $Add_1140
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Add_1137)
+            (global.get $Add_1140)
            )
            (i32.const 3)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $None_1139)
+            (global.get $None_1142)
            )
           )
           (call $decRef_0
@@ -60,10 +60,10 @@ imports › import_alias_multiple_constructor
        (block $do_backpatches.1
        )
       )
-      (call $sum_1135
+      (call $sum_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1135)
+        (global.get $sum_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.45beae05.0.snapshot
+++ b/compiler/test/__snapshots__/imports.45beae05.0.snapshot
@@ -8,7 +8,7 @@ imports › annotation_across_import
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1136 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1139 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › annotation_across_import
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $Empty_1136)
+       (global.get $Empty_1139)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -8,10 +8,10 @@ imports › import_alias_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $x_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $x_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_alias_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $x_1137
+      (call $x_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1137)
+        (global.get $x_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1138)
+        (global.get $y_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
@@ -8,7 +8,7 @@ imports › import_alias
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_alias
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $y_1137)
+       (global.get $y_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple_trailing
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_some_multiple_trailing
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1137
+      (call $y_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1137)
+        (global.get $y_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1138)
+        (global.get $x_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_some_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1137
+      (call $y_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1137)
+        (global.get $y_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1138)
+        (global.get $x_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -9,12 +9,12 @@ imports › import_relative_path4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1133 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1133 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1136 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,10 +37,10 @@ imports › import_relative_path4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $bar_1133
+          (call $bar_1136
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $bar_1133)
+            (global.get $bar_1136)
            )
            (i32.const 5)
           )
@@ -54,10 +54,10 @@ imports › import_relative_path4
        (block $do_backpatches.1
        )
       )
-      (call $print_1131
+      (call $print_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1131)
+        (global.get $print_1134)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
@@ -8,7 +8,7 @@ imports › import_all_except_constructor
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_all_except_constructor
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $Empty_1135)
+       (global.get $Empty_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
@@ -9,10 +9,10 @@ imports › import_some_constructor
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1137 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1140 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,15 +30,15 @@ imports › import_some_constructor
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $Cons_1135
+      (call $Cons_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Cons_1135)
+        (global.get $Cons_1138)
        )
        (i32.const 11)
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1137)
+        (global.get $Empty_1140)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
@@ -8,7 +8,7 @@ imports › import_module
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_module
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1137)
+       (global.get $x_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -8,10 +8,10 @@ imports › import_module2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_module2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1137
+      (call $y_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1137)
+        (global.get $y_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1138)
+        (global.get $x_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
@@ -9,10 +9,10 @@ imports › import_same_module_unify2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1137 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1140 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,15 +30,15 @@ imports › import_same_module_unify2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $Cons_1135
+      (call $Cons_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Cons_1135)
+        (global.get $Cons_1138)
        )
        (i32.const 11)
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1137)
+        (global.get $Empty_1140)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
@@ -9,9 +9,9 @@ imports › import_with_export_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$sameExport\" \"GRAIN$EXPORT$foo\" (global $foo_1131 (mut i32)))
+ (import \"GRAIN$MODULE$sameExport\" \"GRAIN$EXPORT$foo\" (global $foo_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$sameExport\" \"foo\" (func $foo_1131 (param i32) (result i32)))
+ (import \"GRAIN$MODULE$sameExport\" \"foo\" (func $foo_1134 (param i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,10 +29,10 @@ imports › import_with_export_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $foo_1131
+      (call $foo_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1134)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
@@ -9,10 +9,10 @@ imports › import_same_module_unify
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1139 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1137 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1142 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1137 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1140 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,15 +30,15 @@ imports › import_same_module_unify
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $Cons_1137
+      (call $Cons_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Cons_1137)
+        (global.get $Cons_1140)
        )
        (i32.const 11)
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1139)
+        (global.get $Empty_1142)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -8,10 +8,10 @@ imports › import_all_except_multiple_constructor
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1136 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1139 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_all_except_multiple_constructor
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $sum_1135
+      (call $sum_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1135)
+        (global.get $sum_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1136)
+        (global.get $Empty_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
+++ b/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple_trailing2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1137 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1137 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_some_multiple_trailing2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1137
+      (call $y_1140
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1137)
+        (global.get $y_1140)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1138)
+        (global.get $x_1141)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -8,10 +8,10 @@ imports › import_alias_constructor
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $None_1136 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $None_1139 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -29,14 +29,14 @@ imports › import_alias_constructor
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $sum_1135
+      (call $sum_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1135)
+        (global.get $sum_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $None_1136)
+        (global.get $None_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.e295854d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e295854d.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$../../test/test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1137 (mut i32)))
+ (import \"GRAIN$MODULE$../../test/test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_relative_path2
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1137)
+       (global.get $x_1140)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$nested/nested\" \"GRAIN$EXPORT$j\" (global $j_1131 (mut i32)))
+ (import \"GRAIN$MODULE$nested/nested\" \"GRAIN$EXPORT$j\" (global $j_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -29,7 +29,7 @@ imports › import_relative_path3
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $j_1131)
+       (global.get $j_1134)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
@@ -9,11 +9,11 @@ imports › import_muliple_modules
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1146 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1145 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1144 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1149 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1148 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1147 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1147 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -31,18 +31,18 @@ imports › import_muliple_modules
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $Cons_1144
+      (call $Cons_1147
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Cons_1144)
+        (global.get $Cons_1147)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1145)
+        (global.get $x_1148)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $Empty_1146)
+        (global.get $Empty_1149)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -10,13 +10,13 @@ imports › import_some_mixed
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1139 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1137 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1135 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Empty\" (global $Empty_1142 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$Cons\" (global $Cons_1140 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1137 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"Cons\" (func $Cons_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,15 +39,15 @@ imports › import_some_mixed
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $Cons_1137
+          (call $Cons_1140
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Cons_1137)
+            (global.get $Cons_1140)
            )
            (i32.const 11)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Empty_1139)
+            (global.get $Empty_1142)
            )
           )
           (call $decRef_0
@@ -60,10 +60,10 @@ imports › import_some_mixed
        (block $do_backpatches.1
        )
       )
-      (call $sum_1135
+      (call $sum_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1135)
+        (global.get $sum_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -34,13 +34,13 @@ let mut › let-mut_division1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -52,14 +52,14 @@ let mut › let-mut_division1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1132
+          (call $/_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1132)
+            (global.get $/_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -74,7 +74,7 @@ let mut › let-mut_division1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -83,7 +83,7 @@ let mut › let-mut_division1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_multiplication2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_multiplication2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1132
+          (call $*_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1132)
+            (global.get $*_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_multiplication2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_multiplication2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_multiplication2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -13,7 +13,7 @@ let mut › let-mut3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -32,7 +32,7 @@ let mut › let-mut3
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -57,7 +57,7 @@ let mut › let-mut3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -68,7 +68,7 @@ let mut › let-mut3
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1128)
+        (global.get $b_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_division3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_division3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1132
+          (call $/_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1132)
+            (global.get $/_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_division3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_division3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_division3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut5
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut5
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 3)
           )
@@ -77,7 +77,7 @@ let mut › let-mut5
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut5
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut5
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -13,7 +13,7 @@ let mut › let-mut2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -71,7 +71,7 @@ let mut › let-mut2
        )
       )
       (block $compile_store.6
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -103,7 +103,7 @@ let mut › let-mut2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -113,7 +113,7 @@ let mut › let-mut2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -34,13 +34,13 @@ let mut › let-mut_multiplication1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -52,14 +52,14 @@ let mut › let-mut_multiplication1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1132
+          (call $*_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1132)
+            (global.get $*_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -74,7 +74,7 @@ let mut › let-mut_multiplication1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -83,7 +83,7 @@ let mut › let-mut_multiplication1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_multiplication3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_multiplication3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1132
+          (call $*_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1132)
+            (global.get $*_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_multiplication3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_multiplication3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_multiplication3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -11,7 +11,7 @@ let mut › let-mut4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -31,13 +31,13 @@ let mut › let-mut4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -48,13 +48,13 @@ let mut › let-mut4
       (block $compile_store.5
        (local.set $6
         (block $compile_set.3 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (i32.const 7)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -67,7 +67,7 @@ let mut › let-mut4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -34,13 +34,13 @@ let mut › let-mut_subtraction1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -52,14 +52,14 @@ let mut › let-mut_subtraction1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -74,7 +74,7 @@ let mut › let-mut_subtraction1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -83,7 +83,7 @@ let mut › let-mut_subtraction1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_subtraction2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_subtraction2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_subtraction2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_subtraction2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_subtraction2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_addition2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_addition2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1132
+          (call $+_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1132)
+            (global.get $+_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_addition2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_addition2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_addition2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -34,13 +34,13 @@ let mut › let-mut_addition1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -52,14 +52,14 @@ let mut › let-mut_addition1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1132
+          (call $+_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1132)
+            (global.get $+_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -74,7 +74,7 @@ let mut › let-mut_addition1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -83,7 +83,7 @@ let mut › let-mut_addition1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_subtraction3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_subtraction3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1132
+          (call $-_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1132)
+            (global.get $-_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_subtraction3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_subtraction3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_subtraction3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_addition3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_addition3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1132
+          (call $+_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1132)
+            (global.get $+_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_addition3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_addition3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_addition3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1132 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -35,13 +35,13 @@ let mut › let-mut_division2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -53,14 +53,14 @@ let mut › let-mut_division2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1132
+          (call $/_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1132)
+            (global.get $/_1135)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1128)
+            (global.get $b_1131)
            )
            (i32.const 39)
           )
@@ -77,7 +77,7 @@ let mut › let-mut_division2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1128
+         (global.set $b_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -86,7 +86,7 @@ let mut › let-mut_division2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1128)
+             (global.get $b_1131)
             )
            )
           )
@@ -99,7 +99,7 @@ let mut › let-mut_division2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -11,7 +11,7 @@ let mut › let-mut1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -30,13 +30,13 @@ let mut › let-mut1
     (local.set $0
      (block $compile_block.3 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -46,7 +46,7 @@ let mut › let-mut1
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -10,12 +10,12 @@ lists › list_spread
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1133 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1129 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1129 (param i32 i32 i32) (result i32)))
- (global $a_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1132 (param i32 i32 i32) (result i32)))
+ (global $a_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,15 +39,15 @@ lists › list_spread
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 9)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1133)
+            (global.get $[]_1136)
            )
           )
           (call $decRef_0
@@ -61,13 +61,13 @@ lists › list_spread
        )
       )
       (block $compile_store.4
-       (global.set $a_1128
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 7)
            (call $incRef_0
@@ -77,7 +77,7 @@ lists › list_spread
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1128)
+           (global.get $a_1131)
           )
          )
         )
@@ -89,15 +89,15 @@ lists › list_spread
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1129
+          (call $[...]_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1129)
+            (global.get $[...]_1132)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $a_1128)
+            (global.get $a_1131)
            )
           )
           (call $decRef_0
@@ -110,10 +110,10 @@ lists › list_spread
        (block $do_backpatches.5
        )
       )
-      (call $[...]_1129
+      (call $[...]_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $[...]_1129)
+        (global.get $[...]_1132)
        )
        (i32.const 3)
        (call $incRef_0

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -10,11 +10,11 @@ lists › list1_trailing_space
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,15 +38,15 @@ lists › list1_trailing_space
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 7)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0
@@ -63,10 +63,10 @@ lists › list1_trailing_space
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 5)
            (call $incRef_0
@@ -84,10 +84,10 @@ lists › list1_trailing_space
        (block $do_backpatches.3
        )
       )
-      (call $[...]_1128
+      (call $[...]_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $[...]_1128)
+        (global.get $[...]_1131)
        )
        (i32.const 3)
        (call $incRef_0

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -10,11 +10,11 @@ lists › list1_trailing
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,15 +38,15 @@ lists › list1_trailing
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 7)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0
@@ -63,10 +63,10 @@ lists › list1_trailing
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 5)
            (call $incRef_0
@@ -84,10 +84,10 @@ lists › list1_trailing
        (block $do_backpatches.3
        )
       )
-      (call $[...]_1128
+      (call $[...]_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $[...]_1128)
+        (global.get $[...]_1131)
        )
        (i32.const 3)
        (call $incRef_0

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -11,17 +11,17 @@ loops › loop2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1143 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1140 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1146 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1143 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1143 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1140 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $count_1129 (mut i32) (i32.const 0))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1146 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1143 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1138 (param i32 i32 i32) (result i32)))
+ (global $count_1132 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -46,7 +46,7 @@ loops › loop2
     (local.set $0
      (block $compile_block.29 (result i32)
       (block $compile_store.3
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -71,7 +71,7 @@ loops › loop2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -80,7 +80,7 @@ loops › loop2
        )
       )
       (block $compile_store.6
-       (global.set $count_1129
+       (global.set $count_1132
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -105,7 +105,7 @@ loops › loop2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1129)
+           (global.get $count_1132)
           )
          )
         )
@@ -132,7 +132,7 @@ loops › loop2
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
                       (i32.load offset=8
-                       (global.get $b_1128)
+                       (global.get $b_1131)
                       )
                      )
                      (call $decRef_0
@@ -145,10 +145,10 @@ loops › loop2
                   (block $do_backpatches.10
                   )
                  )
-                 (call $>_1143
+                 (call $>_1146
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1143)
+                   (global.get $>_1146)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
@@ -172,7 +172,7 @@ loops › loop2
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
                     (i32.load offset=8
-                     (global.get $b_1128)
+                     (global.get $b_1131)
                     )
                    )
                    (call $decRef_0
@@ -189,10 +189,10 @@ loops › loop2
                 (local.set $7
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1135
+                   (call $-_1138
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1135)
+                     (global.get $-_1138)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
@@ -214,7 +214,7 @@ loops › loop2
                 (local.set $11
                  (block $MTupleSet.17 (result i32)
                   (i32.store offset=8
-                   (global.get $b_1128)
+                   (global.get $b_1131)
                    (tuple.extract 0
                     (tuple.make
                      (call $incRef_0
@@ -224,7 +224,7 @@ loops › loop2
                      (call $decRef_0
                       (global.get $GRAIN$EXPORT$decRef_0)
                       (i32.load offset=8
-                       (global.get $b_1128)
+                       (global.get $b_1131)
                       )
                      )
                     )
@@ -243,7 +243,7 @@ loops › loop2
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
                     (i32.load offset=8
-                     (global.get $count_1129)
+                     (global.get $count_1132)
                     )
                    )
                    (call $decRef_0
@@ -260,10 +260,10 @@ loops › loop2
                 (local.set $9
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1140
+                   (call $+_1143
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1140)
+                     (global.get $+_1143)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
@@ -283,7 +283,7 @@ loops › loop2
                )
                (block $MTupleSet.24 (result i32)
                 (i32.store offset=8
-                 (global.get $count_1129)
+                 (global.get $count_1132)
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -293,7 +293,7 @@ loops › loop2
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
                     (i32.load offset=8
-                     (global.get $count_1129)
+                     (global.get $count_1132)
                     )
                    )
                   )
@@ -317,7 +317,7 @@ loops › loop2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $count_1129)
+        (global.get $count_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -10,16 +10,16 @@ loops › loop5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>=\" (global $>=_1141 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1139 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>=\" (global $>=_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">=\" (func $>=_1141 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1139 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $count_1129 (mut i32) (i32.const 0))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">=\" (func $>=_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1142 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1138 (param i32 i32 i32) (result i32)))
+ (global $count_1132 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -41,13 +41,13 @@ loops › loop5
     (local.set $0
      (block $compile_block.21 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 25)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -56,13 +56,13 @@ loops › loop5
        )
       )
       (block $compile_store.4
-       (global.set $count_1129
+       (global.set $count_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 1)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1129)
+           (global.get $count_1132)
           )
          )
         )
@@ -86,14 +86,14 @@ loops › loop5
                   (local.set $6
                    (tuple.extract 0
                     (tuple.make
-                     (call $-_1139
+                     (call $-_1142
                       (call $incRef_0
                        (global.get $GRAIN$EXPORT$incRef_0)
-                       (global.get $-_1139)
+                       (global.get $-_1142)
                       )
                       (call $incRef_0
                        (global.get $GRAIN$EXPORT$incRef_0)
-                       (global.get $b_1128)
+                       (global.get $b_1131)
                       )
                       (i32.const 3)
                      )
@@ -110,7 +110,7 @@ loops › loop5
                  (block $compile_store.12
                   (local.set $8
                    (block $compile_set.10 (result i32)
-                    (global.set $b_1128
+                    (global.set $b_1131
                      (tuple.extract 0
                       (tuple.make
                        (call $incRef_0
@@ -119,7 +119,7 @@ loops › loop5
                        )
                        (call $decRef_0
                         (global.get $GRAIN$EXPORT$decRef_0)
-                        (global.get $b_1128)
+                        (global.get $b_1131)
                        )
                       )
                      )
@@ -130,14 +130,14 @@ loops › loop5
                   (block $do_backpatches.11
                   )
                  )
-                 (call $>=_1141
+                 (call $>=_1144
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>=_1141)
+                   (global.get $>=_1144)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1128)
+                   (global.get $b_1131)
                   )
                   (i32.const 1)
                  )
@@ -154,14 +154,14 @@ loops › loop5
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1135
+                   (call $+_1138
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1135)
+                     (global.get $+_1138)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $count_1129)
+                     (global.get $count_1132)
                     )
                     (i32.const 3)
                    )
@@ -176,7 +176,7 @@ loops › loop5
                 )
                )
                (block $compile_set.16 (result i32)
-                (global.set $count_1129
+                (global.set $count_1132
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -185,7 +185,7 @@ loops › loop5
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $count_1129)
+                    (global.get $count_1132)
                    )
                   )
                  )
@@ -207,7 +207,7 @@ loops › loop5
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $count_1129)
+       (global.get $count_1132)
       )
      )
     )

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -10,13 +10,13 @@ loops › loop3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1135 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1135 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1138 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1136 (param i32 i32 i32) (result i32)))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -37,13 +37,13 @@ loops › loop3
     (local.set $0
      (block $compile_block.14 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 7)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -63,14 +63,14 @@ loops › loop3
               (i32.eqz
                (i32.shr_u
                 (block $compile_block.6 (result i32)
-                 (call $>_1135
+                 (call $>_1138
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1135)
+                   (global.get $>_1138)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1128)
+                   (global.get $b_1131)
                   )
                   (i32.const 1)
                  )
@@ -87,14 +87,14 @@ loops › loop3
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1133
+                   (call $-_1136
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1133)
+                     (global.get $-_1136)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $b_1128)
+                     (global.get $b_1131)
                     )
                     (i32.const 3)
                    )
@@ -109,7 +109,7 @@ loops › loop3
                 )
                )
                (block $compile_set.9 (result i32)
-                (global.set $b_1128
+                (global.set $b_1131
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -118,7 +118,7 @@ loops › loop3
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $b_1128)
+                    (global.get $b_1131)
                    )
                   )
                  )
@@ -140,7 +140,7 @@ loops › loop3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1128)
+       (global.get $b_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -10,16 +10,16 @@ loops › loop4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1141 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1139 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1141 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1139 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $count_1129 (mut i32) (i32.const 0))
- (global $b_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1138 (param i32 i32 i32) (result i32)))
+ (global $count_1132 (mut i32) (i32.const 0))
+ (global $b_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -41,13 +41,13 @@ loops › loop4
     (local.set $0
      (block $compile_block.21 (result i32)
       (block $compile_store.2
-       (global.set $b_1128
+       (global.set $b_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 25)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1128)
+           (global.get $b_1131)
           )
          )
         )
@@ -56,13 +56,13 @@ loops › loop4
        )
       )
       (block $compile_store.4
-       (global.set $count_1129
+       (global.set $count_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 1)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1129)
+           (global.get $count_1132)
           )
          )
         )
@@ -82,14 +82,14 @@ loops › loop4
               (i32.eqz
                (i32.shr_u
                 (block $compile_block.8 (result i32)
-                 (call $>_1141
+                 (call $>_1144
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1141)
+                   (global.get $>_1144)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1128)
+                   (global.get $b_1131)
                   )
                   (i32.const 1)
                  )
@@ -106,14 +106,14 @@ loops › loop4
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1135
+                   (call $-_1138
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1135)
+                     (global.get $-_1138)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $b_1128)
+                     (global.get $b_1131)
                     )
                     (i32.const 3)
                    )
@@ -130,7 +130,7 @@ loops › loop4
                (block $compile_store.13
                 (local.set $8
                  (block $compile_set.11 (result i32)
-                  (global.set $b_1128
+                  (global.set $b_1131
                    (tuple.extract 0
                     (tuple.make
                      (call $incRef_0
@@ -139,7 +139,7 @@ loops › loop4
                      )
                      (call $decRef_0
                       (global.get $GRAIN$EXPORT$decRef_0)
-                      (global.get $b_1128)
+                      (global.get $b_1131)
                      )
                     )
                    )
@@ -154,14 +154,14 @@ loops › loop4
                 (local.set $7
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1139
+                   (call $+_1142
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1139)
+                     (global.get $+_1142)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $count_1129)
+                     (global.get $count_1132)
                     )
                     (i32.const 3)
                    )
@@ -176,7 +176,7 @@ loops › loop4
                 )
                )
                (block $compile_set.16 (result i32)
-                (global.set $count_1129
+                (global.set $count_1132
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -185,7 +185,7 @@ loops › loop4
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $count_1129)
+                    (global.get $count_1132)
                    )
                   )
                  )
@@ -207,7 +207,7 @@ loops › loop4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $count_1129)
+       (global.get $count_1132)
       )
      )
     )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -14,14 +14,14 @@ optimizations › trs1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $f1_1128 (mut i32) (i32.const 0))
+ (global $f1_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $f1_1128 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $f1_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -77,7 +77,7 @@ optimizations › trs1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $f1_1128
+       (global.set $f1_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -106,21 +106,21 @@ optimizations › trs1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $f1_1128)
+           (global.get $f1_1131)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $f1_1128)
+         (global.get $f1_1131)
         )
        )
       )
-      (call $f1_1128
+      (call $f1_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $f1_1128)
+        (global.get $f1_1131)
        )
        (i32.const 3)
        (i32.const 5)

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -11,13 +11,13 @@ optimizations › test_dead_branch_elimination_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1141 (param i32 i32 i32) (result i32)))
- (global $y_1129 (mut i32) (i32.const 0))
- (global $x_1128 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
+ (global $y_1132 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -40,7 +40,7 @@ optimizations › test_dead_branch_elimination_5
     (local.set $0
      (block $compile_block.17 (result i32)
       (block $compile_store.3
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -65,7 +65,7 @@ optimizations › test_dead_branch_elimination_5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -74,7 +74,7 @@ optimizations › test_dead_branch_elimination_5
        )
       )
       (block $compile_store.6
-       (global.set $y_1129
+       (global.set $y_1132
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -99,7 +99,7 @@ optimizations › test_dead_branch_elimination_5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $y_1129)
+           (global.get $y_1132)
           )
          )
         )
@@ -111,14 +111,14 @@ optimizations › test_dead_branch_elimination_5
        (local.set $8
         (block $MTupleSet.7 (result i32)
          (i32.store offset=8
-          (global.get $x_1128)
+          (global.get $x_1131)
           (tuple.extract 0
            (tuple.make
             (i32.const 7)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $x_1128)
+              (global.get $x_1131)
              )
             )
            )
@@ -134,14 +134,14 @@ optimizations › test_dead_branch_elimination_5
        (local.set $9
         (block $MTupleSet.10 (result i32)
          (i32.store offset=8
-          (global.get $y_1129)
+          (global.get $y_1132)
           (tuple.extract 0
            (tuple.make
             (i32.const 9)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $y_1129)
+              (global.get $y_1132)
              )
             )
            )
@@ -160,7 +160,7 @@ optimizations › test_dead_branch_elimination_5
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $x_1128)
+            (global.get $x_1131)
            )
           )
           (call $decRef_0
@@ -180,7 +180,7 @@ optimizations › test_dead_branch_elimination_5
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $y_1129)
+            (global.get $y_1132)
            )
           )
           (call $decRef_0
@@ -193,10 +193,10 @@ optimizations › test_dead_branch_elimination_5
        (block $do_backpatches.15
        )
       )
-      (call $+_1141
+      (call $+_1144
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1141)
+        (global.get $+_1144)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -65,7 +65,7 @@ pattern matching › record_match_3
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -135,7 +135,7 @@ pattern matching › record_match_3
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -303,10 +303,10 @@ pattern matching › record_match_3
          )
          (br $switch.16_outer
           (block $compile_block.17 (result i32)
-           (call $+_1141
+           (call $+_1144
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $+_1141)
+             (global.get $+_1144)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -11,12 +11,12 @@ pattern matching › adt_match_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1136 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1139 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1136 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -69,7 +69,7 @@ pattern matching › adt_match_deep
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -123,7 +123,7 @@ pattern matching › adt_match_deep
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -149,10 +149,10 @@ pattern matching › adt_match_deep
         (local.set $7
          (tuple.extract 0
           (tuple.make
-           (call $[...]_1133
+           (call $[...]_1136
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $[...]_1133)
+             (global.get $[...]_1136)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -160,7 +160,7 @@ pattern matching › adt_match_deep
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $[]_1136)
+             (global.get $[]_1139)
             )
            )
            (call $decRef_0

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -11,14 +11,14 @@ pattern matching › tuple_match_deep4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1169 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1143 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1172 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1146 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1169 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1172 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -68,15 +68,15 @@ pattern matching › tuple_match_deep4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1143)
+            (global.get $[]_1146)
            )
           )
           (call $decRef_0
@@ -935,10 +935,10 @@ pattern matching › tuple_match_deep4
                  (local.set $20
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1169
+                    (call $+_1172
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1169)
+                      (global.get $+_1172)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -963,10 +963,10 @@ pattern matching › tuple_match_deep4
                  (local.set $21
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1169
+                    (call $+_1172
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1169)
+                      (global.get $+_1172)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -987,10 +987,10 @@ pattern matching › tuple_match_deep4
                  (block $do_backpatches.98
                  )
                 )
-                (call $+_1169
+                (call $+_1172
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1169)
+                  (global.get $+_1172)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1011,10 +1011,10 @@ pattern matching › tuple_match_deep4
                (local.set $20
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1169
+                  (call $+_1172
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1169)
+                    (global.get $+_1172)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1035,10 +1035,10 @@ pattern matching › tuple_match_deep4
                (block $do_backpatches.93
                )
               )
-              (call $+_1169
+              (call $+_1172
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1169)
+                (global.get $+_1172)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1055,10 +1055,10 @@ pattern matching › tuple_match_deep4
           )
           (br $switch.90_outer
            (block $compile_block.92 (result i32)
-            (call $+_1169
+            (call $+_1172
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1169)
+              (global.get $+_1172)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -10,13 +10,13 @@ pattern matching › adt_match_4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1165 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1141 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1168 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1165 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1168 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -61,15 +61,15 @@ pattern matching › adt_match_4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 13)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1141)
+            (global.get $[]_1144)
            )
           )
           (call $decRef_0
@@ -86,10 +86,10 @@ pattern matching › adt_match_4
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 11)
            (call $incRef_0
@@ -111,10 +111,10 @@ pattern matching › adt_match_4
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 9)
            (call $incRef_0
@@ -749,10 +749,10 @@ pattern matching › adt_match_4
                  (local.set $15
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1165
+                    (call $+_1168
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1165)
+                      (global.get $+_1168)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -773,10 +773,10 @@ pattern matching › adt_match_4
                  (block $do_backpatches.79
                  )
                 )
-                (call $+_1165
+                (call $+_1168
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1165)
+                  (global.get $+_1168)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -793,10 +793,10 @@ pattern matching › adt_match_4
             )
             (br $switch.75_outer
              (block $compile_block.78 (result i32)
-              (call $+_1165
+              (call $+_1168
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1165)
+                (global.get $+_1168)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -61,7 +61,7 @@ pattern matching › record_match_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -165,7 +165,7 @@ pattern matching › record_match_2
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1143 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -257,10 +257,10 @@ pattern matching › guarded_match_2
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1140
+        (call $==_1143
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1140)
+          (global.get $==_1143)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1146 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1149 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1146 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1149 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -405,10 +405,10 @@ pattern matching › tuple_match_deep
            (local.set $17
             (tuple.extract 0
              (tuple.make
-              (call $+_1146
+              (call $+_1149
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1146)
+                (global.get $+_1149)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -433,10 +433,10 @@ pattern matching › tuple_match_deep
            (local.set $18
             (tuple.extract 0
              (tuple.make
-              (call $+_1146
+              (call $+_1149
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1146)
+                (global.get $+_1149)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -457,10 +457,10 @@ pattern matching › tuple_match_deep
            (block $do_backpatches.32
            )
           )
-          (call $+_1146
+          (call $+_1149
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1146)
+            (global.get $+_1149)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -61,7 +61,7 @@ pattern matching › record_match_1
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -165,7 +165,7 @@ pattern matching › record_match_1
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
@@ -11,12 +11,12 @@ pattern matching › alias_match_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$None\" (global $None_1146 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$None\" (global $None_1149 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $equal_0 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1134 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,10 +48,10 @@ pattern matching › alias_match_5
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $Some_1131
+          (call $Some_1134
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Some_1131)
+            (global.get $Some_1134)
            )
            (i32.const 11)
           )
@@ -387,7 +387,7 @@ pattern matching › alias_match_5
              (block $compile_block.40 (result i32)
               (call $incRef_0
                (global.get $GRAIN$EXPORT$incRef_0)
-               (global.get $None_1146)
+               (global.get $None_1149)
               )
              )
             )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -68,7 +68,7 @@ pattern matching › record_match_4
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -138,7 +138,7 @@ pattern matching › record_match_4
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -367,10 +367,10 @@ pattern matching › record_match_4
             (local.set $13
              (tuple.extract 0
               (tuple.make
-               (call $+_1142
+               (call $+_1145
                 (call $incRef_0
                  (global.get $GRAIN$EXPORT$incRef_0)
-                 (global.get $+_1142)
+                 (global.get $+_1145)
                 )
                 (call $incRef_0
                  (global.get $GRAIN$EXPORT$incRef_0)
@@ -391,10 +391,10 @@ pattern matching › record_match_4
             (block $do_backpatches.22
             )
            )
-           (call $+_1142
+           (call $+_1145
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $+_1142)
+             (global.get $+_1145)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -11,14 +11,14 @@ pattern matching › tuple_match_deep6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1173 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1147 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1176 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1150 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1173 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1176 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -70,15 +70,15 @@ pattern matching › tuple_match_deep6
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 13)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1147)
+            (global.get $[]_1150)
            )
           )
           (call $decRef_0
@@ -95,10 +95,10 @@ pattern matching › tuple_match_deep6
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 11)
            (call $incRef_0
@@ -120,10 +120,10 @@ pattern matching › tuple_match_deep6
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 9)
            (call $incRef_0
@@ -987,10 +987,10 @@ pattern matching › tuple_match_deep6
                  (local.set $22
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1173
+                    (call $+_1176
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1173)
+                      (global.get $+_1176)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1015,10 +1015,10 @@ pattern matching › tuple_match_deep6
                  (local.set $23
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1173
+                    (call $+_1176
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1173)
+                      (global.get $+_1176)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1039,10 +1039,10 @@ pattern matching › tuple_match_deep6
                  (block $do_backpatches.102
                  )
                 )
-                (call $+_1173
+                (call $+_1176
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1173)
+                  (global.get $+_1176)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1063,10 +1063,10 @@ pattern matching › tuple_match_deep6
                (local.set $22
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1173
+                  (call $+_1176
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1173)
+                    (global.get $+_1176)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1087,10 +1087,10 @@ pattern matching › tuple_match_deep6
                (block $do_backpatches.97
                )
               )
-              (call $+_1173
+              (call $+_1176
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1173)
+                (global.get $+_1176)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1107,10 +1107,10 @@ pattern matching › tuple_match_deep6
           )
           (br $switch.94_outer
            (block $compile_block.96 (result i32)
-            (call $+_1173
+            (call $+_1176
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1173)
+              (global.get $+_1176)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -11,12 +11,12 @@ pattern matching › tuple_match_deep3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1166 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1169 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1166 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1169 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -87,7 +87,7 @@ pattern matching › tuple_match_deep3
             (local.get $0)
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $[]_1140)
+             (global.get $[]_1143)
             )
            )
            (local.get $0)
@@ -907,10 +907,10 @@ pattern matching › tuple_match_deep3
                  (local.set $19
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1166
+                    (call $+_1169
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1166)
+                      (global.get $+_1169)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -935,10 +935,10 @@ pattern matching › tuple_match_deep3
                  (local.set $20
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1166
+                    (call $+_1169
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1166)
+                      (global.get $+_1169)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -959,10 +959,10 @@ pattern matching › tuple_match_deep3
                  (block $do_backpatches.96
                  )
                 )
-                (call $+_1166
+                (call $+_1169
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1166)
+                  (global.get $+_1169)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -983,10 +983,10 @@ pattern matching › tuple_match_deep3
                (local.set $19
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1166
+                  (call $+_1169
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1166)
+                    (global.get $+_1169)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1007,10 +1007,10 @@ pattern matching › tuple_match_deep3
                (block $do_backpatches.91
                )
               )
-              (call $+_1166
+              (call $+_1169
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1166)
+                (global.get $+_1169)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1027,10 +1027,10 @@ pattern matching › tuple_match_deep3
           )
           (br $switch.88_outer
            (block $compile_block.90 (result i32)
-            (call $+_1166
+            (call $+_1169
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1166)
+              (global.get $+_1169)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -10,11 +10,11 @@ pattern matching › adt_match_1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1158 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1161 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1158 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1161 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -145,7 +145,7 @@ pattern matching › adt_match_1
       (block $compile_store.14
        (local.set $18
         (i32.load offset=12
-         (global.get $[]_1134)
+         (global.get $[]_1137)
         )
        )
        (block $do_backpatches.13
@@ -182,7 +182,7 @@ pattern matching › adt_match_1
               (call $incRef_0
                (global.get $GRAIN$EXPORT$incRef_0)
                (i32.load offset=20
-                (global.get $[]_1134)
+                (global.get $[]_1137)
                )
               )
               (call $decRef_0
@@ -202,7 +202,7 @@ pattern matching › adt_match_1
               (call $incRef_0
                (global.get $GRAIN$EXPORT$incRef_0)
                (i32.load offset=24
-                (global.get $[]_1134)
+                (global.get $[]_1137)
                )
               )
               (call $decRef_0
@@ -669,10 +669,10 @@ pattern matching › adt_match_1
                  (local.set $12
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1158
+                    (call $+_1161
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1158)
+                      (global.get $+_1161)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -693,10 +693,10 @@ pattern matching › adt_match_1
                  (block $do_backpatches.73
                  )
                 )
-                (call $+_1158
+                (call $+_1161
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1158)
+                  (global.get $+_1161)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -713,10 +713,10 @@ pattern matching › adt_match_1
             )
             (br $switch.69_outer
              (block $compile_block.72 (result i32)
-              (call $+_1158
+              (call $+_1161
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1158)
+                (global.get $+_1161)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1164 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1164 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -774,10 +774,10 @@ pattern matching › tuple_match_deep2
            (local.set $29
             (tuple.extract 0
              (tuple.make
-              (call $+_1164
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1164)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -802,10 +802,10 @@ pattern matching › tuple_match_deep2
            (local.set $30
             (tuple.extract 0
              (tuple.make
-              (call $+_1164
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1164)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -830,10 +830,10 @@ pattern matching › tuple_match_deep2
            (local.set $31
             (tuple.extract 0
              (tuple.make
-              (call $+_1164
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1164)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -858,10 +858,10 @@ pattern matching › tuple_match_deep2
            (local.set $32
             (tuple.extract 0
              (tuple.make
-              (call $+_1164
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1164)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -886,10 +886,10 @@ pattern matching › tuple_match_deep2
            (local.set $33
             (tuple.extract 0
              (tuple.make
-              (call $+_1164
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1164)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -910,10 +910,10 @@ pattern matching › tuple_match_deep2
            (block $do_backpatches.68
            )
           )
-          (call $+_1164
+          (call $+_1167
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1164)
+            (global.get $+_1167)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -62,7 +62,7 @@ pattern matching › record_match_deep
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -74,7 +74,7 @@ pattern matching › record_match_deep
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 68719477865)
+           (i64.const 68719477868)
           )
           (i64.store offset=56
            (local.get $0)
@@ -128,7 +128,7 @@ pattern matching › record_match_deep
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -173,7 +173,7 @@ pattern matching › record_match_deep
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -258,10 +258,10 @@ pattern matching › guarded_match_4
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1141
+        (call $==_1144
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1141)
+          (global.get $==_1144)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -281,10 +281,10 @@ pattern matching › guarded_match_4
           (i32.const 31)
          )
          (block $compile_block.21 (result i32)
-          (call $==_1141
+          (call $==_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1141)
+            (global.get $==_1144)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1143 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -257,10 +257,10 @@ pattern matching › guarded_match_1
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1140
+        (call $==_1143
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1140)
+          (global.get $==_1143)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -10,13 +10,13 @@ pattern matching › adt_match_2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1161 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1164 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1161 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1164 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -59,15 +59,15 @@ pattern matching › adt_match_2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 5)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1137)
+            (global.get $[]_1140)
            )
           )
           (call $decRef_0
@@ -697,10 +697,10 @@ pattern matching › adt_match_2
                  (local.set $13
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1161
+                    (call $+_1164
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1161)
+                      (global.get $+_1164)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -721,10 +721,10 @@ pattern matching › adt_match_2
                  (block $do_backpatches.75
                  )
                 )
-                (call $+_1161
+                (call $+_1164
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1161)
+                  (global.get $+_1164)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -741,10 +741,10 @@ pattern matching › adt_match_2
             )
             (br $switch.71_outer
              (block $compile_block.74 (result i32)
-              (call $+_1161
+              (call $+_1164
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1161)
+                (global.get $+_1164)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -258,10 +258,10 @@ pattern matching › guarded_match_3
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1141
+        (call $==_1144
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1141)
+          (global.get $==_1144)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -281,10 +281,10 @@ pattern matching › guarded_match_3
           (i32.const 31)
          )
          (block $compile_block.21 (result i32)
-          (call $==_1141
+          (call $==_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1141)
+            (global.get $==_1144)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -10,13 +10,13 @@ pattern matching › adt_match_3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1163 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1139 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1166 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1163 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1166 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -60,15 +60,15 @@ pattern matching › adt_match_3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 11)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1139)
+            (global.get $[]_1142)
            )
           )
           (call $decRef_0
@@ -85,10 +85,10 @@ pattern matching › adt_match_3
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 9)
            (call $incRef_0
@@ -723,10 +723,10 @@ pattern matching › adt_match_3
                  (local.set $14
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1163
+                    (call $+_1166
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1163)
+                      (global.get $+_1166)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -747,10 +747,10 @@ pattern matching › adt_match_3
                  (block $do_backpatches.77
                  )
                 )
-                (call $+_1163
+                (call $+_1166
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1163)
+                  (global.get $+_1166)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -767,10 +767,10 @@ pattern matching › adt_match_3
             )
             (br $switch.73_outer
              (block $compile_block.76 (result i32)
-              (call $+_1163
+              (call $+_1166
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1163)
+                (global.get $+_1166)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › alias_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $equal_0 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1130 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1133 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,10 +45,10 @@ pattern matching › alias_match_4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $Some_1130
+          (call $Some_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Some_1130)
+            (global.get $Some_1133)
            )
            (i32.const 11)
           )

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -10,13 +10,13 @@ pattern matching › adt_match_5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1143 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1170 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1146 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1170 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -62,15 +62,15 @@ pattern matching › adt_match_5
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 15)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1143)
+            (global.get $[]_1146)
            )
           )
           (call $decRef_0
@@ -87,10 +87,10 @@ pattern matching › adt_match_5
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 13)
            (call $incRef_0
@@ -112,10 +112,10 @@ pattern matching › adt_match_5
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 11)
            (call $incRef_0
@@ -137,10 +137,10 @@ pattern matching › adt_match_5
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1135
+          (call $[...]_1138
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1135)
+            (global.get $[...]_1138)
            )
            (i32.const 9)
            (call $incRef_0
@@ -775,10 +775,10 @@ pattern matching › adt_match_5
                  (local.set $16
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1167
+                    (call $+_1170
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1167)
+                      (global.get $+_1170)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -799,10 +799,10 @@ pattern matching › adt_match_5
                  (block $do_backpatches.81
                  )
                 )
-                (call $+_1167
+                (call $+_1170
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1167)
+                  (global.get $+_1170)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -819,10 +819,10 @@ pattern matching › adt_match_5
             )
             (br $switch.77_outer
              (block $compile_block.80 (result i32)
-              (call $+_1167
+              (call $+_1170
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1170)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -11,14 +11,14 @@ pattern matching › tuple_match_deep5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1171 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1145 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1174 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1148 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1171 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1174 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -69,15 +69,15 @@ pattern matching › tuple_match_deep5
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 11)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1145)
+            (global.get $[]_1148)
            )
           )
           (call $decRef_0
@@ -94,10 +94,10 @@ pattern matching › tuple_match_deep5
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 9)
            (call $incRef_0
@@ -961,10 +961,10 @@ pattern matching › tuple_match_deep5
                  (local.set $21
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1171
+                    (call $+_1174
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1171)
+                      (global.get $+_1174)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -989,10 +989,10 @@ pattern matching › tuple_match_deep5
                  (local.set $22
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1171
+                    (call $+_1174
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1171)
+                      (global.get $+_1174)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1013,10 +1013,10 @@ pattern matching › tuple_match_deep5
                  (block $do_backpatches.100
                  )
                 )
-                (call $+_1171
+                (call $+_1174
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1171)
+                  (global.get $+_1174)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1037,10 +1037,10 @@ pattern matching › tuple_match_deep5
                (local.set $21
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1171
+                  (call $+_1174
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1171)
+                    (global.get $+_1174)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1061,10 +1061,10 @@ pattern matching › tuple_match_deep5
                (block $do_backpatches.95
                )
               )
-              (call $+_1171
+              (call $+_1174
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1171)
+                (global.get $+_1174)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1081,10 +1081,10 @@ pattern matching › tuple_match_deep5
           )
           (br $switch.92_outer
            (block $compile_block.94 (result i32)
-            (call $+_1171
+            (call $+_1174
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1171)
+              (global.get $+_1174)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -12,12 +12,12 @@ pattern matching › constant_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $equal_0 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -277,10 +277,10 @@ pattern matching › constant_match_4
           )
           (block $compile_store.22
            (local.set $14
-            (call $==_1141
+            (call $==_1144
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $==_1141)
+              (global.get $==_1144)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -373,10 +373,10 @@ pattern matching › constant_match_4
               )
               (block $compile_store.30
                (local.set $16
-                (call $==_1141
+                (call $==_1144
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $==_1141)
+                  (global.get $==_1144)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -11,14 +11,14 @@ pattern matching › tuple_match_deep7
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1175 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1149 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1178 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1152 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1175 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1178 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1144 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -71,15 +71,15 @@ pattern matching › tuple_match_deep7
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 15)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1149)
+            (global.get $[]_1152)
            )
           )
           (call $decRef_0
@@ -96,10 +96,10 @@ pattern matching › tuple_match_deep7
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 13)
            (call $incRef_0
@@ -121,10 +121,10 @@ pattern matching › tuple_match_deep7
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 11)
            (call $incRef_0
@@ -146,10 +146,10 @@ pattern matching › tuple_match_deep7
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1141
+          (call $[...]_1144
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1141)
+            (global.get $[...]_1144)
            )
            (i32.const 9)
            (call $incRef_0
@@ -1013,10 +1013,10 @@ pattern matching › tuple_match_deep7
                  (local.set $23
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1175
+                    (call $+_1178
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1175)
+                      (global.get $+_1178)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1041,10 +1041,10 @@ pattern matching › tuple_match_deep7
                  (local.set $24
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1175
+                    (call $+_1178
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1175)
+                      (global.get $+_1178)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1065,10 +1065,10 @@ pattern matching › tuple_match_deep7
                  (block $do_backpatches.104
                  )
                 )
-                (call $+_1175
+                (call $+_1178
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1175)
+                  (global.get $+_1178)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1089,10 +1089,10 @@ pattern matching › tuple_match_deep7
                (local.set $23
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1175
+                  (call $+_1178
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1175)
+                    (global.get $+_1178)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1113,10 +1113,10 @@ pattern matching › tuple_match_deep7
                (block $do_backpatches.99
                )
               )
-              (call $+_1175
+              (call $+_1178
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1175)
+                (global.get $+_1178)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1133,10 +1133,10 @@ pattern matching › tuple_match_deep7
           )
           (br $switch.96_outer
            (block $compile_block.98 (result i32)
-            (call $+_1175
+            (call $+_1178
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1175)
+              (global.get $+_1178)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
@@ -10,11 +10,11 @@ pattern matching › or_match_3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1132 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1135 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -51,15 +51,15 @@ pattern matching › or_match_3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1132
+          (call $[...]_1135
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1132)
+            (global.get $[...]_1135)
            )
            (i32.const 11)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0

--- a/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › or_match_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1129 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $equal_0 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1129 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,10 +45,10 @@ pattern matching › or_match_2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $Some_1129
+          (call $Some_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $Some_1129)
+            (global.get $Some_1132)
            )
            (i32.const 11)
           )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -11,11 +11,11 @@ records › record_get_multiple
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -63,7 +63,7 @@ records › record_get_multiple
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -125,7 +125,7 @@ records › record_get_multiple
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -191,10 +191,10 @@ records › record_get_multiple
         (block $do_backpatches.8
         )
        )
-       (call $+_1134
+       (call $+_1137
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $+_1134)
+         (global.get $+_1137)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -53,7 +53,7 @@ records › record_definition_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -103,7 +103,7 @@ records › record_definition_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -103,7 +103,7 @@ records › record_pun
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1129 (mut i32) (i32.const 0))
+ (global $foo_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -61,7 +61,7 @@ records › record_destruct_1
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -165,7 +165,7 @@ records › record_destruct_1
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -199,13 +199,13 @@ records › record_destruct_1
         )
        )
        (block $compile_store.10
-        (global.set $foo_1129
+        (global.set $foo_1132
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $foo_1129)
+            (global.get $foo_1132)
            )
           )
          )
@@ -237,7 +237,7 @@ records › record_destruct_1
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.13 (result i32)
-          (global.set $foo_1129
+          (global.set $foo_1132
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -246,7 +246,7 @@ records › record_destruct_1
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $foo_1129)
+              (global.get $foo_1132)
              )
             )
            )
@@ -257,7 +257,7 @@ records › record_destruct_1
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1129)
+        (global.get $foo_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -11,14 +11,14 @@ records › record_destruct_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
- (global $bar_1130 (mut i32) (i32.const 0))
- (global $foo_1129 (mut i32) (i32.const 0))
- (global $baz_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
+ (global $bar_1133 (mut i32) (i32.const 0))
+ (global $foo_1132 (mut i32) (i32.const 0))
+ (global $baz_1134 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -68,7 +68,7 @@ records › record_destruct_4
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_4
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -169,13 +169,13 @@ records › record_destruct_4
         )
        )
        (block $compile_store.7
-        (global.set $foo_1129
+        (global.set $foo_1132
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $foo_1129)
+            (global.get $foo_1132)
            )
           )
          )
@@ -184,13 +184,13 @@ records › record_destruct_4
         )
        )
        (block $compile_store.9
-        (global.set $bar_1130
+        (global.set $bar_1133
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $bar_1130)
+            (global.get $bar_1133)
            )
           )
          )
@@ -199,13 +199,13 @@ records › record_destruct_4
         )
        )
        (block $compile_store.11
-        (global.set $baz_1131
+        (global.set $baz_1134
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $baz_1131)
+            (global.get $baz_1134)
            )
           )
          )
@@ -277,7 +277,7 @@ records › record_destruct_4
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.18 (result i32)
-          (global.set $baz_1131
+          (global.set $baz_1134
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -286,7 +286,7 @@ records › record_destruct_4
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $baz_1131)
+              (global.get $baz_1134)
              )
             )
            )
@@ -299,7 +299,7 @@ records › record_destruct_4
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.19 (result i32)
-          (global.set $bar_1130
+          (global.set $bar_1133
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -308,7 +308,7 @@ records › record_destruct_4
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $bar_1130)
+              (global.get $bar_1133)
              )
             )
            )
@@ -321,7 +321,7 @@ records › record_destruct_4
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.20 (result i32)
-          (global.set $foo_1129
+          (global.set $foo_1132
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -330,7 +330,7 @@ records › record_destruct_4
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $foo_1129)
+              (global.get $foo_1132)
              )
             )
            )
@@ -343,18 +343,18 @@ records › record_destruct_4
         (local.set $10
          (tuple.extract 0
           (tuple.make
-           (call $+_1142
+           (call $+_1145
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $+_1142)
+             (global.get $+_1145)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $foo_1129)
+             (global.get $foo_1132)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $bar_1130)
+             (global.get $bar_1133)
             )
            )
            (call $decRef_0
@@ -367,10 +367,10 @@ records › record_destruct_4
         (block $do_backpatches.21
         )
        )
-       (call $+_1142
+       (call $+_1145
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $+_1142)
+         (global.get $+_1145)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -378,7 +378,7 @@ records › record_destruct_4
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $baz_1131)
+         (global.get $baz_1134)
         )
        )
       )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -53,7 +53,7 @@ records › record_value_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -103,7 +103,7 @@ records › record_value_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -10,12 +10,12 @@ records › record_recursive_data_definition
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1139 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$None\" (global $None_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$Some\" (global $Some_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$None\" (global $None_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1139 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"Some\" (func $Some_1142 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -65,7 +65,7 @@ records › record_recursive_data_definition
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477865)
+           (i64.const 68719477868)
           )
           (i64.store offset=32
            (local.get $0)
@@ -77,7 +77,7 @@ records › record_recursive_data_definition
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=56
            (local.get $0)
@@ -131,7 +131,7 @@ records › record_recursive_data_definition
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)
@@ -141,7 +141,7 @@ records › record_recursive_data_definition
              (local.get $0)
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $None_1135)
+              (global.get $None_1138)
              )
             )
             (local.get $0)
@@ -179,7 +179,7 @@ records › record_recursive_data_definition
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -189,7 +189,7 @@ records › record_recursive_data_definition
              (local.get $0)
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $None_1135)
+              (global.get $None_1138)
              )
             )
             (local.get $0)
@@ -208,10 +208,10 @@ records › record_recursive_data_definition
         (local.set $8
          (tuple.extract 0
           (tuple.make
-           (call $Some_1139
+           (call $Some_1142
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Some_1139)
+             (global.get $Some_1142)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -258,10 +258,10 @@ records › record_recursive_data_definition
         (local.set $9
          (tuple.extract 0
           (tuple.make
-           (call $Some_1139
+           (call $Some_1142
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $Some_1139)
+             (global.get $Some_1142)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_mixed_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_mixed_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $bar_1129 (mut i32) (i32.const 0))
+ (global $bar_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -61,7 +61,7 @@ records › record_destruct_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -165,7 +165,7 @@ records › record_destruct_2
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -199,13 +199,13 @@ records › record_destruct_2
         )
        )
        (block $compile_store.10
-        (global.set $bar_1129
+        (global.set $bar_1132
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $bar_1129)
+            (global.get $bar_1132)
            )
           )
          )
@@ -237,7 +237,7 @@ records › record_destruct_2
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.13 (result i32)
-          (global.set $bar_1129
+          (global.set $bar_1132
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -246,7 +246,7 @@ records › record_destruct_2
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $bar_1129)
+              (global.get $bar_1132)
              )
             )
            )
@@ -257,7 +257,7 @@ records › record_destruct_2
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $bar_1129)
+        (global.get $bar_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -103,7 +103,7 @@ records › record_pun_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1130 (mut i32) (i32.const 0))
+ (global $foo_1133 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -62,7 +62,7 @@ records › record_destruct_deep
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -74,7 +74,7 @@ records › record_destruct_deep
           )
           (i64.store offset=48
            (local.get $0)
-           (i64.const 68719477865)
+           (i64.const 68719477868)
           )
           (i64.store offset=56
            (local.get $0)
@@ -128,7 +128,7 @@ records › record_destruct_deep
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -173,7 +173,7 @@ records › record_destruct_deep
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)
@@ -199,13 +199,13 @@ records › record_destruct_deep
         )
        )
        (block $compile_store.10
-        (global.set $foo_1130
+        (global.set $foo_1133
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $foo_1130)
+            (global.get $foo_1133)
            )
           )
          )
@@ -257,7 +257,7 @@ records › record_destruct_deep
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.15 (result i32)
-          (global.set $foo_1130
+          (global.set $foo_1133
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -266,7 +266,7 @@ records › record_destruct_deep
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $foo_1130)
+              (global.get $foo_1133)
              )
             )
            )
@@ -277,7 +277,7 @@ records › record_destruct_deep
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1130)
+        (global.get $foo_1133)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -11,13 +11,13 @@ records › record_destruct_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1141 (param i32 i32 i32) (result i32)))
- (global $bar_1130 (mut i32) (i32.const 0))
- (global $foo_1129 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
+ (global $bar_1133 (mut i32) (i32.const 0))
+ (global $foo_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -65,7 +65,7 @@ records › record_destruct_3
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -135,7 +135,7 @@ records › record_destruct_3
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -166,13 +166,13 @@ records › record_destruct_3
         )
        )
        (block $compile_store.7
-        (global.set $foo_1129
+        (global.set $foo_1132
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $foo_1129)
+            (global.get $foo_1132)
            )
           )
          )
@@ -181,13 +181,13 @@ records › record_destruct_3
         )
        )
        (block $compile_store.9
-        (global.set $bar_1130
+        (global.set $bar_1133
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $bar_1130)
+            (global.get $bar_1133)
            )
           )
          )
@@ -239,7 +239,7 @@ records › record_destruct_3
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.14 (result i32)
-          (global.set $bar_1130
+          (global.set $bar_1133
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -248,7 +248,7 @@ records › record_destruct_3
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $bar_1130)
+              (global.get $bar_1133)
              )
             )
            )
@@ -261,7 +261,7 @@ records › record_destruct_3
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.15 (result i32)
-          (global.set $foo_1129
+          (global.set $foo_1132
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -270,7 +270,7 @@ records › record_destruct_3
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $foo_1129)
+              (global.get $foo_1132)
              )
             )
            )
@@ -279,18 +279,18 @@ records › record_destruct_3
          )
         )
        )
-       (call $+_1141
+       (call $+_1144
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $+_1141)
+         (global.get $+_1144)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $foo_1129)
+         (global.get $foo_1132)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $bar_1130)
+         (global.get $bar_1133)
         )
        )
       )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -60,7 +60,7 @@ records › record_get_multilevel
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -80,7 +80,7 @@ records › record_get_multilevel
           )
           (i64.store offset=64
            (local.get $0)
-           (i64.const 68719477865)
+           (i64.const 68719477868)
           )
           (i64.store offset=72
            (local.get $0)
@@ -134,7 +134,7 @@ records › record_get_multilevel
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -183,7 +183,7 @@ records › record_get_multilevel
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2259)
+             (i32.const 2265)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -58,7 +58,7 @@ records › record_multiple_fields_definition_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -158,7 +158,7 @@ records › record_multiple_fields_definition_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -58,7 +58,7 @@ records › record_get_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -112,7 +112,7 @@ records › record_get_2
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_mixed
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_mixed
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -11,14 +11,14 @@ records › record_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
- (global $bar_1130 (mut i32) (i32.const 0))
- (global $foo_1129 (mut i32) (i32.const 0))
- (global $baz_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
+ (global $bar_1133 (mut i32) (i32.const 0))
+ (global $foo_1132 (mut i32) (i32.const 0))
+ (global $baz_1134 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -68,7 +68,7 @@ records › record_destruct_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -138,7 +138,7 @@ records › record_destruct_trailing
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -169,13 +169,13 @@ records › record_destruct_trailing
         )
        )
        (block $compile_store.7
-        (global.set $foo_1129
+        (global.set $foo_1132
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $foo_1129)
+            (global.get $foo_1132)
            )
           )
          )
@@ -184,13 +184,13 @@ records › record_destruct_trailing
         )
        )
        (block $compile_store.9
-        (global.set $bar_1130
+        (global.set $bar_1133
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $bar_1130)
+            (global.get $bar_1133)
            )
           )
          )
@@ -199,13 +199,13 @@ records › record_destruct_trailing
         )
        )
        (block $compile_store.11
-        (global.set $baz_1131
+        (global.set $baz_1134
          (tuple.extract 0
           (tuple.make
            (i32.const 0)
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
-            (global.get $baz_1131)
+            (global.get $baz_1134)
            )
           )
          )
@@ -277,7 +277,7 @@ records › record_destruct_trailing
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.18 (result i32)
-          (global.set $baz_1131
+          (global.set $baz_1134
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -286,7 +286,7 @@ records › record_destruct_trailing
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $baz_1131)
+              (global.get $baz_1134)
              )
             )
            )
@@ -299,7 +299,7 @@ records › record_destruct_trailing
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.19 (result i32)
-          (global.set $bar_1130
+          (global.set $bar_1133
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -308,7 +308,7 @@ records › record_destruct_trailing
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $bar_1130)
+              (global.get $bar_1133)
              )
             )
            )
@@ -321,7 +321,7 @@ records › record_destruct_trailing
         (call $decRef_0
          (global.get $GRAIN$EXPORT$decRef_0)
          (block $compile_set.20 (result i32)
-          (global.set $foo_1129
+          (global.set $foo_1132
            (tuple.extract 0
             (tuple.make
              (call $incRef_0
@@ -330,7 +330,7 @@ records › record_destruct_trailing
              )
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $foo_1129)
+              (global.get $foo_1132)
              )
             )
            )
@@ -343,18 +343,18 @@ records › record_destruct_trailing
         (local.set $10
          (tuple.extract 0
           (tuple.make
-           (call $+_1142
+           (call $+_1145
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $+_1142)
+             (global.get $+_1145)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $foo_1129)
+             (global.get $foo_1132)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $bar_1130)
+             (global.get $bar_1133)
             )
            )
            (call $decRef_0
@@ -367,10 +367,10 @@ records › record_destruct_trailing
         (block $do_backpatches.21
         )
        )
-       (call $+_1142
+       (call $+_1145
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $+_1142)
+         (global.get $+_1145)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -378,7 +378,7 @@ records › record_destruct_trailing
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $baz_1131)
+         (global.get $baz_1134)
         )
        )
       )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_mixed_2
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_mixed_2
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -58,7 +58,7 @@ records › record_multiple_fields_both_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -158,7 +158,7 @@ records › record_multiple_fields_both_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -53,7 +53,7 @@ records › record_both_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -103,7 +103,7 @@ records › record_both_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_multiple
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_multiple
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_multiple_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_multiple_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -58,7 +58,7 @@ records › record_multiple_fields_value_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -158,7 +158,7 @@ records › record_multiple_fields_value_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -53,7 +53,7 @@ records › record_pun_mixed_2_trailing
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_mixed_2_trailing
         )
         (i32.store offset=8
          (local.get $0)
-         (i32.const 2257)
+         (i32.const 2263)
         )
         (i32.store offset=12
          (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_20
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1130 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -64,7 +64,7 @@ stdlib › stdlib_equal_20
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -168,7 +168,7 @@ stdlib › stdlib_equal_20
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -258,7 +258,7 @@ stdlib › stdlib_equal_20
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -291,10 +291,10 @@ stdlib › stdlib_equal_20
         (block $do_backpatches.13
         )
        )
-       (call $==_1130
+       (call $==_1133
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $==_1130)
+         (global.get $==_1133)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_18
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -103,10 +103,10 @@ stdlib › stdlib_equal_18
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -10,11 +10,11 @@ stdlib › stdlib_cons
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,15 +38,15 @@ stdlib › stdlib_cons
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 7)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1134)
+            (global.get $[]_1137)
            )
           )
           (call $decRef_0
@@ -63,10 +63,10 @@ stdlib › stdlib_cons
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1128
+          (call $[...]_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1128)
+            (global.get $[...]_1131)
            )
            (i32.const 5)
            (call $incRef_0
@@ -84,10 +84,10 @@ stdlib › stdlib_cons
        (block $do_backpatches.3
        )
       )
-      (call $[...]_1128
+      (call $[...]_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $[...]_1128)
+        (global.get $[...]_1131)
        )
        (i32.const 3)
        (call $incRef_0

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_19
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1130 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -64,7 +64,7 @@ stdlib › stdlib_equal_19
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -168,7 +168,7 @@ stdlib › stdlib_equal_19
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -258,7 +258,7 @@ stdlib › stdlib_equal_19
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -291,10 +291,10 @@ stdlib › stdlib_equal_19
         (block $do_backpatches.13
         )
        )
-       (call $==_1130
+       (call $==_1133
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $==_1130)
+         (global.get $==_1133)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_16
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -103,10 +103,10 @@ stdlib › stdlib_equal_16
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_12
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -127,10 +127,10 @@ stdlib › stdlib_equal_12
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_21
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1130 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -64,7 +64,7 @@ stdlib › stdlib_equal_21
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -168,7 +168,7 @@ stdlib › stdlib_equal_21
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -258,7 +258,7 @@ stdlib › stdlib_equal_21
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -291,10 +291,10 @@ stdlib › stdlib_equal_21
         (block $do_backpatches.13
         )
        )
-       (call $==_1130
+       (call $==_1133
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $==_1130)
+         (global.get $==_1133)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_15
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -99,10 +99,10 @@ stdlib › stdlib_equal_15
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_14
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -99,10 +99,10 @@ stdlib › stdlib_equal_14
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -10,13 +10,13 @@ stdlib › stdlib_equal_3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1256 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1250 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[]\" (global $[]_1259 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$[...]\" (global $[...]_1253 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1250 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"[...]\" (func $[...]_1253 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,15 +44,15 @@ stdlib › stdlib_equal_3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 7)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1256)
+            (global.get $[]_1259)
            )
           )
           (call $decRef_0
@@ -69,10 +69,10 @@ stdlib › stdlib_equal_3
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 5)
            (call $incRef_0
@@ -94,10 +94,10 @@ stdlib › stdlib_equal_3
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 3)
            (call $incRef_0
@@ -119,15 +119,15 @@ stdlib › stdlib_equal_3
        (local.set $9
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 7)
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[]_1256)
+            (global.get $[]_1259)
            )
           )
           (call $decRef_0
@@ -144,10 +144,10 @@ stdlib › stdlib_equal_3
        (local.set $10
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 5)
            (call $incRef_0
@@ -169,10 +169,10 @@ stdlib › stdlib_equal_3
        (local.set $11
         (tuple.extract 0
          (tuple.make
-          (call $[...]_1250
+          (call $[...]_1253
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $[...]_1250)
+            (global.get $[...]_1253)
            )
            (i32.const 3)
            (call $incRef_0
@@ -190,10 +190,10 @@ stdlib › stdlib_equal_3
        (block $do_backpatches.11
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_11
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -107,10 +107,10 @@ stdlib › stdlib_equal_11
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_9
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -99,10 +99,10 @@ stdlib › stdlib_equal_9
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1165 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1165 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1169 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -111,10 +111,10 @@ stdlib › stdlib_equal_2
        (block $do_backpatches.5
        )
       )
-      (call $==_1165
+      (call $==_1169
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1165)
+        (global.get $==_1169)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_22
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1130 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1130 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -64,7 +64,7 @@ stdlib › stdlib_equal_22
           )
           (i64.store offset=24
            (local.get $0)
-           (i64.const 68719477864)
+           (i64.const 68719477867)
           )
           (i64.store offset=32
            (local.get $0)
@@ -168,7 +168,7 @@ stdlib › stdlib_equal_22
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -258,7 +258,7 @@ stdlib › stdlib_equal_22
             )
             (i32.store offset=8
              (local.get $0)
-             (i32.const 2257)
+             (i32.const 2263)
             )
             (i32.store offset=12
              (local.get $0)
@@ -291,10 +291,10 @@ stdlib › stdlib_equal_22
         (block $do_backpatches.13
         )
        )
-       (call $==_1130
+       (call $==_1133
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $==_1130)
+         (global.get $==_1133)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_10
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -103,10 +103,10 @@ stdlib › stdlib_equal_10
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_13
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -95,10 +95,10 @@ stdlib › stdlib_equal_13
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_8
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -95,10 +95,10 @@ stdlib › stdlib_equal_8
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_17
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1248 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1248 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -103,10 +103,10 @@ stdlib › stdlib_equal_17
        (block $do_backpatches.5
        )
       )
-      (call $==_1248
+      (call $==_1251
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1248)
+        (global.get $==_1251)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -11,11 +11,11 @@ strings › concat
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$++\" (global $++_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$++\" (global $++_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"++\" (func $++_1128 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"++\" (func $++_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -103,10 +103,10 @@ strings › concat
        (block $do_backpatches.5
        )
       )
-      (call $++_1128
+      (call $++_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $++_1128)
+        (global.get $++_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -13,10 +13,10 @@ tuples › nested_tup_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
- (global $a_1130 (mut i32) (i32.const 0))
- (global $y_1129 (mut i32) (i32.const 0))
- (global $x_1128 (mut i32) (i32.const 0))
+ (global $b_1134 (mut i32) (i32.const 0))
+ (global $a_1133 (mut i32) (i32.const 0))
+ (global $y_1132 (mut i32) (i32.const 0))
+ (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -163,13 +163,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.11
-       (global.set $x_1128
+       (global.set $x_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1128)
+           (global.get $x_1131)
           )
          )
         )
@@ -178,13 +178,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.13
-       (global.set $y_1129
+       (global.set $y_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $y_1129)
+           (global.get $y_1132)
           )
          )
         )
@@ -236,7 +236,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $y_1129
+         (global.set $y_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -245,7 +245,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $y_1129)
+             (global.get $y_1132)
             )
            )
           )
@@ -258,7 +258,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $x_1128
+         (global.set $x_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -267,7 +267,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $x_1128)
+             (global.get $x_1131)
             )
            )
           )
@@ -282,7 +282,7 @@ tuples › nested_tup_3
          (tuple.make
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
-           (global.get $y_1129)
+           (global.get $y_1132)
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
@@ -295,13 +295,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.23
-       (global.set $a_1130
+       (global.set $a_1133
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1130)
+           (global.get $a_1133)
           )
          )
         )
@@ -310,13 +310,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.25
-       (global.set $b_1131
+       (global.set $b_1134
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1134)
           )
          )
         )
@@ -368,7 +368,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.30 (result i32)
-         (global.set $b_1131
+         (global.set $b_1134
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -377,7 +377,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1134)
             )
            )
           )
@@ -390,7 +390,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.31 (result i32)
-         (global.set $a_1130
+         (global.set $a_1133
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -399,7 +399,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1130)
+             (global.get $a_1133)
             )
            )
           )
@@ -410,7 +410,7 @@ tuples › nested_tup_3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $a_1130)
+       (global.get $a_1133)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -13,8 +13,8 @@ tuples › nested_tup_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1129 (mut i32) (i32.const 0))
- (global $a_1128 (mut i32) (i32.const 0))
+ (global $b_1132 (mut i32) (i32.const 0))
+ (global $a_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -158,13 +158,13 @@ tuples › nested_tup_1
        )
       )
       (block $compile_store.11
-       (global.set $a_1128
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1128)
+           (global.get $a_1131)
           )
          )
         )
@@ -173,13 +173,13 @@ tuples › nested_tup_1
        )
       )
       (block $compile_store.13
-       (global.set $b_1129
+       (global.set $b_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1129)
+           (global.get $b_1132)
           )
          )
         )
@@ -231,7 +231,7 @@ tuples › nested_tup_1
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $b_1129
+         (global.set $b_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -240,7 +240,7 @@ tuples › nested_tup_1
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1129)
+             (global.get $b_1132)
             )
            )
           )
@@ -253,7 +253,7 @@ tuples › nested_tup_1
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $a_1128
+         (global.set $a_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -262,7 +262,7 @@ tuples › nested_tup_1
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1128)
+             (global.get $a_1131)
             )
            )
           )
@@ -273,7 +273,7 @@ tuples › nested_tup_1
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $a_1128)
+       (global.get $a_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
@@ -13,9 +13,9 @@ tuples › tup1_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1128 (mut i32) (i32.const 0))
- (global $c_1130 (mut i32) (i32.const 0))
- (global $b_1129 (mut i32) (i32.const 0))
+ (global $a_1131 (mut i32) (i32.const 0))
+ (global $c_1133 (mut i32) (i32.const 0))
+ (global $b_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -80,13 +80,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.5
-       (global.set $a_1128
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1128)
+           (global.get $a_1131)
           )
          )
         )
@@ -95,13 +95,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.7
-       (global.set $b_1129
+       (global.set $b_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1129)
+           (global.get $b_1132)
           )
          )
         )
@@ -110,13 +110,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.9
-       (global.set $c_1130
+       (global.set $c_1133
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1130)
+           (global.get $c_1133)
           )
          )
         )
@@ -188,7 +188,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.16 (result i32)
-         (global.set $c_1130
+         (global.set $c_1133
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -197,7 +197,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1130)
+             (global.get $c_1133)
             )
            )
           )
@@ -210,7 +210,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.17 (result i32)
-         (global.set $b_1129
+         (global.set $b_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -219,7 +219,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1129)
+             (global.get $b_1132)
             )
            )
           )
@@ -232,7 +232,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $a_1128
+         (global.set $a_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -241,7 +241,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1128)
+             (global.get $a_1131)
             )
            )
           )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -13,10 +13,10 @@ tuples › big_tup_access
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1128 (mut i32) (i32.const 0))
- (global $d_1131 (mut i32) (i32.const 0))
- (global $c_1130 (mut i32) (i32.const 0))
- (global $b_1129 (mut i32) (i32.const 0))
+ (global $a_1131 (mut i32) (i32.const 0))
+ (global $d_1134 (mut i32) (i32.const 0))
+ (global $c_1133 (mut i32) (i32.const 0))
+ (global $b_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -86,13 +86,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.5
-       (global.set $a_1128
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1128)
+           (global.get $a_1131)
           )
          )
         )
@@ -101,13 +101,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.7
-       (global.set $b_1129
+       (global.set $b_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1129)
+           (global.get $b_1132)
           )
          )
         )
@@ -116,13 +116,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.9
-       (global.set $c_1130
+       (global.set $c_1133
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1130)
+           (global.get $c_1133)
           )
          )
         )
@@ -131,13 +131,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.11
-       (global.set $d_1131
+       (global.set $d_1134
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $d_1131)
+           (global.get $d_1134)
           )
          )
         )
@@ -229,7 +229,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.20 (result i32)
-         (global.set $d_1131
+         (global.set $d_1134
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -238,7 +238,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $d_1131)
+             (global.get $d_1134)
             )
            )
           )
@@ -251,7 +251,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.21 (result i32)
-         (global.set $c_1130
+         (global.set $c_1133
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -260,7 +260,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1130)
+             (global.get $c_1133)
             )
            )
           )
@@ -273,7 +273,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.22 (result i32)
-         (global.set $b_1129
+         (global.set $b_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -282,7 +282,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1129)
+             (global.get $b_1132)
             )
            )
           )
@@ -295,7 +295,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.23 (result i32)
-         (global.set $a_1128
+         (global.set $a_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -304,7 +304,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1128)
+             (global.get $a_1131)
             )
            )
           )
@@ -315,7 +315,7 @@ tuples › big_tup_access
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $c_1130)
+       (global.get $c_1133)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -13,10 +13,10 @@ tuples › nested_tup_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1128 (mut i32) (i32.const 0))
- (global $d_1131 (mut i32) (i32.const 0))
- (global $c_1130 (mut i32) (i32.const 0))
- (global $b_1129 (mut i32) (i32.const 0))
+ (global $a_1131 (mut i32) (i32.const 0))
+ (global $d_1134 (mut i32) (i32.const 0))
+ (global $c_1133 (mut i32) (i32.const 0))
+ (global $b_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -163,13 +163,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.11
-       (global.set $a_1128
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1128)
+           (global.get $a_1131)
           )
          )
         )
@@ -178,13 +178,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.13
-       (global.set $b_1129
+       (global.set $b_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1129)
+           (global.get $b_1132)
           )
          )
         )
@@ -236,7 +236,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $b_1129
+         (global.set $b_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -245,7 +245,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1129)
+             (global.get $b_1132)
             )
            )
           )
@@ -258,7 +258,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $a_1128
+         (global.set $a_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -267,7 +267,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1128)
+             (global.get $a_1131)
             )
            )
           )
@@ -282,7 +282,7 @@ tuples › nested_tup_2
          (tuple.make
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
-           (global.get $b_1129)
+           (global.get $b_1132)
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
@@ -295,13 +295,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.23
-       (global.set $c_1130
+       (global.set $c_1133
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1130)
+           (global.get $c_1133)
           )
          )
         )
@@ -310,13 +310,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.25
-       (global.set $d_1131
+       (global.set $d_1134
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $d_1131)
+           (global.get $d_1134)
           )
          )
         )
@@ -368,7 +368,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.30 (result i32)
-         (global.set $d_1131
+         (global.set $d_1134
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -377,7 +377,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $d_1131)
+             (global.get $d_1134)
             )
            )
           )
@@ -390,7 +390,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.31 (result i32)
-         (global.set $c_1130
+         (global.set $c_1133
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -399,7 +399,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1130)
+             (global.get $c_1133)
             )
            )
           )
@@ -410,7 +410,7 @@ tuples › nested_tup_2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $d_1131)
+       (global.get $d_1134)
       )
      )
     )

--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -349,22 +349,15 @@ assert Array.slice(1, 4, [>]) == [>]
 
 // Array.sort
 // Numbers
-let comp = (left, right) => {
-  match ((left, right)) {
-    (left, right) when left > right => 1,
-    (left, right) when left == right => 0,
-    _ => -1,
-  }
-}
 let arr = [> 5, 3, 4, 6, 2, 1]
-Array.sort(comp, arr)
+Array.sort(compare, arr)
 assert arr == [> 1, 2, 3, 4, 5, 6]
 // Empty
 let arr = [>]
-Array.sort(comp, arr)
+Array.sort(compare, arr)
 assert arr == [>]
 // Strings
-let comp = (left, right) => {
+let compareLengths = (left, right) => {
   match ((String.length(left), String.length(right))) {
     (left, right) when left > right => 1,
     (left, right) when left == right => 0,
@@ -372,7 +365,7 @@ let comp = (left, right) => {
   }
 }
 let arr = [> "a", "abcde", "abc", "ab", "abcd", "a"]
-let result = Array.sort(comp, arr)
+let result = Array.sort(compareLengths, arr)
 assert arr == [> "a", "a", "ab", "abc", "abcd", "abcde"]
 // Returns void
 assert result == void

--- a/compiler/test/stdlib/list.test.gr
+++ b/compiler/test/stdlib/list.test.gr
@@ -241,16 +241,9 @@ assert join(", ", ["a", "b", "c"]) == "a, b, c"
 assert join(", ", []) == ""
 
 // List.sort
-let comp = (left, right) => {
-  match ((left, right)) {
-    (left, right) when left > right => 1,
-    (left, right) when left == right => 0,
-    _ => -1,
-  }
-}
-assert sort(comp, [3, 5, 2, 4, 1]) == [1, 2, 3, 4, 5]
-assert sort(comp, []) == []
-let comp = (left, right) => {
+assert sort(compare, [3, 5, 2, 4, 1]) == [1, 2, 3, 4, 5]
+assert sort(compare, []) == []
+let compareLengths = (left, right) => {
   match ((String.length(left), String.length(right))) {
     (left, right) when left > right => 1,
     (left, right) when left == right => 0,
@@ -258,5 +251,5 @@ let comp = (left, right) => {
   }
 }
 let list = ["a", "abcde", "abc", "ab", "abcd", "a"]
-assert sort(comp, list) == ["a", "a", "ab", "abc", "abcd", "abcde"]
-assert sort(comp, ["a", "a", "a", "a"]) == ["a", "a", "a", "a"]
+assert sort(compareLengths, list) == ["a", "a", "ab", "abc", "abcd", "abcde"]
+assert sort(compareLengths, ["a", "a", "a", "a"]) == ["a", "a", "a", "a"]

--- a/compiler/test/stdlib/pervasives.test.gr
+++ b/compiler/test/stdlib/pervasives.test.gr
@@ -1,0 +1,63 @@
+// compare
+
+// Number comparisons are tested thoroughly by other tests
+assert compare(0, 1) < 0
+assert compare(0, 0) == 0
+assert compare(1, 0) > 0
+// Specific NaN and Infinity tests
+assert compare(1 / 0.0, 987654321) > 0
+assert compare(1 / 0.0, 987654321.) > 0
+assert compare(0.0 / 0.0, -1 / 0.0) < 0
+assert compare(0.0 / 0.0, 987654321.) < 0
+assert compare(0.0 / 0.0, 987654321) < 0
+assert compare(0.0 / 0.0, 0) < 0
+// Booleans
+assert compare(false, true) < 0
+assert compare(true, false) > 0
+assert compare(true, true) == 0
+// Void
+assert compare(void, void) == 0
+// Chars
+assert compare('a', 'c') < 0
+assert compare('d', 'c') > 0
+assert compare('d', 'd') == 0
+assert compare('🌾', '🙂') < 0
+assert compare('💯', '🌾') > 0
+// Strings
+assert compare("", "") == 0
+assert compare("", "abc") < 0
+assert compare("abc", "def") < 0
+assert compare("abc", "d") < 0
+assert compare("ab", "abc") < 0
+assert compare("abc", "abc") == 0
+assert compare("abc", "ab") > 0
+// Tuples
+assert compare((1, 2), (3, 4)) < 0
+assert compare((1, 2), (1, 4)) < 0
+assert compare((1, 2), (1, 2)) == 0
+assert compare(('d', 2), ('c', 2)) > 0
+// Arrays
+assert compare([>], [>]) == 0
+assert compare([>], [> 1]) < 0
+assert compare([> 1, 2], [> 3, 4]) < 0
+assert compare([> 1, 2], [> 1, 4]) < 0
+assert compare([> 1, 2], [> 1, 2]) == 0
+// Enums
+enum Comparable {
+  A,
+  B(Bool),
+  C,
+}
+assert compare(A, A) == 0
+assert compare(B(true), B(true)) == 0
+assert compare(A, B(true)) < 0
+assert compare(C, B(true)) > 0
+assert compare(B(false), B(true)) < 0
+// Records
+record Comparable2 {
+  a: Number,
+  b: Bool,
+  c: Void,
+}
+assert compare({ a: 1, b: true, c: void }, { a: 1, b: true, c: void }) == 0
+assert compare({ a: 1, b: true, c: void }, { a: 1, b: false, c: void }) > 0

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -76,6 +76,12 @@ describe("numbers", ({test, testSkip}) => {
   assertRun("nan_equality3", {|print(0.0 / 0.0 == 0.0 / 0.0)|}, "false\n");
   assertRun("number_equality", {|print(5.0 == 5)|}, "true\n");
   assertRun("number_equality2", {|print(5 == 5.0)|}, "true\n");
+  // comparison checks
+  assertRun(
+    "number_compare1",
+    {|print(9007199254740992 < 9007199254740993)|},
+    "true\n",
+  );
   // syntax errors
   assertCompileError(
     "number_syntax_err2",

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -102,6 +102,7 @@ describe("stdlib", ({test, testSkip}) => {
   assertStdlib("map.test");
   assertStdlib("number.test");
   assertStdlib("option.test");
+  assertStdlib("pervasives.test");
   assertStdlib("queue.test");
   assertStdlib("range.test");
   assertStdlib("result.test");

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -11,6 +11,7 @@ import Memory from "runtime/unsafe/memory"
 import WasmI32 from "runtime/unsafe/wasmi32"
 
 import { equal as (==) } from "runtime/equal"
+import { compare } from "runtime/compare"
 
 import {
   incr,
@@ -217,6 +218,19 @@ export (<=)
  * @since v0.1.0
  */
 export (>=)
+
+/**
+ * Compares the first argument to the second argument and produces an integer result.
+ * Provides a consistent ordering over all types and is suitable for sorting and other kinds of ordering.
+ * `compare` treats `NaN` differently than the other comparison operators in that it considers `NaN` equal to itself and smaller than any other number.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise
+ *
+ * @since v0.5.3
+ */
+export compare
 
 /**
  * @section Math operations: Infix functions for working with Number values.

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -369,6 +369,34 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first operand is greater than or equal to the second operand or `false` otherwise|
 
+### Pervasives.**compare**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+compare : (a, a) -> Number
+```
+
+Compares the first argument to the second argument and produces an integer result.
+Provides a consistent ordering over all types and is suitable for sorting and other kinds of ordering.
+`compare` treats `NaN` differently than the other comparison operators in that it considers `NaN` equal to itself and smaller than any other number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`a`|The first operand|
+|`num2`|`a`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise|
+
 ## Math operations
 
 Infix functions for working with Number values.

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -19,12 +19,11 @@ import WasmI64 from "runtime/unsafe/wasmi64"
 import Memory from "runtime/unsafe/memory"
 import Tags from "runtime/unsafe/tags"
 import { tagSimpleNumber } from "runtime/dataStructures"
+import { isNumber, cmp as numberCompare } from "runtime/numbers"
 
 primitive (!): Bool -> Bool = "@not"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
-
-import { isNumber, cmp as numberCompare } from "runtime/numbers"
 
 @unsafe
 let zero = WasmI32.fromGrain(0)

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -1,0 +1,179 @@
+/* grainc-flags --no-pervasives */
+
+import WasmI32, {
+  eq as (==),
+  ne as (!=),
+  and as (&),
+  xor as (^),
+  or as (|),
+  add as (+),
+  sub as (-),
+  mul as (*),
+  ltS as (<),
+  gtS as (>),
+  remS as (%),
+  shl as (<<),
+  shrU as (>>>),
+} from "runtime/unsafe/wasmi32"
+import WasmI64 from "runtime/unsafe/wasmi64"
+import Memory from "runtime/unsafe/memory"
+import Tags from "runtime/unsafe/tags"
+import { tagSimpleNumber } from "runtime/dataStructures"
+
+primitive (!): Bool -> Bool = "@not"
+primitive (||): (Bool, Bool) -> Bool = "@or"
+primitive (&&): (Bool, Bool) -> Bool = "@and"
+
+import { isNumber, cmp as numberCompare } from "runtime/numbers"
+
+@unsafe
+let zero = WasmI32.fromGrain(0)
+
+@unsafe
+let rec heapCompareHelp = (heapTag, xptr, yptr) => {
+  match (heapTag) {
+    t when t == Tags._GRAIN_ADT_HEAP_TAG => {
+      // Check if the same constructor variant
+      let xvariant = WasmI32.load(xptr, 12n)
+      let yvariant = WasmI32.load(yptr, 12n)
+      if (xvariant != yvariant) {
+        tagSimpleNumber(xvariant - yvariant)
+      } else {
+        let xarity = WasmI32.load(xptr, 16n)
+        let yarity = WasmI32.load(yptr, 16n)
+
+        let mut result = 0
+
+        let bytes = xarity * 4n
+        for (let mut i = 0n; i < bytes; i += 4n) {
+          let sub = compareHelp(
+            WasmI32.load(xptr + i, 20n),
+            WasmI32.load(yptr + i, 20n)
+          )
+          if (WasmI32.fromGrain(sub) != zero) {
+            result = sub
+            break
+          }
+        }
+
+        result
+      }
+    },
+    t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
+      let xlength = WasmI32.load(xptr, 12n)
+      let ylength = WasmI32.load(yptr, 12n)
+
+      let mut result = 0
+
+      let bytes = xlength * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        let sub = compareHelp(
+          WasmI32.load(xptr + i, 16n),
+          WasmI32.load(yptr + i, 16n)
+        )
+        if (WasmI32.fromGrain(sub) != zero) {
+          result = sub
+          break
+        }
+      }
+
+      result
+    },
+    t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
+      let xlength = WasmI32.load(xptr, 4n)
+      let ylength = WasmI32.load(yptr, 4n)
+
+      // Check if the same length
+      if (xlength != ylength) {
+        tagSimpleNumber(xlength - ylength)
+      } else {
+        let mut result = 0
+        let bytes = xlength * 4n
+        for (let mut i = 0n; i < bytes; i += 4n) {
+          let sub = compareHelp(
+            WasmI32.load(xptr + i, 8n),
+            WasmI32.load(yptr + i, 8n)
+          )
+          if (WasmI32.fromGrain(sub) != zero) {
+            result = sub
+            break
+          }
+        }
+
+        result
+      }
+    },
+    t when (
+      t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG
+    ) => {
+      let xlength = WasmI32.load(xptr, 4n)
+      let ylength = WasmI32.load(yptr, 4n)
+
+      if (xlength == ylength) {
+        tagSimpleNumber(Memory.compare(xptr + 8n, yptr + 8n, xlength))
+      } else {
+        if (xlength < ylength) {
+          let sub = Memory.compare(xptr + 8n, yptr + 8n, xlength)
+          // The shorter one comes first
+          if (sub == 0n) -1 else tagSimpleNumber(sub)
+        } else {
+          let sub = Memory.compare(xptr + 8n, yptr + 8n, ylength)
+          // The shorter one comes first
+          if (sub == 0n) 1 else tagSimpleNumber(sub)
+        }
+      }
+    },
+    t when t == Tags._GRAIN_TUPLE_HEAP_TAG => {
+      let xsize = WasmI32.load(xptr, 4n)
+      let ysize = WasmI32.load(yptr, 4n)
+
+      let mut result = 0
+      let bytes = xsize * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        let sub = compareHelp(
+          WasmI32.load(xptr + i, 8n),
+          WasmI32.load(yptr + i, 8n)
+        )
+        if (WasmI32.fromGrain(sub) != zero) {
+          result = sub
+          break
+        }
+      }
+
+      result
+    },
+    _ => {
+      // No other implementation
+      tagSimpleNumber(xptr - yptr)
+    },
+  }
+}, compareHelp = (x, y) => {
+  let xtag = x & Tags._GRAIN_GENERIC_TAG_MASK
+  let ytag = y & Tags._GRAIN_GENERIC_TAG_MASK
+  if ((xtag & ytag) != Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
+    // Short circuit for non-pointer values
+    if ((xtag & Tags._GRAIN_NUMBER_TAG_MASK) == Tags._GRAIN_NUMBER_TAG_TYPE) {
+      // Signed comparisons are necessary for numbers
+      if (x < y) -1 else if (x > y) 1 else 0
+    } else {
+      // Unsigned comparisons are necessary for other stack-allocated values
+      if (WasmI32.ltU(x, y)) -1 else if (WasmI32.gtU(x, y)) 1 else 0
+    }
+  } else if (isNumber(x)) {
+    // Numbers have special comparison rules, e.g. NaN == NaN
+    tagSimpleNumber(numberCompare(x, y, true))
+  } else {
+    // Handle all other heap allocated things
+    // Can short circuit if pointers are the same
+    if (x == y) {
+      0
+    } else {
+      heapCompareHelp(WasmI32.load(x, 0n), x, y)
+    }
+  }
+}
+
+@unsafe
+export let compare = (x: a, y: a) => {
+  compareHelp(WasmI32.fromGrain(x), WasmI32.fromGrain(y))
+}

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -1,0 +1,6 @@
+### Compare.**compare**
+
+```grain
+compare : (a, a) -> Number
+```
+

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -14,12 +14,11 @@ import WasmI32, {
 } from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import Tags from "runtime/unsafe/tags"
+import { isNumber, numberEqual } from "runtime/numbers"
 
 primitive (!): Bool -> Bool = "@not"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
-
-import { isNumber, numberEqual } from "runtime/numbers"
 
 @unsafe
 let cycleMarker = 0x80000000n

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -14,11 +14,12 @@ import WasmI32, {
 } from "runtime/unsafe/wasmi32"
 import WasmI64 from "runtime/unsafe/wasmi64"
 import Tags from "runtime/unsafe/tags"
-import { isNumber, numberEqual } from "runtime/numbers"
 
 primitive (!): Bool -> Bool = "@not"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
+
+import { isNumber, numberEqual } from "runtime/numbers"
 
 @unsafe
 let cycleMarker = 0x80000000n

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -20,6 +20,7 @@ primitive (||): (Bool, Bool) -> Bool = "@or"
 primitive throw: Exception -> a = "@throw"
 
 exception UnknownNumberTag
+exception InvariantViolation
 
 import {
   newRational,
@@ -1703,10 +1704,19 @@ let numberMod = (x, y) => {
 }
 
 /*
- * ===== LESS THAN / GREATER THAN / LESS EQUAL / GREATER EQUAL =====
- * Coerce to float64 and then do comparisons
+ * ===== COMPARISONS =====
+ * Int/int and float/float comparisons are always accurate.
+ * Rational/rational comparisons are approximations with the exception of
+ * equality, which is always accurate.
+ * 
+ * Values compared to floats or rationals are first converted to floats.
+ * 
+ * All comparison operators consider NaN not equal to, less than, or greater
+ * than NaN, with the exception of `compare`, which considers NaN equal to
+ * itself and otherwise smaller than any other float value. This provides a
+ * total order (https://en.wikipedia.org/wiki/Total_order) over all numerical
+ * values, making `compare` suitable for sorting or ordering.
  */
-// TODO(#305): Could probably be made more efficient
 
 @unsafe
 let cmpBigInt = (x: WasmI32, y: WasmI32) => {
@@ -1743,79 +1753,284 @@ let cmpBigInt = (x: WasmI32, y: WasmI32) => {
   }
 }
 
-// TODO(#305): is this safe? I think it's safe?
+@unsafe
+let cmpFloat = (x: WasmI32, y: WasmI32, is64: Bool, totalOrdering: Bool) => {
+  let xf = if (is64) {
+    boxedFloat64Number(x)
+  } else {
+    WasmF64.promoteF32(boxedFloat32Number(x))
+  }
+  if (isSimpleNumber(y)) {
+    let yf = WasmF64.convertI32S(untagSimple(y))
+    // special NaN cases
+    if (totalOrdering && WasmF64.ne(xf, xf)) {
+      if (WasmF64.ne(yf, yf)) {
+        0n
+      } else {
+        -1n
+      }
+    } else if (totalOrdering && WasmF64.ne(yf, yf)) {
+      if (WasmF64.ne(xf, xf)) {
+        0n
+      } else {
+        1n
+      }
+    } else {
+      if (WasmF64.lt(xf, yf)) -1n else if (WasmF64.gt(xf, yf)) 1n else 0n
+    }
+  } else {
+    let yBoxedNumberTag = boxedNumberTag(y)
+    if (yBoxedNumberTag == Tags._GRAIN_BIGINT_BOXED_NUM_TAG) {
+      WasmI32.sub(0n, cmpBigInt(y, x))
+    } else {
+      let yf = match (yBoxedNumberTag) {
+        t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
+          WasmF64.convertI32S(boxedInt32Number(y))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
+          WasmF64.convertI64S(boxedInt64Number(y))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
+          throw InvariantViolation
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
+          WasmF64.div(
+            BI.toFloat64(boxedRationalNumerator(y)),
+            BI.toFloat64(boxedRationalDenominator(y))
+          )
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+          WasmF64.promoteF32(boxedFloat32Number(y))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
+          boxedFloat64Number(y)
+        },
+        _ => {
+          throw UnknownNumberTag
+        },
+      }
+      // special NaN cases
+      if (totalOrdering && WasmF64.ne(xf, xf)) {
+        if (WasmF64.ne(yf, yf)) {
+          0n
+        } else {
+          -1n
+        }
+      } else if (totalOrdering && WasmF64.ne(yf, yf)) {
+        if (WasmF64.ne(xf, xf)) {
+          0n
+        } else {
+          1n
+        }
+      } else {
+        if (WasmF64.lt(xf, yf)) -1n else if (WasmF64.gt(xf, yf)) 1n else 0n
+      }
+    }
+  }
+}
+
+@unsafe
+let cmpSmallInt = (x: WasmI32, y: WasmI32, is64: Bool, totalOrdering: Bool) => {
+  let xi = if (is64) {
+    boxedInt64Number(x)
+  } else {
+    WasmI64.extendI32S(boxedInt32Number(x))
+  }
+  if (isSimpleNumber(y)) {
+    let yi = WasmI64.extendI32S(untagSimple(y))
+    if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
+  } else {
+    let yBoxedNumberTag = boxedNumberTag(y)
+    match (yBoxedNumberTag) {
+      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
+        let yi = WasmI64.extendI32S(boxedInt32Number(y))
+        if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
+        let yi = boxedInt64Number(y)
+        if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpBigInt(y, x))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
+        // Rationals and ints are never considered equal
+        if (
+          WasmF64.lt(
+            WasmF64.convertI64S(xi),
+            WasmF64.div(
+              BI.toFloat64(boxedRationalNumerator(y)),
+              BI.toFloat64(boxedRationalDenominator(y))
+            )
+          )
+        ) -1n else 1n
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpFloat(y, x, false, totalOrdering))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpFloat(y, x, true, totalOrdering))
+      },
+      _ => {
+        throw UnknownNumberTag
+      },
+    }
+  }
+}
+
+@unsafe
+let cmpRational = (x: WasmI32, y: WasmI32, totalOrdering: Bool) => {
+  if (isSimpleNumber(y)) {
+    let xf = WasmF64.div(
+      BI.toFloat64(boxedRationalNumerator(x)),
+      BI.toFloat64(boxedRationalDenominator(x))
+    )
+    // Rationals and ints are never considered equal
+    if (WasmF64.lt(xf, WasmF64.convertI32S(untagSimple(y)))) -1n else 1n
+  } else {
+    let yBoxedNumberTag = boxedNumberTag(y)
+    match (yBoxedNumberTag) {
+      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpSmallInt(y, x, false, totalOrdering))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpSmallInt(y, x, true, totalOrdering))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpBigInt(y, x))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
+        // Comparing rationals efficiently is an open problem
+        // Producing a definitive answer is quite expensive, so if the two
+        // values are not strictly equal we approximate an answer
+
+        let xNumerator = boxedRationalNumerator(x)
+        let xDenominator = boxedRationalDenominator(x)
+        let yNumerator = boxedRationalNumerator(y)
+        let yDenominator = boxedRationalDenominator(y)
+
+        if (
+          BI.cmp(xNumerator, yNumerator) == 0n &&
+          BI.cmp(xDenominator, yDenominator) == 0n
+        ) {
+          0n
+        } else {
+          let xf = WasmF64.div(
+            BI.toFloat64(xNumerator),
+            BI.toFloat64(xDenominator)
+          )
+          let yf = WasmF64.div(
+            BI.toFloat64(yNumerator),
+            BI.toFloat64(yDenominator)
+          )
+          if (WasmF64.lt(xf, yf)) -1n else 1n
+        }
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpFloat(y, x, false, totalOrdering))
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
+        WasmI32.sub(0n, cmpFloat(y, x, true, totalOrdering))
+      },
+      _ => {
+        throw UnknownNumberTag
+      },
+    }
+  }
+}
+
+@unsafe
+export let cmp = (x: WasmI32, y: WasmI32, totalOrdering: Bool) => {
+  if (isSimpleNumber(x)) {
+    if (isSimpleNumber(y)) {
+      if (WasmI32.ltS(x, y)) -1n else if (WasmI32.gtS(x, y)) 1n else 0n
+    } else {
+      let yBoxedNumberTag = boxedNumberTag(y)
+      match (yBoxedNumberTag) {
+        t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpSmallInt(y, x, false, totalOrdering))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpSmallInt(y, x, true, totalOrdering))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpBigInt(y, x))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpRational(y, x, totalOrdering))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpFloat(y, x, false, totalOrdering))
+        },
+        t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
+          WasmI32.sub(0n, cmpFloat(y, x, true, totalOrdering))
+        },
+        _ => {
+          throw UnknownNumberTag
+        },
+      }
+    }
+  } else {
+    let xBoxedNumberTag = boxedNumberTag(x)
+    match (xBoxedNumberTag) {
+      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
+        cmpSmallInt(x, y, false, totalOrdering)
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
+        cmpSmallInt(x, y, true, totalOrdering)
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
+        cmpBigInt(x, y)
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
+        cmpRational(x, y, totalOrdering)
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
+        cmpFloat(x, y, false, totalOrdering)
+      },
+      t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
+        cmpFloat(x, y, true, totalOrdering)
+      },
+      _ => {
+        throw UnknownNumberTag
+      },
+    }
+  }
+}
+
 @unsafe
 export let (<) = (x: Number, y: Number) => {
-  let xw32 = WasmI32.fromGrain(x)
-  let yw32 = WasmI32.fromGrain(y)
-  if (isBigInt(xw32)) {
-    WasmI32.ltS(cmpBigInt(xw32, yw32), 0n)
-  } else if (isBigInt(yw32)) {
-    WasmI32.geS(cmpBigInt(yw32, xw32), 0n)
-  } else {
-    let xval = coerceNumberToWasmF64(x)
-    let yval = coerceNumberToWasmF64(y)
-    WasmF64.lt(xval, yval)
-  }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  WasmI32.ltS(cmp(x, y, false), 0n)
 }
 
 @unsafe
 export let (>) = (x: Number, y: Number) => {
-  let xw32 = WasmI32.fromGrain(x)
-  let yw32 = WasmI32.fromGrain(y)
-  if (isBigInt(xw32)) {
-    WasmI32.gtS(cmpBigInt(xw32, yw32), 0n)
-  } else if (isBigInt(yw32)) {
-    WasmI32.leS(cmpBigInt(yw32, xw32), 0n)
-  } else {
-    let xval = coerceNumberToWasmF64(x)
-    let yval = coerceNumberToWasmF64(y)
-    WasmF64.gt(xval, yval)
-  }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  WasmI32.gtS(cmp(x, y, false), 0n)
 }
 
 @unsafe
 export let (<=) = (x: Number, y: Number) => {
-  let xw32 = WasmI32.fromGrain(x)
-  let yw32 = WasmI32.fromGrain(y)
-  if (isBigInt(xw32)) {
-    WasmI32.leS(cmpBigInt(xw32, yw32), 0n)
-  } else if (isBigInt(yw32)) {
-    WasmI32.geS(cmpBigInt(yw32, xw32), 0n)
-  } else {
-    // Equality is finicky, so delegate
-    let xval = coerceNumberToWasmF64(x)
-    let yval = coerceNumberToWasmF64(y)
-    if (WasmF64.lt(xval, yval)) {
-      true
-    } else {
-      let x = WasmI32.fromGrain(x)
-      let y = WasmI32.fromGrain(y)
-      numberEqual(x, y)
-    }
-  }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  WasmI32.leS(cmp(x, y, false), 0n)
 }
 
 @unsafe
 export let (>=) = (x: Number, y: Number) => {
-  let xw32 = WasmI32.fromGrain(x)
-  let yw32 = WasmI32.fromGrain(y)
-  if (isBigInt(xw32)) {
-    WasmI32.leS(cmpBigInt(xw32, yw32), 0n)
-  } else if (isBigInt(yw32)) {
-    WasmI32.geS(cmpBigInt(yw32, xw32), 0n)
-  } else {
-    // Equality is finicky, so delegate
-    let xval = coerceNumberToWasmF64(x)
-    let yval = coerceNumberToWasmF64(y)
-    if (WasmF64.gt(xval, yval)) {
-      true
-    } else {
-      let x = WasmI32.fromGrain(x)
-      let y = WasmI32.fromGrain(y)
-      numberEqual(x, y)
-    }
-  }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  WasmI32.geS(cmp(x, y, false), 0n)
+}
+
+@unsafe
+export let compare = (x: Number, y: Number) => {
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  WasmI32.toGrain(tagSimple(cmp(x, y, true))): Number
 }
 
 /*

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -106,6 +106,12 @@ coerceNumberToWasmI32 : Number -> WasmI32
 numberEqual : (WasmI32, WasmI32) -> Bool
 ```
 
+### Numbers.**cmp**
+
+```grain
+cmp : (WasmI32, WasmI32, Bool) -> WasmI32
+```
+
 ### Numbers.**(<)**
 
 ```grain
@@ -128,6 +134,12 @@ numberEqual : (WasmI32, WasmI32) -> Bool
 
 ```grain
 (>=) : (Number, Number) -> Bool
+```
+
+### Numbers.**compare**
+
+```grain
+compare : (Number, Number) -> Number
 ```
 
 ### Numbers.**numberEq**


### PR DESCRIPTION
`compare` can be used for sorting or other kinds of ordering operations. Works on all types. This also improves the accuracy of all of our comparison operators.

Closes #305