### PR TITLE
fix(grainfmt): Indent exception primitives if wrapped

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -2062,7 +2062,7 @@ and print_other_application =
     Doc.concat([
       print_expression(~original_source, ~comments, func),
       Doc.space,
-      print_expression(~original_source, ~comments, first_expr),
+      Doc.indent(print_expression(~original_source, ~comments, first_expr)),
     ])
   | [first_expr, ..._] =>
     // standard function application

--- a/compiler/test/formatter_inputs/assert.gr
+++ b/compiler/test/formatter_inputs/assert.gr
@@ -1,0 +1,3 @@
+assert Option.mapWithDefaultFn(x => String.concat("hello ", x), () => fail "Shouldn't be called",Some("🌾")) =="hello 🌾"
+
+assert 1 == 2

--- a/compiler/test/formatter_outputs/assert.gr
+++ b/compiler/test/formatter_outputs/assert.gr
@@ -1,0 +1,7 @@
+assert Option.mapWithDefaultFn(x => String.concat("hello ", x),
+  () => fail "Shouldn't be called",
+  Some("🌾")
+  ) ==
+  "hello 🌾"
+
+assert 1 == 2

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -46,4 +46,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("windows", "windows");
   assertFormatOutput("patterns", "patterns");
   assertFormatOutput("constraints", "constraints");
+  assertFormatOutput("assert", "assert");
 });

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -167,8 +167,8 @@ export let slice = (start: Number, length: Number, bytes: Bytes) => {
   let length = coerceNumberToWasmI32(length)
   if (start + length > size) {
     throw Exception.InvalidArgument(
-      "The given index and length do not specify a valid range of bytes"
-    )
+        "The given index and length do not specify a valid range of bytes"
+      )
   }
   let dst = allocateBytes(length)
   let offset = start

--- a/stdlib/runtime/bigint.gr
+++ b/stdlib/runtime/bigint.gr
@@ -126,8 +126,8 @@ let init = (limbs: WasmI32) => {
     // in our multiplication/division algorithms. This means that BigInts
     // are limited to 16+17179869176 bytes, or just over 16GiB.
     throw Exception.InvalidArgument(
-      "Cannot allocate BigInt with >= 2147483648 limbs"
-    )
+        "Cannot allocate BigInt with >= 2147483648 limbs"
+      )
   }
 
   let numtagLen = 4n

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -950,8 +950,8 @@ let utoa64_any_core = (buffer, num, offset, radix) => {
 export let utoa32Buffered = (buf, value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
-      "toString() radix argument must be between 2 and 36"
-    )
+        "toString() radix argument must be between 2 and 36"
+      )
   }
   if (WasmI32.eqz(value)) {
     WasmI32.store8(buf, _CHAR_CODE_0, 0n)
@@ -972,8 +972,8 @@ export let utoa32Buffered = (buf, value, radix) => {
 export let utoa32 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
-      "toString() radix argument must be between 2 and 36"
-    )
+        "toString() radix argument must be between 2 and 36"
+      )
   }
   if (WasmI32.eqz(value)) {
     "0"
@@ -1000,8 +1000,8 @@ export let itoa32 = (value, radix) => {
   let mut value = value
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
-      "toString() radix argument must be between 2 and 36"
-    )
+        "toString() radix argument must be between 2 and 36"
+      )
   }
   let sign = WasmI32.shrU(value, 31n)
 
@@ -1035,8 +1035,8 @@ export let itoa32 = (value, radix) => {
 export let utoa64 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
-      "toString() radix argument must be between 2 and 36"
-    )
+        "toString() radix argument must be between 2 and 36"
+      )
   }
   if (WasmI64.eqz(value)) {
     "0"
@@ -1071,8 +1071,8 @@ export let utoa64 = (value, radix) => {
 export let itoa64 = (value, radix) => {
   if (WasmI32.ltS(radix, 2n) || WasmI32.gtS(radix, 36n)) {
     throw Exception.InvalidArgument(
-      "toString() radix argument must be between 2 and 36"
-    )
+        "toString() radix argument must be between 2 and 36"
+      )
   }
 
   let mut value = value


### PR DESCRIPTION
Tiny fix that indents exception primitives if wrapped, should help with the stdlib tests reformat in #1389 