### PR TITLE
fix(grainfmt): Handle source files with no code, only comments

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4199,18 +4199,24 @@ let format_ast =
     print_attributes(attributes);
   };
 
-  let top_level_stmts =
-    block_item_iterator(
-      ~previous=TopOfFile,
-      ~get_loc,
-      ~print_item,
-      ~comments=cleaned_comments,
-      ~print_attribute=get_attributes,
-      ~original_source,
-      parsed_program.statements,
-    );
+  // special case where we have no code, we still format the comments
 
-  let final_doc = Doc.concat([top_level_stmts, Doc.hardLine]);
+  let final_doc =
+    switch (parsed_program.statements) {
+    | [] => Comment_utils.new_comments_to_docs(cleaned_comments)
+    | _ =>
+      let top_level_stmts =
+        block_item_iterator(
+          ~previous=TopOfFile,
+          ~get_loc,
+          ~print_item,
+          ~comments=cleaned_comments,
+          ~print_attribute=get_attributes,
+          ~original_source,
+          parsed_program.statements,
+        );
+      Doc.concat([top_level_stmts, Doc.hardLine]);
+    };
 
   Doc.toString(~width=80, ~eol, final_doc);
 };

--- a/compiler/test/formatter_inputs/only_comments.gr
+++ b/compiler/test/formatter_inputs/only_comments.gr
@@ -1,0 +1,10 @@
+     
+     
+     
+     
+     /* this is just a comment */
+
+
+
+
+        // and this too

--- a/compiler/test/formatter_outputs/only_comments.gr
+++ b/compiler/test/formatter_outputs/only_comments.gr
@@ -1,0 +1,3 @@
+/* this is just a comment */
+
+// and this too

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -47,4 +47,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("patterns", "patterns");
   assertFormatOutput("rationals", "rationals");
   assertFormatOutput("constraints", "constraints");
+  assertFormatOutput("only_comments", "only_comments");
 });


### PR DESCRIPTION
Still format the comments correctly.