### PR TITLE
chore(compiler): Upgrade to Binaryen 108

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -31,7 +31,7 @@
     "check-format": "dune build @fmt"
   },
   "dependencies": {
-    "@grain/binaryen.ml": ">= 0.17.0 < 0.18.0",
+    "@grain/binaryen.ml": ">= 0.18.0 < 0.19.0",
     "@opam/cmdliner": ">= 1.0.2",
     "@opam/dune": ">= 2.0.0 < 3.0.0",
     "@opam/dune-build-info": ">= 2.0.0 < 3.0.0",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "511f9f60006b8d57d1174cd5c18dc409",
+  "checksum": "dc7d09ea4d700cb31329628ff5bba1bd",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -51,7 +51,7 @@
         "@reason-native/cli@github:reasonml/reason-native:cli.json#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
         "@opam/reason@opam:3.8.1@189445c6", "@opam/re@opam:1.10.4@c4910ba6",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ],
       "devDependencies": []
     },
@@ -68,7 +68,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/re@opam:1.10.4@c4910ba6",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/reason@3.7.0@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -85,7 +85,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
-        "@opam/re@opam:1.10.4@c4910ba6", "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/re@opam:1.10.4@c4910ba6", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -106,7 +106,7 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
         "@opam/reason@opam:3.8.1@189445c6", "@opam/re@opam:1.10.4@c4910ba6",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ],
       "devDependencies": []
     },
@@ -129,13 +129,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/easy-format@opam:1.3.3@5d74d95b",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/cppo@opam:1.6.9@db929a12",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/cppo@opam:1.6.9@db929a12",
         "@opam/biniou@opam:1.2.2@c7862a8d",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/easy-format@opam:1.3.3@5d74d95b",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/biniou@opam:1.2.2@c7862a8d"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/biniou@opam:1.2.2@c7862a8d"
       ]
     },
     "@opam/utf8@github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9": {
@@ -153,11 +153,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/uri@opam:4.2.0@9c45eeb8": {
@@ -179,13 +179,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/stringext@opam:1.6.0@ac4f328b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/angstrom@opam:0.15.0@105656d9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/stringext@opam:1.6.0@ac4f328b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/angstrom@opam:0.15.0@105656d9"
       ]
     },
@@ -235,11 +235,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/stdlib-shims@opam:0.3.0@72c7bc98": {
@@ -260,11 +260,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/sexplib0@opam:v0.15.1@51111c0c": {
@@ -285,39 +285,39 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
-    "@opam/sexplib@opam:v0.15.0@a3338ad9": {
-      "id": "@opam/sexplib@opam:v0.15.0@a3338ad9",
+    "@opam/sexplib@opam:v0.15.1@1824bfd6": {
+      "id": "@opam/sexplib@opam:v0.15.1@1824bfd6",
       "name": "@opam/sexplib",
-      "version": "opam:v0.15.0",
+      "version": "opam:v0.15.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/a5/a562348f2cc150224c31e424e0fb4cb11b5980ddc1effbb3b34c431f822b45f7#sha256:a562348f2cc150224c31e424e0fb4cb11b5980ddc1effbb3b34c431f822b45f7",
-          "archive:https://ocaml.janestreet.com/ocaml-core/v0.15/files/sexplib-v0.15.0.tar.gz#sha256:a562348f2cc150224c31e424e0fb4cb11b5980ddc1effbb3b34c431f822b45f7"
+          "archive:https://opam.ocaml.org/cache/sha256/75/75da7d290d92d758c01f441f9589ccce031e11301563efde1c19149d39edbcbc#sha256:75da7d290d92d758c01f441f9589ccce031e11301563efde1c19149d39edbcbc",
+          "archive:https://github.com/janestreet/sexplib/archive/refs/tags/v0.15.1.tar.gz#sha256:75da7d290d92d758c01f441f9589ccce031e11301563efde1c19149d39edbcbc"
         ],
         "opam": {
           "name": "sexplib",
-          "version": "v0.15.0",
-          "path": "esy.lock/opam/sexplib.v0.15.0"
+          "version": "v0.15.1",
+          "path": "esy.lock/opam/sexplib.v0.15.1"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/parsexp@opam:v0.15.0@742345c3", "@opam/num@opam:1.4@54b259a0",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/parsexp@opam:v0.15.0@742345c3", "@opam/num@opam:1.4@54b259a0",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -359,12 +359,12 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/uchar@opam:0.0.2@aedf91f9",
         "@opam/ppxlib@opam:0.26.0@cc81525b", "@opam/gen@opam:1.0@eb721ea1",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/uchar@opam:0.0.2@aedf91f9",
         "@opam/ppxlib@opam:0.26.0@cc81525b", "@opam/gen@opam:1.0@eb721ea1",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/result@opam:1.5@1c6a6533": {
@@ -385,11 +385,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/reason@opam:3.8.1@189445c6": {
@@ -415,7 +415,7 @@
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
         "@opam/merlin-extend@opam:0.6.1@7d979feb",
         "@opam/menhir@opam:20211125@5ae9a0c2",
-        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -423,7 +423,7 @@
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/merlin-extend@opam:0.6.1@7d979feb",
         "@opam/menhir@opam:20211125@5ae9a0c2",
-        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/re@opam:1.10.4@c4910ba6": {
@@ -445,11 +445,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ppxlib@opam:0.26.0@cc81525b": {
@@ -474,14 +474,14 @@
         "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocaml-compiler-libs@opam:v0.12.4@41979882",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
         "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocaml-compiler-libs@opam:v0.12.4@41979882",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7": {
@@ -503,11 +503,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ppx_sexp_conv@opam:v0.15.1@0f138aac": {
@@ -530,13 +530,13 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/base@opam:v0.15.0@85d52a98",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/base@opam:v0.15.0@85d52a98",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/base@opam:v0.15.0@85d52a98"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/base@opam:v0.15.0@85d52a98"
       ]
     },
     "@opam/ppx_deriving_yojson@github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#0809ea014a6cdd27d5863e05cf330ff74d0114ae@d41d8cd9": {
@@ -557,14 +557,14 @@
         "@opam/result@opam:1.5@1c6a6533",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
         "@opam/result@opam:1.5@1c6a6533",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ppx_deriving_cmdliner@github:hammerlab/ppx_deriving_cmdliner:ppx_deriving_cmdliner.opam#1f086651fe7f8dd98e371b09c6fcc4dbc6db1c7c@d41d8cd9": {
@@ -584,7 +584,7 @@
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -592,7 +592,7 @@
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cmdliner@opam:1.1.1@03763729"
       ]
     },
@@ -618,7 +618,7 @@
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/cppo@opam:1.6.9@db929a12",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/cppo@opam:1.6.9@db929a12",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -626,7 +626,7 @@
         "@opam/ppxlib@opam:0.26.0@cc81525b",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ppx_derivers@opam:1.2.1@e2cbad12": {
@@ -647,11 +647,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/pp@opam:1.1.2@89ad03b5": {
@@ -672,11 +672,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/parsexp@opam:v0.15.0@742345c3": {
@@ -698,12 +698,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/base@opam:v0.15.0@85d52a98",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/base@opam:v0.15.0@85d52a98",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/base@opam:v0.15.0@85d52a98"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/base@opam:v0.15.0@85d52a98"
       ]
     },
     "@opam/ocamlgraph@opam:2.0.0@929b9eba": {
@@ -725,11 +725,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ocamlformat-rpc-lib@opam:0.18.0@4bef249f": {
@@ -751,12 +751,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
     "@opam/ocamlfind@opam:1.9.3@6f4741ee": {
@@ -831,11 +831,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/ocaml-lsp-server@opam:1.8.3@b64dff17": {
@@ -862,7 +862,7 @@
         "@opam/pp@opam:1.1.2@89ad03b5",
         "@opam/ocamlformat-rpc-lib@opam:0.18.0@4bef249f",
         "@opam/dune-build-info@opam:2.9.3@ae518c8c",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/dot-merlin-reader@opam:4.5@2a523ca0",
         "@opam/csexp@opam:1.5.1@8a8fb3a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -873,7 +873,7 @@
         "@opam/pp@opam:1.1.2@89ad03b5",
         "@opam/ocamlformat-rpc-lib@opam:0.18.0@4bef249f",
         "@opam/dune-build-info@opam:2.9.3@ae518c8c",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/dot-merlin-reader@opam:4.5@2a523ca0",
         "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
@@ -896,11 +896,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/num@opam:1.4@54b259a0": {
@@ -949,11 +949,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cppo@opam:1.6.9@db929a12", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/menhirSdk@opam:20211125@ead404b0": {
@@ -974,11 +974,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/menhirLib@opam:20211125@0a5e6a40": {
@@ -999,11 +999,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/menhir@opam:20211125@5ae9a0c2": {
@@ -1026,12 +1026,12 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/menhirSdk@opam:20211125@ead404b0",
         "@opam/menhirLib@opam:20211125@0a5e6a40",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/menhirSdk@opam:20211125@ead404b0",
         "@opam/menhirLib@opam:20211125@0a5e6a40",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/js_of_ocaml-compiler@opam:3.11.0@6004d7b8": {
@@ -1058,7 +1058,7 @@
         "@opam/menhirSdk@opam:20211125@ead404b0",
         "@opam/menhirLib@opam:20211125@0a5e6a40",
         "@opam/menhir@opam:20211125@5ae9a0c2",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1068,7 +1068,7 @@
         "@opam/menhirSdk@opam:20211125@ead404b0",
         "@opam/menhirLib@opam:20211125@0a5e6a40",
         "@opam/menhir@opam:20211125@5ae9a0c2",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cmdliner@opam:1.1.1@03763729"
       ]
     },
@@ -1092,14 +1092,14 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
@@ -1119,12 +1119,12 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
         "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
         "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9": {
@@ -1142,11 +1142,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/reason@opam:3.8.1@189445c6",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/fix@opam:20220121@17b9a1a4": {
@@ -1167,11 +1167,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/easy-format@opam:1.3.3@5d74d95b": {
@@ -1197,11 +1197,11 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/dune-configurator@opam:2.9.3@174e411b": {
@@ -1223,12 +1223,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
     "@opam/dune-build-info@opam:2.9.3@ae518c8c": {
@@ -1249,12 +1249,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "@opam/dune@opam:2.9.3@421ab494" ]
+      "devDependencies": [ "@opam/dune@opam:2.9.3@4d52c673" ]
     },
-    "@opam/dune@opam:2.9.3@421ab494": {
-      "id": "@opam/dune@opam:2.9.3@421ab494",
+    "@opam/dune@opam:2.9.3@4d52c673": {
+      "id": "@opam/dune@opam:2.9.3@4d52c673",
       "name": "@opam/dune",
       "version": "opam:2.9.3",
       "source": {
@@ -1300,13 +1300,13 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
-        "@opam/dune@opam:2.9.3@421ab494", "@opam/csexp@opam:1.5.1@8a8fb3a7"
+        "@opam/dune@opam:2.9.3@4d52c673", "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
     "@opam/csexp@opam:1.5.1@8a8fb3a7": {
@@ -1327,11 +1327,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/cppo@opam:1.6.9@db929a12": {
@@ -1352,12 +1352,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -1442,11 +1442,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/biniou@opam:1.2.2@c7862a8d": {
@@ -1468,13 +1468,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/easy-format@opam:1.3.3@5d74d95b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/camlp-streams@opam:5.0.1@daaa0f94",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/easy-format@opam:1.3.3@5d74d95b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/camlp-streams@opam:5.0.1@daaa0f94"
       ]
     },
@@ -1496,12 +1496,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494",
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/conf-pkg-config@opam:2@85f8644d",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@421ab494"
+        "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -1580,12 +1580,12 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/dune@opam:2.9.3@4d52c673"
       ]
     },
     "@opam/angstrom@opam:0.15.0@105656d9": {
@@ -1608,31 +1608,31 @@
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
         "@opam/ocaml-syntax-shims@opam:1.0.0@9f361fbb",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/bigstringaf@opam:0.9.0@5762d1bc",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/bigstringaf@opam:0.9.0@5762d1bc"
       ]
     },
-    "@grain/libbinaryen@107.0.1@d41d8cd9": {
-      "id": "@grain/libbinaryen@107.0.1@d41d8cd9",
+    "@grain/libbinaryen@108.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@108.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "107.0.1",
+      "version": "108.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-107.0.1.tgz#sha1:d274f7ea8365952c31f625b4572221896b99e525"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-108.0.0.tgz#sha1:a1edd55b8179d4e4abfdc1c17d1ce90788ae1db8"
         ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/conf-cmake@github:grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869@d41d8cd9"
       ],
       "devDependencies": [],
@@ -1648,7 +1648,7 @@
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@69d87312",
         "@opam/utf8@github:reasonml/reason-native:utf8.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/uri@opam:4.2.0@9c45eeb8",
-        "@opam/sexplib@opam:v0.15.0@a3338ad9",
+        "@opam/sexplib@opam:v0.15.1@1824bfd6",
         "@opam/sedlex@opam:3.0@6e37d05e", "@opam/reason@opam:3.8.1@189445c6",
         "@opam/ppx_sexp_conv@opam:v0.15.1@0f138aac",
         "@opam/ppx_deriving_yojson@github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#0809ea014a6cdd27d5863e05cf330ff74d0114ae@d41d8cd9",
@@ -1660,9 +1660,9 @@
         "@opam/fp@github:reasonml/reason-native:fp.opam#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
         "@opam/dune-build-info@opam:2.9.3@ae518c8c",
-        "@opam/dune@opam:2.9.3@421ab494",
+        "@opam/dune@opam:2.9.3@4d52c673",
         "@opam/cmdliner@opam:1.1.1@03763729",
-        "@grain/binaryen.ml@0.17.1@d41d8cd9"
+        "@grain/binaryen.ml@0.18.0@d41d8cd9"
       ],
       "devDependencies": [
         "@reason-native/rely@github:reasonml/reason-native:rely.json#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
@@ -1671,22 +1671,22 @@
       ],
       "installConfig": { "pnp": false }
     },
-    "@grain/binaryen.ml@0.17.1@d41d8cd9": {
-      "id": "@grain/binaryen.ml@0.17.1@d41d8cd9",
+    "@grain/binaryen.ml@0.18.0@d41d8cd9": {
+      "id": "@grain/binaryen.ml@0.18.0@d41d8cd9",
       "name": "@grain/binaryen.ml",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.17.1.tgz#sha1:f82967a662e58ea91eae601c4354d8d5ae246e28"
+          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.18.0.tgz#sha1:151889274970096c1eb10d41fcb84388d18c4659"
         ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
-        "@opam/dune@opam:2.9.3@421ab494",
-        "@grain/libbinaryen@107.0.1@d41d8cd9"
+        "@opam/dune@opam:2.9.3@4d52c673",
+        "@grain/libbinaryen@108.0.0@d41d8cd9"
       ],
       "devDependencies": [],
       "installConfig": { "pnp": false }
@@ -1722,7 +1722,7 @@
         "@opam/ocamlfind@opam:1.9.3@6f4741ee",
         "@opam/merlin-extend@opam:0.6.1@7d979feb",
         "@opam/menhir@opam:20211125@5ae9a0c2",
-        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@421ab494"
+        "@opam/fix@opam:20220121@17b9a1a4", "@opam/dune@opam:2.9.3@4d52c673"
       ],
       "devDependencies": []
     }

--- a/compiler/esy.lock/opam/dune.2.9.3/opam
+++ b/compiler/esy.lock/opam/dune.2.9.3/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/compiler/esy.lock/opam/sexplib.v0.15.1/opam
+++ b/compiler/esy.lock/opam/sexplib.v0.15.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.08.0" & < "5.0"}
+  "ocaml"    {>= "4.08.0"}
   "parsexp"  {>= "v0.15" & < "v0.16"}
   "sexplib0" {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}
@@ -24,6 +24,6 @@ OCaml's standard library that was developed by Jane Street, the
 largest industrial user of OCaml.
 "
 url {
-src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/sexplib-v0.15.0.tar.gz"
-checksum: "sha256=a562348f2cc150224c31e424e0fb4cb11b5980ddc1effbb3b34c431f822b45f7"
+src: "https://github.com/janestreet/sexplib/archive/refs/tags/v0.15.1.tar.gz"
+checksum: "sha256=75da7d290d92d758c01f441f9589ccce031e11301563efde1c19149d39edbcbc"
 }


### PR DESCRIPTION
I was discussing with @ospencer about Binaryen versions and he reminded me that Binaryen 108 allowed us to disable the building of their "tools". This update should reduce build times a fair bit.