### PR TITLE
chore(stdlib): Add examples to the Array module

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -48,6 +48,7 @@ let initLength = length => {
  * @param array: The array to inspect
  * @returns The number of elements in the array
  *
+ * @example let array = [> 10, 20, 30, 40, 50]; print(Array.length(array)); // prints 5
  * @since v0.1.0
  */
 @disableGC
@@ -145,6 +146,7 @@ export let rec init /*: (Number, Number -> a) -> Array<a>*/ =
  * @param index: The index to access
  * @param array: The array to access
  * @returns The element from the array
+ * @example let array = [> 10, 20, 30, 40, 50]; print(Array.get(1,array)) // prints 20
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -162,6 +164,7 @@ export let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
+ * @example let array = [> 10, 20, 30, 40, 50]; Array.set(1,22,array); print(array) // prints [> 10, 22, 30, 40, 50]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -177,6 +180,8 @@ export let set = (index, value, array) => {
  * @param array1: The array containing elements to appear first
  * @param array2: The array containing elements to appear second
  * @returns The new array containing elements from `array1` followed by elements from `array2`
+ * @example let array1 = [> 10, 20]; let array2 =[>30, 40, 50]; let combined = Array.append(array1,array2); print(combined) // prints [> 10, 20, 30, 40, 50]
+ // prints [> 10, 22, 30, 40, 50]
  *
  * @since v0.1.0
  */
@@ -199,6 +204,7 @@ export let append = (array1, array2) => {
  *
  * @param arrays: A list containing all arrays to combine
  * @returns The new array
+ * @example let array1 = [>10, 20]; let array2 =[>30, 40, 50]; let combined = Array.concat([array1,array2]); print(combined) // prints [> 10, 20, 30, 40, 50]
  *
  * @since v0.1.0
  */

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -203,7 +203,7 @@ export let append = (array1, array2) => {
  *
  * @param arrays: A list containing all arrays to combine
  * @returns The new array
- * @example let array1 = [>10, 20]; let array2 =[>30, 40, 50]; let combined = Array.concat([array1,array2]); print(combined) // prints [> 10, 20, 30, 40, 50]
+ * @example Array.concat([[> 1, 2], [> 3, 4], [> 5, 6]]) == [> 1, 2, 3, 4, 5, 6]
  *
  * @since v0.1.0
  */

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -146,7 +146,7 @@ export let rec init /*: (Number, Number -> a) -> Array<a>*/ =
  * @param index: The index to access
  * @param array: The array to access
  * @returns The element from the array
- * @example let array = [> 10, 20, 30, 40, 50]; print(Array.get(1,array)) // prints 20
+ * @example Array.get([> 1, 2, 3, 4, 5]) == 2
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -48,7 +48,7 @@ let initLength = length => {
  * @param array: The array to inspect
  * @returns The number of elements in the array
  *
- * @example let array = [> 10, 20, 30, 40, 50]; print(Array.length(array)); // prints 5
+ * @example Array.length([> 1, 2, 3, 4, 5]) == 5
  * @since v0.1.0
  */
 @disableGC

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -164,7 +164,7 @@ export let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
- * @example let array = [> 10, 20, 30, 40, 50]; Array.set(1,22,array); print(array) // prints [> 10, 22, 30, 40, 50]
+ * @example Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -180,8 +180,7 @@ export let set = (index, value, array) => {
  * @param array1: The array containing elements to appear first
  * @param array2: The array containing elements to appear second
  * @returns The new array containing elements from `array1` followed by elements from `array2`
- * @example let array1 = [> 10, 20]; let array2 =[>30, 40, 50]; let combined = Array.append(array1,array2); print(combined) // prints [> 10, 20, 30, 40, 50]
- // prints [> 10, 22, 30, 40, 50]
+ * @example Array.append([> 1, 2], [> 3, 4, 5]) == [> 1, 2, 3, 4, 5]
  *
  * @since v0.1.0
  */

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -146,7 +146,7 @@ export let rec init /*: (Number, Number -> a) -> Array<a>*/ =
  * @param index: The index to access
  * @param array: The array to access
  * @returns The element from the array
- * @example Array.get([> 1, 2, 3, 4, 5]) == 2
+ * @example Array.get(1,[> 1, 2, 3, 4, 5]) == 2
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -50,6 +50,12 @@ Returns:
 |----|-----------|
 |`Number`|The number of elements in the array|
 
+Examples:
+
+```grain
+Array.length([> 1, 2, 3, 4, 5]) == 5
+```
+
 ### Array.**make**
 
 <details disabled>
@@ -153,6 +159,12 @@ Returns:
 |----|-----------|
 |`a`|The element from the array|
 
+Examples:
+
+```grain
+Array.get(1,[> 1, 2, 3, 4, 5]) == 2
+```
+
 ### Array.**set**
 
 <details>
@@ -184,6 +196,12 @@ Parameters:
 |`value`|`a`|The value to store|
 |`array`|`Array<a>`|The array to update|
 
+Examples:
+
+```grain
+Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
+```
+
 ### Array.**append**
 
 <details disabled>
@@ -211,6 +229,12 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array containing elements from `array1` followed by elements from `array2`|
 
+Examples:
+
+```grain
+Array.append([> 1, 2], [> 3, 4, 5]) == [> 1, 2, 3, 4, 5]
+```
+
 ### Array.**concat**
 
 <details disabled>
@@ -236,6 +260,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The new array|
+
+Examples:
+
+```grain
+Array.concat([[> 1, 2], [> 3, 4], [> 5, 6]]) == [> 1, 2, 3, 4, 5, 6]
+```
 
 ### Array.**copy**
 


### PR DESCRIPTION
Updated the grains docs for array.gr to add examples for length,get,set,append,concat methods for array