### PR TITLE
fix(grainfmt): Write comments found between top level data statements

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3729,11 +3729,26 @@ let data_print =
       ~comments: list(Parsetree.comment),
       datas: list((Parsetree.export_flag, Parsetree.data_declaration)),
     ) => {
+  let previous_data: ref(option(Parsetree.data_declaration)) = ref(None);
   Doc.join(
     ~sep=Doc.concat([Doc.comma, Doc.hardLine]),
     List.map(
       data => {
         let (expt, decl: Parsetree.data_declaration) = data;
+
+        let leading_comments =
+          switch (previous_data^) {
+          | None => []
+          | Some(prev) =>
+            Comment_utils.get_comments_between_locations(
+              ~loc1=prev.pdata_loc,
+              ~loc2=decl.pdata_loc,
+              comments,
+            )
+          };
+
+        let leading_comment_docs =
+          Comment_utils.new_comments_to_docs(leading_comments);
 
         let data_comments =
           Comment_utils.get_comments_inside_location(
@@ -3741,7 +3756,10 @@ let data_print =
             comments,
           );
 
+        previous_data := Some(decl);
+
         Doc.concat([
+          leading_comment_docs,
           switch ((expt: Asttypes.export_flag)) {
           | Nonexported => Doc.nil
           | Exported => Doc.text("export ")

--- a/compiler/test/formatter_inputs/data_docs.gr
+++ b/compiler/test/formatter_inputs/data_docs.gr
@@ -7,7 +7,12 @@ enum EventType {
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext)
+type Event = (EventType, Token, TokenizeContext),
+/**
+ *   Another event is the start or end of a token amongst other events.
+ *   Tokens can “contain” other tokens, even though they are stored in a flat
+ *   list, through `enter`ing before them, and `exit`ing after them.
+ */
 
 
 enum EventType2 {

--- a/compiler/test/formatter_inputs/data_docs.gr
+++ b/compiler/test/formatter_inputs/data_docs.gr
@@ -1,0 +1,18 @@
+enum EventType {
+  Enter,
+  Exit,
+},
+/**
+ *   An event is the start or end of a token amongst other events.
+ *   Tokens can “contain” other tokens, even though they are stored in a flat
+ *   list, through `enter`ing before them, and `exit`ing after them.
+ */
+type Event = (EventType, Token, TokenizeContext)
+
+
+enum EventType2 {
+  Enter2,
+  Exit2,
+},
+// line comment
+type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/formatter_outputs/data_docs.gr
+++ b/compiler/test/formatter_outputs/data_docs.gr
@@ -7,8 +7,12 @@ enum EventType {
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext)
-
+type Event = (EventType, Token, TokenizeContext),
+/**
+ *   Another event is the start or end of a token amongst other events.
+ *   Tokens can “contain” other tokens, even though they are stored in a flat
+ *   list, through `enter`ing before them, and `exit`ing after them.
+ */
 enum EventType2 {
   Enter2,
   Exit2,

--- a/compiler/test/formatter_outputs/data_docs.gr
+++ b/compiler/test/formatter_outputs/data_docs.gr
@@ -1,0 +1,17 @@
+enum EventType {
+  Enter,
+  Exit,
+},
+/**
+ *   An event is the start or end of a token amongst other events.
+ *   Tokens can “contain” other tokens, even though they are stored in a flat
+ *   list, through `enter`ing before them, and `exit`ing after them.
+ */
+type Event = (EventType, Token, TokenizeContext)
+
+enum EventType2 {
+  Enter2,
+  Exit2,
+},
+// line comment
+type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -48,4 +48,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("rationals", "rationals");
   assertFormatOutput("constraints", "constraints");
   assertFormatOutput("only_comments", "only_comments");
+  assertFormatOutput("data_docs", "data_docs");
 });


### PR DESCRIPTION
Fixes #1317 

Formatter was ignoring comments between top level data declarations

Fixed and tests added