### PR TITLE
fix(utils): Use option converter instead of Some

### DIFF
--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -391,7 +391,7 @@ let profile =
   opt(
     ~doc="Set a compilation profile.",
     ~names=["profile"],
-    ~conv=Cmdliner.Arg.enum([("release", Some(Release))]),
+    ~conv=option_conv(Cmdliner.Arg.enum([("release", Release)])),
     None,
   );
 


### PR DESCRIPTION
When trying to use --help for grainc, this makes the docs printer for enum look for a None value on the enum list, which yields an Invalid_argument exception, crashing the grainc executable.