### PR TITLE
fix(grainfmt): Stop adding an extra line after block comments

### DIFF
--- a/compiler/src/formatting/comment_utils.re
+++ b/compiler/src/formatting/comment_utils.re
@@ -521,7 +521,7 @@ let rec new_comments_inner =
 
       | 1 => [
           switch (prev_cmt) {
-          | Line(_) 
+          | Line(_)
           | Doc(_) => Doc.nil
           | _ => Doc.hardLine
           },

--- a/compiler/src/formatting/comment_utils.re
+++ b/compiler/src/formatting/comment_utils.re
@@ -521,7 +521,8 @@ let rec new_comments_inner =
 
       | 1 => [
           switch (prev_cmt) {
-          | Line(_) => Doc.nil
+          | Line(_) 
+          | Doc(_) => Doc.nil
           | _ => Doc.hardLine
           },
           comment_to_doc(cmt),

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4186,14 +4186,6 @@ let format_ast =
     toplevel_print(~original_source, ~comments, stmt);
   };
 
-  let leading_comments = [];
-
-  let cleaned_comments =
-    remove_used_comments(
-      ~remove_comments=leading_comments,
-      parsed_program.comments,
-    );
-
   let get_attributes = (stmt: Parsetree.toplevel_stmt) => {
     let attributes = stmt.ptop_attributes;
     print_attributes(attributes);
@@ -4203,14 +4195,14 @@ let format_ast =
 
   let final_doc =
     switch (parsed_program.statements) {
-    | [] => Comment_utils.new_comments_to_docs(cleaned_comments)
+    | [] => Comment_utils.new_comments_to_docs(parsed_program.comments)
     | _ =>
       let top_level_stmts =
         block_item_iterator(
           ~previous=TopOfFile,
           ~get_loc,
           ~print_item,
-          ~comments=cleaned_comments,
+          ~comments=parsed_program.comments,
           ~print_attribute=get_attributes,
           ~original_source,
           parsed_program.statements,

--- a/compiler/test/formatter_inputs/comments.gr
+++ b/compiler/test/formatter_inputs/comments.gr
@@ -5,6 +5,10 @@
 
 let myfun = (/* a */ x /*post*/, y) => 10
 
+/**
+ * Then a doc
+ */
+// Then a line
 let myfun1 = (/* a */ x , y) => 10
 
 let myfun2 = (x /*post*/, y) => 10

--- a/compiler/test/formatter_outputs/comments.gr
+++ b/compiler/test/formatter_outputs/comments.gr
@@ -5,6 +5,10 @@
 
 let myfun = (/* a */ x, /*post*/ y) => 10
 
+/**
+ * Then a doc
+ */
+// Then a line
 let myfun1 = (/* a */ x, y) => 10
 
 let myfun2 = (x, /*post*/ y) => 10


### PR DESCRIPTION
Fixes #1310 