### PR TITLE
fix(stdlib): Fix anchoring behavior in Regex.replaceAll

### DIFF
--- a/compiler/test/stdlib/regex.test.gr
+++ b/compiler/test/stdlib/regex.test.gr
@@ -763,3 +763,5 @@ assert replaceAll(unwrapResult(make("a(.)")), "xabcyawz", "&$1\\$&$99=") ==
 assert replaceAll(unwrapResult(make("p")), "apple", "$0$.0") == "ap0p0le"
 assert replaceAll(unwrapResult(make("b(ar)")), "bazbarfoo", "$`") == "bazbazfoo"
 assert replaceAll(unwrapResult(make("b(ar)")), "bazbarfoo", "$'") == "bazfoofoo"
+// https://github.com/grain-lang/grain/issues/1431
+assert replaceAll(unwrapResult(make("^.")), "asdf", "-") == "-sdf"

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -3954,11 +3954,12 @@ let regexReplaceHelp =
   let mut out = []
   let rec loop = searchPos => {
     let state = Array.make(rx.reNumGroups, None)
+    let inStart = max(0, searchPos - rx.reMaxLookbehind)
     let poss = searchMatch(
       rx,
       buf,
       searchPos,
-      searchPos,
+      inStart,
       Array.length(buf.matchInputExploded),
       state
     )


### PR DESCRIPTION
Fixes #1431.