### PR TITLE
fix(compiler): Fully expand types when finding concrete representation

### DIFF
--- a/compiler/src/typed/type_utils.re
+++ b/compiler/src/typed/type_utils.re
@@ -97,7 +97,7 @@ let allocation_type_of_wasm_repr = repr => {
 };
 
 let repr_of_type = (env, ty) =>
-  if (is_function(ty)) {
+  if (is_function(Ctype.full_expand(env, ty))) {
     let (args, ret) = get_fn_allocation_type(env, ty);
     let args = List.map(wasm_repr_of_allocation_type, args);
     let rets =

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -211,8 +211,12 @@ describe("aliased types", ({test, testSkip}) => {
   );
 });
 
-describe("abstract types", ({test}) => {
+describe("abstract types", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
   let assertCompileError = makeCompileErrorRunner(test);
+  let assertRun = makeRunner(test_or_skip);
 
   assertCompileError(
     "type_abstract_1",
@@ -224,5 +228,14 @@ describe("abstract types", ({test}) => {
     // TODO: This will be a type error when we support fully abstract types
     // "expected of type
     //      Foo",
+  );
+
+  assertRun(
+    "regression_annotated_func_export",
+    {|
+      import A from "funcAliasExport"
+      print(A.function())
+    |},
+    "abc\n",
   );
 });

--- a/compiler/test/test-libs/funcAliasExport.gr
+++ b/compiler/test/test-libs/funcAliasExport.gr
@@ -1,0 +1,3 @@
+export type FnType = () -> String
+
+export let function: FnType = () => "abc"


### PR DESCRIPTION
Fixes #1424 

Thanks @alex-snezhko for the report!