### PR TITLE
fix(compiler): Panic immediately when out of memory

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -176,7 +176,8 @@ type prim0 =
     | AllocateInt64
     | AllocateFloat32
     | AllocateFloat64
-    | AllocateRational;
+    | AllocateRational
+    | Unreachable;
 
 type prim1 =
   Parsetree.prim1 =

--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -48,6 +48,7 @@ let rec analyze_comp_expression =
         AllocateRational,
       ) =>
       true
+    | CPrim0(Unreachable) => false
     | CPrim1(
         AllocateArray | AllocateTuple | AllocateBytes | AllocateString |
         NewInt32 |

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -162,7 +162,8 @@ type prim0 =
     | AllocateInt64
     | AllocateFloat32
     | AllocateFloat64
-    | AllocateRational;
+    | AllocateRational
+    | Unreachable;
 
 type prim1 =
   Parsetree.prim1 =

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -163,7 +163,8 @@ type prim0 =
     | AllocateInt64
     | AllocateFloat32
     | AllocateFloat64
-    | AllocateRational;
+    | AllocateRational
+    | Unreachable;
 
 type prim1 =
   Parsetree.prim1 =

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -308,7 +308,8 @@ type prim0 =
   | AllocateInt64
   | AllocateFloat32
   | AllocateFloat64
-  | AllocateRational;
+  | AllocateRational
+  | Unreachable;
 
 /** Single-argument operators */
 [@deriving (sexp, yojson)]

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -76,6 +76,7 @@ let prim_map =
       ("@ignore", Primitive1(Ignore)),
       ("@assert", Primitive1(Assert)),
       ("@throw", Primitive1(Throw)),
+      ("@unreachable", Primitive0(Unreachable)),
       ("@is", Primitive2(Is)),
       ("@eq", Primitive2(Eq)),
       ("@and", Primitive2(And)),
@@ -1507,7 +1508,8 @@ let transl_prim = (env, desc) => {
     | Primitive0(
         (
           AllocateInt32 | AllocateInt64 | AllocateFloat32 | AllocateFloat64 |
-          AllocateRational
+          AllocateRational |
+          Unreachable
         ) as p,
       ) => (
         Exp.lambda(~loc, ~attributes=disable_gc, [], Exp.prim0(~loc, p)),

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -104,7 +104,8 @@ let prim0_type =
   | AllocateInt64
   | AllocateFloat32
   | AllocateFloat64
-  | AllocateRational => Builtin_types.type_wasmi32;
+  | AllocateRational => Builtin_types.type_wasmi32
+  | Unreachable => newvar(~name="a", ());
 
 let prim1_type =
   fun

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -180,7 +180,8 @@ type prim0 =
     | AllocateInt64
     | AllocateFloat32
     | AllocateFloat64
-    | AllocateRational;
+    | AllocateRational
+    | Unreachable;
 
 type prim1 =
   Parsetree.prim1 =

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -180,7 +180,8 @@ type prim0 =
     | AllocateInt64
     | AllocateFloat32
     | AllocateFloat64
-    | AllocateRational;
+    | AllocateRational
+    | Unreachable;
 
 type prim1 =
   Parsetree.prim1 =

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -7,7 +7,7 @@ arrays › array_access
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
@@ -15,7 +15,7 @@ arrays › array_access
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -31,9 +31,9 @@ arrays › array_access
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.7 (result i32)
+     (block $compile_block.5 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,7 +76,7 @@ arrays › array_access
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.6 (result i32)
+      (block $MArrayGet.4 (result i32)
        (local.set $1
         (i32.shr_s
          (i32.const 1)
@@ -97,14 +97,9 @@ arrays › array_access
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.5
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )
@@ -116,14 +111,9 @@ arrays › array_access
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.4
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -7,7 +7,7 @@ arrays › array_access4
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
@@ -15,7 +15,7 @@ arrays › array_access4
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -31,9 +31,9 @@ arrays › array_access4
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.7 (result i32)
+     (block $compile_block.5 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,7 +76,7 @@ arrays › array_access4
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.6 (result i32)
+      (block $MArrayGet.4 (result i32)
        (local.set $1
         (i32.shr_s
          (i32.const -3)
@@ -97,14 +97,9 @@ arrays › array_access4
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.5
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )
@@ -116,14 +111,9 @@ arrays › array_access4
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.4
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -7,7 +7,7 @@ arrays › array_access2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
@@ -15,7 +15,7 @@ arrays › array_access2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -31,9 +31,9 @@ arrays › array_access2
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.7 (result i32)
+     (block $compile_block.5 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,7 +76,7 @@ arrays › array_access2
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.6 (result i32)
+      (block $MArrayGet.4 (result i32)
        (local.set $1
         (i32.shr_s
          (i32.const 3)
@@ -97,14 +97,9 @@ arrays › array_access2
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.5
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )
@@ -116,14 +111,9 @@ arrays › array_access2
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.4
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -7,7 +7,7 @@ arrays › array_access3
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
@@ -15,7 +15,7 @@ arrays › array_access3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -31,9 +31,9 @@ arrays › array_access3
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.7 (result i32)
+     (block $compile_block.5 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,7 +76,7 @@ arrays › array_access3
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.6 (result i32)
+      (block $MArrayGet.4 (result i32)
        (local.set $1
         (i32.shr_s
          (i32.const 5)
@@ -97,14 +97,9 @@ arrays › array_access3
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.5
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )
@@ -116,14 +111,9 @@ arrays › array_access3
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.4
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -7,7 +7,7 @@ arrays › array_access5
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
@@ -15,7 +15,7 @@ arrays › array_access5
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (global $x_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -31,9 +31,9 @@ arrays › array_access5
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.7 (result i32)
+     (block $compile_block.5 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,7 +76,7 @@ arrays › array_access5
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.6 (result i32)
+      (block $MArrayGet.4 (result i32)
        (local.set $1
         (i32.shr_s
          (i32.const -5)
@@ -97,14 +97,9 @@ arrays › array_access5
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.5
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )
@@ -116,14 +111,9 @@ arrays › array_access5
          (local.get $1)
         )
         (drop
-         (block $call_error_handler.4
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-           )
-          )
-          (unreachable)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
          )
         )
        )

--- a/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
@@ -7,11 +7,11 @@ basic functionality › assert2
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$AssertionError\" (global $GRAIN$EXPORT$AssertionError_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"AssertionError\" (func $AssertionError_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -27,70 +27,65 @@ basic functionality › assert2
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.5 (result i32)
+   (block $cleanup_locals.4 (result i32)
     (local.set $0
-     (block $compile_block.4 (result i32)
-      (block $Assert.3 (result i32)
+     (block $compile_block.3 (result i32)
+      (block $Assert.2 (result i32)
        (if
         (i32.eq
          (i32.const -2)
          (i32.const 2147483646)
         )
         (drop
-         (block $call_error_handler.2
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (call $AssertionError_0
-             (global.get $GRAIN$EXPORT$AssertionError_0)
-             (block $allocate_string.1 (result i32)
-              (i32.store
-               (local.tee $0
-                (call $malloc_0
-                 (global.get $GRAIN$EXPORT$malloc_0)
-                 (i32.const 64)
-                )
-               )
-               (i32.const 1)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (call $AssertionError_0
+           (global.get $GRAIN$EXPORT$AssertionError_0)
+           (block $allocate_string.1 (result i32)
+            (i32.store
+             (local.tee $0
+              (call $malloc_0
+               (global.get $GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 51)
-              )
-              (i64.store offset=8
-               (local.get $0)
-               (i64.const 8028075845441778497)
-              )
-              (i64.store offset=16
-               (local.get $0)
-               (i64.const 2322294380849939822)
-              )
-              (i64.store offset=24
-               (local.get $0)
-               (i64.const 8028075845441778497)
-              )
-              (i64.store offset=32
-               (local.get $0)
-               (i64.const 7234307576302018670)
-              )
-              (i64.store offset=40
-               (local.get $0)
-               (i64.const 7310313481145575712)
-              )
-              (i64.store offset=48
-               (local.get $0)
-               (i64.const 7956009102162949234)
-              )
-              (i64.store offset=56
-               (local.get $0)
-               (i64.const 3219557)
-              )
-              (local.get $0)
              )
+             (i32.const 1)
             )
+            (i32.store offset=4
+             (local.get $0)
+             (i32.const 51)
+            )
+            (i64.store offset=8
+             (local.get $0)
+             (i64.const 8028075845441778497)
+            )
+            (i64.store offset=16
+             (local.get $0)
+             (i64.const 2322294380849939822)
+            )
+            (i64.store offset=24
+             (local.get $0)
+             (i64.const 8028075845441778497)
+            )
+            (i64.store offset=32
+             (local.get $0)
+             (i64.const 7234307576302018670)
+            )
+            (i64.store offset=40
+             (local.get $0)
+             (i64.const 7310313481145575712)
+            )
+            (i64.store offset=48
+             (local.get $0)
+             (i64.const 7956009102162949234)
+            )
+            (i64.store offset=56
+             (local.get $0)
+             (i64.const 3219557)
+            )
+            (local.get $0)
            )
           )
-          (unreachable)
          )
         )
        )

--- a/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
@@ -7,11 +7,11 @@ basic functionality › assert1
  (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$printException\" (global $GRAIN$EXPORT$printException_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$AssertionError\" (global $GRAIN$EXPORT$AssertionError_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$runtime/exception\" \"printException\" (func $printException_0 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"AssertionError\" (func $AssertionError_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -27,70 +27,65 @@ basic functionality › assert1
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.5 (result i32)
+   (block $cleanup_locals.4 (result i32)
     (local.set $0
-     (block $compile_block.4 (result i32)
-      (block $Assert.3 (result i32)
+     (block $compile_block.3 (result i32)
+      (block $Assert.2 (result i32)
        (if
         (i32.eq
          (i32.const -2)
          (i32.const 2147483646)
         )
         (drop
-         (block $call_error_handler.2
-          (drop
-           (call $printException_0
-            (global.get $GRAIN$EXPORT$printException_0)
-            (call $AssertionError_0
-             (global.get $GRAIN$EXPORT$AssertionError_0)
-             (block $allocate_string.1 (result i32)
-              (i32.store
-               (local.tee $0
-                (call $malloc_0
-                 (global.get $GRAIN$EXPORT$malloc_0)
-                 (i32.const 64)
-                )
-               )
-               (i32.const 1)
+         (call $panicWithException_0
+          (global.get $GRAIN$EXPORT$panicWithException_0)
+          (call $AssertionError_0
+           (global.get $GRAIN$EXPORT$AssertionError_0)
+           (block $allocate_string.1 (result i32)
+            (i32.store
+             (local.tee $0
+              (call $malloc_0
+               (global.get $GRAIN$EXPORT$malloc_0)
+               (i32.const 64)
               )
-              (i32.store offset=4
-               (local.get $0)
-               (i32.const 51)
-              )
-              (i64.store offset=8
-               (local.get $0)
-               (i64.const 8028075845441778497)
-              )
-              (i64.store offset=16
-               (local.get $0)
-               (i64.const 2322294380849939822)
-              )
-              (i64.store offset=24
-               (local.get $0)
-               (i64.const 8028075845441778497)
-              )
-              (i64.store offset=32
-               (local.get $0)
-               (i64.const 7234307576302018670)
-              )
-              (i64.store offset=40
-               (local.get $0)
-               (i64.const 7310313481145575712)
-              )
-              (i64.store offset=48
-               (local.get $0)
-               (i64.const 7956009102162883698)
-              )
-              (i64.store offset=56
-               (local.get $0)
-               (i64.const 3219557)
-              )
-              (local.get $0)
              )
+             (i32.const 1)
             )
+            (i32.store offset=4
+             (local.get $0)
+             (i32.const 51)
+            )
+            (i64.store offset=8
+             (local.get $0)
+             (i64.const 8028075845441778497)
+            )
+            (i64.store offset=16
+             (local.get $0)
+             (i64.const 2322294380849939822)
+            )
+            (i64.store offset=24
+             (local.get $0)
+             (i64.const 8028075845441778497)
+            )
+            (i64.store offset=32
+             (local.get $0)
+             (i64.const 7234307576302018670)
+            )
+            (i64.store offset=40
+             (local.get $0)
+             (i64.const 7310313481145575712)
+            )
+            (i64.store offset=48
+             (local.get $0)
+             (i64.const 7956009102162883698)
+            )
+            (i64.store offset=56
+             (local.get $0)
+             (i64.const 3219557)
+            )
+            (local.get $0)
            )
           )
-          (unreachable)
          )
         )
        )

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -9,6 +9,8 @@ import foreign wasm fd_write: (
   WasmI32,
 ) -> WasmI32 from "wasi_snapshot_preview1"
 
+primitive unreachable: () -> a = "@unreachable"
+
 enum Option<a> {
   Some(a),
   None,
@@ -79,8 +81,8 @@ let exceptionToString = (e: Exception) => {
 // the runtime heap, but this is the only module that needs to do it
 let iov = WasmI32.fromGrain([> 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n])
 
-export let printException = (e: Exception) => {
-  let ptr = WasmI32.fromGrain(exceptionToString(e))
+export let panic = (msg: String) => {
+  let ptr = WasmI32.fromGrain(msg)
   let written = iov + 32n
   let lf = iov + 36n
   WasmI32.store(iov, ptr + 8n, 0n)
@@ -89,7 +91,11 @@ export let printException = (e: Exception) => {
   WasmI32.store(iov, lf, 8n)
   WasmI32.store(iov, 1n, 12n)
   fd_write(2n, iov, 2n, written)
-  void
+  unreachable()
+}
+
+export let panicWithException = (e: Exception) => {
+  panic(exceptionToString(e))
 }
 
 export exception IndexOutOfBounds
@@ -109,7 +115,6 @@ export exception MatchFailure
  */
 export exception AssertionError(String)
 export exception InvalidArgument(String)
-export exception OutOfMemory
 
 let runtimeErrorPrinter = e => {
   match (e) {
@@ -123,7 +128,6 @@ let runtimeErrorPrinter = e => {
       Some("NumberNotRational: Can't coerce number to rational"),
     MatchFailure => Some("MatchFailure: No matching pattern"),
     AssertionError(s) => Some(s),
-    OutOfMemory => Some("OutOfMemory: Maximum memory size exceeded"),
     InvalidArgument(msg) => Some(msg),
     _ => None,
   }

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -22,9 +22,15 @@ dangerouslyRegisterBasePrinter : a -> Void
 dangerouslyRegisterPrinter : a -> Void
 ```
 
-### Exception.**printException**
+### Exception.**panic**
 
 ```grain
-printException : Exception -> Void
+panic : String -> a
+```
+
+### Exception.**panicWithException**
+
+```grain
+panicWithException : Exception -> a
 ```
 

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -28,8 +28,6 @@ primitive (!): Bool -> Bool = "@not"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
 primitive (||): (Bool, Bool) -> Bool = "@or"
 
-primitive throw: Exception -> a = "@throw"
-
 primitive heapBase: WasmI32 = "@heap.base"
 
 /* UNDERSTANDING THE STRUCTURE OF THE FREE LIST
@@ -221,7 +219,7 @@ let morecore = (nbytes: WasmI32) => {
 
   // If there was an error, fail
   if (cp == -1n) {
-    throw Exception.OutOfMemory
+    Exception.panic("OutOfMemory: Maximum memory size exceeded")
   } else {
     // Set the size of the new block to the amount the
     // heap was grown.


### PR DESCRIPTION
This is a bit of a fun bug I discovered while working on refactoring constructors. When an `OutOfMemory` is thrown, if any memory is allocated during the chain of exception printer calls, we wind up in an infinite loop: we're out of memory, so trying to allocate something to report that we're out of memory ends up entering the out of memory flow again.

This PR adds `Exception.panic` in the runtime to print a string and immediately hit `unreachable`, and changes the implementation of `morecore` to immediately panic when out of memory instead of following the normal exception handling logic which could potentially try to allocate memory.

This seemed like a reasonable approach to me, since (in the future) users shouldn't be allowed to catch an `OutOfMemory` error.

I didn't consider this a breaking change because the API changes are only in the runtime.