### PR TITLE
fix(stdlib)!: Make `Number.neg(-1) == -1`

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -118,11 +118,11 @@ assert Number.abs(-25.5) == 25.5
 assert Number.abs(25.5) == 25.5
 assert Number.abs(-1/2) == 1/2
 // neg
-assert Number.neg(-25.5) == 25.5
+assert Number.neg(-25.5) == -25.5
 assert Number.neg(25.5) == -25.5
 assert Number.neg(1/2) == -1/2
 assert Number.neg(BI.toNumber(1234t)) == BI.toNumber(-1234t)
-assert Number.neg(BI.toNumber(-1234t)) == BI.toNumber(1234t)
+assert Number.neg(BI.toNumber(-1234t)) == BI.toNumber(-1234t)
 
 // isFloat
 assert Number.isFloat(0.0)

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -27,21 +27,21 @@ import Tags from "runtime/unsafe/tags"
 
 /**
  * Pi represented as a Number value.
- * 
+ *
  * @since v0.5.2
  */
 export let pi = 3.141592653589793
 
 /**
  * Tau represented as a Number value.
- * 
+ *
  * @since v0.5.2
  */
 export let tau = 6.283185307179586
 
 /**
  * Euler's number represented as a Number value.
- * 
+ *
  * @since v0.5.2
  */
 export let e = 2.718281828459045
@@ -231,8 +231,9 @@ export let abs = (x: Number) => if (0 > x) x * -1 else x
  * @returns The negated operand
  *
  * @since v0.4.0
+ * @history v0.5.3: Make this function always return a negative
  */
-export let neg = (x: Number) => x * -1
+export let neg = (x: Number) => if (x > 0) x * -1 else x
 
 /**
  * Checks if a number is a floating point value.

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -402,9 +402,16 @@ Returns:
 
 ### Number.**neg**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.4.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.5.3</code></td><td>Make this function always return a negative</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain


### PR DESCRIPTION
As `Number.neg` is the opposite of `Number.abs` and the purpose of `Number.neg` is to always recieve a negative value i relized an issue in the original implementation where we were just flipping the sign. This pr corrects that making `Number.neg` the opposite of `Number.abs`

* This pr is breaking as we are changing the behavour of an established function.