### PR TITLE
fix(grainfmt): Group expressions inside array accessors

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -2454,7 +2454,7 @@ and print_expression =
       Doc.concat([
         print_expression(~original_source, ~comments, expression1),
         Doc.lbracket,
-        print_expression(~original_source, ~comments, expression2),
+        Doc.group(print_expression(~original_source, ~comments, expression2)),
         Doc.rbracket,
       ])
     | PExpArraySet(expression1, expression2, expression3) =>
@@ -2462,7 +2462,7 @@ and print_expression =
         Doc.concat([
           print_expression(~original_source, ~comments, expression1),
           Doc.lbracket,
-          print_expression(~original_source, ~comments, expression2),
+          Doc.group(print_expression(~original_source, ~comments, expression2)),
           Doc.rbracket,
           Doc.space,
           Doc.text("="),

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -2454,7 +2454,9 @@ and print_expression =
       Doc.concat([
         print_expression(~original_source, ~comments, expression1),
         Doc.lbracket,
-        Doc.group(print_expression(~original_source, ~comments, expression2)),
+        Doc.group(
+          print_expression(~original_source, ~comments, expression2),
+        ),
         Doc.rbracket,
       ])
     | PExpArraySet(expression1, expression2, expression3) =>
@@ -2462,7 +2464,9 @@ and print_expression =
         Doc.concat([
           print_expression(~original_source, ~comments, expression1),
           Doc.lbracket,
-          Doc.group(print_expression(~original_source, ~comments, expression2)),
+          Doc.group(
+            print_expression(~original_source, ~comments, expression2),
+          ),
           Doc.rbracket,
           Doc.space,
           Doc.text("="),

--- a/compiler/test/formatter_inputs/arrays.gr
+++ b/compiler/test/formatter_inputs/arrays.gr
@@ -37,3 +37,5 @@ let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
     }
   }
 }
+
+export let getBefore = (array, index) => if (array == [>]) "nope" else array[index - 1]

--- a/compiler/test/formatter_outputs/arrays.gr
+++ b/compiler/test/formatter_outputs/arrays.gr
@@ -36,3 +36,6 @@ let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
     },
   }
 }
+
+export let getBefore = (array, index) => if (array == [>]) "nope"
+else array[index - 1]


### PR DESCRIPTION
Fixes #1461

Handle expressions inside array accessors as groups so they break properly