### PR TITLE
feat(stdlib): Added `empty` constant to immutable data structures

### DIFF
--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -2,6 +2,8 @@ import ImmutablePriorityQueue from "immutablepriorityqueue"
 import List from "list"
 import Array from "array"
 
+assert ImmutablePriorityQueue.make(compare) == ImmutablePriorityQueue.empty
+
 // formatter-ignore
 let lotsOfVals = [>
   3, 2, 1, 5, 3, 2, 2, 10, 6, 5,

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -41,8 +41,18 @@ record ImmutablePriorityQueue<a> {
 }
 
 /**
- * @section Values: Functions for working with ImmutablePriorityQueues.
+ * @section Values: Functions and constants for working with ImmutablePriorityQueues.
  */
+
+/**
+ * An empty priority queue with the default `compare` comparator.
+ * 
+ * @since v0.5.4
+ */
+export let empty = {
+  let empty = { comp: compare, size: 0, root: None }
+  empty
+}
 
 /**
  * Creates a new priority queue with a comparator function, which is used to

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -27,7 +27,7 @@ Immutable data structure which maintains a priority order for its elements.
 
 ## Values
 
-Functions for working with ImmutablePriorityQueues.
+Functions and constants for working with ImmutablePriorityQueues.
 
 ### ImmutablePriorityQueue.**empty**
 

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -29,6 +29,19 @@ Immutable data structure which maintains a priority order for its elements.
 
 Functions for working with ImmutablePriorityQueues.
 
+### ImmutablePriorityQueue.**empty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+empty : ImmutablePriorityQueue<a>
+```
+
+An empty priority queue with the default `compare` comparator.
+
 ### ImmutablePriorityQueue.**make**
 
 <details disabled>

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -15,13 +15,26 @@ record Queue<a> {
 }
 
 /**
- * @section Values: Functions for working with queues.
+ * @section Values: Functions and constants for working with queues.
  */
+
+/**
+ * An empty queue.
+ * 
+ * @since v0.5.4
+ */
+export let empty = {
+  let empty = { forwards: [], backwards: [] }
+  empty
+}
 
 /**
  * Creates an empty queue.
  * 
  * @returns An empty queue
+ * 
+ * @deprecated This will be removed in a future release of Grain.
+ * 
  * @since v0.2.0
  */
 export let make = () => {

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -33,7 +33,7 @@ export let empty = {
  * 
  * @returns An empty queue
  * 
- * @deprecated This will be removed in a future release of Grain.
+ * @deprecated This will be removed in the v0.6.0 release of Grain.
  * 
  * @since v0.2.0
  */

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -25,9 +25,24 @@ type Queue<a>
 
 ## Values
 
-Functions for working with queues.
+Functions and constants for working with queues.
+
+### Queue.**empty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+empty : Queue<a>
+```
+
+An empty queue.
 
 ### Queue.**make**
+
+> **Deprecated:** This will be removed in a future release of Grain.
 
 <details disabled>
 <summary tabindex="-1">Added in <code>0.2.0</code></summary>

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -42,7 +42,7 @@ An empty queue.
 
 ### Queue.**make**
 
-> **Deprecated:** This will be removed in a future release of Grain.
+> **Deprecated:** This will be removed in the v0.6.0 release of Grain.
 
 <details disabled>
 <summary tabindex="-1">Added in <code>0.2.0</code></summary>

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -35,7 +35,7 @@ export let empty = {
  *
  * @returns An empty stack
  * 
- * @deprecated This will be removed in a future release of Grain.
+ * @deprecated This will be removed in the v0.6.0 release of Grain.
  */
 export let make = () => {
   { data: [], }

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -21,9 +21,21 @@ record Stack<a> {
  */
 
 /**
+ * An empty stack.
+ * 
+ * @since v0.5.4
+ */
+export let empty = {
+  let empty = { data: [], }
+  empty
+}
+
+/**
  * Creates a new stack.
  *
  * @returns An empty stack
+ * 
+ * @deprecated This will be removed in a future release of Grain.
  */
 export let make = () => {
   { data: [], }

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -39,7 +39,7 @@ An empty stack.
 
 ### Stack.**make**
 
-> **Deprecated:** This will be removed in a future release of Grain.
+> **Deprecated:** This will be removed in the v0.6.0 release of Grain.
 
 ```grain
 make : () -> Stack<a>

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -24,7 +24,22 @@ Stacks are immutable data structures that store their data in a List.
 
 Functions and constants included in the Stack module.
 
+### Stack.**empty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+empty : Stack<a>
+```
+
+An empty stack.
+
 ### Stack.**make**
+
+> **Deprecated:** This will be removed in a future release of Grain.
 
 ```grain
 make : () -> Stack<a>


### PR DESCRIPTION
As suggested in https://github.com/grain-lang/grain/pull/1414#discussion_r1001171918, immutable data structures should have an `empty` constant instead of a `make()` function where possible. This PR extends this idea to the remaining immutable data structures (Stack, Queue, Immutable Priority Queue).