### PR TITLE
fix(grainfmt): Handle chained value bindings properly

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3452,7 +3452,28 @@ and print_value_bind =
       );
     };
 
-  let value_bindings = Doc.join(~sep=Doc.line, formatted_items);
+  let value_bindings =
+    List.mapi(
+      (index, doc) => {
+        let item =
+          if (index > 0) {
+            Doc.concat([Doc.line, doc]);
+          } else {
+            doc;
+          };
+        let vb = List.nth(vbs, index);
+        switch (vb.pvb_expr.pexp_desc) {
+        | PExpLambda(fn, _) => item
+        | _ =>
+          if (index > 0) {
+            Doc.indent(item);
+          } else {
+            item;
+          }
+        };
+      },
+      formatted_items,
+    );
 
   Doc.group(
     Doc.concat([
@@ -3461,7 +3482,7 @@ and print_value_bind =
       Doc.space,
       recursive,
       mutble,
-      value_bindings,
+      Doc.concat(value_bindings),
     ]),
   );
 };

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3358,9 +3358,9 @@ and print_value_bind =
     | Mutable => Doc.text("mut ")
     };
 
-  let value_bindings =
+  let formatted_items =
     switch (vbs) {
-    | [] => Doc.nil
+    | [] => []
     | [first, ...rem] =>
       let get_loc = (vb: Parsetree.value_binding) => vb.pvb_loc;
       let print_item = (~comments, vb: Parsetree.value_binding) => {
@@ -3443,16 +3443,16 @@ and print_value_bind =
         ]);
       };
 
-      let items =
-        item_iterator(
-          ~get_loc,
-          ~print_item,
-          ~comments,
-          ~separator=Doc.comma,
-          vbs,
-        );
-      Doc.join(~sep=Doc.space, items);
+      item_iterator(
+        ~get_loc,
+        ~print_item,
+        ~comments,
+        ~separator=Doc.comma,
+        vbs,
+      );
     };
+
+  let value_bindings = Doc.join(~sep=Doc.line, formatted_items);
 
   Doc.group(
     Doc.concat([

--- a/compiler/test/formatter_inputs/chained.gr
+++ b/compiler/test/formatter_inputs/chained.gr
@@ -1,0 +1,27 @@
+
+
+  let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+      p = 8, // another comment
+      q = 32
+
+
+let myFunction2 = x => {
+  let inter = x + 1
+  "some string"
+}, myFunction3 = y => {
+  let myVal = 5
+  "some string"
+}
+
+  let g = 7, 
+      p = 8, 
+      q = 32
+
+  let myFunction2 = x => {
+  let inter = x + 1
+  "some string"
+},  // a comment
+myFunction3 = y => {
+  let myVal = 5
+  "some string"
+}

--- a/compiler/test/formatter_inputs/lets.gr
+++ b/compiler/test/formatter_inputs/lets.gr
@@ -32,6 +32,4 @@ let rotate = (count, list) => {
   append(end, beginning)
 }
 
-  let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-      p = 8, // another comment
-      q = 32
+

--- a/compiler/test/formatter_inputs/lets.gr
+++ b/compiler/test/formatter_inputs/lets.gr
@@ -31,3 +31,7 @@ let rotate = (count, list) => {
   else part(length(list) + count, list)
   append(end, beginning)
 }
+
+  let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+      p = 8, // another comment
+      q = 32

--- a/compiler/test/formatter_outputs/chained.gr
+++ b/compiler/test/formatter_outputs/chained.gr
@@ -1,6 +1,6 @@
 let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-p = 8, // another comment
-q = 32
+  p = 8, // another comment
+  q = 32
 
 let myFunction2 = x => {
   let inter = x + 1

--- a/compiler/test/formatter_outputs/chained.gr
+++ b/compiler/test/formatter_outputs/chained.gr
@@ -1,0 +1,23 @@
+let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+p = 8, // another comment
+q = 32
+
+let myFunction2 = x => {
+  let inter = x + 1
+  "some string"
+},
+myFunction3 = y => {
+  let myVal = 5
+  "some string"
+}
+
+let g = 7, p = 8, q = 32
+
+let myFunction2 = x => {
+  let inter = x + 1
+  "some string"
+}, // a comment
+myFunction3 = y => {
+  let myVal = 5
+  "some string"
+}

--- a/compiler/test/formatter_outputs/lets.gr
+++ b/compiler/test/formatter_outputs/lets.gr
@@ -7,7 +7,8 @@ let myBlock = {
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-}, myFunction3 = y => {
+},
+myFunction3 = y => {
   let myVal = 5
   "some string"
 }
@@ -27,3 +28,7 @@ let rotate = (count, list) => {
     else part(length(list) + count, list)
   append(end, beginning)
 }
+
+let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+p = 8, // another comment
+q = 32

--- a/compiler/test/formatter_outputs/lets.gr
+++ b/compiler/test/formatter_outputs/lets.gr
@@ -28,7 +28,3 @@ let rotate = (count, list) => {
     else part(length(list) + count, list)
   append(end, beginning)
 }
-
-let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-p = 8, // another comment
-q = 32

--- a/compiler/test/suites/formatter.re
+++ b/compiler/test/suites/formatter.re
@@ -50,4 +50,5 @@ describe("formatter", ({test, testSkip}) => {
   assertFormatOutput("only_comments", "only_comments");
   assertFormatOutput("data_docs", "data_docs");
   assertFormatOutput("custom_operators", "custom_operators");
+  assertFormatOutput("chained", "chained");
 });

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -241,7 +241,8 @@ let rec rangeAdd = (rng: CharRange, v: CharRangeElt) => {
     _ when rangeContains(rng, v) => rng,
     _ => rangeUnion(rng, [(v, v)]),
   }
-}, rangeUnion = (rng1, rng2) => {
+},
+rangeUnion = (rng1, rng2) => {
   match ((rng1, rng2)) {
     ([], _) => rng2,
     (_, []) => rng1,
@@ -636,7 +637,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       Ok(_) => parseRange(buf),
     }
   }
-}, parseRange = (buf: RegExBuf) => {
+},
+parseRange = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing closing `]`", 0))
   } else {
@@ -659,7 +661,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       Ok(_) => parseRangeRest(buf, [], None, None),
     }
   }
-}, parseClass = (buf: RegExBuf) => {
+},
+parseClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(
       "no chars"
@@ -694,7 +697,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       Ok(c) => Err("unknown class: " ++ toString(c)),
     }
   }
-}, parsePosixCharClass = (buf: RegExBuf) => {
+},
+parsePosixCharClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing POSIX character class after `[`", 0))
   } else {
@@ -810,7 +814,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
         ),
     }
   }
-}, parseRangeRest =
+},
+parseRangeRest =
   (
     buf: RegExBuf,
     rng: CharRange,
@@ -962,7 +967,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       },
     }
   }
-}, parseRangeRestSpan =
+},
+parseRangeRestSpan =
   (
     buf: RegExBuf,
     c,
@@ -1213,7 +1219,8 @@ let rec parseAtom = (buf: RegExBuf) => {
         _ => parseLiteral(buf),
       },
   }
-}, parseLook = (buf: RegExBuf) => {
+},
+parseLook = (buf: RegExBuf) => {
   let preNumGroups = unbox(buf.config.groupNumber)
   let spanNumGroups = () => unbox(buf.config.groupNumber) - preNumGroups
   // (isMatch, isAhead)
@@ -1279,7 +1286,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       }
     },
   }
-}, parseTest = (buf: RegExBuf) => {
+},
+parseTest = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected test", 0))
   } else {
@@ -1316,7 +1324,8 @@ let rec parseAtom = (buf: RegExBuf) => {
         ),
     }
   }
-}, parseInteger = (buf: RegExBuf, n) => {
+},
+parseInteger = (buf: RegExBuf, n) => {
   if (!more(buf)) {
     Ok(n)
   } else {
@@ -1331,7 +1340,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       Ok(_) => Ok(n),
     }
   }
-}, parseMode = (buf: RegExBuf) => {
+},
+parseMode = (buf: RegExBuf) => {
   let processState = ((cs, ml)) => {
     let withCs = match (cs) {
       None => buf.config,
@@ -1390,7 +1400,8 @@ let rec parseAtom = (buf: RegExBuf) => {
     }
   }
   help((None, None))
-}, parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
+},
+parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected unicode category", 0))
   } else {
@@ -1558,7 +1569,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       Ok(_) => Err(parseErr(buf, "Expected `{` after `\\" ++ pC ++ "`", 0)),
     }
   }
-}, parseLiteral = (buf: RegExBuf) => {
+},
+parseLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected literal", 0))
   } else {
@@ -1592,7 +1604,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       },
     }
   }
-}, parseBackslashLiteral = (buf: RegExBuf) => {
+},
+parseBackslashLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     // Special case: EOS after backslash matches null
     Err(parseErr(buf, "Expected to find escaped value after backslash", 0))
@@ -1655,7 +1668,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       },
     }
   }
-}, parseNonGreedy = (buf: RegExBuf) => {
+},
+parseNonGreedy = (buf: RegExBuf) => {
   let checkNotNested = res => {
     if (!more(buf)) {
       res
@@ -1681,7 +1695,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       Ok(_) => checkNotNested(Ok(false)),
     }
   }
-}, parsePCE = (buf: RegExBuf) => {
+},
+parsePCE = (buf: RegExBuf) => {
   match (parseAtom(buf)) {
     Err(e) => Err(e),
     Ok(atom) => {
@@ -1775,7 +1790,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       }
     },
   }
-}, parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
+},
+parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
   if (!more(buf)) {
     Ok([])
   } else {
@@ -1801,7 +1817,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       },
     }
   }
-}, parseRegex = (buf: RegExBuf) => {
+},
+parseRegex = (buf: RegExBuf) => {
   if (!more(buf)) {
     Ok(REEmpty)
   } else {
@@ -1836,7 +1853,8 @@ let rec parseAtom = (buf: RegExBuf) => {
       },
     }
   }
-}, parseRegexNonEmpty = (buf: RegExBuf) => {
+},
+parseRegexNonEmpty = (buf: RegExBuf) => {
   match (parsePCEs(buf, false)) {
     Err(e) => Err(e),
     Ok(pces) => {

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -146,7 +146,8 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
       tagSimpleNumber(xptr - yptr)
     },
   }
-}, compareHelp = (x, y) => {
+},
+compareHelp = (x, y) => {
   let xtag = x & Tags._GRAIN_GENERIC_TAG_MASK
   let ytag = y & Tags._GRAIN_GENERIC_TAG_MASK
   if ((xtag & ytag) != Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -189,7 +189,8 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
       xptr == yptr
     },
   }
-}, equalHelp = (x, y) => {
+},
+equalHelp = (x, y) => {
   if (
     (x & Tags._GRAIN_GENERIC_TAG_MASK) != 0n &&
     (y & Tags._GRAIN_GENERIC_TAG_MASK) != 0n

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -213,7 +213,8 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
   } else {
     userPtr
   }
-}, decRefChildren = (userPtr: WasmI32) => {
+},
+decRefChildren = (userPtr: WasmI32) => {
   match (WasmI32.load(userPtr, 0n)) {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = WasmI32.load(userPtr, 4n)

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -547,7 +547,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       join(strings)
     },
   }
-}, toStringHelp = (grainValue, extraIndents, toplevel) => {
+},
+toStringHelp = (grainValue, extraIndents, toplevel) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
@@ -572,7 +573,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       "<unknown value>"
     }
   }
-}, listToString = (ptr, extraIndents) => {
+},
+listToString = (ptr, extraIndents) => {
   let mut cur = ptr
   let mut isFirst = true
 


### PR DESCRIPTION
Fixed #1454 

This formats chained value bindings properly so that they now break over lines if over the width or end in line comments.

It does change how we display chained functions, I think it's more consistent now but let me know what you think