### PR TITLE
chore(ci): Lock ubuntu to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node-version: ["16"]
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   push_base_image:
     name: Push base Docker image to multiple registries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -97,7 +97,7 @@ jobs:
 
   push_slim_image:
     name: Push slim Docker image to multiple registries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release-please:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -23,7 +23,7 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Prepare artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       stdlib_download_url: ${{ steps.stdlib-upload.outputs.browser_download_url }}
       js-runner_download_url: ${{ steps.js-runner-upload.outputs.browser_download_url }}
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: "16"
           check-latest: true
-          cache: 'npm'
+          cache: "npm"
 
       - name: Setup environment
         run: |
@@ -141,7 +141,7 @@ jobs:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Dispatch website release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: grain-lang/workflow-dispatch-action@v1.0.0
         with:
@@ -155,7 +155,7 @@ jobs:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Dispatch homebrew release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: grain-lang/workflow-dispatch-action@v1.0.0
         with:
@@ -169,7 +169,7 @@ jobs:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Dispatch Docker builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: grain-lang/workflow-dispatch-action@v1.0.0
         with:
@@ -183,7 +183,7 @@ jobs:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Publish stdlib to npm registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup NodeJS
         uses: actions/setup-node@v3.1.1
@@ -201,7 +201,7 @@ jobs:
     needs: [release-please, prepare-artifacts]
     if: ${{ needs.release-please.outputs.releases_created }}
     name: Publish js-runner to npm registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup NodeJS
         uses: actions/setup-node@v3.1.1


### PR DESCRIPTION
This pins ubuntu to 20.04 instead of latest. It seems that GitHub is slowly rolling out 22.04 as "latest" and that caused CI to fail in #1457 

We would need a newer OCaml to support this new version of Ubuntu (similar to our problem with newer GCC on Fedora) but we can't upgrade due to breaking Windows static linking.