### PR TITLE
fix(compiler): Raise appropriate exception when modules are missing during dependency graph construction

### DIFF
--- a/compiler/src/parsing/driver.rei
+++ b/compiler/src/parsing/driver.rei
@@ -4,4 +4,5 @@ let parse:
   (~name: string=?, Sedlexing.lexbuf, unit => string) =>
   Parsetree.parsed_program;
 
-let scan_for_imports: (~defer_errors: bool=?, string) => list(string);
+let scan_for_imports:
+  (~defer_errors: bool=?, string) => list(Location.loc(string));

--- a/compiler/test/input/brokenImports/broken.gr
+++ b/compiler/test/input/brokenImports/broken.gr
@@ -1,0 +1,4 @@
+import Number from "number"
+import Foo from "./foo"
+
+export let min = Number.min

--- a/compiler/test/input/brokenImports/main.gr
+++ b/compiler/test/input/brokenImports/main.gr
@@ -1,0 +1,3 @@
+import Broken from "./broken"
+
+print(Broken.min(2, 3))

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -295,6 +295,24 @@ let makeFileRunner =
   });
 };
 
+let makeFileCompileErrorRunner = (test, name, filename, expected) => {
+  test(
+    name,
+    ({expect}) => {
+      let error =
+        try({
+          let infile = grainfile(filename);
+          let outfile = wasmfile(name);
+          ignore @@ compile_file(infile, outfile);
+          "";
+        }) {
+        | exn => Printexc.to_string(exn)
+        };
+      expect.string(error).toMatch(expected);
+    },
+  );
+};
+
 let makeFileErrorRunner = (test, name, filename, expected) => {
   test(
     name,

--- a/compiler/test/suites/imports.re
+++ b/compiler/test/suites/imports.re
@@ -9,6 +9,7 @@ describe("imports", ({test, testSkip}) => {
   let assertCompileError = makeCompileErrorRunner(test);
   let assertRun = makeRunner(test_or_skip);
   let assertFileRun = makeFileRunner(test_or_skip);
+  let assertFileCompileError = makeFileCompileErrorRunner(test_or_skip);
   let assertFileSnapshot = makeSnapshotFileRunner(test);
 
   /* import * tests */
@@ -212,4 +213,9 @@ describe("imports", ({test, testSkip}) => {
     "import TList, { Empty } from \"tlists\"; let foo : TList.TList<String> = Empty; foo",
   );
   assertFileRun("relative_import_linking", "relativeImportLinking", "2\n2\n");
+  assertFileCompileError(
+    "import_broken",
+    "brokenImports/main",
+    "./broken.gr\", line 2, characters 16-23",
+  );
 });


### PR DESCRIPTION
Fixes #1480. Additionally, this PR modifies the missing module error message to contain the correct source locations. For example, given the following files:
`tst.gr`:
```grain
import Number from "./numberr"
print(Number.min(2, 3))
```
`numberr.gr`:
```grain
import Number from "number"
import Foo from "foo" // <- does not exist
export let min = Number.min
```
The following error is reported:
```
 λ grain git:(philip/file-missing-import) > grain tst.gr
File "././numberr.gr", line 2, characters 16-21:
Error: Missing file for module foo
```