### PR TITLE
fix(compiler): Perform partial match checking on let-binds

### DIFF
--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1991,6 +1991,20 @@ and type_let =
       )
       pat_list
       (List.map2 (fun (attrs, _) e -> attrs, e) spatl exp_list);*/
+  List.iter2(
+    (pat, (attrs, exp)) => {
+      ignore(
+        check_partial(
+          env,
+          pat.pat_type,
+          pat.pat_loc,
+          [{mb_pat: pat, mb_body: exp, mb_guard: None, mb_loc: pat.pat_loc}],
+        ),
+      )
+    },
+    pat_list,
+    List.map2(((attrs, _), e) => (attrs, e), spatl, exp_list),
+  );
   end_def();
   let mutable_let = mut_flag == Mutable;
   List.iter2(

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1980,17 +1980,7 @@ and type_let =
         (fun () ->
            Location.prerr_warning pvb_pat.ppat_loc Warnings.Unused_rec_flag
         )
-    end;
-    List.iter2
-      (fun pat (attrs, exp) ->
-         Builtin_attributes.warning_scope ~ppwarning:false attrs
-           (fun () ->
-              ignore(check_partial env pat.pat_type pat.pat_loc
-                       [case pat exp])
-           )
-      )
-      pat_list
-      (List.map2 (fun (attrs, _) e -> attrs, e) spatl exp_list);*/
+    end;*/
   List.iter2(
     (pat, (attrs, exp)) => {
       ignore(

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -299,6 +299,11 @@ describe("pattern matching", ({test, testSkip}) => {
       "true\n(However, some guarded clause may match this value.)",
     ),
   );
+  assertWarning(
+    "let_exhaustiveness",
+    "let a = None\nlet Some(b) = a",
+    Warnings.PartialMatch("None"),
+  );
   assertCompileError(
     "newline_before_arrow",
     {|


### PR DESCRIPTION
Fixes #1453.

New warnings with the fix:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/4998607/202918158-4e8b979e-9999-4b2f-92ae-7ccafc7e71a2.png">
