### PR TITLE
feat(stdlib): Improve perf for array flatMap, array & list some & every

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -425,7 +425,19 @@ export let reducei = (fn, initial, array) => {
  * @since v0.3.0
  */
 export let flatMap = (fn, array) => {
-  reduce((result, value) => append(result, fn(value)), [>], array)
+  let nested = map(fn, array)
+  let arrLen = reduce((acc, arr) => acc + length(arr), 0, nested)
+  let mut outerI = 0
+  let mut innerI = 0
+  init(arrLen, i => {
+    if (innerI >= length(nested[outerI])) {
+      innerI = 0
+      outerI += 1
+    }
+    let res = nested[outerI][innerI]
+    innerI += 1
+    res
+  })
 }
 
 /**
@@ -439,9 +451,12 @@ export let flatMap = (fn, array) => {
  * @since v0.3.0
  */
 export let every = (fn, array) => {
-  reduce((acc, value) => {
-    acc && fn(value)
-  }, true, array)
+  let len = length(array)
+  let mut all = true
+  for (let mut index = 0; all && index < len; index += 1) {
+    all = fn(array[index])
+  }
+  all
 }
 
 /**
@@ -455,9 +470,12 @@ export let every = (fn, array) => {
  * @since v0.3.0
  */
 export let some = (fn, array) => {
-  reduce((acc, value) => {
-    acc || fn(value)
-  }, false, array)
+  let len = length(array)
+  let mut found = false
+  for (let mut index = 0; !found && index < len; index += 1) {
+    found = fn(array[index])
+  }
+  found
 }
 
 /**

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -550,7 +550,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((a -> Array<b>), Array<a>) -> Array<b>
+flatMap : ((b -> Array<a>), Array<b>) -> Array<a>
 ```
 
 Produces a new array by calling a function on each element
@@ -562,14 +562,14 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Array<b>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
-|`array`|`Array<a>`|The array to iterate|
+|`fn`|`b -> Array<a>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
+|`array`|`Array<b>`|The array to iterate|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Array<b>`|The new array|
+|`Array<a>`|The new array|
 
 ### Array.**every**
 

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -233,6 +233,7 @@ export let rec flatMap = (fn, list) => {
 export let rec every = (fn, list) => {
   match (list) {
     [] => true,
+    // The short-circuiting of `&&` makes this tail-recursive
     [first, ...rest] => fn(first) && every(fn, rest),
   }
 }
@@ -250,6 +251,7 @@ export let rec every = (fn, list) => {
 export let rec some = (fn, list) => {
   match (list) {
     [] => false,
+    // The short-circuiting of `||` makes this tail-recursive
     [first, ...rest] => fn(first) || some(fn, rest),
   }
 }

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -230,10 +230,11 @@ export let rec flatMap = (fn, list) => {
  *
  * @since v0.1.0
  */
-export let every = (fn, list) => {
-  reduce((acc, value) => {
-    acc && fn(value)
-  }, true, list)
+export let rec every = (fn, list) => {
+  match (list) {
+    [] => true,
+    [first, ...rest] => fn(first) && every(fn, rest),
+  }
 }
 
 /**
@@ -246,10 +247,11 @@ export let every = (fn, list) => {
  *
  * @since v0.1.0
  */
-export let some = (fn, list) => {
-  reduce((acc, value) => {
-    acc || fn(value)
-  }, false, list)
+export let rec some = (fn, list) => {
+  match (list) {
+    [] => false,
+    [first, ...rest] => fn(first) || some(fn, rest),
+  }
 }
 
 /**


### PR DESCRIPTION
Improves `Array.flatMap` performance addressing #458. Also small performance upgrade for `every` and `some` for `Array` and `List`, as I noticed that in their current state they would always traverse the entire collection even after a suitable match/counterexample was found.