### PR TITLE
fix(grainlsp): Properly surface errors in other files

### DIFF
--- a/compiler/src/language_server/protocol.re
+++ b/compiler/src/language_server/protocol.re
@@ -47,6 +47,20 @@ let diagnostic_severity_of_yojson = json =>
     }
   });
 
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
+[@deriving yojson]
+type location = {
+  uri,
+  range,
+};
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticRelatedInformation
+[@deriving yojson]
+type diagnostic_related_information = {
+  location,
+  message: string,
+};
+
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic
 [@deriving yojson]
 type diagnostic = {
@@ -54,6 +68,8 @@ type diagnostic = {
   range,
   severity: diagnostic_severity,
   message: string,
+  [@key "relatedInformation"]
+  related_information: list(diagnostic_related_information),
 };
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#command
@@ -282,4 +298,8 @@ let notification = (~method, params) => {
 
 let uri_to_filename = (uri: uri): string => {
   Uri.path(uri);
+};
+
+let filename_to_uri = (filename: string): uri => {
+  Uri.of_string(filename);
 };

--- a/compiler/src/language_server/protocol.rei
+++ b/compiler/src/language_server/protocol.rei
@@ -33,12 +33,27 @@ type diagnostic_severity =
   | Information
   | Hint;
 
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
+[@deriving yojson]
+type location = {
+  uri,
+  range,
+};
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticRelatedInformation
+[@deriving yojson]
+type diagnostic_related_information = {
+  location,
+  message: string,
+};
+
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic
 [@deriving yojson]
 type diagnostic = {
   range,
   severity: diagnostic_severity,
   message: string,
+  related_information: list(diagnostic_related_information),
 };
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#command
@@ -138,3 +153,4 @@ let error: (~id: message_id=?, response_error) => unit;
 let notification: (~method: string, Yojson.Safe.t) => unit;
 
 let uri_to_filename: uri => string;
+let filename_to_uri: string => uri;


### PR DESCRIPTION
While looking into #1485, I noticed that the reporting of a missing file was being shown on the line & col of the top-level file we were compiling. This lead me down a rabbit-hole where I found that all errors were being surfaced within the file you were editing (which is very wrong).

This PR changes the error surfacing logic of the LSP to check to see if the error matches the file being compiled. If it matches, the error is surfaced normally; however, if the filenames don't match, we set an error on 0,0 that says which file failed to compile and add its error message to the `related_information` list. This will show "problems" that link to the correct location in the source.

Here's an example for a missing module once #1485 lands:
<img width="513" alt="Screen Shot 2022-11-28 at 7 08 58 PM" src="https://user-images.githubusercontent.com/992373/204423836-43ca8a74-48e4-4f74-95cb-23ff25a45b9b.png">
