### PR TITLE
feat(graindoc): Add attribute for exceptions that may be thrown

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -246,7 +246,7 @@ let signature_item_in_range =
   };
 };
 
-// Used for joining multiple `@throws` annotations with the exact same name
+// Used for joining multiple `@throws` annotations with the exact same type
 module StringMap = Map.Make(String);
 
 let to_markdown = (~current_version, docblock) => {

--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -246,6 +246,9 @@ let signature_item_in_range =
   };
 };
 
+// Used for joining multiple `@throws` annotations with the exact same name
+module StringMap = Map.Make(String);
+
 let to_markdown = (~current_version, docblock) => {
   let buf = Buffer.create(0);
   Buffer.add_string(buf, Markdown.heading(~level=3, docblock.name));
@@ -351,6 +354,47 @@ let to_markdown = (~current_version, docblock) => {
     Buffer.add_string(
       buf,
       Markdown.table(~headers=["type", "description"], returns),
+    );
+  };
+  let throws =
+    docblock.attributes
+    |> List.filter(Comments.Attribute.is_throws)
+    |> List.fold_left(
+         (map, attr: Comments.Attribute.t) => {
+           switch (attr) {
+           | Throws({attr_type: Some(attr_type), attr_desc}) =>
+             StringMap.update(
+               attr_type,
+               descs => {
+                 switch (descs) {
+                 | None => Some([attr_desc])
+                 | Some(descs) => Some([attr_desc, ...descs])
+                 }
+               },
+               map,
+             )
+           | Throws({attr_type: None, attr_desc}) =>
+             failwith(
+               "Unreachable: `throws` attribute requires an exception type.",
+             )
+           | _ =>
+             failwith("Unreachable: Non-`throws` attribute can't exist here.")
+           }
+         },
+         StringMap.empty,
+       )
+    |> StringMap.bindings;
+  if (List.length(throws) > 0) {
+    Buffer.add_string(buf, Markdown.paragraph("Throws:"));
+    List.iter(
+      ((exception_type, exception_descriptions)) => {
+        Buffer.add_string(
+          buf,
+          Markdown.paragraph(Markdown.code(exception_type)),
+        );
+        Buffer.add_string(buf, Markdown.bullet_list(exception_descriptions));
+      },
+      throws,
     );
   };
   let examples =

--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -392,7 +392,10 @@ let to_markdown = (~current_version, docblock) => {
           buf,
           Markdown.paragraph(Markdown.code(exception_type)),
         );
-        Buffer.add_string(buf, Markdown.bullet_list(exception_descriptions));
+        Buffer.add_string(
+          buf,
+          Markdown.bullet_list(List.rev(exception_descriptions)),
+        );
       },
       throws,
     );

--- a/compiler/src/diagnostics/comments.re
+++ b/compiler/src/diagnostics/comments.re
@@ -38,6 +38,10 @@ module Attribute = {
     | History({
         attr_version,
         attr_desc,
+      })
+    | Throws({
+        attr_type,
+        attr_desc,
       });
 
   let parse_param = (~attr, content) => {
@@ -142,6 +146,23 @@ module Attribute = {
     };
   };
 
+  let parse_throws = (~attr, content) => {
+    let re = Str.regexp({|^\([^:]+\):[ ]+\(.+\)$|});
+    if (Str.string_match(re, content, 0)) {
+      let attr_type = Str.matched_group(1, content);
+      let attr_desc = Str.matched_group(2, content);
+      // Name and Type are conflated for exceptions
+      Throws({attr_type: Some(attr_type), attr_desc});
+    } else {
+      raise(
+        MalformedAttribute(
+          attr,
+          "@throws ExceptionType: Explanation of exceptional case",
+        ),
+      );
+    };
+  };
+
   let extract = comment => {
     let attrs = ref([]);
     let attr_line_re = Str.regexp({|^@\([a-zA-Z_]+\)\b\(.*\)$|});
@@ -179,6 +200,9 @@ module Attribute = {
           | "history" =>
             let history_attr = parse_history(~attr, content);
             attrs := [history_attr, ...attrs^];
+          | "throws" =>
+            let throws_attr = parse_throws(~attr, content);
+            attrs := [throws_attr, ...attrs^];
           | _ => raise(InvalidAttribute(attr))
           };
 
@@ -250,6 +274,13 @@ module Attribute = {
   let is_history = (attr: t) => {
     switch (attr) {
     | History(_) => true
+    | _ => false
+    };
+  };
+
+  let is_throws = (attr: t) => {
+    switch (attr) {
+    | Throws(_) => true
     | _ => false
     };
   };

--- a/compiler/src/diagnostics/comments.re
+++ b/compiler/src/diagnostics/comments.re
@@ -151,7 +151,6 @@ module Attribute = {
     if (Str.string_match(re, content, 0)) {
       let attr_type = Str.matched_group(1, content);
       let attr_desc = Str.matched_group(2, content);
-      // Name and Type are conflated for exceptions
       Throws({attr_type: Some(attr_type), attr_desc});
     } else {
       raise(

--- a/compiler/src/utils/markdown.re
+++ b/compiler/src/utils/markdown.re
@@ -57,3 +57,10 @@ let bold = str => {
 let blockquote = str => {
   Format.sprintf("> %s\n\n", str);
 };
+
+let bullet_list = items => {
+  let bullets =
+    List.map(item => Format.sprintf("* %s", item), items)
+    |> String.concat("\n");
+  Format.sprintf("%s\n\n", bullets);
+};

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -58,6 +58,9 @@ export let length = array => {
  * @param item: The value to store at each index
  * @returns The new array
  *
+ * @throws InvalidArgument(String): When `length` is not an integer
+ * @throws InvalidArgument(String): When `length` is negative
+ *
  * @example Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
  *
  * @since v0.1.0
@@ -87,6 +90,9 @@ export let make: (Number, a) -> Array<a> = (length: Number, item: a) => {
  * @param length: The length of the new array
  * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
  * @returns The new array
+ *
+ * @throws InvalidArgument(String): When `length` is not an integer
+ * @throws InvalidArgument(String): When `length` is negative
  *
  * @example Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
  *
@@ -796,11 +802,11 @@ export let unique = array => {
  * The first tuple will contain the first item of each array, the second tuple
  * will contain the second item of each array, and so on.
  *
- * Calling this function with arrays of different sizes will throw an error.
- *
  * @param array1: The array to provide values for the first tuple element
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing indexed pairs of `(a, b)`
+ *
+ * @throws Failure(String): When the arrays have different sizes
  *
  * @since v0.4.0
  */

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -87,8 +87,8 @@ Throws:
 
 `InvalidArgument(String)`
 
-* When `length` is negative
 * When `length` is not an integer
+* When `length` is negative
 
 Examples:
 
@@ -128,8 +128,8 @@ Throws:
 
 `InvalidArgument(String)`
 
-* When `length` is negative
 * When `length` is not an integer
+* When `length` is negative
 
 Examples:
 

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -83,6 +83,13 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When `length` is negative
+* When `length` is not an integer
+
 Examples:
 
 ```grain
@@ -116,6 +123,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The new array|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `length` is negative
+* When `length` is not an integer
 
 Examples:
 
@@ -999,8 +1013,6 @@ Produces a new array filled with tuples of elements from both given arrays.
 The first tuple will contain the first item of each array, the second tuple
 will contain the second item of each array, and so on.
 
-Calling this function with arrays of different sizes will throw an error.
-
 Parameters:
 
 |param|type|description|
@@ -1013,6 +1025,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<(a, b)>`|The new array containing indexed pairs of `(a, b)`|
+
+Throws:
+
+`Failure(String)`
+
+* When the arrays have different sizes
 
 ### Array.**zipWith**
 

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -114,6 +114,8 @@ let addInt32help = (value, buffer) => {
  * @param initialSize: The initial size of the buffer
  * @returns The new buffer
  *
+ * @throws InvalidArgument(String): When the `initialSize` is a negative number
+ *
  * @since v0.4.0
  */
 export let make = initialSize => {
@@ -168,6 +170,9 @@ export let reset = buffer => {
  * @param length: The number of bytes to truncate the buffer to
  * @param buffer: The buffer to truncate
  *
+ * @throws IndexOutOfBounds: When the `length` is negative
+ * @throws IndexOutOfBounds: When the `length` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -201,6 +206,10 @@ export let toBytes = buffer => {
  * @param length: The number of bytes to include after the starting index
  * @param buffer: The buffer to copy from
  * @returns A byte sequence with bytes copied from the buffer
+ *
+ * @throws IndexOutOfBounds: When `start` is negative
+ * @throws IndexOutOfBounds: When `start` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `start + length` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -329,6 +338,11 @@ export let addStringSlice = (start: Number, end, string, buffer) => {
  * @param bytes: The byte sequence to append
  * @param buffer: The buffer to mutate
  *
+ * @throws IndexOutOfBounds: When the `start` is negative
+ * @throws IndexOutOfBounds: When the `start` is greater than or equal to the `bytes` size
+ * @throws IndexOutOfBounds: When the `length` is negative
+ * @throws IndexOutOfBounds: When the `length` is greater than the `bytes` length minus `start`
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -410,6 +424,10 @@ export let addBufferSlice = (start, length, srcBuffer, dstBuffer) => {
  * @param buffer: The buffer to access
  * @returns A 32-bit integer representing a signed 8-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt8S = (index, buffer) => {
@@ -424,6 +442,10 @@ export let getInt8S = (index, buffer) => {
  * @param buffer: The buffer to access
  * @returns A 32-bit integer representing an unsigned 8-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt8U = (index, buffer) => {
@@ -437,6 +459,10 @@ export let getInt8U = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -464,6 +490,10 @@ export let addInt8 = (value, buffer) => {
  * @param buffer: The buffer to access
  * @returns A 32-bit integer representing a signed 16-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt16S = (index, buffer) => {
@@ -478,6 +508,10 @@ export let getInt16S = (index, buffer) => {
  * @param buffer: The buffer to access
  * @returns A 32-bit integer representing an unsigned 16-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt16U = (index, buffer) => {
@@ -491,6 +525,10 @@ export let getInt16U = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -518,6 +556,10 @@ export let addInt16 = (value, buffer) => {
  * @param buffer: The buffer to access
  * @returns A signed 32-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt32 = (index, buffer) => {
@@ -531,6 +573,10 @@ export let getInt32 = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -558,6 +604,10 @@ export let addInt32 = (value, buffer) => {
  * @param buffer: The buffer to access
  * @returns A 32-bit float that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getFloat32 = (index, buffer) => {
@@ -571,6 +621,10 @@ export let getFloat32 = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -601,6 +655,10 @@ export let addFloat32 = (value, buffer) => {
  * @param buffer: The buffer to access
  * @returns A signed 64-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getInt64 = (index, buffer) => {
@@ -614,6 +672,10 @@ export let getInt64 = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the buffer size
  *
  * @since v0.4.0
  */
@@ -644,6 +706,10 @@ export let addInt64 = (value, buffer) => {
  * @param buffer: The buffer to access
  * @returns A 64-bit float that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the buffer size
+ *
  * @since v0.4.0
  */
 export let getFloat64 = (index, buffer) => {
@@ -657,6 +723,10 @@ export let getFloat64 = (index, buffer) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param buffer: The buffer to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index` is greater than or equal to the buffer size
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the buffer size
  *
  * @since v0.4.0
  */

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -146,8 +146,8 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When the `length` is greater than the buffer size
 * When the `length` is negative
+* When the `length` is greater than the buffer size
 
 ### Buffer.**toBytes**
 
@@ -205,9 +205,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `start + length` is greater than the buffer size
-* When `start` is greater than or equal to the buffer size
 * When `start` is negative
+* When `start` is greater than or equal to the buffer size
+* When `start + length` is greater than the buffer size
 
 ### Buffer.**toString**
 
@@ -376,10 +376,10 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When the `length` is greater than the `bytes` length minus `start`
-* When the `length` is negative
-* When the `start` is greater than or equal to the `bytes` size
 * When the `start` is negative
+* When the `start` is greater than or equal to the `bytes` size
+* When the `length` is negative
+* When the `length` is greater than the `bytes` length minus `start`
 
 ### Buffer.**addBuffer**
 
@@ -461,9 +461,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 1` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 1` is greater than the buffer size
 
 ### Buffer.**getInt8U**
 
@@ -495,9 +495,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 1` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 1` is greater than the buffer size
 
 ### Buffer.**setInt8**
 
@@ -524,9 +524,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 1` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 1` is greater than the buffer size
 
 ### Buffer.**addInt8**
 
@@ -578,9 +578,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 2` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 2` is greater than the buffer size
 
 ### Buffer.**getInt16U**
 
@@ -612,9 +612,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 2` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 2` is greater than the buffer size
 
 ### Buffer.**setInt16**
 
@@ -641,9 +641,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 2` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 2` is greater than the buffer size
 
 ### Buffer.**addInt16**
 
@@ -695,9 +695,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 4` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 4` is greater than the buffer size
 
 ### Buffer.**setInt32**
 
@@ -724,9 +724,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 4` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 4` is greater than the buffer size
 
 ### Buffer.**addInt32**
 
@@ -778,9 +778,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 4` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 4` is greater than the buffer size
 
 ### Buffer.**setFloat32**
 
@@ -807,9 +807,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 4` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 4` is greater than the buffer size
 
 ### Buffer.**addFloat32**
 
@@ -861,9 +861,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 8` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 8` is greater than the buffer size
 
 ### Buffer.**setInt64**
 
@@ -890,9 +890,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 8` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 8` is greater than the buffer size
 
 ### Buffer.**addInt64**
 
@@ -944,9 +944,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 8` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 8` is greater than the buffer size
 
 ### Buffer.**setFloat64**
 
@@ -973,9 +973,9 @@ Throws:
 
 `IndexOutOfBounds`
 
-* When `index + 8` is greater than the buffer size
-* When `index` is greater than or equal to the buffer size
 * When `index` is negative
+* When `index` is greater than or equal to the buffer size
+* When `index + 8` is greater than the buffer size
 
 ### Buffer.**addFloat64**
 

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -47,6 +47,12 @@ Returns:
 |----|-----------|
 |`Buffer`|The new buffer|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the `initialSize` is a negative number
+
 ### Buffer.**length**
 
 <details disabled>
@@ -136,6 +142,13 @@ Parameters:
 |`length`|`Number`|The number of bytes to truncate the buffer to|
 |`buffer`|`Buffer`|The buffer to truncate|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When the `length` is greater than the buffer size
+* When the `length` is negative
+
 ### Buffer.**toBytes**
 
 <details disabled>
@@ -187,6 +200,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bytes`|A byte sequence with bytes copied from the buffer|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `start + length` is greater than the buffer size
+* When `start` is greater than or equal to the buffer size
+* When `start` is negative
 
 ### Buffer.**toString**
 
@@ -351,6 +372,15 @@ Parameters:
 |`bytes`|`Bytes`|The byte sequence to append|
 |`buffer`|`Buffer`|The buffer to mutate|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When the `length` is greater than the `bytes` length minus `start`
+* When the `length` is negative
+* When the `start` is greater than or equal to the `bytes` size
+* When the `start` is negative
+
 ### Buffer.**addBuffer**
 
 <details disabled>
@@ -427,6 +457,14 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing a signed 8-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 1` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**getInt8U**
 
 <details disabled>
@@ -453,6 +491,14 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing an unsigned 8-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 1` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setInt8**
 
 <details disabled>
@@ -473,6 +519,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 1` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addInt8**
 
@@ -520,6 +574,14 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing a signed 16-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 2` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**getInt16U**
 
 <details disabled>
@@ -546,6 +608,14 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing an unsigned 16-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 2` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setInt16**
 
 <details disabled>
@@ -566,6 +636,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 2` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addInt16**
 
@@ -613,6 +691,14 @@ Returns:
 |----|-----------|
 |`Int32`|A signed 32-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 4` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setInt32**
 
 <details disabled>
@@ -633,6 +719,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 4` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addInt32**
 
@@ -680,6 +774,14 @@ Returns:
 |----|-----------|
 |`Float32`|A 32-bit float that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 4` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setFloat32**
 
 <details disabled>
@@ -700,6 +802,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Float32`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 4` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addFloat32**
 
@@ -747,6 +857,14 @@ Returns:
 |----|-----------|
 |`Int64`|A signed 64-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 8` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setInt64**
 
 <details disabled>
@@ -767,6 +885,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int64`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 8` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addInt64**
 
@@ -814,6 +940,14 @@ Returns:
 |----|-----------|
 |`Float64`|A 64-bit float that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 8` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
+
 ### Buffer.**setFloat64**
 
 <details disabled>
@@ -834,6 +968,14 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Float64`|The value to set|
 |`buffer`|`Buffer`|The buffer to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index + 8` is greater than the buffer size
+* When `index` is greater than or equal to the buffer size
+* When `index` is negative
 
 ### Buffer.**addFloat64**
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -153,6 +153,8 @@ export let copy = (b: Bytes) => {
  * @param bytes: The byte sequence to copy from
  * @returns A byte sequence with of the copied bytes
  *
+ * @throws InvalidArgument(String): When `start + length` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -185,6 +187,8 @@ export let slice = (start: Number, length: Number, bytes: Bytes) => {
  * @param right: The number of uninitialized bytes to append
  * @param bytes: The byte sequence get a subset of bytes from
  * @returns A resized byte sequence
+ *
+ * @throws InvalidArgument(String): When the new size is negative
  *
  * @since v0.3.2
  */
@@ -240,6 +244,9 @@ export let resize = (left: Number, right: Number, bytes: Bytes) => {
  * @param length: The amount of bytes to copy from the source buffer
  * @param src: The source byte sequence
  * @param dst: The destination byte sequence
+ *
+ * @throws InvalidArgument(String): When `srcIndex + length` is greater than the `src` bytes size
+ * @throws InvalidArgument(String): When the `dstIndex + length` is greater than the `dst` bytes size
  *
  * @since v0.3.2
  */
@@ -338,6 +345,9 @@ export let clear = (bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A 32-bit integer representing a signed 8-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -357,6 +367,9 @@ export let getInt8S = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to access
  * @param bytes: The byte sequence to access
  * @returns A 32-bit integer representing an unsigned 8-bit integer that starts at the given index
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -378,6 +391,9 @@ export let getInt8U = (index: Number, bytes: Bytes) => {
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -397,6 +413,9 @@ export let setInt8 = (index: Number, value: Int32, bytes: Bytes) => {
  * @param index: The byte index to access
  * @param bytes: The byte sequence to access
  * @returns A 32-bit integer representing a signed 16-bit integer that starts at the given index
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -418,6 +437,9 @@ export let getInt16S = (index: Number, bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A 32-bit integer representing an unsigned 16-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -437,6 +459,9 @@ export let getInt16U = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -458,6 +483,9 @@ export let setInt16 = (index: Number, value: Int32, bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A signed 32-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -477,6 +505,9 @@ export let getInt32 = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -498,6 +529,9 @@ export let setInt32 = (index: Number, value: Int32, bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A 32-bit float that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -517,6 +551,9 @@ export let getFloat32 = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -538,6 +575,9 @@ export let setFloat32 = (index: Number, value: Float32, bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A signed 64-bit integer that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -557,6 +597,9 @@ export let getInt64 = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
  *
  * @since v0.3.2
  */
@@ -578,6 +621,9 @@ export let setInt64 = (index: Number, value: Int64, bytes: Bytes) => {
  * @param bytes: The byte sequence to access
  * @returns A 64-bit float that starts at the given index
  *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -597,6 +643,9 @@ export let getFloat64 = (index: Number, bytes: Bytes) => {
  * @param index: The byte index to update
  * @param value: The value to set
  * @param bytes: The byte sequence to mutate
+ *
+ * @throws IndexOutOfBounds: When `index` is negative
+ * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
  *
  * @since v0.3.2
  */

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -182,6 +182,12 @@ Returns:
 |----|-----------|
 |`Bytes`|A byte sequence with of the copied bytes|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When `start + length` is greater than the bytes size
+
 ### Bytes.**resize**
 
 <details disabled>
@@ -211,6 +217,12 @@ Returns:
 |----|-----------|
 |`Bytes`|A resized byte sequence|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the new size is negative
+
 ### Bytes.**move**
 
 <details disabled>
@@ -234,6 +246,13 @@ Parameters:
 |`length`|`Number`|The amount of bytes to copy from the source buffer|
 |`src`|`Bytes`|The source byte sequence|
 |`dst`|`Bytes`|The destination byte sequence|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `srcIndex + length` is greater than the `src` bytes size
+* When the `dstIndex + length` is greater than the `dst` bytes size
 
 ### Bytes.**concat**
 
@@ -330,6 +349,13 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing a signed 8-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 1` is greater than the bytes size
+
 ### Bytes.**getInt8U**
 
 <details disabled>
@@ -356,6 +382,13 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing an unsigned 8-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 1` is greater than the bytes size
+
 ### Bytes.**setInt8**
 
 <details disabled>
@@ -376,6 +409,13 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 1` is greater than the bytes size
 
 ### Bytes.**getInt16S**
 
@@ -403,6 +443,13 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing a signed 16-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 2` is greater than the bytes size
+
 ### Bytes.**getInt16U**
 
 <details disabled>
@@ -429,6 +476,13 @@ Returns:
 |----|-----------|
 |`Int32`|A 32-bit integer representing an unsigned 16-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 2` is greater than the bytes size
+
 ### Bytes.**setInt16**
 
 <details disabled>
@@ -449,6 +503,13 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 2` is greater than the bytes size
 
 ### Bytes.**getInt32**
 
@@ -476,6 +537,13 @@ Returns:
 |----|-----------|
 |`Int32`|A signed 32-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 4` is greater than the bytes size
+
 ### Bytes.**setInt32**
 
 <details disabled>
@@ -496,6 +564,13 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int32`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 4` is greater than the bytes size
 
 ### Bytes.**getFloat32**
 
@@ -523,6 +598,13 @@ Returns:
 |----|-----------|
 |`Float32`|A 32-bit float that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 4` is greater than the bytes size
+
 ### Bytes.**setFloat32**
 
 <details disabled>
@@ -543,6 +625,13 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Float32`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 4` is greater than the bytes size
 
 ### Bytes.**getInt64**
 
@@ -570,6 +659,13 @@ Returns:
 |----|-----------|
 |`Int64`|A signed 64-bit integer that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 8` is greater than the bytes size
+
 ### Bytes.**setInt64**
 
 <details disabled>
@@ -590,6 +686,13 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Int64`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 8` is greater than the bytes size
 
 ### Bytes.**getFloat64**
 
@@ -617,6 +720,13 @@ Returns:
 |----|-----------|
 |`Float64`|A 64-bit float that starts at the given index|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 8` is greater than the bytes size
+
 ### Bytes.**setFloat64**
 
 <details disabled>
@@ -637,4 +747,11 @@ Parameters:
 |`index`|`Number`|The byte index to update|
 |`value`|`Float64`|The value to set|
 |`bytes`|`Bytes`|The byte sequence to mutate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is negative
+* When `index + 8` is greater than the bytes size
 

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -4,7 +4,7 @@
  * The Char type represents a single [Unicode scalar value](https://www.unicode.org/glossary/#unicode_scalar_value).
  *
  * @example import Char from "char"
- * 
+ *
  * @since 0.3.0
  */
 
@@ -26,23 +26,23 @@ exception MalformedUtf8
 
 /**
  * The minimum valid Unicode scalar value.
- * 
+ *
  * @since 0.3.0
  */
 export let min = 0x0000
 /**
  * The maximum valid Unicode scalar value.
- * 
+ *
  * @since 0.3.0
  */
 export let max = 0x10FFFF
 
 /**
  * Determines whether the given character code is a valid Unicode scalar value.
- * 
+ *
  * @param charCode: The number to check
  * @returns `true` if the number refers to a valid Unicode scalar value or `false` otherwise
- * 
+ *
  * @since 0.3.0
  */
 export let isValid = charCode => {
@@ -53,10 +53,10 @@ export let isValid = charCode => {
 
 /**
  * Determines the Unicode scalar value for a character.
- * 
+ *
  * @param char: The character
  * @returns The Unicode scalar value for the given character
- * 
+ *
  * @since 0.3.0
  */
 @unsafe
@@ -70,11 +70,12 @@ export let code = (char: Char) => {
 
 /**
  * Creates a character from the given Unicode scalar value.
- * Throws an exception if the Unicode scalar value is invalid.
- * 
+ *
  * @param usv: The Unicode scalar value
  * @returns The character for the given Unicode scalar value
- * 
+ *
+ * @throws InvalidArgument(String): When the Unicode scalar value is invalid
+ *
  * @since 0.3.0
  */
 @unsafe
@@ -101,11 +102,12 @@ export let fromCode = (usv: Number) => {
 
 /**
  * Returns the next valid character by Unicode scalar value.
- * Throws if the input character is the max valid Unicode scalar value.
- * 
+ *
  * @param char: The character
  * @returns The next valid character by Unicode scalar value
- * 
+ *
+ * @throws Failure(String): When the input character is the maximum valid Unicode scalar value
+ *
  * @since 0.3.0
  */
 export let succ = char => {
@@ -121,11 +123,12 @@ export let succ = char => {
 
 /**
  * Returns the previous valid character by Unicode scalar value.
- * Throws if the input character is the min valid Unicode scalar value.
- * 
+ *
  * @param char: The character
  * @returns The previous valid character by Unicode scalar value
- * 
+ *
+ * @throws Failure(String): When the input character is the minimum valid Unicode scalar value
+ *
  * @since 0.3.0
  */
 export let pred = char => {
@@ -141,10 +144,10 @@ export let pred = char => {
 
 /**
  * Converts the given character to a string.
- * 
+ *
  * @param char: The character to convert
  * @returns A string containing the given character
- * 
+ *
  * @since 0.3.0
  */
 @unsafe

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -107,7 +107,6 @@ fromCode : Number -> Char
 ```
 
 Creates a character from the given Unicode scalar value.
-Throws an exception if the Unicode scalar value is invalid.
 
 Parameters:
 
@@ -121,6 +120,12 @@ Returns:
 |----|-----------|
 |`Char`|The character for the given Unicode scalar value|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the Unicode scalar value is invalid
+
 ### Char.**succ**
 
 <details disabled>
@@ -133,7 +138,6 @@ succ : Char -> Char
 ```
 
 Returns the next valid character by Unicode scalar value.
-Throws if the input character is the max valid Unicode scalar value.
 
 Parameters:
 
@@ -147,6 +151,12 @@ Returns:
 |----|-----------|
 |`Char`|The next valid character by Unicode scalar value|
 
+Throws:
+
+`Failure(String)`
+
+* When the input character is the maximum valid Unicode scalar value
+
 ### Char.**pred**
 
 <details disabled>
@@ -159,7 +169,6 @@ pred : Char -> Char
 ```
 
 Returns the previous valid character by Unicode scalar value.
-Throws if the input character is the min valid Unicode scalar value.
 
 Parameters:
 
@@ -172,6 +181,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Char`|The previous valid character by Unicode scalar value|
+
+Throws:
+
+`Failure(String)`
+
+* When the input character is the minimum valid Unicode scalar value
 
 ### Char.**toString**
 

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -46,7 +46,7 @@ record ImmutablePriorityQueue<a> {
 
 /**
  * An empty priority queue with the default `compare` comparator.
- * 
+ *
  * @since v0.5.4
  */
 export let empty = {
@@ -59,10 +59,10 @@ export let empty = {
  * determine priority of elements. The comparator function takes two elements
  * and must return 0 if both share priority, a positive number if the first
  * has greater priority, and a negative number if the first has less priority.
- * 
+ *
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
- * 
+ *
  * @example ImmutablePriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
  * @example ImmutablePriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
  *
@@ -74,7 +74,7 @@ export let make = comp => {
 
 /**
  * Gets the number of elements in a priority queue.
- * 
+ *
  * @param pq: The priority queue to inspect
  * @returns The number of elements in the priority queue
  *
@@ -86,7 +86,7 @@ export let size = pq => {
 
 /**
  * Determines if the priority queue contains no elements.
- * 
+ *
  * @param pq: The priority queue to check
  * @returns `true` if the priority queue is empty and `false` otherwise
  *
@@ -131,7 +131,7 @@ let skewInsert = (comp, val, pq) => {
 
 /**
  * Produces a new priority queue by inserting the given element into the given priority queue.
- * 
+ *
  * @param val: The value to add into the priority queue
  * @param pq: The priority queue
  * @returns A new priority queue with the given element inserted
@@ -156,7 +156,7 @@ export let push = (val, pq) => {
 /**
  * Retrieves the highest priority element in the priority queue. It is not
  * removed from the queue.
- * 
+ *
  * @param pq: The priority queue to inspect
  * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
@@ -227,7 +227,7 @@ let merge = (comp, pq1, pq2) =>
 let rec separateHighestPriority = (comp, pq) => {
   match (pq) {
     // empty list case should never happen; this is here just to satisfy the compiler
-    [] => fail "getHighestPriority called with empty PQ",
+    [] => fail "Impossible: getHighestPriority called with empty PQ",
     [node] => (node, []),
     [node, ...rest] => {
       let (currMinNode, currNonMinNodes) = separateHighestPriority(comp, rest)
@@ -267,7 +267,7 @@ let withoutHighestPriority = (comp, pq) => {
 let rec findHighestPriority = (comp, pq) => {
   match (pq) {
     // empty list case should never happen; this is here just to satisfy the compiler
-    [] => fail "findHighestPriority with empty PQ",
+    [] => fail "Impossible: findHighestPriority with empty PQ",
     [node] => node.val,
     [node, ...rest] => {
       let currMin = findHighestPriority(comp, rest)
@@ -280,7 +280,7 @@ let rec findHighestPriority = (comp, pq) => {
  * Produces a new priority queue without the highest priority element in the
  * given priority queue. If the input priority queue is empty, this function will
  * return it.
- * 
+ *
  * @param pq: The priority queue
  * @returns A new priority queue without the highest priority element
  *
@@ -309,7 +309,7 @@ export let pop = pq => {
 
 /**
  * Produces a list of all elements in the priority queue in priority order.
- * 
+ *
  * @param pq: The priority queue to drain
  * @returns A list of all elements in the priority in priority order
  *
@@ -331,7 +331,7 @@ export let drain = pq => {
  * elements. The comparator function takes two elements and must return 0 if
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
- * 
+ *
  * @param list: A list of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
  * @returns A priority queue containing the elements from the list
@@ -348,7 +348,7 @@ export let fromList = (list, comp) => {
  * elements. The comparator function takes two elements and must return 0 if
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
- * 
+ *
  * @param array: An array of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
  * @returns A priority queue containing the elements from the array

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -1,7 +1,7 @@
 /**
  * @module Int32: Utilities for working with the Int32 type.
  * @example import Int32 from "int32"
- * 
+ *
  * @since v0.2.0
  */
 import WasmI32 from "runtime/unsafe/wasmi32"
@@ -23,7 +23,7 @@ import {
  *
  * @param number: The value to convert
  * @returns The Number represented as an Int32
- * 
+ *
  * @since v0.2.0
  */
 export fromNumber
@@ -33,7 +33,7 @@ export fromNumber
  *
  * @param value: The value to convert
  * @returns The Int32 represented as a Number
- * 
+ *
  * @since v0.2.0
  */
 export toNumber
@@ -47,7 +47,7 @@ export toNumber
  *
  * @param value: The value to increment
  * @returns The incremented value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -62,7 +62,7 @@ export let incr = (value: Int32) => {
  *
  * @param value: The value to decrement
  * @returns The decremented value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -78,7 +78,7 @@ export let decr = (value: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -95,7 +95,7 @@ export let add = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -112,7 +112,7 @@ export let sub = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -129,7 +129,7 @@ export let mul = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -146,7 +146,7 @@ export let div = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -163,7 +163,7 @@ export let divU = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -180,7 +180,7 @@ export let rem = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -198,13 +198,15 @@ let abs = n => {
 }
 
 /**
- * Computes the remainder of the division of the first operand by the second. 
+ * Computes the remainder of the division of the first operand by the second.
  * The result will have the sign of the second operand.
  *
  * @param x: The first operand
  * @param y: The second operand
  * @returns The modulus of its operands
- * 
+ *
+ * @throws ModuloByZero: When `y` is zero
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -242,7 +244,7 @@ export let mod = (x: Int32, y: Int32) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -259,7 +261,7 @@ export let rotl = (value: Int32, amount: Int32) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -276,7 +278,7 @@ export let rotr = (value: Int32, amount: Int32) => {
  * @param value: The value to shift
  * @param amount: The number of bits to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -293,7 +295,7 @@ export let shl = (value: Int32, amount: Int32) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -310,7 +312,7 @@ export let shr = (value: Int32, amount: Int32) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -331,7 +333,7 @@ export let shrU = (value: Int32, amount: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -347,7 +349,7 @@ export let eq = (x: Int32, y: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -362,7 +364,7 @@ export let ne = (x: Int32, y: Int32) => {
  *
  * @param value: The value to inspect
  * @returns `true` if the first value is equal to zero or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -377,7 +379,7 @@ export let eqz = (value: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -409,7 +411,7 @@ export let ltU = (x: Int32, y: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -441,7 +443,7 @@ export let gtU = (x: Int32, y: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -473,7 +475,7 @@ export let lteU = (x: Int32, y: Int32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -508,7 +510,7 @@ export let gteU = (x: Int32, y: Int32) => {
  *
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -524,7 +526,7 @@ export let lnot = (value: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -541,7 +543,7 @@ export let land = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -558,7 +560,7 @@ export let lor = (x: Int32, y: Int32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -574,7 +576,7 @@ export let lxor = (x: Int32, y: Int32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of leading zeros
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -589,7 +591,7 @@ export let clz = (value: Int32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of trailing zeros
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -604,7 +606,7 @@ export let ctz = (value: Int32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of 1-bits in its operand
- * 
+ *
  * @since v0.4.0
  */
 @unsafe

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -330,6 +330,12 @@ Returns:
 |----|-----------|
 |`Int32`|The modulus of its operands|
 
+Throws:
+
+`ModuloByZero`
+
+* When `y` is zero
+
 ## Bitwise operations
 
 Functions for operating on bits of Int32 values.

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -1,7 +1,7 @@
 /**
  * @module Int64: Utilities for working with the Int64 type.
  * @example import Int64 from "int64"
- * 
+ *
  * @since v0.2.0
  */
 import WasmI32 from "runtime/unsafe/wasmi32"
@@ -24,7 +24,7 @@ import {
  *
  * @param number: The value to convert
  * @returns The Number represented as an Int64
- * 
+ *
  * @since v0.2.0
  */
 export fromNumber
@@ -34,7 +34,7 @@ export fromNumber
  *
  * @param value: The value to convert
  * @returns The Int64 represented as a Number
- * 
+ *
  * @since v0.2.0
  */
 export toNumber
@@ -48,7 +48,7 @@ export toNumber
  *
  * @param value: The value to increment
  * @returns The incremented value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -63,7 +63,7 @@ export let incr = (value: Int64) => {
  *
  * @param value: The value to decrement
  * @returns The decremented value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -79,7 +79,7 @@ export let decr = (value: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -96,7 +96,7 @@ export let add = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -113,7 +113,7 @@ export let sub = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -130,7 +130,7 @@ export let mul = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -147,7 +147,7 @@ export let div = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -164,7 +164,7 @@ export let divU = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -181,7 +181,7 @@ export let rem = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -199,13 +199,15 @@ let abs = n => {
 }
 
 /**
- * Computes the remainder of the division of the first operand by the second. 
+ * Computes the remainder of the division of the first operand by the second.
  * The result will have the sign of the second operand.
  *
  * @param x: The first operand
  * @param y: The second operand
  * @returns The modulus of its operands
- * 
+ *
+ * @throws ModuloByZero: When `y` is zero
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -243,7 +245,7 @@ export let mod = (x: Int64, y: Int64) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -260,7 +262,7 @@ export let rotl = (value: Int64, amount: Int64) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -277,7 +279,7 @@ export let rotr = (value: Int64, amount: Int64) => {
  * @param value: The value to shift
  * @param amount: The number of bits to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -294,7 +296,7 @@ export let shl = (value: Int64, amount: Int64) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -311,7 +313,7 @@ export let shr = (value: Int64, amount: Int64) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -332,7 +334,7 @@ export let shrU = (value: Int64, amount: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -348,7 +350,7 @@ export let eq = (x: Int64, y: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -363,7 +365,7 @@ export let ne = (x: Int64, y: Int64) => {
  *
  * @param value: The value to inspect
  * @returns `true` if the first value is equal to zero or `false` otherwise
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -378,7 +380,7 @@ export let eqz = (value: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -410,7 +412,7 @@ export let ltU = (x: Int64, y: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -442,7 +444,7 @@ export let gtU = (x: Int64, y: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -474,7 +476,7 @@ export let lteU = (x: Int64, y: Int64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -509,7 +511,7 @@ export let gteU = (x: Int64, y: Int64) => {
  *
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -525,7 +527,7 @@ export let lnot = (value: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -542,7 +544,7 @@ export let land = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -559,7 +561,7 @@ export let lor = (x: Int64, y: Int64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -575,7 +577,7 @@ export let lxor = (x: Int64, y: Int64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of leading zeros
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -590,7 +592,7 @@ export let clz = (value: Int64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of trailing zeros
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -605,7 +607,7 @@ export let ctz = (value: Int64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of 1-bits in its operand
- * 
+ *
  * @since v0.4.0
  */
 @unsafe

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -330,6 +330,12 @@ Returns:
 |----|-----------|
 |`Int64`|The modulus of its operands|
 
+Throws:
+
+`ModuloByZero`
+
+* When `y` is zero
+
 ## Bitwise operations
 
 Functions for operating on bits of Int64 values.

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -437,12 +437,14 @@ export let rec flatten = list => {
 
 /**
  * Inserts a new value into a list at the specified index.
- * Fails if the index is out-of-bounds.
  *
  * @param value: The value to insert
  * @param index: The index to update
  * @param list: The list to update
  * @returns The new list
+ *
+ * @throws Failure(String): When `index` is negative
+ * @throws Failure(String): When `index` is more than 0 and greater than the list size
  *
  * @since v0.1.0
  */
@@ -481,11 +483,13 @@ export let count = (fn, list) => {
 
 /**
  * Split a list into two, with the first list containing the required number of elements.
- * Fails if the input list doesn't contain at least the required amount of elements.
  *
  * @param count: The number of elements required
  * @param list: The list to split
  * @returns Two lists where the first contains exactly the required amount of elements and the second contains any remaining elements
+ *
+ * @throws Failure(String): When `count` is negative
+ * @throws Failure(String): When the list doesn't contain at least the required amount of elements
  *
  * @since v0.1.0
  */
@@ -513,13 +517,13 @@ export let part = (count, list) => {
  * If value is negative, list elements will be rotated by the
  * specified amount to the right. See examples.
  *
- * Fails if the input list doesn't contain at least the required amount of elements.
- *
  * @param count: The number of elements to rotate by
  * @param list: The list to be rotated
  *
  * @example List.rotate(2, [1, 2, 3, 4, 5]) // [3, 4, 5, 1, 2]
  * @example List.rotate(-1, [1, 2, 3, 4, 5]) // [5, 1, 2, 3, 4]
+ *
+ * @throws Failure(String): When the list doesn't contain at least the required amount of elements
  *
  * @since v0.1.0
  */
@@ -556,7 +560,7 @@ export let unique = list => {
  * Produces a new list filled with tuples of elements from both given lists.
  * The first tuple will contain the first item of each list, the second tuple
  * will contain the second item of each list, and so on.
- * 
+ *
  * Calling this function with lists of different sizes will cause the returned
  * list to have the length of the smaller list.
  *
@@ -566,7 +570,7 @@ export let unique = list => {
  *
  * @example List.zip([1, 2, 3], [4, 5, 6]) // [(1, 4), (2, 5), (3, 6)]
  * @example List.zip([1, 2, 3], [4, 5]) // [(1, 4), (2, 5)]
- * 
+ *
  * @since v0.5.3
  */
 export let zip = (list1, list2) => {
@@ -586,7 +590,7 @@ export let zip = (list1, list2) => {
  * applying the function to the first elements of each list, the second element
  * will contain the result of applying the function to the second elements of
  * each list, and so on.
- * 
+ *
  * Calling this function with lists of different sizes will cause the returned
  * list to have the length of the smaller list.
  *
@@ -597,7 +601,7 @@ export let zip = (list1, list2) => {
  *
  * @example List.zipWith((a, b) => a + b, [1, 2, 3], [4, 5, 6]) // [5, 7, 9]
  * @example List.zipWith((a, b) => a * b, [1, 2, 3], [4, 5]) // [4, 10]
- * 
+ *
  * @since v0.5.3
  */
 export let zipWith = (fn, list1, list2) => {
@@ -629,11 +633,11 @@ export let unzip = list => {
  * Produces a new list with the specified number of elements removed from
  * the beginning of the input list.
  *
- * Fails if the specified amount is a negative number.
- *
  * @param count: The amount of elements to remove
  * @param list: The input list
  * @returns The new list without the dropped elements
+ *
+ * @throws Failure(String): When `count` is negative
  *
  * @since v0.2.0
  */
@@ -671,11 +675,11 @@ export let rec dropWhile = (fn, list) => {
  * Produces a new list with–at most—the specified amount elements from
  * the beginning of the input list.
  *
- * Fails if the specified amount is a negative number.
- *
  * @param count: The amount of elements to keep
  * @param list: The input list
  * @returns The new list containing the taken elements
+ *
+ * @throws Failure(String): When `count` is negative
  *
  * @since v0.2.0
  */
@@ -773,12 +777,13 @@ export let product = (list1, list2) => {
  * Provides the subset of a list given zero-based start index and amount of elements
  * to include.
  *
- * Fails if the start index or amount of elements are negative numbers.
- *
  * @param start: The index of the list where the subset will begin (inclusive)
  * @param length: The amount of elements to be included in the subset
  * @param list: The input list
  * @returns The subset of the list
+ *
+ * @throws Failure(String): When `start` is negative
+ * @throws Failure(String): When `length` is negative
  *
  * @since v0.2.0
  */

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -674,7 +674,6 @@ insert : (a, Number, List<a>) -> List<a>
 ```
 
 Inserts a new value into a list at the specified index.
-Fails if the index is out-of-bounds.
 
 Parameters:
 
@@ -689,6 +688,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`List<a>`|The new list|
+
+Throws:
+
+`Failure(String)`
+
+* When `index` is negative
+* When `index` is more than 0 and greater than the list size
 
 ### List.**count**
 
@@ -735,7 +741,6 @@ part : (Number, List<a>) -> (List<a>, List<a>)
 ```
 
 Split a list into two, with the first list containing the required number of elements.
-Fails if the input list doesn't contain at least the required amount of elements.
 
 Parameters:
 
@@ -749,6 +754,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`(List<a>, List<a>)`|Two lists where the first contains exactly the required amount of elements and the second contains any remaining elements|
+
+Throws:
+
+`Failure(String)`
+
+* When `count` is negative
+* When the list doesn't contain at least the required amount of elements
 
 ### List.**rotate**
 
@@ -766,14 +778,18 @@ Rotates list elements by the specified amount to the left.
 If value is negative, list elements will be rotated by the
 specified amount to the right. See examples.
 
-Fails if the input list doesn't contain at least the required amount of elements.
-
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
 |`count`|`Number`|The number of elements to rotate by|
 |`list`|`List<a>`|The list to be rotated|
+
+Throws:
+
+`Failure(String)`
+
+* When the list doesn't contain at least the required amount of elements
 
 Examples:
 
@@ -943,8 +959,6 @@ drop : (Number, List<a>) -> List<a>
 Produces a new list with the specified number of elements removed from
 the beginning of the input list.
 
-Fails if the specified amount is a negative number.
-
 Parameters:
 
 |param|type|description|
@@ -957,6 +971,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`List<a>`|The new list without the dropped elements|
+
+Throws:
+
+`Failure(String)`
+
+* When `count` is negative
 
 ### List.**dropWhile**
 
@@ -1000,8 +1020,6 @@ take : (Number, List<a>) -> List<a>
 Produces a new list with–at most—the specified amount elements from
 the beginning of the input list.
 
-Fails if the specified amount is a negative number.
-
 Parameters:
 
 |param|type|description|
@@ -1014,6 +1032,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`List<a>`|The new list containing the taken elements|
+
+Throws:
+
+`Failure(String)`
+
+* When `count` is negative
 
 ### List.**takeWhile**
 
@@ -1152,8 +1176,6 @@ sub : (Number, Number, List<a>) -> List<a>
 Provides the subset of a list given zero-based start index and amount of elements
 to include.
 
-Fails if the start index or amount of elements are negative numbers.
-
 Parameters:
 
 |param|type|description|
@@ -1167,6 +1189,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`List<a>`|The subset of the list|
+
+Throws:
+
+`Failure(String)`
+
+* When `start` is negative
+* When `length` is negative
 
 ### List.**join**
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1052,7 +1052,7 @@ export let tan = (radians: Number) => {
  * @param z: The value to interpolate
  * @returns The gamma of the given value
  *
- * @throws InvalidArgument(String): When the given value is zero.
+ * @throws InvalidArgument(String): When `z` is zero
  *
  * @since v0.5.4
  */
@@ -1101,10 +1101,11 @@ export let rec gamma = z => {
 
 /**
  * Computes the product of consecutive integers for an integer input and computes the gamma function for non-integer inputs.
- * Fails if the input is a negative number.
  *
  * @param n: The value to factorialize
  * @returns The factorial of the given value
+ *
+ * @throws InvalidArgument(String): When `n` is negative
  *
  * @since v0.5.4
  */

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1048,10 +1048,11 @@ export let tan = (radians: Number) => {
 // https://en.wikipedia.org/wiki/Lanczos_approximation
 /**
  * Computes the gamma function of a value using Lanczos approximation.
- * Fails when the given value is zero.
  *
  * @param z: The value to interpolate
  * @returns The gamma of the given value
+ *
+ * @throws InvalidArgument(String): When the given value is zero.
  *
  * @since v0.5.4
  */

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -899,7 +899,7 @@ Throws:
 
 `InvalidArgument(String)`
 
-* When the given value is zero.
+* When `z` is zero
 
 ### Number.**factorial**
 
@@ -913,7 +913,6 @@ factorial : Number -> Number
 ```
 
 Computes the product of consecutive integers for an integer input and computes the gamma function for non-integer inputs.
-Fails if the input is a negative number.
 
 Parameters:
 
@@ -926,6 +925,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The factorial of the given value|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `n` is negative
 
 ### Number.**toRadians**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -882,7 +882,6 @@ gamma : Number -> Number
 ```
 
 Computes the gamma function of a value using Lanczos approximation.
-Fails when the given value is zero.
 
 Parameters:
 
@@ -895,6 +894,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The gamma of the given value|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When the given value is zero.
 
 ### Number.**factorial**
 

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -1,13 +1,13 @@
 /**
  * @module Option: Utilities for working with the Option data type.
- * 
+ *
  * The Option type is an enum that represents the possibility of something being present (with the `Some` variant), or not (with the `None` variant). There’s no standalone `null` or `nil` type in Grain; use an Option where you would normally reach for `null` or `nil`.
- * 
+ *
  * @example import Option from "option"
- * 
+ *
  * @example let hasValue = Some(1234) // Creates an Option containing 1234
  * @example let noValue = None // Creates an Option containing nothing
- * 
+ *
  * @since v0.2.0
  */
 
@@ -20,7 +20,7 @@
  *
  * @param option: The option to check
  * @returns `true` if the Option is the `Some` variant or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let isSome = option => {
@@ -35,7 +35,7 @@ export let isSome = option => {
  *
  * @param option: The option to check
  * @returns `true` if the Option is the `None` variant or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let isNone = option => {
@@ -51,7 +51,7 @@ export let isNone = option => {
  * @param value: The value to search for
  * @param option: The option to search
  * @returns `true` if the Option is equivalent to `Some(value)` or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let contains = (value, option) => {
@@ -68,7 +68,9 @@ export let contains = (value, option) => {
  * @param msg: The message to use upon failure
  * @param option: The option to extract a value from
  * @returns The unwrapped value if the Option is the `Some` variant
- * 
+ *
+ * @throws Failure(String): When the `option` is `None`
+ *
  * @since v0.2.0
  */
 export let expect = (msg, option) => {
@@ -79,12 +81,14 @@ export let expect = (msg, option) => {
 }
 
 /**
- * Extracts the value inside a `Some` option, otherwise 
+ * Extracts the value inside a `Some` option, otherwise
  * throws an exception containing a default message.
  *
  * @param option: The option to extract the value from
  * @returns The unwrapped value if the Option is the `Some` variant
- * 
+ *
+ * @throws Failure(String): When the `option` is `None`
+ *
  * @since v0.2.0
  */
 export let unwrap = option => {
@@ -97,7 +101,7 @@ export let unwrap = option => {
  * @param default: The default value
  * @param option: The option to unwrap
  * @returns The unwrapped value if the Option is the `Some` variant or the default value otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let unwrapWithDefault = (default, option) => {
@@ -113,7 +117,7 @@ export let unwrapWithDefault = (default, option) => {
  * @param fn: The function to call on the value of a `Some` variant
  * @param option: The option to map
  * @returns A new `Some` variant produced by the mapping function if the variant was `Some` or the unmodified `None` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let map = (fn, option) => {
@@ -131,7 +135,7 @@ export let map = (fn, option) => {
  * @param default: A fallback value for a `None` variant
  * @param option: The option to map
  * @returns The value produced by the mapping function if the Option is of the `Some` variant or the default value otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let mapWithDefault = (fn, default, option) => {
@@ -150,7 +154,7 @@ export let mapWithDefault = (fn, default, option) => {
  * @param defaultFn: The default function
  * @param option: The option to map
  * @returns The value produced by one of the mapping functions
- * 
+ *
  * @since v0.2.0
  */
 export let mapWithDefaultFn = (fn, defaultFn, option) => {
@@ -166,7 +170,7 @@ export let mapWithDefaultFn = (fn, defaultFn, option) => {
  * @param fn: The function to call on the value of a `Some` variant
  * @param option: The option to map
  * @returns A new Option produced by the mapping function if the variant was `Some` or the unmodified `None` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let flatMap = (fn, option) => {
@@ -183,7 +187,7 @@ export let flatMap = (fn, option) => {
  * @param fn: The predicate function to indicate if the option should remain `Some`
  * @param option: The option to inspect
  * @returns `Some(value)` if the variant was `Some` and the predicate returns `true` or `None` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let filter = (fn, option) => {
@@ -204,7 +208,7 @@ export let filter = (fn, option) => {
  * @param optionA: The first option to combine
  * @param optionB: The second option to combine
  * @returns `Some((valueA, valueB))` if both Options are `Some` variants or `None` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let zip = (optionA, optionB) => {
@@ -221,7 +225,7 @@ export let zip = (optionA, optionB) => {
  * @param optionA: The first option to combine
  * @param optionB: The second option to combine
  * @returns `Some(newValue)` if both Options are `Some` variants or `None` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let zipWith = (fn, optionA, optionB) => {
@@ -236,7 +240,7 @@ export let zipWith = (fn, optionA, optionB) => {
  *
  * @param option: The option to flatten
  * @returns `Some(innerValue)` if all nested options were the `Some` variant or `None` otherwise
- * 
+ *
  * @example Option.flatten(Some(Some(1))) == Some(1)
  *
  * @since v0.2.0
@@ -253,7 +257,7 @@ export let flatten = option => {
  *
  * @param option: The option to convert
  * @returns `[value]` if the Option was the `Some` variant or `[]` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let toList = option => {
@@ -268,7 +272,7 @@ export let toList = option => {
  *
  * @param option: The option to convert
  * @returns `[> value]` if the Option was the `Some` variant or `[> ]` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let toArray = option => {
@@ -284,7 +288,7 @@ export let toArray = option => {
  * @param err: The error to use if the option is `None`
  * @param option: The option to convert
  * @returns `Ok(value)` if the Option is `Some(value)` or `Err(err)` if the Option is `None`
- * 
+ *
  * @since v0.2.0
  */
 export let toResult = (err, option) => {
@@ -299,7 +303,7 @@ export let toResult = (err, option) => {
  *
  * @param fn: The function to call on the value of a `Some` variant
  * @param option: The option to inspect
- * 
+ *
  * @since v0.2.0
  */
 export let sideEffect = (fn, option) => {
@@ -316,7 +320,7 @@ export let sideEffect = (fn, option) => {
  * @param fn: The function to call on the value of a `Some` variant
  * @param option: The option to inspect
  * @returns The unmodified option
- * 
+ *
  * @since v0.2.0
  */
 export let peek = (fn, option) => {
@@ -330,7 +334,7 @@ export let peek = (fn, option) => {
  * @param optionA: The first option
  * @param optionB: The second option
  * @returns The first Option if it is the `Some` variant or the second Option otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let or = (optionA, optionB) => {
@@ -346,7 +350,7 @@ export let or = (optionA, optionB) => {
  * @param optionA: The first option
  * @param optionB: The second option
  * @returns The second Option if both are the `Some` variant or the first Option otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let and = (optionA, optionB) => {

--- a/stdlib/option.md
+++ b/stdlib/option.md
@@ -130,6 +130,12 @@ Returns:
 |----|-----------|
 |`a`|The unwrapped value if the Option is the `Some` variant|
 
+Throws:
+
+`Failure(String)`
+
+* When the `option` is `None`
+
 ### Option.**unwrap**
 
 <details disabled>
@@ -155,6 +161,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`a`|The unwrapped value if the Option is the `Some` variant|
+
+Throws:
+
+`Failure(String)`
+
+* When the `option` is `None`
 
 ### Option.**unwrapWithDefault**
 

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -473,9 +473,10 @@ export primitive ignore: a -> Void = "@ignore"
 
 /**
  * Assert that the given Boolean condition is `true`.
- * Throws an `AssertionError` if the condition is `false`.
  *
  * @param condition: The condition to assert
+ *
+ * @throws AssertionError: When the `condition` is false
  *
  * @example assert 3 > 2
  * @example assert true

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -942,13 +942,18 @@ assert : Bool -> Void
 ```
 
 Assert that the given Boolean condition is `true`.
-Throws an `AssertionError` if the condition is `false`.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
 |`condition`|`Bool`|The condition to assert|
+
+Throws:
+
+`AssertionError`
+
+* When the `condition` is false
 
 Examples:
 

--- a/stdlib/result.gr
+++ b/stdlib/result.gr
@@ -1,15 +1,15 @@
 /**
  * @module Result: Utilities for working with the Result data type.
- * 
+ *
  * The Result type is an enum that represents the possibility of a success case (with the `Ok` variant),
  * or an error case (with the `Err` variant). Use a Result as the return type of a function that may return an error.
- * 
+ *
  * @example import Result from "result"
- * 
- * 
+ *
+ *
  * @example let success = Ok((x) => 1 + x) // Creates a successful Result containing (x) => 1 + x
  * @example let failure = Err("Something bad happened") // Creates an unsuccessful Result containing "Something bad happened"
- * 
+ *
  * @since v0.2.0
  */
 
@@ -22,7 +22,7 @@
  *
  * @param result: The result to check
  * @returns `true` if the Result is the `Ok` variant or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let isOk = result => {
@@ -37,7 +37,7 @@ export let isOk = result => {
  *
  * @param result: The result to check
  * @returns `true` if the Result is the `Err` variant or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let isErr = result => !isOk(result)
@@ -47,7 +47,7 @@ export let isErr = result => !isOk(result)
  *
  * @param result: The result to convert
  * @returns `Some(value)` if the Result is `Ok(value)` or `None` if the Result is an `Err`
- * 
+ *
  * @since v0.2.0
  */
 export let toOption = result => {
@@ -63,7 +63,7 @@ export let toOption = result => {
  * @param fn: The function to call on the value of an `Ok` variant
  * @param result: The result to map
  * @returns A new Result produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let flatMap = (fn, result) => {
@@ -79,7 +79,7 @@ export let flatMap = (fn, result) => {
  * @param fn: The function to call on the value of an `Err` variant
  * @param result: The result to map
  * @returns A new Result produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let flatMapErr = (fn, result) => {
@@ -95,7 +95,7 @@ export let flatMapErr = (fn, result) => {
  * @param fn: The function to call on the value of an `Ok` variant
  * @param result: The result to map
  * @returns A new `Ok` variant produced by the mapping function if the variant was `Ok` or the unmodified `Err` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let map = (fn, result) => {
@@ -111,7 +111,7 @@ export let map = (fn, result) => {
  * @param fn: The function to call on the value of an `Err` variant
  * @param result: The result to map
  * @returns A new `Err` variant produced by the mapping function if the variant was `Err` or the unmodified `Ok` otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let mapErr = (fn, result) => {
@@ -129,8 +129,8 @@ export let mapErr = (fn, result) => {
  * @param def: A fallback value for an `Err` variant
  * @param result: The result to map
  * @returns The value produced by the mapping function if the result is of the `Ok` variant or the default value otherwise
- * 
- * @since v0.2.0 
+ *
+ * @since v0.2.0
  */
 export let mapWithDefault = (fn, def, result) => {
   match (result) {
@@ -148,7 +148,7 @@ export let mapWithDefault = (fn, def, result) => {
  * @param fnErr: The function to call on the value of an `Err` variant
  * @param result: The result to map
  * @returns The value produced by one of the mapping functions
- * 
+ *
  * @since v0.2.0
  */
 export let mapWithDefaultFn = (fnOk, fnErr, result) => {
@@ -164,7 +164,7 @@ export let mapWithDefaultFn = (fnOk, fnErr, result) => {
  * @param result1: The first result
  * @param result2: The second result
  * @returns The first Result if it is the `Ok` variant or the second Result otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let or = (result1, result2) => {
@@ -180,7 +180,7 @@ export let or = (result1, result2) => {
  * @param result1: The first result
  * @param result2: The second result
  * @returns The second Result if both are the `Ok` variant or the first Result otherwise
- * 
+ *
  * @since v0.2.0
  */
 export let and = (result1, result2) => {
@@ -198,7 +198,7 @@ export let and = (result1, result2) => {
  * @param fnOk: The function to call on the value of an `Ok` variant
  * @param fnErr: The function to call on the value of an `Err` variant
  * @param result: The result to inspect
- * 
+ *
  * @since v0.2.0
  */
 export let peek = (fnOk, fnErr, result) => {
@@ -213,7 +213,7 @@ export let peek = (fnOk, fnErr, result) => {
  *
  * @param fn: The function to call on the value of an `Ok` variant
  * @param result: The result to inspect
- * 
+ *
  * @since v0.2.0
  */
 export let peekOk = (fn, result) => {
@@ -225,7 +225,7 @@ export let peekOk = (fn, result) => {
  *
  * @param fn: The function to call on the value of an `Err` variant
  * @param result: The result to inspect
- * 
+ *
  * @since v0.2.0
  */
 export let peekErr = (fn, result) => {
@@ -239,6 +239,8 @@ export let peekErr = (fn, result) => {
  * @param msg: The message to prepend if the result contains an `Err`
  * @param result: The result to extract a value from
  * @returns The unwrapped value if the Result is the `Ok` variant
+ *
+ * @throws Failure(String): When the `result` is `Err`
  *
  * @example Result.expect("Unexpected error", Ok(1234)) + 42
  *
@@ -257,6 +259,8 @@ export let expect = (msg, result) => {
  *
  * @param result: The result to extract a value from
  * @returns The unwrapped value if the result is the `Ok` variant
+ *
+ * @throws Failure(String): When the `result` is `Err`
  *
  * @example Result.unwrap(Err("This will throw"))
  *

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -406,6 +406,12 @@ Returns:
 |----|-----------|
 |`a`|The unwrapped value if the Result is the `Ok` variant|
 
+Throws:
+
+`Failure(String)`
+
+* When the `result` is `Err`
+
 Examples:
 
 ```grain
@@ -437,6 +443,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`a`|The unwrapped value if the result is the `Ok` variant|
+
+Throws:
+
+`Failure(String)`
+
+* When the `result` is `Err`
 
 Examples:
 


### PR DESCRIPTION
Closes #767 

This adds a `@throws` attribute to graindoc. This is a draft because we need to figure out some design...

Currently, the "exception name" is optional; however, the generated table looks really weird without an exception name. Should we make this required?

<img width="399" alt="Screen Shot 2022-11-30 at 8 28 53 PM" src="https://user-images.githubusercontent.com/992373/204964206-559b1f03-453e-45b5-8fa2-e102e408461e.png">

Things look good with the "exception name", but do we want to represent the entire pattern (like you'd match on)? Or just the name of the exception?
<img width="463" alt="Screen Shot 2022-11-30 at 8 43 59 PM" src="https://user-images.githubusercontent.com/992373/204964298-d28b1c11-f512-4f38-9e8f-721f4dadc4a4.png">

I also started adding the attributes to the stdlib and it felt better to document separate exceptional cases individually, even if they are throwing the same exception.

Please take a look at this and give me some feedback so I can wrap up this feature. 🙏 
