### PR TITLE
chore(stdlib): Re-enable type annotations in Array module

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -60,7 +60,6 @@ export let rec length = array => {
   ret
 }
 
-// [FIXME] (#793) Type annotation breaks compiler
 /**
  * Creates a new array of the specified length with each element being
  * initialized with the given value.
@@ -74,11 +73,7 @@ export let rec length = array => {
  * @since v0.1.0
  */
 @disableGC
-export let rec make /*: (Number, a) -> Array<a>*/ =
-  (
-    length: Number,
-    item: a,
-  ) => {
+export let rec make: (Number, a) -> Array<a> = (length: Number, item: a) => {
   let lengthArg = length
   let length = initLength(length)
   let byteLength = WasmI32.mul(length, 4n)
@@ -111,7 +106,7 @@ export let rec make /*: (Number, a) -> Array<a>*/ =
  * @since v0.1.0
  */
 @disableGC
-export let rec init /*: (Number, Number -> a) -> Array<a>*/ =
+export let rec init: (Number, Number -> a) -> Array<a> =
   (
     length: Number,
     fn: Number -> a,
@@ -842,7 +837,7 @@ export let zip = (array1: Array<a>, array2: Array<b>) => {
  * applying the function to the first elements of each array, the second element
  * will contain the result of applying the function to the second elements of
  * each array, and so on.
- * 
+ *
  * Calling this function with arrays of different sizes will cause the returned
  * array to have the length of the smaller array.
  *
@@ -853,7 +848,7 @@ export let zip = (array1: Array<a>, array2: Array<b>) => {
  *
  * @example Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) // [> 5, 7, 9]
  * @example Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) // [> 4, 10]
- * 
+ *
  * @since v0.5.3
  */
 export let zipWith = (fn, array1: Array<a>, array2: Array<b>) => {


### PR DESCRIPTION
These didn't get cleaned up when #793 was completed. I noticed them in #1494 