### PR TITLE
feat(graindoc): Support deprecations on module docblocks

### DIFF
--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -2,6 +2,8 @@
  * @module Queue: An immutable queue implementation. A queue is a FIFO (first-in-first-out) data structure where new values are added to the end and retrieved or removed from the beginning.
  * @example import Queue from "queue"
  * @since v0.2.0
+ *
+ * @deprecated This will be renamed to ImmutableQueue in the v0.6.0 release of Grain.
  */
 import List from "list"
 
@@ -20,7 +22,7 @@ record Queue<a> {
 
 /**
  * An empty queue.
- * 
+ *
  * @since v0.5.4
  */
 export let empty = {
@@ -30,11 +32,11 @@ export let empty = {
 
 /**
  * Creates an empty queue.
- * 
+ *
  * @returns An empty queue
- * 
+ *
  * @deprecated This will be removed in the v0.6.0 release of Grain.
- * 
+ *
  * @since v0.2.0
  */
 export let make = () => {
@@ -43,7 +45,7 @@ export let make = () => {
 
 /**
  * Checks if the given queue contains any values.
- * 
+ *
  * @param queue: The queue to check
  * @returns `true` if the given queue is empty or `false` otherwise
  *
@@ -58,7 +60,7 @@ export let isEmpty = queue => {
 
 /**
  * Returns the value at the beginning of the queue. It is not removed from the queue.
- * 
+ *
  * @param queue: The queue to inspect
  * @returns `Some(value)` containing the value at the beginning of the queue, or `None` if the queue is empty
  *
@@ -76,7 +78,7 @@ export let peek = queue => {
 
 /**
  * Adds a value to the end of the queue.
- * 
+ *
  * @param value: The value to append
  * @param queue: The queue to update
  * @returns An updated queue
@@ -95,7 +97,7 @@ export let push = (value, queue) => {
 
 /**
  * Dequeues the next value in the queue.
- * 
+ *
  * @param queue: The queue to change
  * @returns An updated queue
  *
@@ -119,7 +121,7 @@ export let pop = queue => {
 
 /**
  * Get the number of values in a queue.
- * 
+ *
  * @param queue: The queue to inspect
  * @returns The number of values in the queue
  *

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -2,6 +2,8 @@
 title: Queue
 ---
 
+> **Deprecated:** This will be renamed to ImmutableQueue in the v0.6.0 release of Grain.
+
 An immutable queue implementation. A queue is a FIFO (first-in-first-out) data structure where new values are added to the end and retrieved or removed from the beginning.
 
 <details disabled>

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -1,6 +1,8 @@
 /**
  * @module Stack: An immutable stack implementation. A stack is a LIFO (last-in-first-out) data structure where new values are added, retrieved, and removed from the end.
  * @example import Stack from "stack"
+ *
+ * @deprecated This will be renamed to ImmutableStack in the v0.6.0 release of Grain.
  */
 
 import List from "list"
@@ -22,7 +24,7 @@ record Stack<a> {
 
 /**
  * An empty stack.
- * 
+ *
  * @since v0.5.4
  */
 export let empty = {
@@ -34,7 +36,7 @@ export let empty = {
  * Creates a new stack.
  *
  * @returns An empty stack
- * 
+ *
  * @deprecated This will be removed in the v0.6.0 release of Grain.
  */
 export let make = () => {

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -2,6 +2,8 @@
 title: Stack
 ---
 
+> **Deprecated:** This will be renamed to ImmutableStack in the v0.6.0 release of Grain.
+
 An immutable stack implementation. A stack is a LIFO (last-in-first-out) data structure where new values are added, retrieved, and removed from the end.
 
 ```grain


### PR DESCRIPTION
I went to deprecate the `Stack` and `Queue` modules as outlined in https://github.com/grain-lang/grain/pull/1479#issuecomment-1332893678 and found that the docs weren't changing. It turns out that we didn't support the `@deprecated` attribute on a `@module` docblock. This adds support for deprecations on the module docblocks and deprecates the Stack & Queue modules (to be renamed in 0.6)