### PR TITLE
chore: Convert FIXME comments to TODOs

### DIFF
--- a/compiler/src/codegen/optimize_mod.re
+++ b/compiler/src/codegen/optimize_mod.re
@@ -45,7 +45,7 @@ let default_function_optimization_passes =
   List.concat([
     // All the additions here are optional if DWARF must be preserved. That is,
     // when DWARF is relevant we run fewer optimizations.
-    // support DWARF in all of them.
+    // FIXME(BINARYEN): support DWARF in all of them.
     // Untangling to semi-ssa form is helpful (but best to ignore merges
     // so as to not introduce new copies).
     if (optimize_level >= 3 || shrink_level >= 1) {

--- a/compiler/src/codegen/optimize_mod.re
+++ b/compiler/src/codegen/optimize_mod.re
@@ -45,7 +45,7 @@ let default_function_optimization_passes =
   List.concat([
     // All the additions here are optional if DWARF must be preserved. That is,
     // when DWARF is relevant we run fewer optimizations.
-    // FIXME: support DWARF in all of them.
+    // support DWARF in all of them.
     // Untangling to semi-ssa form is helpful (but best to ignore merges
     // so as to not introduce new copies).
     if (optimize_level >= 3 || shrink_level >= 1) {

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -1325,8 +1325,7 @@ let bind_constructor =
 };
 
 let linearize_decl = (env, loc, typath, decl) => {
-  /* FIXME: [philip] This is kind of hacky...would be better to store this in the Env directly...not to mention,
-     I think this'll be much more fragile than if it were in the static info */
+  // TODO(#1510): This is kind of hacky, it would be better to store this in the Env directly
   let ty_id = get_type_id(typath);
   let descrs = Datarepr.constructors_of_type(typath, decl);
   List.map(bind_constructor(env, loc, ty_id), descrs);

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -191,7 +191,7 @@ let types_have_correct_case = (errs, super) => {
     check_uppercase(name_loc, name);
     super.data(self, d);
   };
-  /* FIXME: The parser should read in uppercase types as PTyConstr instances */
+  // TODO(#1502): The parser should read in uppercase types as PTyConstr instances
   let iterator = {...super, data: iter_data};
   {errs, iterator};
 };
@@ -533,6 +533,6 @@ let well_formedness_checker = () =>
 let check_well_formedness = ({statements}) => {
   let checker = well_formedness_checker();
   List.iter(checker.iterator.toplevel(checker.iterator), statements);
-  /* FIXME: We should be able to raise _all_ errors at once */
+  // TODO(#1503): We should be able to raise _all_ errors at once
   List.iter(e => raise(Error(e)), checker.errs^);
 };

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1153,7 +1153,7 @@ let rec lookup_module_descr_aux = (~mark, id, env) =>
     | IdentExternal(m, {txt: n}) =>
       let (p, descr) = lookup_module_descr(~mark, m, env);
       /* let (_, pos) = Tbl.find n (get_components descr).comp_components in */
-      /* FIXME: Should this have a proper position? */
+      // TODO(#1509): Should this have a proper position?
       (PExternal(p, n, Path.nopos), descr);
     }
   )

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1785,7 +1785,7 @@ let rec initial_only_guarded =
 /* Exhaustiveness check */
 /************************/
 
-/* FIXME: If we port over untypeast, then use its function instead */
+// If we were to port untypeast(https://docs.mirage.io/ocaml/Untypeast/index.html) over, we could use its function instead of this
 let untype_constant =
   fun
   | Const_number(Const_number_int(i)) =>

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -82,9 +82,6 @@ let remove_loc =
     location: (_this, _loc) => Location.dummy_loc,
   };
 
-/* FIXME: Remove*/
-let attrs = (s, x) => x;
-
 let rec module_path = (s, path) =>
   try(PathMap.find(path, s.modules)) {
   | Not_found =>
@@ -117,14 +114,6 @@ let type_path = (s, path) =>
     | PExternal(p, n, pos) => PExternal(module_path(s, p), n, pos)
     }
   };
-
-/* FIXME: Decide if this is needed */
-/*let type_path s p =
-  match Path.constructor_typath p with
-  | Regular p -> type_path s p
-  | Cstr (ty_path, cstr) -> Pdot(type_path s ty_path, cstr, nopos)
-  | LocalExt _ -> type_path s p
-  | Ext (p, cstr) -> Pdot(module_path s p, cstr, nopos)*/
 
 let to_subst_by_type_function = (s, p) =>
   switch (PathMap.find(p, s.types)) {

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1258,7 +1258,7 @@ and type_function =
     | [{pmb_pat: {ppat_desc: PPatConstraint(p, _)}, _} as mb] =>
       arity([{...mb, pmb_pat: p}])
     | [{pmb_pat: {ppat_desc: PPatTuple(args)}, _}] => List.length(args)
-    /* FIXME: Less hard-coding, please */
+    // TODO(#1507): Reduce the number of hard-coded cases
     | [{pmb_pat: {ppat_desc: PPatConstruct({txt: ident, _}, []), _}, _}]
         when Identifier.equal(ident, Identifier.IdentName(mknoloc("()"))) => 0
     | _ => failwith("Impossible: type_function: impossible caselist")

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -824,7 +824,7 @@ let transl_data_decl = (env, rec_flag, sdecl_list) => {
     (List.map init_variance decls)
     (List.map (fun _ -> false) decls)*/
 
-  /* FIXME: Check re-exportation */
+  // TODO(#1508): Check re-exportation
   /*List.iter2 (check_abbrev final_env) sdecl_list final_decls;*/
   /* Keep original declaration */
   let final_decls =

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -122,7 +122,6 @@ module MakeIterator =
     Iter.leave_data_declaration(decl);
   }
 
-  // TODO(#1505): Refactor this function
   and iter_toplevel_stmt = stmt => {
     Iter.enter_toplevel_stmt(stmt);
     switch (stmt.ttop_desc) {
@@ -137,7 +136,6 @@ module MakeIterator =
     };
     Iter.leave_toplevel_stmt(stmt);
   }
-  // TODO(#1505): Refactor this function
   and iter_toplevel_stmts = stmts =>
     List.iter(
       cur =>

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -122,7 +122,7 @@ module MakeIterator =
     Iter.leave_data_declaration(decl);
   }
 
-  /* FIXME: These two functions are gross */
+  // TODO(#1505): Refactor this function
   and iter_toplevel_stmt = stmt => {
     Iter.enter_toplevel_stmt(stmt);
     switch (stmt.ttop_desc) {
@@ -137,7 +137,7 @@ module MakeIterator =
     };
     Iter.leave_toplevel_stmt(stmt);
   }
-
+  // TODO(#1505): Refactor this function
   and iter_toplevel_stmts = stmts =>
     List.iter(
       cur =>

--- a/compiler/src/typed/typetexp.re
+++ b/compiler/src/typed/typetexp.re
@@ -119,7 +119,7 @@ let find_component = (lookup: (~mark: _=?) => _, make_error, env, loc, lid) =>
     }
   ) {
   | Not_found =>
-    /* [FIXME] This should be replaced with a more specific exception, since it can eat errors from compilation of submodules */
+    // TODO(#1506): Replace this with a more specific exception as it can eat errors from compilation of submodules
     narrow_unbound_lid_error(env, loc, lid, make_error)
   };
 

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -165,7 +165,7 @@ let nerrors = ref(0);
 let defaults = [
   LetRecNonFunction(""),
   AmbiguousName([], [], false),
-  // [FIXME] see if we can reenable (grain-lang/grain#681)
+  // TODO(#681): Look into reenabling these
   //NotPrincipal(""),
   //NameOutOfScope("", [], false),
   StatementType,

--- a/js-runner/src/core/grain-module.js
+++ b/js-runner/src/core/grain-module.js
@@ -248,7 +248,8 @@ export async function readFile(filepath) {
 }
 
 export async function readURL(url) {
-  let modname = url; // FIXME
+  // TODO(#1537): Switch to using the real module name over the url
+  let modname = url;
   let response = await fetch(url);
   if (!response.ok)
     throw new Error(`[Grain] Could not load ${url} due to a network error.`);

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -110,8 +110,6 @@ export let init: (Number, Number -> a) -> Array<a> =
   let array = allocateArray(length)
   let mut index = 0n
   for (let mut i = 0n; WasmI32.ltS(i, byteLength); i = WasmI32.add(i, 4n)) {
-    // [FIXME] This line fails the array/map test suite (#815)
-    // assert !WasmI32.eqz(WasmI32.and(WasmI32.fromGrain(index), 1n)) // must be a simple int for next line to be correct
     WasmI32.store(
       WasmI32.add(array, i),
       Memory.incRef(WasmI32.fromGrain(fn(tagSimpleNumber(index)))),

--- a/stdlib/runtime/unsafe/printWasm.gr
+++ b/stdlib/runtime/unsafe/printWasm.gr
@@ -2,7 +2,6 @@ import Conv from "runtime/unsafe/conv"
 import WasmI32 from "runtime/unsafe/wasmi32"
 import Memory from "runtime/unsafe/memory"
 
-// TODO(#791): These functions currently leak memory
 @unsafe
 export let printI32 = val => {
   let conv = Conv.toInt32(val)

--- a/stdlib/runtime/unsafe/printWasm.gr
+++ b/stdlib/runtime/unsafe/printWasm.gr
@@ -2,8 +2,7 @@ import Conv from "runtime/unsafe/conv"
 import WasmI32 from "runtime/unsafe/wasmi32"
 import Memory from "runtime/unsafe/memory"
 
-// [FIXME] These all leak ATM (grain-lang/grain#791)
-
+// TODO(#791): These functions currently leak memory
 @unsafe
 export let printI32 = val => {
   let conv = Conv.toInt32(val)


### PR DESCRIPTION
Closes #1499.

This pr converts all `FIXME` comments in the code base to the standardized `TODO format. 

I had to open some new issues for these if anyone wants to add some more context to any of the issues it would probably be helpful for anyone looking to take them on in the future.
#1511 - Is this what this is refering to https://docs.mirage.io/ocaml/Untypeast/index.html?
#1510 
#1509 
#1508 
#1507 
#1506 
#1505 
#1504 
#1503 
#1502 
#1501 - I do not know if I understood this issue properly
#1500 

