### PR TITLE
fix(grainfmt): Ensure comments on function arguments are maintained

### DIFF
--- a/compiler/test/formatter_inputs/comments.gr
+++ b/compiler/test/formatter_inputs/comments.gr
@@ -129,3 +129,9 @@ true
 }
 else
 false
+
+Result.expect(
+    "Unexpected error when writing to stdout",
+    // Is stdout correct here?
+    File.fdWrite(File.stdout, "Status: 500\n\nInternal Server Error")
+)

--- a/compiler/test/formatter_outputs/comments.gr
+++ b/compiler/test/formatter_outputs/comments.gr
@@ -119,3 +119,9 @@ if (true) {
 } else {
   false
 }
+
+Result.expect(
+  "Unexpected error when writing to stdout",
+  // Is stdout correct here?
+  File.fdWrite(File.stdout, "Status: 500\n\nInternal Server Error")
+)


### PR DESCRIPTION
Fixes #983 

Uses new iterator to ensure comments in function argument lists are maintained