### PR TITLE
fix(compiler): Increase JS stack size

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -11,6 +11,8 @@ const v8 = require("v8");
  * This seems to work for our needs with Node 16, but we should be cautious when updating.
  */
 v8.setFlagsFromString("--experimental-wasm-return-call");
+// TODO(#1580): Remove this flag
+v8.setFlagsFromString("--stack-size=2048");
 
 const commander = require("commander");
 const exec = require("./exec.js");


### PR DESCRIPTION
There appears to be a problem we've exposed in the latest release in regards to stack overflows when compiling some programs. This is a temporary fix until we can roll out a full refactor. See https://github.com/grain-lang/grain/issues/1530 for details.