### PR TITLE
feat(docs)!: Update approvals process using CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,78 @@
+# In the format of:
+# FILE @PRIMARY_OWNER ...@SECONDARY_OWNERS
+
+# Order of precendence is top-to-bottom. The last line to match a file will assign the codeowners
+
+# Deliberately no catch-all so we know when we need to add something to this file
+
+/.gitpod.Dockerfile                         @marcusroberts @ospencer
+/.gitpod.yml                                @marcusroberts @ospencer
+/README.md                                  @ospencer @phated @peblair
+
+/.vscode/                                   @phated @ospencer
+
+/docs/                                      @ospencer @phated @peblair @marcusroberts @jozanza
+
+/.github/workflows/ci.yml                   @phated @ospencer
+/.github/workflows/docker-publish.yml       @ospencer @phated
+/.github/workflows/release.yml              @phated @ospencer
+
+/cli/.prettierignore                        @ospencer @phated @jozanza
+/cli/.prettierrc.json                       @ospencer @phated @jozanza
+/cli/__test__/                              @jozanza @phated @ospencer @peblair
+/cli/bin/                                   @phated @ospencer @marcusroberts
+/cli/package.json                           @phated @ospencer
+
+/compiler/esy.lock/                         @phated @ospencer
+/compiler/dune-project                      @ospencer @phated
+/compiler/dune-workspace                    @ospencer @phated
+/compiler/dune                              @ospencer @phated
+/compiler/src/dune                          @phated @ospencer
+/compiler/test/                             @ospencer @phated @peblair
+/compiler/test/formatter_inputs             @marcusroberts @phated @ospencer
+/compiler/test/formatter_outputs            @marcusroberts @phated @ospencer
+/compiler/test/stdlib/                      @ospencer @phated @peblair @marcusroberts @jozanza
+/compiler/grainc/                           @peblair @phated @ospencer
+/compiler/graindoc/                         @phated @marcusroberts @ospencer
+/compiler/grainformat/                      @marcusroberts @phated @ospencer
+/compiler/grainlsp/                         @marcusroberts @phated @ospencer
+/compiler/src/codegen/                      @ospencer @peblair @phated
+/compiler/src/diagnostics/                  @marcusroberts @ospencer @phated
+/compiler/src/formatting/                   @marcusroberts @phated @ospencer
+/compiler/src/language_server/              @marcusroberts @ospencer @phated
+/compiler/src/linking/                      @ospencer @phated @peblair
+/compiler/src/middle_end/                   @ospencer @peblair @phated
+/compiler/src/parsing/                      @ospencer @peblair @phated @marcusroberts
+/compiler/src/typed/                        @ospencer @peblair @phated
+/compiler/src/utils/                        @phated @ospencer @marcusroberts @peblair @jozanza
+/compiler/src/compile.re                    @ospencer @peblair @phated
+/compiler/src/compile.rei                   @ospencer @peblair @phated
+/compiler/esy.json                          @ospencer @phated
+/compiler/package.json                      @ospencer @phated
+
+/js-runner/.prettierignore                  @ospencer @phated
+/js-runner/.prettierrc.json                 @ospencer @phated
+/js-runner/README.md                        @ospencer @phated
+/js-runner/src/                             @ospencer @phated @peblair
+/js-runner/package.json                     @ospencer @phated
+/js-runner/webpack.*.js                     @ospencer @phated
+/js-runner/LICENSE                          @ospencer @peblair
+
+/stdlib/                                    @ospencer @phated @peblair @marcusroberts @jozanza
+/stdlib/runtime/                            @ospencer @peblair @jozanza
+/stdlib/package.json                        @phated @ospencer
+/stdlib/index.js                            @phated
+/stdlib/LICENSE                             @ospencer @peblair
+
+/.gitattributes                             @phated @ospencer
+/.gitignore                                 @phated @ospencer
+/CODE_OF_CONDUCT.md                         @ospencer @phated
+/CONTRIBUTING.md                            @ospencer @peblair @phated @marcusroberts @jozanza
+/.dockerignore                              @ospencer @peblair
+/Dockerfile                                 @ospencer @peblair @phated
+/Dockerfile-slim                            @ospencer @peblair @phated
+/.npmrc                                     @phated @ospencer
+/package-lock.json                          @phated @ospencer
+/package.json                               @phated @ospencer
+/release-please-config.json                 @phated @ospencer
+/LICENSE                                    @ospencer @peblair

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.associations": {
-    "*.dyp": "ocaml.ocamllex"
+    "*.dyp": "ocaml.ocamllex",
+    "CODEOWNERS": "ignore"
   },
   "ocaml.sandbox": {
     "kind": "esy",

--- a/docs/contributor/commits_pull_requests_and_merging.md
+++ b/docs/contributor/commits_pull_requests_and_merging.md
@@ -40,15 +40,15 @@ Introduces a new package `Grain_diagnostics` that provides information needed by
 
 Generally, we want to scope our types to the three primary types defined by the spec:
 
-* `feat:` - This should be the most used type, as most work we are doing in the project are new features. Commits using this type will always show up in the Changelog.
-* `fix:` - When fixing a bug, we should use this type. Commits using this type will always show up in the Changelog.
-* `chore:` - The least used type, these are **not** included in the Changelog unless they are breaking changes.
+- `feat:` - This should be the most used type, as most work we are doing in the project are new features. Commits using this type will always show up in the Changelog.
+- `fix:` - When fixing a bug, we should use this type. Commits using this type will always show up in the Changelog.
+- `chore:` - The least used type, these are **not** included in the Changelog unless they are breaking changes.
 
 We've used some legacy types previously, but these often have a better format:
 
-* `docs:` - These should be annotated as `chore(docs)` if they aren't being changed with a feature or fix.
-* `refactor:` - These should be annotated as `chore(refactor)`.
-* `ci:` - These should be annotated as `chore(ci)`.
+- `docs:` - These should be annotated as `chore(docs)` if they aren't being changed with a feature or fix.
+- `refactor:` - These should be annotated as `chore(refactor)`.
+- `ci:` - These should be annotated as `chore(ci)`.
 
 ### Conventional Commits: Breaking Changes
 
@@ -81,7 +81,7 @@ The easiest way to do this is to have multiple Conventional Commits while you wo
 
 ### Reviews
 
-As the Grain core team has grown, we've adjusted our code review process. On the [grain-lang/grain](https://github.com/grain-lang/grain) repository, we require **two** approvals from core team members for any non-breaking pull request and **three** approvals for pull requests containing breaking changes. For any other repositories in the grain-lang organization, we require **one** approval.
+As the Grain core team has grown, we've adjusted our code review process. On the [grain-lang/grain](https://github.com/grain-lang/grain) repository, we require **one** approval from a "code owner", as defined in the [CODEOWNERS](/.github/CODEOWNERS) file for any non-breaking pull request and approvals from **all** "code owners" for pull requests containing breaking changes. For any other repositories in the grain-lang organization, we require **one** approval from any core team member.
 
 ### With Breaking Changes
 
@@ -97,7 +97,7 @@ We use "squash merging" to merge pull requests. This will cause all commits to b
 
 When squash merging, we can keep intermediate Conventional Commits around by adding them to the body of the commit message; however, the GitHub UI adds a `*` character before each commit message and our releaser bot can't parse that.
 
-When squashing, you want to update both the title of the commit to be a good Conventional Commit and adjust the body to contain any other Conventional Commits that you want to keep (not prefixed with `*`). We also keep any "Co-authored-by:" lines at the bottom of the commit if the change was done by multiple authors. If "Co-authored-by:" lines appear due to accepted PR suggestions, it's good to delete them so the author gets full credit for the change.
+When squashing, you want to update both the title of the commit to be a good Conventional Commit and adjust the body to contain any other Conventional Commits that you want to keep (not prefixed with `*`) and delete any extra information. We also keep any "Co-authored-by:" lines at the bottom of the commit if the change was done by multiple authors. If "Co-authored-by:" lines appear due to accepted PR suggestions, it's good to delete them so the author gets full credit for the change.
 
 Our overall approach to squashing is to be mindful of the impact of each commit. The commits populate our changelog, so it's important to properly convey to Grain consumers what changes have happened. It is also a record that we and others will review in the future. Thus, we want to attribute the change to its correct authors and provide useful information that future contributors need.
 
@@ -105,7 +105,7 @@ Our overall approach to squashing is to be mindful of the impact of each commit.
 
 Before merging, you should mentally review these questions:
 
-* Is continuous integration passing?
-* Do you have the required amount of approvals?
-* Does anyone else need to be pinged for thoughts?
-* Will this cause problems for our release schedule? For example: maybe a patch release still needs to be published.
+- Is continuous integration passing?
+- Do you have the required amount of approvals?
+- Does anyone else need to be pinged for thoughts?
+- Will this cause problems for our release schedule? For example: maybe a patch release still needs to be published.


### PR DESCRIPTION
Closes #976

This introduces a breaking change to our approval process (and thus requires approval from the entire core team). We want to switch to using a CODEOWNERS file and only require one approval from a code owner for non-breaking changes. We'll still require **all** code owner approvals for breaking changes.

Please comment inline on the CODEOWNERS file if you think owners of specific things should be changed—@ospencer and I did the best we could.

From my understanding of CODEOWNERS, this might be clumsy for us to use. GitHub doesn't create a full set of all owners for all touched files, but instead assigns the last match in the file, so order matters. If this doesn't end up working for us, we can look into something else, but this is integrated into the platform. 🤷 