### PR TITLE
fix(compiler): Properly parse large hex numbers

### DIFF
--- a/compiler/src/utils/literals.re
+++ b/compiler/src/utils/literals.re
@@ -3,7 +3,18 @@ let simple_number_max = 1073741823L;
 let simple_number_min = (-1073741824L);
 
 let conv_number_int = s => {
-  Int64.of_string_opt(s);
+  switch (Int64.of_string_opt(s)) {
+  | Some(n) =>
+    // We may accidentally parse the number using its two's
+    // compliment representation when it should be a bigint
+    // We just return None in this case
+    if (n < 0L && s.[0] != '-' || n > 0L && s.[0] == '-') {
+      None;
+    } else {
+      Some(n);
+    }
+  | None => None
+  };
 };
 
 let conv_number_float = s => {

--- a/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
@@ -1,0 +1,69 @@
+basic functionality › bigint_start_pos
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
+ (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
+ (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
+ (elem $elem (global.get $relocBase_0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
+ (func $_gmain (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 f64)
+  (return
+   (block $cleanup_locals.3 (result i32)
+    (local.set $0
+     (block $compile_block.2 (result i32)
+      (block $allocate_number.1 (result i32)
+       (i32.store
+        (local.tee $0
+         (call $malloc_0
+          (global.get $GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+        )
+        (i32.const 5)
+       )
+       (i32.store offset=4
+        (local.get $0)
+        (i32.const 6)
+       )
+       (i32.store offset=8
+        (local.get $0)
+        (i32.const 1)
+       )
+       (i32.store offset=12
+        (local.get $0)
+        (i32.const 0)
+       )
+       (i64.store offset=16
+        (local.get $0)
+        (i64.const -1)
+       )
+       (local.get $0)
+      )
+     )
+    )
+    (local.get $0)
+   )
+  )
+ )
+ (func $_start
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 248
+)

--- a/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
@@ -1,0 +1,69 @@
+basic functionality › bigint_start_neg
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (import \"_grainEnv\" \"mem\" (memory $0 0))
+ (import \"_grainEnv\" \"tbl\" (table $tbl 0 funcref))
+ (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
+ (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
+ (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
+ (elem $elem (global.get $relocBase_0))
+ (export \"memory\" (memory $0))
+ (export \"_gmain\" (func $_gmain))
+ (export \"_start\" (func $_start))
+ (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
+ (func $_gmain (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 f32)
+  (local $5 f64)
+  (return
+   (block $cleanup_locals.3 (result i32)
+    (local.set $0
+     (block $compile_block.2 (result i32)
+      (block $allocate_number.1 (result i32)
+       (i32.store
+        (local.tee $0
+         (call $malloc_0
+          (global.get $GRAIN$EXPORT$malloc_0)
+          (i32.const 24)
+         )
+        )
+        (i32.const 5)
+       )
+       (i32.store offset=4
+        (local.get $0)
+        (i32.const 6)
+       )
+       (i32.store offset=8
+        (local.get $0)
+        (i32.const 1)
+       )
+       (i32.store offset=12
+        (local.get $0)
+        (i32.const 1)
+       )
+       (i64.store offset=16
+        (local.get $0)
+        (i64.const -1)
+       )
+       (local.get $0)
+      )
+     )
+    )
+    (local.get $0)
+   )
+  )
+ )
+ (func $_start
+  (drop
+   (call $_gmain)
+  )
+ )
+ ;; custom section \"cmi\", size 248
+)

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -16,6 +16,8 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("neg", "-40");
   assertSnapshot("simple_min", "-1073741824");
   assertSnapshot("simple_max", "1073741823");
+  assertSnapshot("bigint_start_neg", "-0xffff_ffff_ffff_ffff");
+  assertSnapshot("bigint_start_pos", "0xffff_ffff_ffff_ffff");
   assertSnapshot("heap_number_i32_wrapper", "1073741824");
   assertSnapshot("heap_number_i32_wrapper_max", "2147483647");
   assertSnapshot("heap_number_i64_wrapper", "2147483648");


### PR DESCRIPTION
This makes `0xffff_ffff_ffff_ffff` parse (correctly) as 18446744073709551615 and `-0xffff_ffff_ffff_ffff` as -18446744073709551615. Shoutout to @alex-snezhko for discovering this one.