### PR TITLE
fix(compiler)!: Apply correct rules for parsing Unicode whitespace

### DIFF
--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -7,6 +7,7 @@ describe("parsing", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
   let assertParse = makeParseRunner(test);
+  let assertCompileError = makeCompileErrorRunner(test);
   let assertFileRun = makeFileRunner(test_or_skip);
 
   // operators
@@ -233,6 +234,139 @@ describe("parsing", ({test, testSkip}) => {
           ),
         ),
       ],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+
+  // Whitespace tests
+
+  // Reason does not support OCaml's Unicode escapes, which is why these are
+  // UTF-8 byte sequences instead of pretty Unicode escapes
+
+  assertParse(
+    "whitespace_1",
+    // In order,
+    // HORIZONTAL TABULATION
+    // VERTICAL TABULATION
+    // SPACE
+    // LEFT-TO-RIGHT MARK
+    // RIGHT-TO-LEFT MARK
+    // LINE FEED
+    // FORM FEED
+    // CARRIAGE RETURN
+    // NEXT LINE
+    // LINE SEPARATOR
+    // PARAGRAPH SEPARATOR
+    "
+    module Test
+    \x09
+    \x0b
+    \x20
+    \xe2\x80\x8e
+    \xe2\x80\x8f
+    \x0a
+    \x0c
+    \x0d
+    \xc2\x85
+    \xe2\x80\xa8
+    \xe2\x80\xa9
+    ",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+
+  assertCompileError(
+    "invalid_whitespace_nbsp",
+    "\xc2\xa0",
+    "Grain lexer doesn't recognize this token",
+  );
+  assertCompileError(
+    "invalid_whitespace_emspace",
+    "\xe2\x80\x83",
+    "Grain lexer doesn't recognize this token",
+  );
+  assertCompileError(
+    "invalid_whitespace_hairspace",
+    "\xe2\x80\x8a",
+    "Grain lexer doesn't recognize this token",
+  );
+  assertCompileError(
+    "invalid_whitespace_ideographicspace",
+    "\xe3\x80\x80",
+    "Grain lexer doesn't recognize this token",
+  );
+
+  assertParse(
+    "end_of_statement_linefeed",
+    "module Test; a\x0ab",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_formfeed",
+    "module Test; a\x0cb",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_carriagereturn",
+    "module Test; a\x0db",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_crlf",
+    "module Test; a\x0d\x0ab",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_nextline",
+    "module Test; a\xc2\x85b",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_lineseparator",
+    "module Test; a\xe2\x80\xa8b",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
+  assertParse(
+    "end_of_statement_paragraphseparator",
+    "module Test; a\xe2\x80\xa9b",
+    {
+      module_name: Location.mknoloc("Test"),
+      statements: [Toplevel.expr(a), Toplevel.expr(b)],
       comments: [],
       prog_loc: Location.dummy_loc,
     },


### PR DESCRIPTION
While working on the language reference, I realized that the category used for whitespace wasn't quite right, disallowing some common whitespace while allowing some uncommon ones.

This PR states explicitly that Grain follows https://unicode.org/reports/tr31/#Pattern_Syntax for Unicode allowed in the syntax of the language.

Whitespace in Grain now properly adheres to _Pattern_White_Space_, with additional Grain semantics described below.

Whitespace includes:

Spaces, namely
- Horizontal tab, `U+0009`
- Vertical tab, `U+000B`
- Space, `U+0020`
- Left-to-right mark, `U+200E`
- Right-to-left mark, `U+200F`

Line separators, namely
- Line feed, `U+000A`
- Form feed, `U+000C`
- Carriage return, `U+000D`
- Next line, `U+0085`
- Line separator, `U+2028`
- Paragraph separator, `U+2029`

Line separators act as end-of-statement characters in Grain. Note that this is distinct from file line endings—Grain supports only LF and CRLF (relevant for compiler error messages and tooling).