### PR TITLE
fix(compiler): Provide appropriate error during invalid array access

### DIFF
--- a/compiler/src/codegen/runtime_errors.re
+++ b/compiler/src/codegen/runtime_errors.re
@@ -4,5 +4,6 @@ open Sexplib.Conv;
 [@deriving sexp]
 type grain_error =
   | IndexOutOfBounds
+  | IndexNonInteger
   | MatchFailure
   | AssertionError;

--- a/compiler/src/codegen/runtime_errors.rei
+++ b/compiler/src/codegen/runtime_errors.rei
@@ -3,5 +3,6 @@
 [@deriving sexp]
 type grain_error =
   | IndexOutOfBounds
+  | IndexNonInteger
   | MatchFailure
   | AssertionError;

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -9,6 +9,7 @@ arrays › array_access
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexNonInteger\" (global $GRAIN$EXPORT$IndexNonInteger_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
@@ -31,9 +32,9 @@ arrays › array_access
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.6 (result i32)
+   (block $cleanup_locals.8 (result i32)
     (local.set $0
-     (block $compile_block.5 (result i32)
+     (block $compile_block.7 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,44 +77,89 @@ arrays › array_access
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.4 (result i32)
+      (block $MArrayGet.6 (result i32)
        (local.set $1
-        (i32.shr_s
-         (i32.const 1)
-         (i32.const 1)
-        )
+        (i32.const 1)
        )
        (local.set $2
         (global.get $x_1131)
        )
-       (if
-        (i32.gt_s
-         (i32.mul
+       (block $resolve_idx.5
+        (if
+         (i32.eqz
+          (i32.and
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block $IndexNotSimpleInteger.4
+          (local.set $1
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+          (drop
+           (if (result i32)
+            (i32.or
+             (i32.or
+              (i32.eq
+               (local.get $1)
+               (i32.const 3)
+              )
+              (i32.eq
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i32.eq
+              (local.get $1)
+              (i32.const 6)
+             )
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexNonInteger_0)
+            )
+           )
+          )
+         )
+        )
+        (local.set $1
+         (i32.shr_s
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_s
+          (local.get $1)
+          (i32.const 0)
+         )
+         (local.set $1
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (if
+         (i32.le_u
           (i32.load offset=4
            (local.get $2)
           )
-          (i32.const -1)
+          (local.get $1)
          )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-         )
-        )
-       )
-       (if
-        (i32.le_s
-         (i32.load offset=4
-          (local.get $2)
-         )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+         (drop
+          (call $panicWithException_0
+           (global.get $GRAIN$EXPORT$panicWithException_0)
+           (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+          )
          )
         )
        )
@@ -121,21 +167,9 @@ arrays › array_access
         (global.get $GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
          (i32.add
-          (i32.mul
-           (if (result i32)
-            (i32.lt_s
-             (local.get $1)
-             (i32.const 0)
-            )
-            (i32.add
-             (local.get $1)
-             (i32.load offset=4
-              (local.get $2)
-             )
-            )
-            (local.get $1)
-           )
-           (i32.const 4)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
           (local.get $2)
          )

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -9,6 +9,7 @@ arrays › array_access4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexNonInteger\" (global $GRAIN$EXPORT$IndexNonInteger_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
@@ -31,9 +32,9 @@ arrays › array_access4
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.6 (result i32)
+   (block $cleanup_locals.8 (result i32)
     (local.set $0
-     (block $compile_block.5 (result i32)
+     (block $compile_block.7 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,44 +77,89 @@ arrays › array_access4
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.4 (result i32)
+      (block $MArrayGet.6 (result i32)
        (local.set $1
-        (i32.shr_s
-         (i32.const -3)
-         (i32.const 1)
-        )
+        (i32.const -3)
        )
        (local.set $2
         (global.get $x_1131)
        )
-       (if
-        (i32.gt_s
-         (i32.mul
+       (block $resolve_idx.5
+        (if
+         (i32.eqz
+          (i32.and
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block $IndexNotSimpleInteger.4
+          (local.set $1
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+          (drop
+           (if (result i32)
+            (i32.or
+             (i32.or
+              (i32.eq
+               (local.get $1)
+               (i32.const 3)
+              )
+              (i32.eq
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i32.eq
+              (local.get $1)
+              (i32.const 6)
+             )
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexNonInteger_0)
+            )
+           )
+          )
+         )
+        )
+        (local.set $1
+         (i32.shr_s
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_s
+          (local.get $1)
+          (i32.const 0)
+         )
+         (local.set $1
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (if
+         (i32.le_u
           (i32.load offset=4
            (local.get $2)
           )
-          (i32.const -1)
+          (local.get $1)
          )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-         )
-        )
-       )
-       (if
-        (i32.le_s
-         (i32.load offset=4
-          (local.get $2)
-         )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+         (drop
+          (call $panicWithException_0
+           (global.get $GRAIN$EXPORT$panicWithException_0)
+           (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+          )
          )
         )
        )
@@ -121,21 +167,9 @@ arrays › array_access4
         (global.get $GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
          (i32.add
-          (i32.mul
-           (if (result i32)
-            (i32.lt_s
-             (local.get $1)
-             (i32.const 0)
-            )
-            (i32.add
-             (local.get $1)
-             (i32.load offset=4
-              (local.get $2)
-             )
-            )
-            (local.get $1)
-           )
-           (i32.const 4)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
           (local.get $2)
          )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -9,6 +9,7 @@ arrays › array_access2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexNonInteger\" (global $GRAIN$EXPORT$IndexNonInteger_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
@@ -31,9 +32,9 @@ arrays › array_access2
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.6 (result i32)
+   (block $cleanup_locals.8 (result i32)
     (local.set $0
-     (block $compile_block.5 (result i32)
+     (block $compile_block.7 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,44 +77,89 @@ arrays › array_access2
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.4 (result i32)
+      (block $MArrayGet.6 (result i32)
        (local.set $1
-        (i32.shr_s
-         (i32.const 3)
-         (i32.const 1)
-        )
+        (i32.const 3)
        )
        (local.set $2
         (global.get $x_1131)
        )
-       (if
-        (i32.gt_s
-         (i32.mul
+       (block $resolve_idx.5
+        (if
+         (i32.eqz
+          (i32.and
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block $IndexNotSimpleInteger.4
+          (local.set $1
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+          (drop
+           (if (result i32)
+            (i32.or
+             (i32.or
+              (i32.eq
+               (local.get $1)
+               (i32.const 3)
+              )
+              (i32.eq
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i32.eq
+              (local.get $1)
+              (i32.const 6)
+             )
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexNonInteger_0)
+            )
+           )
+          )
+         )
+        )
+        (local.set $1
+         (i32.shr_s
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_s
+          (local.get $1)
+          (i32.const 0)
+         )
+         (local.set $1
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (if
+         (i32.le_u
           (i32.load offset=4
            (local.get $2)
           )
-          (i32.const -1)
+          (local.get $1)
          )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-         )
-        )
-       )
-       (if
-        (i32.le_s
-         (i32.load offset=4
-          (local.get $2)
-         )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+         (drop
+          (call $panicWithException_0
+           (global.get $GRAIN$EXPORT$panicWithException_0)
+           (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+          )
          )
         )
        )
@@ -121,21 +167,9 @@ arrays › array_access2
         (global.get $GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
          (i32.add
-          (i32.mul
-           (if (result i32)
-            (i32.lt_s
-             (local.get $1)
-             (i32.const 0)
-            )
-            (i32.add
-             (local.get $1)
-             (i32.load offset=4
-              (local.get $2)
-             )
-            )
-            (local.get $1)
-           )
-           (i32.const 4)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
           (local.get $2)
          )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -9,6 +9,7 @@ arrays › array_access3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexNonInteger\" (global $GRAIN$EXPORT$IndexNonInteger_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
@@ -31,9 +32,9 @@ arrays › array_access3
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.6 (result i32)
+   (block $cleanup_locals.8 (result i32)
     (local.set $0
-     (block $compile_block.5 (result i32)
+     (block $compile_block.7 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,44 +77,89 @@ arrays › array_access3
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.4 (result i32)
+      (block $MArrayGet.6 (result i32)
        (local.set $1
-        (i32.shr_s
-         (i32.const 5)
-         (i32.const 1)
-        )
+        (i32.const 5)
        )
        (local.set $2
         (global.get $x_1131)
        )
-       (if
-        (i32.gt_s
-         (i32.mul
+       (block $resolve_idx.5
+        (if
+         (i32.eqz
+          (i32.and
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block $IndexNotSimpleInteger.4
+          (local.set $1
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+          (drop
+           (if (result i32)
+            (i32.or
+             (i32.or
+              (i32.eq
+               (local.get $1)
+               (i32.const 3)
+              )
+              (i32.eq
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i32.eq
+              (local.get $1)
+              (i32.const 6)
+             )
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexNonInteger_0)
+            )
+           )
+          )
+         )
+        )
+        (local.set $1
+         (i32.shr_s
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_s
+          (local.get $1)
+          (i32.const 0)
+         )
+         (local.set $1
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (if
+         (i32.le_u
           (i32.load offset=4
            (local.get $2)
           )
-          (i32.const -1)
+          (local.get $1)
          )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-         )
-        )
-       )
-       (if
-        (i32.le_s
-         (i32.load offset=4
-          (local.get $2)
-         )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+         (drop
+          (call $panicWithException_0
+           (global.get $GRAIN$EXPORT$panicWithException_0)
+           (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+          )
          )
         )
        )
@@ -121,21 +167,9 @@ arrays › array_access3
         (global.get $GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
          (i32.add
-          (i32.mul
-           (if (result i32)
-            (i32.lt_s
-             (local.get $1)
-             (i32.const 0)
-            )
-            (i32.add
-             (local.get $1)
-             (i32.load offset=4
-              (local.get $2)
-             )
-            )
-            (local.get $1)
-           )
-           (i32.const 4)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
           (local.get $2)
          )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -9,6 +9,7 @@ arrays › array_access5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$panicWithException\" (global $GRAIN$EXPORT$panicWithException_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexOutOfBounds\" (global $GRAIN$EXPORT$IndexOutOfBounds_0 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/exception\" \"GRAIN$EXPORT$IndexNonInteger\" (global $GRAIN$EXPORT$IndexNonInteger_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
@@ -31,9 +32,9 @@ arrays › array_access5
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.6 (result i32)
+   (block $cleanup_locals.8 (result i32)
     (local.set $0
-     (block $compile_block.5 (result i32)
+     (block $compile_block.7 (result i32)
       (block $compile_store.3
        (global.set $x_1131
         (tuple.extract 0
@@ -76,44 +77,89 @@ arrays › array_access5
        (block $do_backpatches.2
        )
       )
-      (block $MArrayGet.4 (result i32)
+      (block $MArrayGet.6 (result i32)
        (local.set $1
-        (i32.shr_s
-         (i32.const -5)
-         (i32.const 1)
-        )
+        (i32.const -5)
        )
        (local.set $2
         (global.get $x_1131)
        )
-       (if
-        (i32.gt_s
-         (i32.mul
+       (block $resolve_idx.5
+        (if
+         (i32.eqz
+          (i32.and
+           (local.get $1)
+           (i32.const 1)
+          )
+         )
+         (block $IndexNotSimpleInteger.4
+          (local.set $1
+           (i32.load offset=4
+            (local.get $1)
+           )
+          )
+          (drop
+           (if (result i32)
+            (i32.or
+             (i32.or
+              (i32.eq
+               (local.get $1)
+               (i32.const 3)
+              )
+              (i32.eq
+               (local.get $1)
+               (i32.const 4)
+              )
+             )
+             (i32.eq
+              (local.get $1)
+              (i32.const 6)
+             )
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+            )
+            (call $panicWithException_0
+             (global.get $GRAIN$EXPORT$panicWithException_0)
+             (global.get $GRAIN$EXPORT$IndexNonInteger_0)
+            )
+           )
+          )
+         )
+        )
+        (local.set $1
+         (i32.shr_s
+          (local.get $1)
+          (i32.const 1)
+         )
+        )
+        (if
+         (i32.lt_s
+          (local.get $1)
+          (i32.const 0)
+         )
+         (local.set $1
+          (i32.add
+           (local.get $1)
+           (i32.load offset=4
+            (local.get $2)
+           )
+          )
+         )
+        )
+        (if
+         (i32.le_u
           (i32.load offset=4
            (local.get $2)
           )
-          (i32.const -1)
+          (local.get $1)
          )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
-         )
-        )
-       )
-       (if
-        (i32.le_s
-         (i32.load offset=4
-          (local.get $2)
-         )
-         (local.get $1)
-        )
-        (drop
-         (call $panicWithException_0
-          (global.get $GRAIN$EXPORT$panicWithException_0)
-          (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+         (drop
+          (call $panicWithException_0
+           (global.get $GRAIN$EXPORT$panicWithException_0)
+           (global.get $GRAIN$EXPORT$IndexOutOfBounds_0)
+          )
          )
         )
        )
@@ -121,21 +167,9 @@ arrays › array_access5
         (global.get $GRAIN$EXPORT$incRef_0)
         (i32.load offset=8
          (i32.add
-          (i32.mul
-           (if (result i32)
-            (i32.lt_s
-             (local.get $1)
-             (i32.const 0)
-            )
-            (i32.add
-             (local.get $1)
-             (i32.load offset=4
-              (local.get $2)
-             )
-            )
-            (local.get $1)
-           )
-           (i32.const 4)
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
           (local.get $2)
          )

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -40,8 +40,23 @@ describe("arrays", ({test, testSkip}) => {
     "let x = [> 1, 2, 3]; x[-99]",
     "Index out of bounds",
   );
-  assertCompileError(
+  assertRunError(
     "array_access_err5",
+    "let x = [> 1, 2, 3]; x[1.5]",
+    "Index not an integer",
+  );
+  assertRunError(
+    "array_access_err6",
+    "let x = [> 1, 2, 3]; x[1/3]",
+    "Index not an integer",
+  );
+  assertRunError(
+    "array_access_err7",
+    "let x = [> 1, 2, 3]; x[987654321987654321]",
+    "Index out of bounds",
+  );
+  assertCompileError(
+    "array_access_err8",
     "let x = [> 1, 2, 3]; x[false]",
     "has type Bool but",
   );
@@ -63,6 +78,21 @@ describe("arrays", ({test, testSkip}) => {
   assertRunError(
     "array_set_err2",
     "let x = [> 1, 2, 3]; x[-12] = 4",
+    "Index out of bounds",
+  );
+  assertRunError(
+    "array_set_err3",
+    "let x = [> 1, 2, 3]; x[1.5] = 4",
+    "Index not an integer",
+  );
+  assertRunError(
+    "array_set_err4",
+    "let x = [> 1, 2, 3]; x[1/3] = 4",
+    "Index not an integer",
+  );
+  assertRunError(
+    "array_set_err5",
+    "let x = [> 1, 2, 3]; x[987654321987654321] = 4",
     "Index out of bounds",
   );
   assertCompileError(

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -99,6 +99,7 @@ export let panicWithException = (e: Exception) => {
 }
 
 export exception IndexOutOfBounds
+export exception IndexNonInteger
 export exception DivisionByZero
 export exception ModuloByZero
 export exception Overflow
@@ -119,6 +120,7 @@ export exception InvalidArgument(String)
 let runtimeErrorPrinter = e => {
   match (e) {
     IndexOutOfBounds => Some("IndexOutOfBounds: Index out of bounds"),
+    IndexNonInteger => Some("IndexNonInteger: Index not an integer"),
     DivisionByZero => Some("DivisionByZero: Division by zero"),
     ModuloByZero => Some("ModuloByZero: Modulo by zero"),
     Overflow => Some("Overflow: Number overflow"),


### PR DESCRIPTION
This PR fixes an issue where a potential non-integer or heap-allocated index for an array get/set may not result in an error. It also provides a better error for non-integer indexes.