### PR TITLE
fix(compiler): Fix dependency compilation of wasi polyfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,5 @@ jobs:
       - name: Run NEAR smoketest
         if: matrix.os != 'windows-latest'
         run: |
+          npm run stdlib clean
           npm run cli test

--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -276,7 +276,13 @@ let compile_wasi_polyfill = () => {
         cstate_filename: Some(file),
         cstate_outfile: Some(default_output_filename(file)),
       };
-      ignore(compile_resume(~hook=stop_after_object_file_emitted, cstate));
+      ignore(
+        compile_resume(
+          ~is_root_file=true,
+          ~hook=stop_after_object_file_emitted,
+          cstate,
+        ),
+      );
     })
   | None => ()
   };


### PR DESCRIPTION
Since `~is_root_file` was not set for the polyfill, dependencies were not compiled. Tests didn't catch this because the dependencies were already compiled when the test was run.

Added a clean step to the near smoketest that would catch this in the future.