### PR TITLE
fix(stdlib): build and return stdlib array in File.fdReaddir instead …

### DIFF
--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -34,6 +34,7 @@ import {
 } from "runtime/dataStructures"
 
 import List from "list"
+import { append as appendToArray } from "array"
 
 /**
  * @section Types: Type declarations included in the File module.
@@ -1114,7 +1115,7 @@ export let fdReaddir = (fd: FileDescriptor) => {
         None => {
           Memory.free(bufUsed)
 
-          let arr = allocateArray(numEntries)
+          let mut arr: Array<DirectoryEntry> = [>]
 
           for (let mut i = numEntries - 1n; i >= 0n; i -= 1n) {
             let ent = WasmI32.load(bufs, 0n)
@@ -1130,7 +1131,7 @@ export let fdReaddir = (fd: FileDescriptor) => {
 
             let dirent = { inode, path, filetype }
 
-            WasmI32.store(arr + i * 4n, WasmI32.fromGrain(dirent), 8n)
+            arr = appendToArray([> dirent], arr)
 
             let next = WasmI32.load(bufs, 4n)
             Memory.free(bufs)
@@ -1139,7 +1140,7 @@ export let fdReaddir = (fd: FileDescriptor) => {
             bufs = next
           }
 
-          Ok(WasmI32.toGrain(arr): Array<DirectoryEntry>)
+          Ok(arr)
         },
       }
     }


### PR DESCRIPTION
…of manually managing array memory

I found all sorts of errors when using File.fdReaddir. Sometimes it would hang without outputting data. Sometimes it would output data and then hang. Sometimes it would return cleanly with malformed data. Sometimes but not often it returned the right result!

Most frequent error:
```
RuntimeError: memory access out of bounds
    at wasm://wasm/0011eea6:wasm-function[55]:0x374f
    at wasm://wasm/0011eea6:wasm-function[60]:0x4068
    at wasm://wasm/0011eea6:wasm-function[72]:0x49b6
    at wasm://wasm/0011eea6:wasm-function[484]:0x2c159
    at wasm://wasm/0011eea6:wasm-function[492]:0x2ea9a
    at wasm://wasm/0011eea6:wasm-function[493]:0x2eea4
    at wasm://wasm/0011eea6:wasm-function[495]:0x2f496
    at wasm://wasm/0011eea6:wasm-function[496]:0x2f4d7
    at wasm://wasm/0011eea6:wasm-function[680]:0x47ade
    at wasm://wasm/0011eea6:wasm-function[682]:0x47b4e
```

Examples of malformed data returned:
```grain
// what's up with file x missing and the inode value?
Ok([> <record value>, {
  inode: <enum value>,
  filetype: RegularFile,
  path: "y"
}])

Ok([> <unknown heap tag type: 0x3f9898 | value: 0x3f97d0>, <enum value>, {
  inode: '',
  filetype: ": ",
  path: "z"
}])
```

While debugging I noticed that the when I printed `dirent` here `let dirent = { inode, path, filetype }` it always looked correct so I just changed the arr returned to stdlib array and appended to that. All the problems seem resolved :)