### PR TITLE
fix(compiler): Fix error location reporting of unbound modules and labels

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -2732,7 +2732,9 @@ let () =
     | Error(
         (
           Missing_module(loc, _, _) | Illegal_value_name(loc, _) |
-          Value_not_found_in_module(loc, _, _)
+          Value_not_found_in_module(loc, _, _) |
+          Unbound_module(loc, _) |
+          Unbound_label(loc, _)
         ) as err,
       )
         when loc != Location.dummy_loc =>


### PR DESCRIPTION
This reports the errors inline instead of at the top of the file, like so:

<img width="115" alt="image" src="https://user-images.githubusercontent.com/7244034/210845652-acb1c88b-fc4b-4356-a8c9-a90359ebf60e.png">

<img width="117" alt="image" src="https://user-images.githubusercontent.com/7244034/210845692-7f8e3365-3b54-4acc-bde2-763a2d9db179.png">
