### PR TITLE
fix(grainfmt): Handle comments after braces properly when on one line

### DIFF
--- a/compiler/src/formatting/comment_utils.re
+++ b/compiler/src/formatting/comment_utils.re
@@ -300,22 +300,20 @@ let get_after_brace_comments =
     switch (first) {
     | None => cmts
     | Some(leading) =>
-      let fstclog = Locations.get_comment_loc(fst);
-
-      let (_, itemstartline, itemstartc, _) =
+      let (_, firststartline, firststartc, _) =
         Locations.get_raw_pos_info(leading.loc_start);
 
-      if (itemstartline > startline) {
-        cmts;
-      } else {
-        let (_, cmtstartline, cmtstartc, _) =
-          Locations.get_raw_pos_info(fstclog.loc_start);
-        if (cmtstartline >= itemstartline && cmtstartc > itemstartc) {
-          [];
-        } else {
-          cmts;
-        };
-      };
+      List.filter(
+        cmt => {
+          let cmt_loc = Locations.get_comment_loc(cmt);
+          let (_, cmtendline, cmtendc, _) =
+            Locations.get_raw_pos_info(cmt_loc.loc_end);
+          cmtendline < firststartline
+          || cmtendline == firststartline
+          && cmtendc <= firststartc;
+        },
+        cmts,
+      );
     }
   };
 };

--- a/compiler/test/formatter_inputs/records.gr
+++ b/compiler/test/formatter_inputs/records.gr
@@ -92,3 +92,5 @@ let { // a comment 3
     // comment 2
     num: 1, var: A, // end line comment
     str: "" }
+
+let y = {/* comment 1 */x, /* comment 2 */longlonglongnamenamename2: 12345, /* comment 3 */ longlonglongnamenamename3: 12345 /* comment 4 */} // end line comment

--- a/compiler/test/formatter_outputs/records.gr
+++ b/compiler/test/formatter_outputs/records.gr
@@ -110,3 +110,9 @@ let s = { // comment 1
   var: A, // end line comment
   str: "",
 }
+
+let y = { /* comment 1 */
+  x, /* comment 2 */
+  longlonglongnamenamename2: 12345, /* comment 3 */
+  longlonglongnamenamename3: 12345, /* comment 4 */
+} // end line comment


### PR DESCRIPTION
Fixes #1575 

Handle comments properly when they are on the same line as the brace
