### PR TITLE
feat(compiler)!: Inline record constructors

### DIFF
--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -64,6 +64,8 @@ module CDecl: {
   let mk: (~loc: loc=?, str, constructor_arguments) => constructor_declaration;
   let singleton: (~loc: loc=?, str) => constructor_declaration;
   let tuple: (~loc: loc=?, str, list(parsed_type)) => constructor_declaration;
+  let record:
+    (~loc: loc=?, str, list(label_declaration)) => constructor_declaration;
 };
 
 module LDecl: {
@@ -100,10 +102,14 @@ module Pat: {
   let record:
     (~loc: loc=?, list((option((id, pattern)), Asttypes.closed_flag))) =>
     pattern;
-  let list: (~loc: loc=?, list(listitem(pattern))) => pattern;
+  let list: (~loc: loc, list(listitem(pattern))) => pattern;
   let constant: (~loc: loc=?, constant) => pattern;
   let constraint_: (~loc: loc=?, pattern, parsed_type) => pattern;
-  let construct: (~loc: loc=?, id, list(pattern)) => pattern;
+  let construct: (~loc: loc, id, constructor_pattern) => pattern;
+  let tuple_construct: (~loc: loc, id, list(pattern)) => pattern;
+  let record_construct:
+    (~loc: loc, id, list((option((id, pattern)), Asttypes.closed_flag))) =>
+    pattern;
   let or_: (~loc: loc=?, pattern, pattern) => pattern;
   let alias: (~loc: loc=?, pattern, str) => pattern;
 };
@@ -132,7 +138,7 @@ module Exp: {
     (~loc: loc=?, ~attributes: attributes=?, expression, id, expression) =>
     expression;
   let list:
-    (~loc: loc=?, ~attributes: attributes=?, list(listitem(expression))) =>
+    (~loc: loc, ~attributes: attributes=?, list(listitem(expression))) =>
     expression;
   let array:
     (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
@@ -216,8 +222,12 @@ module Exp: {
     (~loc: loc=?, ~attributes: attributes=?, expression, list(expression)) =>
     expression;
   let construct:
-    (~loc: loc=?, ~attributes: attributes=?, id, list(expression)) =>
+    (~loc: loc, ~attributes: attributes=?, id, constructor_expression) =>
     expression;
+  let tuple_construct:
+    (~loc: loc, ~attributes: attributes=?, id, list(expression)) => expression;
+  let record_construct:
+    (~loc: loc, ~attributes: attributes=?, id, list(recorditem)) => expression;
   let binop:
     (~loc: loc=?, ~attributes: attributes=?, expression, list(expression)) =>
     expression;

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -3388,6 +3388,36 @@ program: LBRACE ELLIPSIS BIGINT COMMA ELLIPSIS BIGINT ARROW
 
 Expected a comma followed by more record fields or an immediate `}` to complete the record expression.
 
+program: UIDENT LBRACE ELLIPSIS UIDENT ARROW
+##
+## Ends in an error in state: 488.
+##
+## construct_expr -> type_id lbrace lseparated_nonempty_list_inner(comma,record_field) . option(comma) rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET LBRACK INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 GETS EOL EOF ELSE DOT DASH COMMA COLON ]
+## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma punned_record_field [ RBRACE EOL COMMA ]
+## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma non_punned_record_field [ RBRACE EOL COMMA ]
+## lseparated_nonempty_list_inner(comma,record_field) -> lseparated_nonempty_list_inner(comma,record_field) . comma spread_record_field [ RBRACE EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## type_id lbrace lseparated_nonempty_list_inner(comma,record_field)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 131, spurious reduction of production type_id -> lseparated_nonempty_list_inner(dot,type_id_str)
+## In state 42, spurious reduction of production construct_expr -> type_id
+## In state 199, spurious reduction of production left_accessor_expr -> construct_expr
+## In state 175, spurious reduction of production non_assign_expr -> left_accessor_expr
+## In state 129, spurious reduction of production non_binop_expr -> non_assign_expr
+## In state 78, spurious reduction of production annotated_expr -> non_binop_expr
+## In state 208, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 68, spurious reduction of production expr -> non_stmt_expr
+## In state 213, spurious reduction of production spread_record_field -> ELLIPSIS expr
+## In state 229, spurious reduction of production lseparated_nonempty_list_inner(comma,record_field) -> spread_record_field
+##
+
+Expected a comma followed by more record fields or an immediate `}` to complete the inline record expression.
+
 program: LBRACE LIDENT COLON BREAK COMMA EOL WHILE
 ##
 ## Ends in an error in state: 336.
@@ -3548,6 +3578,24 @@ program: LBRACE UNDERSCORE
 ##
 
 Expected an expression or a record field.
+
+program: UIDENT LBRACE WHILE
+##
+## Ends in an error in state: 487.
+##
+## construct_expr -> type_id lbrace . record_exprs rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET LBRACK INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 GETS EOL EOF ELSE DOT DASH COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## type_id lbrace
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production lbrace -> LBRACE
+##
+
+Expected an inline record field.
 
 program: LBRACE WASMI64 SEMI RECORD
 ##
@@ -4005,6 +4053,24 @@ program: LET LBRACE WHILE
 ##
 
 Expected a comma-separated list of record field patterns.
+
+program: LET UIDENT LBRACE WHILE
+##
+## Ends in an error in state: 348.
+##
+## pattern -> type_id lbrace . record_patterns rbrace [ WHEN THICKARROW RPAREN RBRACK RBRACE PIPE EQUAL EOL COMMA COLON AS ]
+##
+## The known suffix of the stack is as follows:
+## type_id lbrace
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production lbrace -> LBRACE
+##
+
+Expected a comma-separated list of inline record field patterns.
 
 program: LET LBRACK ELLIPSIS WASMI64 WHILE
 ##

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -35,11 +35,23 @@ and parsed_type = {
   ptyp_loc: Location.t,
 };
 
+/** Type for fields within a record */
+
+[@deriving (sexp, yojson)]
+type label_declaration = {
+  pld_name: loc(Identifier.t),
+  pld_type: parsed_type,
+  pld_mutable: mut_flag,
+  [@sexp_drop_if sexp_locs_disabled]
+  pld_loc: Location.t,
+};
+
 /** Type for arguments to a constructor */
 
 [@deriving (sexp, yojson)]
 type constructor_arguments =
   | PConstrTuple(list(parsed_type))
+  | PConstrRecord(list(label_declaration))
   | PConstrSingleton
 
 [@deriving (sexp, yojson)]
@@ -79,17 +91,6 @@ type constructor_declaration = {
   pcd_args: constructor_arguments,
   [@sexp_drop_if sexp_locs_disabled]
   pcd_loc: Location.t,
-};
-
-/** Type for fields within a record */
-
-[@deriving (sexp, yojson)]
-type label_declaration = {
-  pld_name: loc(Identifier.t),
-  pld_type: parsed_type,
-  pld_mutable: mut_flag,
-  [@sexp_drop_if sexp_locs_disabled]
-  pld_loc: Location.t,
 };
 
 /** Different types of data which can be declared. Currently only one. */
@@ -149,9 +150,14 @@ type pattern_desc =
   | PPatRecord(list((loc(Identifier.t), pattern)), closed_flag)
   | PPatConstant(constant)
   | PPatConstraint(pattern, parsed_type)
-  | PPatConstruct(loc(Identifier.t), list(pattern))
+  | PPatConstruct(loc(Identifier.t), constructor_pattern)
   | PPatOr(pattern, pattern)
   | PPatAlias(pattern, loc(string))
+
+[@deriving (sexp, yojson)]
+and constructor_pattern =
+  | PPatConstrRecord(list((loc(Identifier.t), pattern)), closed_flag)
+  | PPatConstrTuple(list(pattern)) // Empty list used to represent singleton constructors
 
 [@deriving (sexp, yojson)]
 and pattern = {
@@ -459,12 +465,17 @@ and expression_desc =
   | PExpConstraint(expression, parsed_type)
   | PExpLambda(list(pattern), expression)
   | PExpApp(expression, list(expression))
-  | PExpConstruct(loc(Identifier.t), list(expression))
+  | PExpConstruct(loc(Identifier.t), constructor_expression)
   | PExpBlock(list(expression))
   | PExpBoxAssign(expression, expression)
   | PExpAssign(expression, expression)
   | /** Used for modules without body expressions */
     PExpNull
+
+[@deriving (sexp, yojson)]
+and constructor_expression =
+  | PExpConstrTuple(list(expression))
+  | PExpConstrRecord(list((loc(Identifier.t), expression)))
 
 /** let-binding form */
 

--- a/compiler/src/typed/btype.re
+++ b/compiler/src/typed/btype.re
@@ -171,12 +171,15 @@ type type_iterators = {
 let iter_type_expr_cstr_args = f =>
   fun
   | TConstrTuple(tl) => List.iter(f, tl)
+  | TConstrRecord(rfs) => List.iter(rf => f(rf.rf_type), rfs)
   | TConstrSingleton => ();
 
 let map_type_expr_cstr_args = f =>
   fun
   | TConstrSingleton => TConstrSingleton
-  | TConstrTuple(tl) => TConstrTuple(List.map(f, tl));
+  | TConstrTuple(tl) => TConstrTuple(List.map(f, tl))
+  | TConstrRecord(rfs) =>
+    TConstrRecord(List.map(rf => {...rf, rf_type: f(rf.rf_type)}, rfs));
 
 let iter_type_expr_kind = f =>
   fun

--- a/compiler/src/typed/datarepr.re
+++ b/compiler/src/typed/datarepr.re
@@ -46,6 +46,7 @@ let constructor_existentials = (cd_args, cd_res) => {
     switch (cd_args) {
     | TConstrSingleton => []
     | TConstrTuple(l) => l
+    | TConstrRecord(l) => List.map(l => l.rf_type, l)
     };
 
   let existentials =
@@ -65,6 +66,21 @@ let constructor_args = (cd_args, cd_res, path) => {
   switch (cd_args) {
   | TConstrSingleton => (existentials, [], None)
   | TConstrTuple(l) => (existentials, l, None)
+  | TConstrRecord(rfs) =>
+    let arg_vars_set = free_vars(~param=true, newgenty(TTyTuple(tyl)));
+    let type_params = TypeSet.elements(arg_vars_set);
+    let arity = List.length(type_params);
+    let tdecl = {
+      type_params,
+      type_arity: arity,
+      type_kind: TDataRecord(rfs),
+      type_manifest: None,
+      type_loc: Location.dummy_loc,
+      type_newtype_level: None,
+      type_allocation: Managed,
+      type_path: path,
+    };
+    (existentials, [newgenconstr(path, type_params)], Some(tdecl));
   };
 };
 
@@ -114,6 +130,7 @@ let constructor_descrs = (ty_path, decl, cstrs) => {
       cstr_consts: num_consts^,
       cstr_nonconsts: num_nonconsts^,
       cstr_loc: cd_loc,
+      cstr_inlined,
     };
     (cd_id, cstr);
   };
@@ -143,6 +160,7 @@ let extension_descr = (path_ext, ext) => {
     cstr_consts: (-1),
     cstr_nonconsts: (-1),
     cstr_loc: ext.ext_loc,
+    cstr_inlined,
   };
 };
 

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -307,17 +307,6 @@ module TycompTbl = {
       keys2,
     );
   };
-
-  let rec get_all = tbl =>
-    Ident.fold_all((id, x, acc) => [x, ...acc], tbl.current, [])
-    @ (
-      switch (tbl.opened) {
-      | None => []
-      | Some({using, next, components}) =>
-        let rest = get_all(next);
-        Tbl.fold((k, v, acc) => v @ acc, components, []) @ rest;
-      }
-    );
 };
 
 module IdTbl = {
@@ -1305,8 +1294,6 @@ let lookup_modtype = (~mark, id, e) =>
 
 let lookup_all_constructors = (~mark, id, env) =>
   lookup_tycomptbl(~mark, x => x.constructors, x => x.comp_constrs, id, env);
-
-let get_all_constructors = env => TycompTbl.get_all(env.constructors);
 
 let lookup_constructor = (~mark=true, id, env) =>
   switch (lookup_all_constructors(~mark, id, env)) {

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -36,6 +36,7 @@ type error =
   | Missing_module(Location.t, Path.t, Path.t)
   | Unbound_module(Location.t, string)
   | Unbound_label(Location.t, string)
+  | Unbound_label_with_alt(Location.t, string, string)
   | No_module_file(string, option(string))
   | Value_not_found_in_module(Location.t, string, string)
   | Illegal_value_name(Location.t, string)
@@ -105,6 +106,7 @@ let lookup_constructor:
 let lookup_all_constructors:
   (~mark: bool=?, Identifier.t, t) =>
   list((constructor_description, unit => unit));
+let get_all_constructors: t => list(constructor_description);
 let lookup_all_labels:
   (~mark: bool=?, Identifier.t, t) => list((label_description, unit => unit));
 let lookup_module:

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -106,7 +106,6 @@ let lookup_constructor:
 let lookup_all_constructors:
   (~mark: bool=?, Identifier.t, t) =>
   list((constructor_description, unit => unit));
-let get_all_constructors: t => list(constructor_description);
 let lookup_all_labels:
   (~mark: bool=?, Identifier.t, t) => list((label_description, unit => unit));
 let lookup_module:

--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -371,18 +371,13 @@ and print_out_type_1 = ppf =>
   | ty => print_out_type_2(ppf, ty)
 and print_out_type_2 = ppf =>
   fun
-  | Otyp_tuple(tyl) => {
-      pp_open_box(ppf, 1);
-      pp_print_char(ppf, '(');
-      fprintf(
-        ppf,
-        "@[<0>%a@]",
-        print_typlist(print_simple_out_type, ","),
-        tyl,
-      );
-      pp_print_char(ppf, ')');
-      pp_close_box(ppf, ());
-    }
+  | Otyp_tuple(tyl) =>
+    fprintf(
+      ppf,
+      "@[<0>(%a)@]",
+      print_typlist(print_simple_out_type, ","),
+      tyl,
+    )
   | ty => print_simple_out_type(ppf, ty)
 and print_simple_out_type = ppf =>
   fun
@@ -447,13 +442,14 @@ and print_simple_out_type = ppf =>
         tags,
       );
     }
-  | (Otyp_alias(_) | Otyp_poly(_) | Otyp_arrow(_) | Otyp_tuple(_)) as ty => {
+  | (Otyp_alias(_) | Otyp_poly(_) | Otyp_arrow(_)) as ty => {
       pp_open_box(ppf, 1);
       pp_print_char(ppf, '(');
       print_out_type(ppf, ty);
       pp_print_char(ppf, ')');
       pp_close_box(ppf, ());
     }
+  | Otyp_tuple(_) as ty => print_out_type(ppf, ty)
   | Otyp_abstract
   | Otyp_open
   | Otyp_sum(_)
@@ -483,8 +479,8 @@ and print_simple_out_type = ppf =>
 and print_record_decl = (ppf, lbls) =>
   fprintf(
     ppf,
-    "{%a@;<1 -2>}",
-    print_list_init(print_out_label, ppf => fprintf(ppf, "@?")),
+    "{@?@[<v 2>%a@;@]}",
+    print_list_init(print_out_label, ppf => fprintf(ppf, "@;<1 2>")),
     lbls,
   )
 and print_fields = (rest, ppf) =>
@@ -546,7 +542,7 @@ and print_typargs = ppf =>
 and print_out_label = (ppf, (name, mut, arg)) =>
   fprintf(
     ppf,
-    "@[<v>@;<0 2>%s%s: %a,@]",
+    "@[<h>%s%s: %a,@]",
     if (mut) {"mut "} else {""},
     name,
     print_out_type,
@@ -698,20 +694,6 @@ and print_out_sig_item = ppf =>
   | Osig_ellipsis => fprintf(ppf, "...")
 
 and print_out_type_decl = (kwd, ppf, td) => {
-  let print_constraints = ppf =>
-    List.iter(
-      ((ty1, ty2)) =>
-        fprintf(
-          ppf,
-          "@ @[<2>constraint %a =@ %a@]",
-          out_type^,
-          ty1,
-          out_type^,
-          ty2,
-        ),
-      td.otype_cstrs,
-    );
-
   let type_defined = ppf =>
     switch (td.otype_params) {
     | [] => pp_print_string(ppf, td.otype_name)
@@ -743,44 +725,28 @@ and print_out_type_decl = (kwd, ppf, td) => {
     | _ => td.otype_type
     };
 
-  let print_immediate = ppf =>
-    if (td.otype_immediate) {
-      fprintf(ppf, " [%@%@immediate]");
-    } else {
-      ();
-    };
-
-  let print_unboxed = ppf =>
-    if (td.otype_unboxed) {
-      fprintf(ppf, " [%@%@unboxed]");
-    } else {
-      ();
-    };
-
   let print_out_tkind = ppf =>
     fun
     | Otyp_abstract => ()
-    | Otyp_record(lbls) => fprintf(ppf, " %a", print_record_decl, lbls)
+    | Otyp_record(lbls) =>
+      // Similar to print_record_decl, but I couldn't figure out a good way to handle different indents
+      fprintf(
+        ppf,
+        " {@?@[<v 2>%a@]@;}",
+        print_list_init(print_out_label, ppf => fprintf(ppf, "@;")),
+        lbls,
+      )
     | Otyp_sum(constrs) =>
       fprintf(
         ppf,
-        "@[<hov> {@?@[<v>@;<0 2>%a@;<0 0>@]}@]",
-        print_list(print_out_constr, ppf => fprintf(ppf, "@;<0 2>")),
+        " {@?@[<v 2>@;%a,@]@;}",
+        print_list(print_out_constr, ppf => fprintf(ppf, ",@;<0 2>")),
         constrs,
       )
     | Otyp_open => fprintf(ppf, " = ..")
     | ty => fprintf(ppf, " =@;<1 2>%a", out_type^, ty);
 
-  fprintf(
-    ppf,
-    "@[<2>@[<hv 2>%t%a@]%t%t%t@]",
-    print_name_params,
-    print_out_tkind,
-    ty,
-    print_constraints,
-    print_immediate,
-    print_unboxed,
-  );
+  fprintf(ppf, "@[<h>%t%a@]", print_name_params, print_out_tkind, ty);
 }
 
 and print_out_constr = (ppf, (name, tyl, ret_type_opt)) => {
@@ -793,11 +759,11 @@ and print_out_constr = (ppf, (name, tyl, ret_type_opt)) => {
   switch (ret_type_opt) {
   | None =>
     switch (tyl) {
-    | [] => fprintf(ppf, "@[<2>%s,@]", name)
+    | [] => fprintf(ppf, "@?@[<v 2>%s@]", name)
     | _ =>
       fprintf(
         ppf,
-        "@[<2>%s(%a),@]",
+        "%s@?@[<v 2>%a@]",
         name,
         print_typlist(print_simple_out_type, ","),
         tyl,

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1851,7 +1851,7 @@ module Conv = {
           txt: Identifier.IdentName({...cstr_lid, txt: id}),
         };
         Hashtbl.add(constrs, id, cstr);
-        mkpat(PPatConstruct(lid, List.map(loop, lst)));
+        mkpat(PPatConstruct(lid, PPatConstrTuple(List.map(loop, lst)))); // record vs tuple should not matter at this point
       };
 
     let ps = loop(typed);

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -923,7 +923,7 @@ let rec tree_of_type_decl = (id, decl) => {
 
 and tree_of_constructor_arguments =
   fun
-  | TConstrTuple(l) => tree_of_typlist(false, l)
+  | TConstrTuple(l) => [Otyp_tuple(tree_of_typlist(false, l))]
   | TConstrRecord(l) => [Otyp_record(List.map(tree_of_label, l))]
   | TConstrSingleton => []
 

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -815,6 +815,7 @@ let filter_params = tyl => {
 let mark_loops_constructor_arguments =
   fun
   | TConstrTuple(l) => List.iter(mark_loops, l)
+  | TConstrRecord(rfs) => List.iter(rf => mark_loops(rf.rf_type), rfs)
   | TConstrSingleton => ();
 
 let rec tree_of_type_decl = (id, decl) => {
@@ -923,6 +924,7 @@ let rec tree_of_type_decl = (id, decl) => {
 and tree_of_constructor_arguments =
   fun
   | TConstrTuple(l) => tree_of_typlist(false, l)
+  | TConstrRecord(l) => [Otyp_record(List.map(tree_of_label, l))]
   | TConstrSingleton => []
 
 and tree_of_constructor = cd => {
@@ -938,7 +940,13 @@ and tree_of_constructor = cd => {
     names := nm;
     (name, args, Some(ret));
   };
-};
+}
+
+and tree_of_label = l => (
+  Ident.name(l.rf_name),
+  l.rf_mutable,
+  tree_of_typexp(false, l.rf_type),
+);
 
 let tree_of_type_declaration = (id, decl, rs) =>
   Osig_type(tree_of_type_decl(id, decl), tree_of_rec(rs));

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -204,9 +204,17 @@ let type_expr = (s, ty) => {
   ty';
 };
 
+let record_field = (s, l) => {
+  rf_name: l.rf_name,
+  rf_mutable: l.rf_mutable,
+  rf_type: typexp(s, l.rf_type),
+  rf_loc: loc(s, l.rf_loc),
+};
+
 let constructor_arguments = s =>
   fun
   | TConstrTuple(l) => TConstrTuple(List.map(typexp(s), l))
+  | TConstrRecord(l) => TConstrRecord(List.map(record_field(s), l))
   | TConstrSingleton => TConstrSingleton;
 
 let constructor_declaration = (s, c) => {

--- a/compiler/src/typed/translsig.re
+++ b/compiler/src/typed/translsig.re
@@ -78,6 +78,8 @@ let translate_signature = sg =>
             cd => {
               switch (cd.cd_args) {
               | TConstrSingleton => ()
+              | TConstrRecord(rfs) =>
+                List.iter(rf => collect_type_vars(rf.rf_type), rfs)
               | TConstrTuple(tys) => List.iter(collect_type_vars, tys)
               };
               Option.iter(collect_type_vars, cd.cd_res);
@@ -102,6 +104,13 @@ let translate_signature = sg =>
                     | TConstrSingleton => TConstrSingleton
                     | TConstrTuple(tys) =>
                       TConstrTuple(List.map(link_type_vars, tys))
+                    | TConstrRecord(rfs) =>
+                      TConstrRecord(
+                        List.map(
+                          rf => {...rf, rf_type: link_type_vars(rf.rf_type)},
+                          rfs,
+                        ),
+                      )
                     };
                   {
                     ...cd,
@@ -138,12 +147,21 @@ let translate_signature = sg =>
         switch (ec.ext_args) {
         | TConstrSingleton => ()
         | TConstrTuple(tys) => List.iter(collect_type_vars, tys)
+        | TConstrRecord(rfs) =>
+          List.iter(rf => collect_type_vars(rf.rf_type), rfs)
         };
         let ext_type_params = List.map(link_type_vars, ec.ext_type_params);
         let ext_args =
           switch (ec.ext_args) {
           | TConstrSingleton => TConstrSingleton
           | TConstrTuple(tys) => TConstrTuple(List.map(link_type_vars, tys))
+          | TConstrRecord(rfs) =>
+            TConstrRecord(
+              List.map(
+                rf => {...rf, rf_type: link_type_vars(rf.rf_type)},
+                rfs,
+              ),
+            )
           };
         TSigTypeExt(id, {...ec, ext_type_params, ext_args}, ext);
       | TSigModule(_)

--- a/compiler/src/typed/typecore.rei
+++ b/compiler/src/typed/typecore.rei
@@ -138,7 +138,7 @@ type error =
   | No_value_clauses
   | Exception_pattern_below_toplevel
   | Inlined_record_escape
-  | Inlined_record_expected
+  | Inlined_record_misuse(Identifier.t, string, string)
   | Invalid_extension_constructor_payload
   | Not_an_extension_constructor
   | Literal_overflow(string)

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -321,8 +321,18 @@ and core_type_desc =
   | TTyPoly(list(string), core_type);
 
 [@deriving sexp]
+type record_field = {
+  rf_name: Ident.t,
+  rf_type: core_type,
+  rf_mutable: bool,
+  [@sexp_drop_if sexp_locs_disabled]
+  rf_loc: Location.t,
+};
+
+[@deriving sexp]
 type constructor_arguments =
   | TConstrTuple(list(core_type))
+  | TConstrRecord(list(record_field))
   | TConstrSingleton
 
 [@deriving sexp]
@@ -362,15 +372,6 @@ type constructor_declaration = {
   cd_res: option(core_type),
   [@sexp_drop_if sexp_locs_disabled]
   cd_loc: Location.t,
-};
-
-[@deriving sexp]
-type record_field = {
-  rf_name: Ident.t,
-  rf_type: core_type,
-  rf_mutable: bool,
-  [@sexp_drop_if sexp_locs_disabled]
-  rf_loc: Location.t,
 };
 
 [@deriving sexp]
@@ -480,10 +481,16 @@ and expression_desc =
   | TExpConstruct(
       loc(Identifier.t),
       constructor_description,
-      list(expression),
+      constructor_expression,
     )
   | TExpBlock(list(expression))
   | TExpNull
+
+and constructor_expression =
+  | TExpConstrTuple(list(expression))
+  | TExpConstrRecord(
+      array((Types.label_description, record_label_definition)),
+    )
 
 and record_label_definition =
   | Kept

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -300,8 +300,18 @@ and core_type_desc =
   | TTyConstr(Path.t, loc(Identifier.t), list(core_type))
   | TTyPoly(list(string), core_type);
 
+[@deriving sexp]
+type record_field = {
+  rf_name: Ident.t,
+  rf_type: core_type,
+  rf_mutable: bool,
+  [@sexp_drop_if sexp_locs_disabled]
+  rf_loc: Location.t,
+};
+
 type constructor_arguments =
   | TConstrTuple(list(core_type))
+  | TConstrRecord(list(record_field))
   | TConstrSingleton
 
 [@deriving sexp]
@@ -340,15 +350,6 @@ type constructor_declaration = {
   cd_args: constructor_arguments,
   cd_res: option(core_type),
   cd_loc: Location.t,
-};
-
-[@deriving sexp]
-type record_field = {
-  rf_name: Ident.t,
-  rf_type: core_type,
-  rf_mutable: bool,
-  [@sexp_drop_if sexp_locs_disabled]
-  rf_loc: Location.t,
 };
 
 type data_kind =
@@ -448,10 +449,16 @@ and expression_desc =
   | TExpConstruct(
       loc(Identifier.t),
       constructor_description,
-      list(expression),
-    ) // TODO: Decide if needed
+      constructor_expression,
+    )
   | TExpBlock(list(expression))
   | TExpNull
+
+and constructor_expression =
+  | TExpConstrTuple(list(expression))
+  | TExpConstrRecord(
+      array((Types.label_description, record_label_definition)),
+    )
 
 and record_label_definition =
   | Kept

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -858,6 +858,18 @@ let type_module = (~toplevel=false, funct_body, anchor, env, sstr /*scope*/) => 
                       | TConstrSingleton => cd_args
                       | TConstrTuple(exprs) =>
                         TConstrTuple(List.map(resolve_type_expr, exprs))
+                      | TConstrRecord(rfs) =>
+                        TConstrRecord(
+                          List.map(
+                            rf =>
+                              {
+                                ...rf,
+                                Types.rf_type:
+                                  resolve_type_expr(rf.Types.rf_type),
+                              },
+                            rfs,
+                          ),
+                        )
                       },
                   },
                 cdecls,

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -31,14 +31,14 @@ enums › adt_trailing
        (local.tee $0
         (call $malloc_0
          (global.get $GRAIN$EXPORT$malloc_0)
-         (i32.const 80)
+         (i32.const 88)
         )
        )
        (i32.const 1)
       )
       (i32.store offset=4
        (local.get $0)
-       (i32.const 68)
+       (i32.const 76)
       )
       (i64.store offset=8
        (local.get $0)
@@ -46,33 +46,37 @@ enums › adt_trailing
       )
       (i64.store offset=16
        (local.get $0)
-       (i64.const 240518168577)
+       (i64.const 274877906945)
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899347049)
+       (i64.const 103079216233)
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 25769803776)
+       (i64.const 0)
       )
       (i64.store offset=40
        (local.get $0)
-       (i64.const 111546296789059)
+       (i64.const 7306360607450595334)
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 4294967324)
+       (i64.const 137438979443)
       )
       (i64.store offset=56
        (local.get $0)
-       (i64.const 8102087123911311369)
+       (i64.const 4294967296)
       )
       (i64.store offset=64
        (local.get $0)
-       (i64.const 452824363621)
+       (i64.const 8102087123911311369)
       )
       (i64.store offset=72
+       (local.get $0)
+       (i64.const 452824363621)
+      )
+      (i64.store offset=80
        (local.get $0)
        (i64.const 0)
       )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -37,14 +37,14 @@ enums › enum_recursive_data_definition
        (local.tee $0
         (call $malloc_0
          (global.get $GRAIN$EXPORT$malloc_0)
-         (i32.const 120)
+         (i32.const 136)
         )
        )
        (i32.const 1)
       )
       (i32.store offset=4
        (local.get $0)
-       (i32.const 108)
+       (i32.const 124)
       )
       (i64.store offset=8
        (local.get $0)
@@ -52,53 +52,61 @@ enums › enum_recursive_data_definition
       )
       (i64.store offset=16
        (local.get $0)
-       (i64.const 206158430210)
+       (i64.const 240518168578)
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899347050)
+       (i64.const 103079216234)
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 12884901888)
+       (i64.const 0)
       )
       (i64.store offset=40
        (local.get $0)
-       (i64.const 7104846)
+       (i64.const 30515081213116419)
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 4294967316)
+       (i64.const 103079215104)
       )
       (i64.store offset=56
        (local.get $0)
-       (i64.const 8317707895353376772)
+       (i64.const 4294967296)
       )
       (i64.store offset=64
        (local.get $0)
-       (i64.const 206158430208)
+       (i64.const 8317707895353376772)
       )
       (i64.store offset=72
        (local.get $0)
-       (i64.const 85899347049)
+       (i64.const 240518168576)
       )
       (i64.store offset=80
        (local.get $0)
-       (i64.const 21474836480)
+       (i64.const 103079216233)
       )
       (i64.store offset=88
        (local.get $0)
-       (i64.const 521644567877)
+       (i64.const 0)
       )
       (i64.store offset=96
        (local.get $0)
-       (i64.const 4294967316)
+       (i64.const 8390326248911405061)
       )
       (i64.store offset=104
        (local.get $0)
-       (i64.const 7306086876299919364)
+       (i64.const 103079215225)
       )
       (i64.store offset=112
+       (local.get $0)
+       (i64.const 4294967296)
+      )
+      (i64.store offset=120
+       (local.get $0)
+       (i64.const 7306086876299919364)
+      )
+      (i64.store offset=128
        (local.get $0)
        (i64.const 0)
       )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -31,14 +31,14 @@ exceptions › exception_4
        (local.tee $0
         (call $malloc_0
          (global.get $GRAIN$EXPORT$malloc_0)
-         (i32.const 72)
+         (i32.const 80)
         )
        )
        (i32.const 1)
       )
       (i32.store offset=4
        (local.get $0)
-       (i32.const 60)
+       (i32.const 68)
       )
       (i64.store offset=8
        (local.get $0)
@@ -46,29 +46,33 @@ exceptions › exception_4
       )
       (i64.store offset=16
        (local.get $0)
-       (i64.const 206158430209)
+       (i64.const 240518168577)
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899345922)
+       (i64.const 103079215106)
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 12884903017)
+       (i64.const 4849018077184)
       )
       (i64.store offset=40
        (local.get $0)
-       (i64.const 7302982)
+       (i64.const 31366068853276675)
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 4853313044500)
+       (i64.const 103079215104)
       )
       (i64.store offset=56
        (local.get $0)
-       (i64.const 32195083440750595)
+       (i64.const 4853313044480)
       )
       (i64.store offset=64
+       (local.get $0)
+       (i64.const 32195083440750595)
+      )
+      (i64.store offset=72
        (local.get $0)
        (i64.const 0)
       )

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -31,14 +31,14 @@ exceptions › exception_2
        (local.tee $0
         (call $malloc_0
          (global.get $GRAIN$EXPORT$malloc_0)
-         (i32.const 48)
+         (i32.const 56)
         )
        )
        (i32.const 1)
       )
       (i32.store offset=4
        (local.get $0)
-       (i32.const 40)
+       (i32.const 44)
       )
       (i64.store offset=8
        (local.get $0)
@@ -46,19 +46,23 @@ exceptions › exception_2
       )
       (i64.store offset=16
        (local.get $0)
-       (i64.const 120259084289)
+       (i64.const 137438953473)
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899345922)
+       (i64.const 103079215106)
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 12884903017)
+       (i64.const 4849018077184)
       )
       (i64.store offset=40
        (local.get $0)
-       (i64.const 7302982)
+       (i64.const 31366068853276675)
+      )
+      (i64.store offset=48
+       (local.get $0)
+       (i64.const 0)
       )
       (local.get $0)
      )

--- a/compiler/test/formatter_inputs/patterns.gr
+++ b/compiler/test/formatter_inputs/patterns.gr
@@ -26,3 +26,11 @@ match (list) {
   [_, alongidentalongident123456, _] | [_, _, alongidentalongident123456, _, _] => Some(alongidentalongident123456),
   _ => None,
 }
+
+enum Rec { Rec /* first */ { /* second */ x: Number, /* third */ y: Number /* fourth */ } /* fifth */, Tup(Number, Number) }
+
+match (Rec { x: 1, y: 2 }) {
+  Rec  {x: 3, _} => 3,
+  Rec{x, y}|Tup(x, y) => x,
+  Rec{_} => 4
+}

--- a/compiler/test/formatter_inputs/variants.gr
+++ b/compiler/test/formatter_inputs/variants.gr
@@ -17,3 +17,9 @@ enum TrailingComment {
   Cabbage(CabbageColor),
   Broccoli, // We all love squash 
 }
+
+enum InlineRec { Rec {x: Number,y: Number}, Tup(Number, Number) }
+
+let r = Rec { /* first comment */
+x: 1, /* second comment */ y:2 // third comment
+} /* fourth comment */

--- a/compiler/test/formatter_outputs/patterns.gr
+++ b/compiler/test/formatter_outputs/patterns.gr
@@ -21,3 +21,17 @@ match (list) {
     Some(alongidentalongident123456),
   _ => None,
 }
+
+enum Rec { /* first */ /* second */ /* third */ /* fourth */ /* fifth */
+  Rec{
+    x: Number,
+    y: Number,
+  },
+  Tup(Number, Number),
+}
+
+match (Rec{ x: 1, y: 2 }) {
+  Rec{ x: 3, _ } => 3,
+  Rec{ x, y } | Tup(x, y) => x,
+  Rec{ _ } => 4,
+}

--- a/compiler/test/formatter_outputs/variants.gr
+++ b/compiler/test/formatter_outputs/variants.gr
@@ -26,3 +26,16 @@ enum TrailingComment {
   Cabbage(CabbageColor),
   Broccoli, // We all love squash
 }
+
+enum InlineRec {
+  Rec{
+    x: Number,
+    y: Number,
+  },
+  Tup(Number, Number),
+}
+
+let r = Rec{ /* first comment */
+  x: 1, /* second comment */
+  y: 2, // third comment
+} /* fourth comment */

--- a/compiler/test/suites/blocks.re
+++ b/compiler/test/suites/blocks.re
@@ -15,7 +15,8 @@ describe("blocks", ({test}) => {
           statements: [
             Top.expr(
               Exp.block([
-                Exp.construct(
+                Exp.tuple_construct(
+                  ~loc=Location.dummy_loc,
                   Location.mknoloc(
                     Identifier.IdentName(Location.mknoloc("Foo")),
                   ),

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -7,6 +7,7 @@ describe("enums", ({test, testSkip}) => {
 
   let assertSnapshot = makeSnapshotRunner(test);
   let assertRun = makeRunner(test_or_skip);
+  let assertCompileError = makeCompileErrorRunner(test_or_skip);
   let assertFileRun = makeFileRunner(test_or_skip);
 
   assertFileRun("basicenum", "basicenum", "(false, true, true)\n");
@@ -39,5 +40,66 @@ describe("enums", ({test, testSkip}) => {
     "enum_recursive_data_definition_prints",
     recursive_contents,
     "Cons(Node(\"tree 1\", Cons(Node(\"tree 2\", Nil), Nil)), Nil)\n",
+  );
+  // inline record variants
+  assertRun(
+    "enum_inline_record_1",
+    {|
+      enum Rec<a> {
+        Rec{ x: a, y: a },
+        Tup(Number, Number, Number)
+      }
+      let r = Rec{ x: 1, y: 2 }
+      let x = 11
+      let y = 12
+      let r2 = Rec{ y, x }
+      print(r)
+      print(r2)
+      print(r == Rec{ x: 1, y: 2 })
+      print(r == Rec{ x: 2, y: 2 })
+      print(Tup(1, 2, 3))
+    |},
+    "Rec{\n  x: 1,\n  y: 2\n}\nRec{\n  x: 11,\n  y: 12\n}\ntrue\nfalse\nTup(1, 2, 3)\n",
+  );
+  assertCompileError(
+    "enum_inline_record_2",
+    {|
+      enum Rec<a> {
+        Rec{ x: a, y: a }
+      }
+      let r = { x: 1, y: 2, }
+    |},
+    "Unbound record label x. However, this label exists on record constructor Rec, which is incompatible with this record type.",
+  );
+  assertCompileError(
+    "enum_inline_record_3",
+    {|
+      enum Rec<a> {
+        Rec{ x: a, y: a }
+      }
+      let r = Rec{ x: 1 }
+    |},
+    "Some record fields are undefined: y",
+  );
+  assertCompileError(
+    "enum_inline_record_4",
+    {|
+      enum Rec {
+        Rec{ mut x: Number }
+      }
+    |},
+    "An inline record constructor cannot have mutable fields.",
+  );
+  assertRun(
+    "enum_inline_record_5",
+    {|
+      enum Rec {
+        Rec{ x: Number }
+      }
+      let x = 1
+      let b = Rec{ x }
+      print(b)
+    |},
+    "Rec{\n  x: 1\n}\n",
   );
 });

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -416,4 +416,67 @@ describe("pattern matching", ({test, testSkip}) => {
     |},
     "7\n",
   );
+
+  // inline record constructors
+  assertRun(
+    "inline_rec_pattern_1",
+    {|
+      enum E {
+        Tup(String, Number),
+        Rec { x: Number, y: String }
+      }
+      let a = Rec { x: 123, y: "abc" }
+      match (a) {
+        Rec { y, x } => print(x),
+        _ => fail ""
+      }
+      match (a) {
+        Rec { y, _ } | Tup(y, _) => print(y),
+        _ => fail ""
+      }
+      match (a) {
+        Rec { _ } => print("record"),
+        _ => fail ""
+      }
+    |},
+    "123\nabc\nrecord\n",
+  );
+  assertRun(
+    "inline_rec_pattern_2",
+    {|
+      enum E {
+        Rec { x: Number, y: String }
+      }
+      let a = Rec { x: 123, y: "abc" }
+      let Rec { y, _ } = a
+      print(y)
+    |},
+    "abc\n",
+  );
+  assertCompileError(
+    "inline_rec_pattern_3",
+    {|
+      enum E {
+        T(Number),
+        R { x: Number }
+      }
+      match (T(1)) {
+        T { _ } => print("success"),
+        _ => fail ""
+      }
+    |},
+    "T is a tuple constructor but a record constructor pattern was given.",
+  );
+  assertCompileError(
+    "inline_rec_pattern_4",
+    {|
+      enum Rec {
+        Rec { x: Number }
+      }
+      match (Rec { x: 1 }) {
+        Rec(y) => print("success")
+      }
+    |},
+    "Rec is a record constructor but a tuple constructor pattern was given.",
+  );
 });

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -142,7 +142,6 @@ let getVariantMetadata = variant => {
     block += WasmI32.load(block, 0n)
   }
 
-  // result
   return -1n
 }
 

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -81,59 +81,31 @@ let _OK = "Ok"
 let _ERR = "Err"
 
 @unsafe
-let getVariantName = variant => {
+let getBuiltinVariantName = variant => {
   let typeId = WasmI32.load(variant, 8n) >> 1n
   let variantId = WasmI32.load(variant, 12n) >> 1n
 
   match (typeId) {
     id when id == _OPTION_ID => {
       if (variantId == 0n) {
-        return Memory.incRef(WasmI32.fromGrain(_SOME))
+        Memory.incRef(WasmI32.fromGrain(_SOME))
       } else {
-        return Memory.incRef(WasmI32.fromGrain(_NONE))
+        Memory.incRef(WasmI32.fromGrain(_NONE))
       }
     },
     id when id == _RESULT_ID => {
       if (variantId == 0n) {
-        return Memory.incRef(WasmI32.fromGrain(_OK))
+        Memory.incRef(WasmI32.fromGrain(_OK))
       } else {
-        return Memory.incRef(WasmI32.fromGrain(_ERR))
+        Memory.incRef(WasmI32.fromGrain(_ERR))
       }
     },
-    _ => {
-      let mut block = findTypeMetadata(typeId)
-
-      if (block == -1n) return -1n
-
-      let sectionLength = WasmI32.load(block, 0n)
-      block += 8n
-
-      let end = block + sectionLength
-      while (block < end) {
-        if (WasmI32.load(block, 4n) == variantId) {
-          let length = WasmI32.load(block, 8n)
-          let str = allocateString(length)
-          Memory.copy(str + 8n, block + 12n, length)
-          return str
-        }
-        block += WasmI32.load(block, 0n)
-      }
-
-      return -1n
-    },
+    _ => -1n,
   }
 }
 
 @unsafe
-let getRecordFieldNames = record_ => {
-  let typeId = WasmI32.load(record_, 8n) >> 1n
-  let arity = WasmI32.load(record_, 12n)
-
-  let mut fields = findTypeMetadata(typeId)
-
-  if (fields == -1n) return -1n
-  fields += 8n
-
+let getFieldArray = (fields, arity) => {
   let fieldArray = allocateArray(arity)
 
   let mut fieldOffset = 0n
@@ -147,7 +119,44 @@ let getRecordFieldNames = record_ => {
     fieldOffset += WasmI32.load(fields + fieldOffset, 0n)
   }
 
-  return fieldArray
+  fieldArray
+}
+
+@unsafe
+let getVariantMetadata = variant => {
+  let typeId = WasmI32.load(variant, 8n) >> 1n
+  let variantId = WasmI32.load(variant, 12n) >> 1n
+
+  let mut block = findTypeMetadata(typeId)
+
+  if (block == -1n) return -1n
+
+  let sectionLength = WasmI32.load(block, 0n)
+  block += 8n
+
+  let end = block + sectionLength
+  while (block < end) {
+    if (WasmI32.load(block, 8n) == variantId) {
+      return block
+    }
+    block += WasmI32.load(block, 0n)
+  }
+
+  // result
+  return -1n
+}
+
+@unsafe
+let getRecordFieldNames = record_ => {
+  let typeId = WasmI32.load(record_, 8n) >> 1n
+  let arity = WasmI32.load(record_, 12n)
+
+  let mut fields = findTypeMetadata(typeId)
+
+  if (fields == -1n) return -1n
+
+  fields += 8n
+  return getFieldArray(fields, arity)
 }
 
 @unsafe
@@ -384,38 +393,48 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
       // [ <value type tag>, <module_tag>, <type_tag>, <variant_tag>, <arity>, elts ... ]
-      let variantName = getVariantName(ptr)
-
-      if (variantName == -1n) {
-        "<enum value>"
+      let builtinVariantName = getBuiltinVariantName(ptr)
+      if (builtinVariantName != -1n) {
+        // Assumes that all builtin variants do not have inline record
+        // constructors; if this changes this should be changed as well
+        tupleVariantToString(
+          ptr,
+          WasmI32.toGrain(builtinVariantName),
+          extraIndents
+        )
       } else {
-        let variantName = WasmI32.toGrain(variantName): String
-        // Check if this is a list
-        if (isListVariant(variantName)) {
-          listToString(ptr, extraIndents)
+        let variantPtr = getVariantMetadata(ptr)
+        if (variantPtr == -1n) {
+          "<enum value>"
         } else {
-          let variantArity = WasmI32.load(ptr, 16n)
-          if (variantArity == 0n) {
-            variantName
+          let length = WasmI32.load(variantPtr, 12n)
+          let variantName = allocateString(length)
+          Memory.copy(variantName + 8n, variantPtr + 16n, length)
+          let variantName = WasmI32.toGrain(variantName): String
+          // Check if this is a list
+          if (isListVariant(variantName)) {
+            listToString(ptr, extraIndents)
           } else {
-            let comspace = ", "
-            let rparen = ")"
-            let mut strings = [rparen]
-            for (let mut i = variantArity * 4n - 4n; i >= 0n; i -= 4n) {
-              let tmp = toStringHelp(
-                WasmI32.load(ptr + i, 20n),
-                extraIndents,
-                false
+            let distToRecordFields = WasmI32.load(variantPtr, 4n)
+            let isRecordVariant = distToRecordFields != 0n
+            if (isRecordVariant) {
+              let fields = variantPtr + distToRecordFields
+              let recordArity = WasmI32.load(ptr, 16n)
+              let recordVariantFields = getFieldArray(fields, recordArity)
+              let recordString = recordToString(
+                ptr,
+                recordArity,
+                recordVariantFields,
+                20n,
+                extraIndents
               )
-              strings = [tmp, ...strings]
-              if (i > 0n) {
-                strings = [comspace, ...strings]
-              }
-            }
-            let lparen = "("
-            strings = [variantName, lparen, ...strings]
+              Memory.decRef(recordVariantFields)
+              let strings = [variantName, recordString]
 
-            join(strings)
+              join(strings)
+            } else {
+              tupleVariantToString(ptr, variantName, extraIndents)
+            }
           }
         }
       }
@@ -426,43 +445,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       if (fields == -1n) {
         "<record value>"
       } else {
-        let prevPadAmount = extraIndents * 2n
-        let prevSpacePadding = if (prevPadAmount == 0n) {
-          ""
-        } else {
-          let v = allocateString(prevPadAmount)
-          Memory.fill(
-            v + 8n,
-            0x20n,
-            prevPadAmount
-          ) // create indentation for closing brace
-          WasmI32.toGrain(v): String
-        }
-        let padAmount = (extraIndents + 1n) * 2n
-        let spacePadding = allocateString(padAmount)
-        Memory.fill(spacePadding + 8n, 0x20n, padAmount) // create indentation
-        let spacePadding = WasmI32.toGrain(spacePadding): String
-        let newline = "\n"
-        let rbrace = "}"
-        let mut strings = [newline, prevSpacePadding, rbrace]
-        let colspace = ": "
-        let comlf = ",\n"
-        for (let mut i = recordArity * 4n - 4n; i >= 0n; i -= 4n) {
-          let fieldName = WasmI32.toGrain(WasmI32.load(fields + i, 8n)): String
-          let fieldValue = toStringHelp(
-            WasmI32.load(ptr + i, 16n),
-            extraIndents + 1n,
-            false
-          )
-          strings = [spacePadding, fieldName, colspace, fieldValue, ...strings]
-          if (i > 0n) {
-            strings = [comlf, ...strings]
-          }
-        }
-        let lbrace = "{\n"
-        strings = [lbrace, ...strings]
-
-        join(strings)
+        let result = recordToString(ptr, recordArity, fields, 16n, extraIndents)
+        Memory.decRef(fields)
+        result
       }
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
@@ -615,6 +600,66 @@ listToString = (ptr, extraIndents) => {
   strings = [rbrack, ...strings]
   let reversed = reverse(strings)
   join(reversed)
+},
+tupleVariantToString = (ptr, variantName, extraIndents) => {
+  let variantArity = WasmI32.load(ptr, 16n)
+  if (variantArity == 0n) {
+    variantName
+  } else {
+    let comspace = ", "
+    let rparen = ")"
+    let mut strings = [rparen]
+    for (let mut i = variantArity * 4n - 4n; i >= 0n; i -= 4n) {
+      let tmp = toStringHelp(WasmI32.load(ptr + i, 20n), extraIndents, false)
+      strings = [tmp, ...strings]
+      if (i > 0n) {
+        strings = [comspace, ...strings]
+      }
+    }
+    let lparen = "("
+    strings = [variantName, lparen, ...strings]
+
+    join(strings)
+  }
+},
+recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
+  let prevPadAmount = extraIndents * 2n
+  let prevSpacePadding = if (prevPadAmount == 0n) {
+    ""
+  } else {
+    let v = allocateString(prevPadAmount)
+    Memory.fill(
+      v + 8n,
+      0x20n,
+      prevPadAmount
+    ) // create indentation for closing brace
+    WasmI32.toGrain(v): String
+  }
+  let padAmount = (extraIndents + 1n) * 2n
+  let spacePadding = allocateString(padAmount)
+  Memory.fill(spacePadding + 8n, 0x20n, padAmount) // create indentation
+  let spacePadding = WasmI32.toGrain(spacePadding): String
+  let newline = "\n"
+  let rbrace = "}"
+  let mut strings = [newline, prevSpacePadding, rbrace]
+  let colspace = ": "
+  let comlf = ",\n"
+  for (let mut i = recordArity * 4n - 4n; i >= 0n; i -= 4n) {
+    let fieldName = WasmI32.toGrain(WasmI32.load(fields + i, 8n)): String
+    let fieldValue = toStringHelp(
+      WasmI32.load(ptr + i, contentOffset),
+      extraIndents + 1n,
+      false
+    )
+    strings = [spacePadding, fieldName, colspace, fieldValue, ...strings]
+    if (i > 0n) {
+      strings = [comlf, ...strings]
+    }
+  }
+  let lbrace = "{\n"
+  strings = [lbrace, ...strings]
+
+  join(strings)
 }
 
 @unsafe


### PR DESCRIPTION
Inline record constructors; example usage:
```
enum Rec {
  Rec { x: Number, y: Number }
}
let r = Rec { x: 1, y: 2 }
match (r) {
  Rec { x, y } => print((x, y))
}
```

Closes #1545 