### PR TITLE
feat(compiler)!: Enable tail calls by default

### DIFF
--- a/cli/__test__/index.gr
+++ b/cli/__test__/index.gr
@@ -1,4 +1,4 @@
-/* grainc-flags --no-gc --no-bulk-memory */
+/* grainc-flags --no-gc --no-bulk-memory --no-wasm-tail-call */
 module NearTest
 
 include "runtime/unsafe/wasmi32"

--- a/cli/__test__/nearEnv.gr
+++ b/cli/__test__/nearEnv.gr
@@ -1,4 +1,4 @@
-/* grainc-flags --no-gc --no-bulk-memory */
+/* grainc-flags --no-gc --no-bulk-memory --no-wasm-tail-call */
 module NearEnv
 
 provide foreign wasm storage_read: (

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1391,9 +1391,7 @@ let call_lambda =
   | Some(name) =>
     let instr =
       if (tail) {
-        if (Config.experimental_tail_call^) {
-          Expression.Call.make_return;
-        } else {
+        if (Config.no_tail_call^) {
           (
             (wasm_mod, name, args, retty) =>
               Expression.Return.make(
@@ -1401,6 +1399,8 @@ let call_lambda =
                 Expression.Call.make(wasm_mod, name, args, retty),
               )
           );
+        } else {
+          Expression.Call.make_return;
         };
       } else {
         Expression.Call.make;
@@ -1410,9 +1410,7 @@ let call_lambda =
   | None =>
     let instr =
       if (tail) {
-        if (Config.experimental_tail_call^) {
-          Expression.Call_indirect.make_return;
-        } else {
+        if (Config.no_tail_call^) {
           (
             (wasm_mod, table, ptr, args, argty, retty) =>
               Expression.Return.make(
@@ -1427,6 +1425,8 @@ let call_lambda =
                 ),
               )
           );
+        } else {
+          Expression.Call_indirect.make_return;
         };
       } else {
         Expression.Call_indirect.make;

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -466,10 +466,10 @@ let compilation_mode =
 let statically_link =
   toggle_flag(~names=["no-link"], ~doc="Disable static linking", true);
 
-let experimental_tail_call =
+let no_tail_call =
   toggle_flag(
-    ~names=["experimental-wasm-tail-call"],
-    ~doc="Enables tail-call optimization",
+    ~names=["no-wasm-tail-call"],
+    ~doc="Disables tail-call optimization",
     false,
   );
 

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -90,9 +90,9 @@ let compilation_mode: ref(option(string));
 
 let statically_link: ref(bool);
 
-/** Enable tail-call optimizations */
+/** Disables tail-call optimizations */
 
-let experimental_tail_call: ref(bool);
+let no_tail_call: ref(bool);
 
 /** Whether to allow cyclic types. */
 

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const -33)
-     (i32.const 35)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const -33)
+    (i32.const 35)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › land4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $&_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $&_1113)
-     )
-     (i32.const 1)
-     (i32.const 1)
+   (return_call $&_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $&_1113)
     )
+    (i32.const 1)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lxor1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $^_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $^_1113)
-     )
-     (i32.const 3)
-     (i32.const 3)
+   (return_call $^_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $^_1113)
     )
+    (i32.const 3)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lor1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $|_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $|_1113)
-     )
-     (i32.const 3)
-     (i32.const 3)
+   (return_call $|_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $|_1113)
     )
+    (i32.const 3)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo6
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const 35)
-     (i32.const 35)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const 35)
+    (i32.const 35)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
@@ -53,15 +53,13 @@ basic functionality › precedence1
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (i32.const 7)
-     (local.get $6)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (i32.const 7)
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp16
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const 2147483646)
-     (i32.const 2147483646)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const 2147483646)
+    (i32.const 2147483646)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › orshadow
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $+_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1114)
-     )
-     (i32.const 3)
-     (i32.const 5)
+   (return_call $+_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1114)
     )
+    (i32.const 3)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
@@ -53,15 +53,13 @@ basic functionality › precedence2
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (local.get $6)
-     (i32.const 7)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (local.get $6)
+    (i32.const 7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -53,15 +53,13 @@ basic functionality › precedence3
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (i32.const 7)
-     (local.get $6)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (i32.const 7)
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $*_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $*_1113)
-     )
-     (i32.const 5)
-     (i32.const 7)
+   (return_call $*_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $*_1113)
     )
+    (i32.const 5)
+    (i32.const 7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lsl1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $<<_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $<<_1113)
-     )
-     (i32.const 15)
-     (i32.const 3)
+   (return_call $<<_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $<<_1113)
     )
+    (i32.const 15)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -64,11 +64,9 @@ basic functionality › unsafe_wasm_globals
      (global.get $_F32_VAL_1145)
     )
    )
-   (return
-    (call $printF64_1146
-     (global.get $printF64_1146)
-     (global.get $_F64_VAL_1147)
-    )
+   (return_call $printF64_1146
+    (global.get $printF64_1146)
+    (global.get $_F64_VAL_1147)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -260,15 +260,13 @@ basic functionality › comp22
     (block $do_backpatches.17
     )
    )
-   (return
-    (call $isnt_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $isnt_1113)
-     )
-     (local.get $8)
-     (local.get $11)
+   (return_call $isnt_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $isnt_1113)
     )
+    (local.get $8)
+    (local.get $11)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › land1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $&_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $&_1113)
-     )
-     (i32.const 3)
-     (i32.const 3)
+   (return_call $&_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $&_1113)
     )
+    (i32.const 3)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -53,15 +53,13 @@ basic functionality › precedence4
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (local.get $6)
-     (i32.const 7)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (local.get $6)
+    (i32.const 7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $-_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1113)
-     )
-     (i32.const 5)
-     (i32.const 5)
+   (return_call $-_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1113)
     )
+    (i32.const 5)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lsl2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $<<_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $<<_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $<<_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $<<_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp17
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $isnt_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $isnt_1113)
-     )
-     (i32.const 2147483646)
-     (i32.const -2)
+   (return_call $isnt_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $isnt_1113)
     )
+    (i32.const 2147483646)
+    (i32.const -2)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -53,14 +53,12 @@ basic functionality › complex2
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $print_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1113)
-     )
-     (local.get $6)
+   (return_call $print_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1113)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -298,15 +298,13 @@ basic functionality › comp20
     (block $do_backpatches.17
     )
    )
-   (return
-    (call $isnt_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $isnt_1113)
-     )
-     (local.get $8)
-     (local.get $11)
+   (return_call $isnt_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $isnt_1113)
     )
+    (local.get $8)
+    (local.get $11)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lor3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $|_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $|_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $|_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $|_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › decr_3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $decr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $decr_1113)
-     )
-     (i32.const 1)
+   (return_call $decr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $decr_1113)
     )
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
@@ -59,15 +59,13 @@ basic functionality › precedence5
      (i32.const 31)
     )
     (block $compile_block.3
-     (return
-      (call $<_1117
-       (call $incRef_0
-        (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $<_1117)
-       )
-       (i32.const 19)
-       (i32.const 27)
+     (return_call $<_1117
+      (call $incRef_0
+       (global.get $GRAIN$EXPORT$incRef_0)
+       (global.get $<_1117)
       )
+      (i32.const 19)
+      (i32.const 27)
      )
     )
     (block $compile_block.4 (result i32)

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -177,14 +177,12 @@ basic functionality › func_shadow
     (block $do_backpatches.13
     )
    )
-   (return
-    (call $print_1118
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1118)
-     )
-     (local.get $7)
+   (return_call $print_1118
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1118)
     )
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo5
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const 35)
-     (i32.const -33)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const 35)
+    (i32.const -33)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop6
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const 19)
-     (i32.const 11)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const 19)
+    (i32.const 11)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -68,12 +68,10 @@ basic functionality › block_no_expression
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $f_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $f_1113)
-     )
+   (return_call $f_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $f_1113)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lor2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $|_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $|_1113)
-     )
-     (i32.const 3)
-     (i32.const 1)
+   (return_call $|_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $|_1113)
     )
+    (i32.const 3)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $-_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1113)
-     )
-     (i32.const 5)
-     (i32.const 9)
+   (return_call $-_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1113)
     )
+    (i32.const 5)
+    (i32.const 9)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop2.2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $-_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1113)
-     )
-     (i32.const 5)
-     (i32.const 5)
+   (return_call $-_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1113)
     )
+    (i32.const 5)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › land2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $&_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $&_1113)
-     )
-     (i32.const 3)
-     (i32.const 1)
+   (return_call $&_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $&_1113)
     )
+    (i32.const 3)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -84,11 +84,9 @@ basic functionality › pattern_match_unsafe_wasm
      )
     )
    )
-   (return
-    (call $foo_1114
-     (local.get $7)
-     (i32.const 42)
-    )
+   (return_call $foo_1114
+    (local.get $7)
+    (i32.const 42)
    )
   )
  )
@@ -349,14 +347,12 @@ basic functionality › pattern_match_unsafe_wasm
                        )
                       )
                      )
-                     (return
-                      (call $print_1125
-                       (call $incRef_0
-                        (global.get $GRAIN$EXPORT$incRef_0)
-                        (global.get $print_1125)
-                       )
-                       (local.get $8)
+                     (return_call $print_1125
+                      (call $incRef_0
+                       (global.get $GRAIN$EXPORT$incRef_0)
+                       (global.get $print_1125)
                       )
+                      (local.get $8)
                      )
                     )
                    )
@@ -372,14 +368,12 @@ basic functionality › pattern_match_unsafe_wasm
                      )
                     )
                    )
-                   (return
-                    (call $print_1125
-                     (call $incRef_0
-                      (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $print_1125)
-                     )
-                     (i32.const 13)
+                   (return_call $print_1125
+                    (call $incRef_0
+                     (global.get $GRAIN$EXPORT$incRef_0)
+                     (global.get $print_1125)
                     )
+                    (i32.const 13)
                    )
                   )
                  )
@@ -395,14 +389,12 @@ basic functionality › pattern_match_unsafe_wasm
                    )
                   )
                  )
-                 (return
-                  (call $print_1125
-                   (call $incRef_0
-                    (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $print_1125)
-                   )
-                   (i32.const 11)
+                 (return_call $print_1125
+                  (call $incRef_0
+                   (global.get $GRAIN$EXPORT$incRef_0)
+                   (global.get $print_1125)
                   )
+                  (i32.const 11)
                  )
                 )
                )
@@ -418,14 +410,12 @@ basic functionality › pattern_match_unsafe_wasm
                  )
                 )
                )
-               (return
-                (call $print_1125
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $print_1125)
-                 )
-                 (i32.const 9)
+               (return_call $print_1125
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $print_1125)
                 )
+                (i32.const 9)
                )
               )
              )
@@ -441,14 +431,12 @@ basic functionality › pattern_match_unsafe_wasm
                )
               )
              )
-             (return
-              (call $print_1125
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $print_1125)
-               )
-               (i32.const 7)
+             (return_call $print_1125
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $print_1125)
               )
+              (i32.const 7)
              )
             )
            )
@@ -464,14 +452,12 @@ basic functionality › pattern_match_unsafe_wasm
              )
             )
            )
-           (return
-            (call $print_1125
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $print_1125)
-             )
-             (i32.const 5)
+           (return_call $print_1125
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $print_1125)
             )
+            (i32.const 5)
            )
           )
          )
@@ -487,14 +473,12 @@ basic functionality › pattern_match_unsafe_wasm
            )
           )
          )
-         (return
-          (call $print_1125
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $print_1125)
-           )
-           (i32.const 3)
+         (return_call $print_1125
+          (call $incRef_0
+           (global.get $GRAIN$EXPORT$incRef_0)
+           (global.get $print_1125)
           )
+          (i32.const 3)
          )
         )
        )
@@ -537,12 +521,10 @@ basic functionality › pattern_match_unsafe_wasm
     (block $do_backpatches.52
     )
    )
-   (return
-    (call $test_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $test_1113)
-     )
+   (return_call $test_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $test_1113)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › asr1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $>>_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $>>_1113)
-     )
-     (i32.const 359)
-     (i32.const 3)
+   (return_call $>>_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $>>_1113)
     )
+    (i32.const 359)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
@@ -59,14 +59,12 @@ basic functionality › if_one_sided2
      (i32.const 31)
     )
     (block $compile_block.3
-     (return
-      (call $print_1117
-       (call $incRef_0
-        (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1117)
-       )
-       (i32.const 11)
+     (return_call $print_1117
+      (call $incRef_0
+       (global.get $GRAIN$EXPORT$incRef_0)
+       (global.get $print_1117)
       )
+      (i32.const 11)
      )
     )
     (block $compile_block.4 (result i32)

--- a/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp13
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const -2)
-     (i32.const -2)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const -2)
+    (i32.const -2)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › andshadow
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $+_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1114)
-     )
-     (i32.const 3)
-     (i32.const 5)
+   (return_call $+_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1114)
     )
+    (i32.const 3)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lxor3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $^_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $^_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $^_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $^_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › incr_3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $incr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $incr_1113)
-     )
-     (i32.const -1)
+   (return_call $incr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $incr_1113)
     )
+    (i32.const -1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (i32.const 5)
-     (i32.const 5)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (i32.const 5)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
@@ -65,15 +65,13 @@ basic functionality › bigint_1
     (block $do_backpatches.2
     )
    )
-   (return
-    (call $+_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1113)
-     )
-     (local.get $6)
-     (i32.const 3)
+   (return_call $+_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1113)
     )
+    (local.get $6)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lxor2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $^_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $^_1113)
-     )
-     (i32.const 3)
-     (i32.const 1)
+   (return_call $^_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $^_1113)
     )
+    (i32.const 3)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -59,14 +59,12 @@ basic functionality › if_one_sided
      (i32.const 31)
     )
     (block $compile_block.3
-     (return
-      (call $print_1117
-       (call $incRef_0
-        (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1117)
-       )
-       (i32.const 11)
+     (return_call $print_1117
+      (call $incRef_0
+       (global.get $GRAIN$EXPORT$incRef_0)
+       (global.get $print_1117)
       )
+      (i32.const 11)
      )
     )
     (block $compile_block.4 (result i32)

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lxor4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $^_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $^_1113)
-     )
-     (i32.const 1)
-     (i32.const 1)
+   (return_call $^_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $^_1113)
     )
+    (i32.const 1)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -64,15 +64,13 @@ basic functionality › complex1
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $-_1123
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1123)
-     )
-     (i32.const 7)
-     (local.get $6)
+   (return_call $-_1123
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1123)
     )
+    (i32.const 7)
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lsr2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $>>>_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $>>>_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $>>>_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $>>>_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lsr1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $>>>_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $>>>_1113)
-     )
-     (i32.const 15)
-     (i32.const 3)
+   (return_call $>>>_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $>>>_1113)
     )
+    (i32.const 15)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp14
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const -2)
-     (i32.const 2147483646)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const -2)
+    (i32.const 2147483646)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › incr_1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $incr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $incr_1113)
-     )
-     (i32.const 5)
+   (return_call $incr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $incr_1113)
     )
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › incr_2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $incr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $incr_1113)
-     )
-     (i32.const 11)
+   (return_call $incr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $incr_1113)
     )
+    (i32.const 11)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const -33)
-     (i32.const -7)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const -33)
+    (i32.const -7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › lor4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $|_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $|_1113)
-     )
-     (i32.const 1)
-     (i32.const 1)
+   (return_call $|_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $|_1113)
     )
+    (i32.const 1)
+    (i32.const 1)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › int64_pun_1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $*_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $*_1113)
-     )
-     (i32.const 19999999)
-     (i32.const 199999999)
+   (return_call $*_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $*_1113)
     )
+    (i32.const 19999999)
+    (i32.const 199999999)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › decr_1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $decr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $decr_1113)
-     )
-     (i32.const 5)
+   (return_call $decr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $decr_1113)
     )
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const -33)
-     (i32.const 9)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const -33)
+    (i32.const 9)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › land3
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $&_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $&_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $&_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $&_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp18
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $isnt_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $isnt_1113)
-     )
-     (i32.const 9)
-     (i32.const 3)
+   (return_call $isnt_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $isnt_1113)
     )
+    (i32.const 9)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › comp15
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const 2147483646)
-     (i32.const -2)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const 2147483646)
+    (i32.const -2)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
@@ -53,15 +53,13 @@ basic functionality › comp10
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $==_1117
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1117)
-     )
-     (local.get $6)
-     (i32.const 5)
+   (return_call $==_1117
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1117)
     )
+    (local.get $6)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › asr2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $>>_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $>>_1113)
-     )
-     (i32.const 1)
-     (i32.const 3)
+   (return_call $>>_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $>>_1113)
     )
+    (i32.const 1)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › binop2.1
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $-_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1113)
-     )
-     (i32.const 5)
-     (i32.const 5)
+   (return_call $-_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1113)
     )
+    (i32.const 5)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › modulo2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $%_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $%_1113)
-     )
-     (i32.const 35)
-     (i32.const -7)
+   (return_call $%_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $%_1113)
     )
+    (i32.const 35)
+    (i32.const -7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -35,14 +35,12 @@ basic functionality › decr_2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $decr_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $decr_1113)
-     )
-     (i32.const 11)
+   (return_call $decr_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $decr_1113)
     )
+    (i32.const 11)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -36,15 +36,13 @@ basic functionality › int64_pun_2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $-_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $-_1113)
-     )
-     (i32.const -199999997)
-     (i32.const 1999999999)
+   (return_call $-_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $-_1113)
     )
+    (i32.const -199999997)
+    (i32.const 1999999999)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -323,14 +323,12 @@ basic functionality › func_shadow_and_indirect_call
     (block $do_backpatches.30
     )
    )
-   (return
-    (call $print_1121
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1121)
-     )
-     (local.get $8)
+   (return_call $print_1121
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1121)
     )
+    (local.get $8)
    )
   )
  )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -489,14 +489,12 @@ enums › enum_recursive_data_definition
     (block $do_backpatches.28
     )
    )
-   (return
-    (call $print_1129
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1129)
-     )
-     (local.get $14)
+   (return_call $print_1129
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1129)
     )
+    (local.get $14)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -68,12 +68,10 @@ functions › dup_func
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $foo_1117
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1117)
-     )
+   (return_call $foo_1117
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1117)
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.0b8146ea.0.snapshot
+++ b/compiler/test/__snapshots__/functions.0b8146ea.0.snapshot
@@ -75,12 +75,10 @@ functions › regression_1725
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -38,15 +38,13 @@ functions › shorthand_4
      )
     )
    )
-   (return
-    (call $+_1115
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1115)
-     )
-     (local.get $1)
-     (i32.const 7)
+   (return_call $+_1115
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1115)
     )
+    (local.get $1)
+    (i32.const 7)
    )
   )
  )
@@ -74,14 +72,12 @@ functions › shorthand_4
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (i32.const 3)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -67,14 +67,12 @@ functions › shorthand_1
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (i32.const 3)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -300,15 +300,13 @@ functions › lam_destructure_5
      )
     )
    )
-   (return
-    (call $+_1119
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1119)
-     )
-     (local.get $21)
-     (local.get $16)
+   (return_call $+_1119
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1119)
     )
+    (local.get $21)
+    (local.get $16)
    )
   )
  )
@@ -403,12 +401,10 @@ functions › lam_destructure_5
     (block $do_backpatches.42
     )
    )
-   (return
-    (call $lam_lambda_1118
-     (local.get $6)
-     (local.get $7)
-     (local.get $8)
-    )
+   (return_call $lam_lambda_1118
+    (local.get $6)
+    (local.get $7)
+    (local.get $8)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -102,14 +102,12 @@ functions › lambda_pat_any
     (block $do_backpatches.6
     )
    )
-   (return
-    (call $x_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1113)
-     )
-     (local.get $6)
+   (return_call $x_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1113)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -104,15 +104,13 @@ functions › curried_func
       )
      )
     )
-    (return
-     (call $+_1116
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1116)
-      )
-      (local.get $2)
-      (local.get $1)
+    (return_call $+_1116
+     (call $incRef_0
+      (global.get $GRAIN$EXPORT$incRef_0)
+      (global.get $+_1116)
      )
+     (local.get $2)
+     (local.get $1)
     )
    )
   )
@@ -159,13 +157,11 @@ functions › curried_func
     (local.set $0
      (local.get $6)
     )
-    (return
-     (call_indirect (type $i32_i32_=>_i32)
+    (return_call_indirect (type $i32_i32_=>_i32)
+     (local.get $0)
+     (i32.const 7)
+     (i32.load offset=8
       (local.get $0)
-      (i32.const 7)
-      (i32.load offset=8
-       (local.get $0)
-      )
      )
     )
    )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -110,11 +110,9 @@ functions › func_recursive_closure
      )
     )
    )
-   (return
-    (call $foo_1117
-     (local.get $7)
-     (i32.const 11)
-    )
+   (return_call $foo_1117
+    (local.get $7)
+    (i32.const 11)
    )
   )
  )
@@ -144,15 +142,13 @@ functions › func_recursive_closure
       )
      )
     )
-    (return
-     (call $+_1124
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1124)
-      )
-      (local.get $1)
-      (local.get $2)
+    (return_call $+_1124
+     (call $incRef_0
+      (global.get $GRAIN$EXPORT$incRef_0)
+      (global.get $+_1124)
      )
+     (local.get $1)
+     (local.get $2)
     )
    )
   )
@@ -292,11 +288,9 @@ functions › func_recursive_closure
            )
           )
          )
-         (return
-          (call $bar_1120
-           (local.get $9)
-           (i32.const 3)
-          )
+         (return_call $bar_1120
+          (local.get $9)
+          (i32.const 3)
          )
         )
         (block $compile_block.29
@@ -331,11 +325,9 @@ functions › func_recursive_closure
            )
           )
          )
-         (return
-          (call $foo_1117
-           (local.get $0)
-           (local.get $10)
-          )
+         (return_call $foo_1117
+          (local.get $0)
+          (local.get $10)
          )
         )
        )
@@ -437,15 +429,13 @@ functions › func_recursive_closure
       )
      )
     )
-    (return
-     (call $+_1124
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1124)
-      )
-      (local.get $10)
-      (local.get $11)
+    (return_call $+_1124
+     (call $incRef_0
+      (global.get $GRAIN$EXPORT$incRef_0)
+      (global.get $+_1124)
      )
+     (local.get $10)
+     (local.get $11)
     )
    )
   )
@@ -481,12 +471,10 @@ functions › func_recursive_closure
     (block $do_backpatches.49
     )
    )
-   (return
-    (call $truc_1116
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $truc_1116)
-     )
+   (return_call $truc_1116
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $truc_1116)
     )
    )
   )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -65,11 +65,9 @@ functions › app_1
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $lam_lambda_1114
-     (local.get $6)
-     (i32.const 3)
-    )
+   (return_call $lam_lambda_1114
+    (local.get $6)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -67,14 +67,12 @@ functions › shorthand_3
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (i32.const 3)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -182,15 +182,13 @@ functions › lam_destructure_3
      )
     )
    )
-   (return
-    (call $+_1117
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1117)
-     )
-     (local.get $14)
-     (local.get $10)
+   (return_call $+_1117
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1117)
     )
+    (local.get $14)
+    (local.get $10)
    )
   )
  )
@@ -254,11 +252,9 @@ functions › lam_destructure_3
     (block $do_backpatches.24
     )
    )
-   (return
-    (call $lam_lambda_1116
-     (local.get $6)
-     (local.get $7)
-    )
+   (return_call $lam_lambda_1116
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -258,15 +258,13 @@ functions › lam_destructure_7
      )
     )
    )
-   (return
-    (call $+_1118
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1118)
-     )
-     (local.get $18)
-     (local.get $11)
+   (return_call $+_1118
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1118)
     )
+    (local.get $18)
+    (local.get $11)
    )
   )
  )
@@ -361,11 +359,9 @@ functions › lam_destructure_7
     (block $do_backpatches.37
     )
    )
-   (return
-    (call $lam_lambda_1117
-     (local.get $6)
-     (local.get $8)
-    )
+   (return_call $lam_lambda_1117
+    (local.get $6)
+    (local.get $8)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -38,15 +38,13 @@ functions › shorthand_2
      )
     )
    )
-   (return
-    (call $+_1115
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1115)
-     )
-     (local.get $1)
-     (i32.const 7)
+   (return_call $+_1115
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1115)
     )
+    (local.get $1)
+    (i32.const 7)
    )
   )
  )
@@ -74,14 +72,12 @@ functions › shorthand_2
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (i32.const 3)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -183,15 +183,13 @@ functions › lam_destructure_4
      )
     )
    )
-   (return
-    (call $+_1117
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1117)
-     )
-     (local.get $14)
-     (local.get $10)
+   (return_call $+_1117
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1117)
     )
+    (local.get $14)
+    (local.get $10)
    )
   )
  )
@@ -254,14 +252,12 @@ functions › lam_destructure_4
     (block $do_backpatches.24
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (local.get $6)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -259,15 +259,13 @@ functions › lam_destructure_8
      )
     )
    )
-   (return
-    (call $+_1118
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1118)
-     )
-     (local.get $18)
-     (local.get $11)
+   (return_call $+_1118
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1118)
     )
+    (local.get $18)
+    (local.get $11)
    )
   )
  )
@@ -361,14 +359,12 @@ functions › lam_destructure_8
     (block $do_backpatches.37
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (local.get $7)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -100,11 +100,9 @@ functions › lam_destructure_1
     (block $do_backpatches.6
     )
    )
-   (return
-    (call $lam_lambda_1113
-     (local.get $6)
-     (local.get $7)
-    )
+   (return_call $lam_lambda_1113
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -102,14 +102,12 @@ functions › lam_destructure_2
     (block $do_backpatches.6
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (local.get $6)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -38,15 +38,13 @@ functions › fn_trailing_comma
      )
     )
    )
-   (return
-    (call $+_1116
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1116)
-     )
-     (local.get $1)
-     (local.get $2)
+   (return_call $+_1116
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1116)
     )
+    (local.get $1)
+    (local.get $2)
    )
   )
  )
@@ -74,15 +72,13 @@ functions › fn_trailing_comma
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $testFn_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $testFn_1113)
-     )
-     (i32.const 5)
-     (i32.const 7)
+   (return_call $testFn_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $testFn_1113)
     )
+    (i32.const 5)
+    (i32.const 7)
    )
   )
  )

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -301,15 +301,13 @@ functions › lam_destructure_6
      )
     )
    )
-   (return
-    (call $+_1119
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1119)
-     )
-     (local.get $21)
-     (local.get $16)
+   (return_call $+_1119
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1119)
     )
+    (local.get $21)
+    (local.get $16)
    )
   )
  )
@@ -403,15 +401,13 @@ functions › lam_destructure_6
     (block $do_backpatches.42
     )
    )
-   (return
-    (call $foo_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $foo_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/includes.46f78654.0.snapshot
+++ b/compiler/test/__snapshots__/includes.46f78654.0.snapshot
@@ -36,16 +36,14 @@ includes › include_some_multiple
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/includes.6c8d23dc.0.snapshot
+++ b/compiler/test/__snapshots__/includes.6c8d23dc.0.snapshot
@@ -36,16 +36,14 @@ includes › include_some_multiple_trailing2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/includes.6e78c003.0.snapshot
+++ b/compiler/test/__snapshots__/includes.6e78c003.0.snapshot
@@ -36,16 +36,14 @@ includes › include_some_multiple_trailing
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/includes.86ff4075.0.snapshot
+++ b/compiler/test/__snapshots__/includes.86ff4075.0.snapshot
@@ -36,16 +36,14 @@ includes › include_alias_multiple
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/includes.bd3eb3af.0.snapshot
+++ b/compiler/test/__snapshots__/includes.bd3eb3af.0.snapshot
@@ -121,14 +121,12 @@ includes › include_some_mixed
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $sum_1120
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $sum_1120)
-     )
-     (local.get $7)
+   (return_call $sum_1120
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $sum_1120)
     )
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
+++ b/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
@@ -51,14 +51,12 @@ includes › include_relative_path4
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $print_1116
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1116)
-     )
-     (local.get $6)
+   (return_call $print_1116
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1116)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/includes.f4ba5583.0.snapshot
+++ b/compiler/test/__snapshots__/includes.f4ba5583.0.snapshot
@@ -36,16 +36,14 @@ includes › include_module2
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -74,15 +74,13 @@ optimizations › trs1
     (block $do_backpatches.3
     )
    )
-   (return
-    (call $f1_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $f1_1113)
-     )
-     (i32.const 3)
-     (i32.const 5)
+   (return_call $f1_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $f1_1113)
     )
+    (i32.const 3)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -168,15 +168,13 @@ optimizations › test_dead_branch_elimination_5
     (block $do_backpatches.15
     )
    )
-   (return
-    (call $+_1126
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1126)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $+_1126
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1126)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -272,15 +272,13 @@ pattern matching › record_match_3
        )
        (br $switch.18_outer
         (block $compile_block.19
-         (return
-          (call $+_1125
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1125)
-           )
-           (local.get $7)
-           (local.get $8)
+         (return_call $+_1125
+          (call $incRef_0
+           (global.get $GRAIN$EXPORT$incRef_0)
+           (global.get $+_1125)
           )
+          (local.get $7)
+          (local.get $8)
          )
         )
        )

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -1021,15 +1021,13 @@ pattern matching › tuple_match_deep4
                  )
                 )
                )
-               (return
-                (call $+_1153
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1153)
-                 )
-                 (local.get $29)
-                 (local.get $18)
+               (return_call $+_1153
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1153)
                 )
+                (local.get $29)
+                (local.get $18)
                )
               )
              )
@@ -1113,15 +1111,13 @@ pattern matching › tuple_match_deep4
                )
               )
              )
-             (return
-              (call $+_1153
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1153)
-               )
-               (local.get $27)
-               (local.get $14)
+             (return_call $+_1153
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1153)
               )
+              (local.get $27)
+              (local.get $14)
              )
             )
            )
@@ -1179,15 +1175,13 @@ pattern matching › tuple_match_deep4
              )
             )
            )
-           (return
-            (call $+_1153
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1153)
-             )
-             (local.get $10)
-             (local.get $11)
+           (return_call $+_1153
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $+_1153)
             )
+            (local.get $10)
+            (local.get $11)
            )
           )
          )

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -879,15 +879,13 @@ pattern matching › adt_match_4
                  )
                 )
                )
-               (return
-                (call $+_1149
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1149)
-                 )
-                 (local.get $22)
-                 (local.get $15)
+               (return_call $+_1149
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1149)
                 )
+                (local.get $22)
+                (local.get $15)
                )
               )
              )
@@ -921,15 +919,13 @@ pattern matching › adt_match_4
                )
               )
              )
-             (return
-              (call $+_1149
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1149)
-               )
-               (local.get $11)
-               (local.get $12)
+             (return_call $+_1149
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1149)
               )
+              (local.get $11)
+              (local.get $12)
              )
             )
            )

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -380,15 +380,13 @@ pattern matching › tuple_match_deep
            )
           )
          )
-         (return
-          (call $+_1131
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1131)
-           )
-           (local.get $18)
-           (local.get $10)
+         (return_call $+_1131
+          (call $incRef_0
+           (global.get $GRAIN$EXPORT$incRef_0)
+           (global.get $+_1131)
           )
+          (local.get $18)
+          (local.get $10)
          )
         )
        )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -347,15 +347,13 @@ pattern matching › record_match_4
            )
           )
          )
-         (return
-          (call $+_1126
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1126)
-           )
-           (local.get $13)
-           (local.get $9)
+         (return_call $+_1126
+          (call $incRef_0
+           (global.get $GRAIN$EXPORT$incRef_0)
+           (global.get $+_1126)
           )
+          (local.get $13)
+          (local.get $9)
          )
         )
        )

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -1113,15 +1113,13 @@ pattern matching › tuple_match_deep6
                  )
                 )
                )
-               (return
-                (call $+_1157
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1157)
-                 )
-                 (local.get $31)
-                 (local.get $20)
+               (return_call $+_1157
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1157)
                 )
+                (local.get $31)
+                (local.get $20)
                )
               )
              )
@@ -1205,15 +1203,13 @@ pattern matching › tuple_match_deep6
                )
               )
              )
-             (return
-              (call $+_1157
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1157)
-               )
-               (local.get $29)
-               (local.get $16)
+             (return_call $+_1157
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1157)
               )
+              (local.get $29)
+              (local.get $16)
              )
             )
            )
@@ -1271,15 +1267,13 @@ pattern matching › tuple_match_deep6
              )
             )
            )
-           (return
-            (call $+_1157
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1157)
-             )
-             (local.get $12)
-             (local.get $13)
+           (return_call $+_1157
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $+_1157)
             )
+            (local.get $12)
+            (local.get $13)
            )
           )
          )

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -975,15 +975,13 @@ pattern matching › tuple_match_deep3
                  )
                 )
                )
-               (return
-                (call $+_1151
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1151)
-                 )
-                 (local.get $28)
-                 (local.get $17)
+               (return_call $+_1151
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1151)
                 )
+                (local.get $28)
+                (local.get $17)
                )
               )
              )
@@ -1067,15 +1065,13 @@ pattern matching › tuple_match_deep3
                )
               )
              )
-             (return
-              (call $+_1151
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1151)
-               )
-               (local.get $26)
-               (local.get $13)
+             (return_call $+_1151
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1151)
               )
+              (local.get $26)
+              (local.get $13)
              )
             )
            )
@@ -1133,15 +1129,13 @@ pattern matching › tuple_match_deep3
              )
             )
            )
-           (return
-            (call $+_1151
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1151)
-             )
-             (local.get $9)
-             (local.get $10)
+           (return_call $+_1151
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $+_1151)
             )
+            (local.get $9)
+            (local.get $10)
            )
           )
          )

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -741,15 +741,13 @@ pattern matching › adt_match_1
                  )
                 )
                )
-               (return
-                (call $+_1143
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1143)
-                 )
-                 (local.get $19)
-                 (local.get $12)
+               (return_call $+_1143
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1143)
                 )
+                (local.get $19)
+                (local.get $12)
                )
               )
              )
@@ -783,15 +781,13 @@ pattern matching › adt_match_1
                )
               )
              )
-             (return
-              (call $+_1143
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1143)
-               )
-               (local.get $8)
-               (local.get $9)
+             (return_call $+_1143
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1143)
               )
+              (local.get $8)
+              (local.get $9)
              )
             )
            )

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -728,15 +728,13 @@ pattern matching › tuple_match_deep2
            )
           )
          )
-         (return
-          (call $+_1149
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1149)
-           )
-           (local.get $33)
-           (local.get $17)
+         (return_call $+_1149
+          (call $incRef_0
+           (global.get $GRAIN$EXPORT$incRef_0)
+           (global.get $+_1149)
           )
+          (local.get $33)
+          (local.get $17)
          )
         )
        )

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -787,15 +787,13 @@ pattern matching › adt_match_2
                  )
                 )
                )
-               (return
-                (call $+_1145
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1145)
-                 )
-                 (local.get $20)
-                 (local.get $13)
+               (return_call $+_1145
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1145)
                 )
+                (local.get $20)
+                (local.get $13)
                )
               )
              )
@@ -829,15 +827,13 @@ pattern matching › adt_match_2
                )
               )
              )
-             (return
-              (call $+_1145
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1145)
-               )
-               (local.get $9)
-               (local.get $10)
+             (return_call $+_1145
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1145)
               )
+              (local.get $9)
+              (local.get $10)
              )
             )
            )

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -833,15 +833,13 @@ pattern matching › adt_match_3
                  )
                 )
                )
-               (return
-                (call $+_1147
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1147)
-                 )
-                 (local.get $21)
-                 (local.get $14)
+               (return_call $+_1147
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1147)
                 )
+                (local.get $21)
+                (local.get $14)
                )
               )
              )
@@ -875,15 +873,13 @@ pattern matching › adt_match_3
                )
               )
              )
-             (return
-              (call $+_1147
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1147)
-               )
-               (local.get $10)
-               (local.get $11)
+             (return_call $+_1147
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1147)
               )
+              (local.get $10)
+              (local.get $11)
              )
             )
            )

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -925,15 +925,13 @@ pattern matching › adt_match_5
                  )
                 )
                )
-               (return
-                (call $+_1151
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1151)
-                 )
-                 (local.get $23)
-                 (local.get $16)
+               (return_call $+_1151
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1151)
                 )
+                (local.get $23)
+                (local.get $16)
                )
               )
              )
@@ -967,15 +965,13 @@ pattern matching › adt_match_5
                )
               )
              )
-             (return
-              (call $+_1151
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1151)
-               )
-               (local.get $12)
-               (local.get $13)
+             (return_call $+_1151
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1151)
               )
+              (local.get $12)
+              (local.get $13)
              )
             )
            )

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -1067,15 +1067,13 @@ pattern matching › tuple_match_deep5
                  )
                 )
                )
-               (return
-                (call $+_1155
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1155)
-                 )
-                 (local.get $30)
-                 (local.get $19)
+               (return_call $+_1155
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1155)
                 )
+                (local.get $30)
+                (local.get $19)
                )
               )
              )
@@ -1159,15 +1157,13 @@ pattern matching › tuple_match_deep5
                )
               )
              )
-             (return
-              (call $+_1155
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1155)
-               )
-               (local.get $28)
-               (local.get $15)
+             (return_call $+_1155
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1155)
               )
+              (local.get $28)
+              (local.get $15)
              )
             )
            )
@@ -1225,15 +1221,13 @@ pattern matching › tuple_match_deep5
              )
             )
            )
-           (return
-            (call $+_1155
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1155)
-             )
-             (local.get $11)
-             (local.get $12)
+           (return_call $+_1155
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $+_1155)
             )
+            (local.get $11)
+            (local.get $12)
            )
           )
          )

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -1159,15 +1159,13 @@ pattern matching › tuple_match_deep7
                  )
                 )
                )
-               (return
-                (call $+_1159
-                 (call $incRef_0
-                  (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1159)
-                 )
-                 (local.get $32)
-                 (local.get $21)
+               (return_call $+_1159
+                (call $incRef_0
+                 (global.get $GRAIN$EXPORT$incRef_0)
+                 (global.get $+_1159)
                 )
+                (local.get $32)
+                (local.get $21)
                )
               )
              )
@@ -1251,15 +1249,13 @@ pattern matching › tuple_match_deep7
                )
               )
              )
-             (return
-              (call $+_1159
-               (call $incRef_0
-                (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1159)
-               )
-               (local.get $30)
-               (local.get $17)
+             (return_call $+_1159
+              (call $incRef_0
+               (global.get $GRAIN$EXPORT$incRef_0)
+               (global.get $+_1159)
               )
+              (local.get $30)
+              (local.get $17)
              )
             )
            )
@@ -1317,15 +1313,13 @@ pattern matching › tuple_match_deep7
              )
             )
            )
-           (return
-            (call $+_1159
-             (call $incRef_0
-              (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1159)
-             )
-             (local.get $13)
-             (local.get $14)
+           (return_call $+_1159
+            (call $incRef_0
+             (global.get $GRAIN$EXPORT$incRef_0)
+             (global.get $+_1159)
             )
+            (local.get $13)
+            (local.get $14)
            )
           )
          )

--- a/compiler/test/__snapshots__/provides.10f4f118.0.snapshot
+++ b/compiler/test/__snapshots__/provides.10f4f118.0.snapshot
@@ -36,16 +36,14 @@ provides › provide9
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $y_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $y_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $z_1123)
-     )
+   (return_call $y_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $y_1122)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $z_1123)
     )
    )
   )

--- a/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
+++ b/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
@@ -72,14 +72,12 @@ provides › provide_start_function
      )
     )
    )
-   (return
-    (call $print_1117
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1117)
-     )
-     (local.get $7)
+   (return_call $print_1117
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $print_1117)
     )
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
+++ b/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
@@ -74,14 +74,12 @@ provides › provide12
       )
      )
     )
-    (return
-     (call $print_1161
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $print_1161)
-      )
-      (local.get $8)
+    (return_call $print_1161
+     (call $incRef_0
+      (global.get $GRAIN$EXPORT$incRef_0)
+      (global.get $print_1161)
      )
+     (local.get $8)
     )
    )
   )
@@ -140,14 +138,12 @@ provides › provide12
      )
     )
    )
-   (return
-    (call $apply_1159
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $apply_1159)
-     )
-     (local.get $6)
+   (return_call $apply_1159
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $apply_1159)
     )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/provides.c3bb4eff.0.snapshot
+++ b/compiler/test/__snapshots__/provides.c3bb4eff.0.snapshot
@@ -53,18 +53,16 @@ provides › provide8
     (block $do_backpatches.1
     )
    )
-   (return
-    (call $+_1122
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1122)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1123)
-     )
-     (local.get $6)
+   (return_call $+_1122
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1122)
     )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $x_1123)
+    )
+    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -180,15 +180,13 @@ records › record_get_multiple
      )
     )
    )
-   (return
-    (call $+_1118
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1118)
-     )
-     (local.get $7)
-     (local.get $8)
+   (return_call $+_1118
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1118)
     )
+    (local.get $7)
+    (local.get $8)
    )
   )
  )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -307,17 +307,15 @@ records › record_destruct_4
     (block $do_backpatches.22
     )
    )
-   (return
-    (call $+_1126
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1126)
-     )
-     (local.get $10)
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $baz_1116)
-     )
+   (return_call $+_1126
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1126)
+    )
+    (local.get $10)
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $baz_1116)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -246,20 +246,18 @@ records › record_destruct_3
      (i32.const 1879048190)
     )
    )
-   (return
-    (call $+_1125
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1125)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $foo_1114)
-     )
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $bar_1115)
-     )
+   (return_call $+_1125
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1125)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $foo_1114)
+    )
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $bar_1115)
     )
    )
   )

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -307,17 +307,15 @@ records › record_destruct_trailing
     (block $do_backpatches.22
     )
    )
-   (return
-    (call $+_1126
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1126)
-     )
-     (local.get $10)
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $baz_1116)
-     )
+   (return_call $+_1126
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $+_1126)
+    )
+    (local.get $10)
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $baz_1116)
     )
    )
   )

--- a/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
@@ -36,15 +36,13 @@ stdlib › stdlib_equal_4
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const 3)
-     (i32.const 3)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const 3)
+    (i32.const 3)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -256,15 +256,13 @@ stdlib › stdlib_equal_20
     (block $do_backpatches.13
     )
    )
-   (return
-    (call $==_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1114)
-     )
-     (local.get $7)
-     (local.get $9)
+   (return_call $==_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1114)
     )
+    (local.get $7)
+    (local.get $9)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -92,15 +92,13 @@ stdlib › stdlib_equal_18
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -256,15 +256,13 @@ stdlib › stdlib_equal_19
     (block $do_backpatches.13
     )
    )
-   (return
-    (call $==_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1114)
-     )
-     (local.get $7)
-     (local.get $9)
+   (return_call $==_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1114)
     )
+    (local.get $7)
+    (local.get $9)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -92,15 +92,13 @@ stdlib › stdlib_equal_16
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -116,15 +116,13 @@ stdlib › stdlib_equal_12
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -256,15 +256,13 @@ stdlib › stdlib_equal_21
     (block $do_backpatches.13
     )
    )
-   (return
-    (call $==_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1114)
-     )
-     (local.get $7)
-     (local.get $9)
+   (return_call $==_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1114)
     )
+    (local.get $7)
+    (local.get $9)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -88,15 +88,13 @@ stdlib › stdlib_equal_15
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -88,15 +88,13 @@ stdlib › stdlib_equal_14
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -390,15 +390,13 @@ stdlib › stdlib_equal_3
     (block $do_backpatches.23
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $9)
-     (local.get $13)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $9)
+    (local.get $13)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -96,15 +96,13 @@ stdlib › stdlib_equal_11
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -88,15 +88,13 @@ stdlib › stdlib_equal_9
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -100,15 +100,13 @@ stdlib › stdlib_equal_2
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
@@ -36,15 +36,13 @@ stdlib › stdlib_equal_6
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const -2)
-     (i32.const -2)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const -2)
+    (i32.const -2)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -256,15 +256,13 @@ stdlib › stdlib_equal_22
     (block $do_backpatches.13
     )
    )
-   (return
-    (call $==_1114
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1114)
-     )
-     (local.get $7)
-     (local.get $9)
+   (return_call $==_1114
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1114)
     )
+    (local.get $7)
+    (local.get $9)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -92,15 +92,13 @@ stdlib › stdlib_equal_10
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -84,15 +84,13 @@ stdlib › stdlib_equal_13
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
@@ -36,15 +36,13 @@ stdlib › stdlib_equal_7
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const -2)
-     (i32.const 2147483646)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const -2)
+    (i32.const 2147483646)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
@@ -36,15 +36,13 @@ stdlib › stdlib_equal_5
   (local $4 f32)
   (local $5 f64)
   (block $compile_block.1
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (i32.const 3)
-     (i32.const 5)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (i32.const 3)
+    (i32.const 5)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -84,15 +84,13 @@ stdlib › stdlib_equal_8
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -92,15 +92,13 @@ stdlib › stdlib_equal_17
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $==_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $==_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $==_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $==_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -92,15 +92,13 @@ strings › concat
     (block $do_backpatches.5
     )
    )
-   (return
-    (call $++_1113
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $++_1113)
-     )
-     (local.get $6)
-     (local.get $7)
+   (return_call $++_1113
+    (call $incRef_0
+     (global.get $GRAIN$EXPORT$incRef_0)
+     (global.get $++_1113)
     )
+    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/input/sinister-tail-call.gr
+++ b/compiler/test/input/sinister-tail-call.gr
@@ -1,4 +1,3 @@
-/* grainc-flags --experimental-wasm-tail-call */
 module SinisterTailCall
 
 // Contrived example to test *ADVANCED* tail calls

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -307,6 +307,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    5033,
+    5043,
   );
 });

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -9,9 +9,6 @@ describe("functions", ({test, testSkip}) => {
   let assertCompileError = makeCompileErrorRunner(test);
   let assertRun = makeRunner(test_or_skip);
   let assertFileRun = makeFileRunner(test_or_skip);
-  let tailCallConfig = () => {
-    Grain_utils.Config.experimental_tail_call := true;
-  };
 
   assertFileRun("fib1", "fib", "55\n");
   assertFileRun("fib2", "fib-better", "75025\n");
@@ -20,18 +17,8 @@ describe("functions", ({test, testSkip}) => {
   /* NOTE: This file also will test that we're doing tail calls
      and mutual recursion properly (should stack overflow otherwise) */
   /* Tests tail calls on only on one branch */
-  assertFileRun(
-    "one_branch_tail_call",
-    ~config_fn=tailCallConfig,
-    "oneBranchTail",
-    "[2]\n",
-  );
-  assertFileRun(
-    "forward_decl",
-    ~config_fn=tailCallConfig,
-    "forward-decl",
-    "true\n",
-  );
+  assertFileRun("one_branch_tail_call", "oneBranchTail", "[2]\n");
+  assertFileRun("forward_decl", "forward-decl", "true\n");
   /* This will test that we are doing tail calls for arbitrary-arity
      functions correctly */
   assertFileRun("sinister_tail_call", "sinister-tail-call", "true\n");

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -261,7 +261,7 @@ describe("optimizations", ({test, testSkip}) => {
   );
   assertAnf(
     "test_no_local_mutation_optimization_of_closure_scope_mut",
-    "/* grainc-flags --experimental-wasm-tail-call */ provide let bar = () => { let mut x = 5; let foo = () => x; foo() }",
+    "provide let bar = () => { let mut x = 5; let foo = () => x; foo() }",
     {
       open Grain_typed;
       let x = Ident.create("x");
@@ -336,7 +336,7 @@ describe("optimizations", ({test, testSkip}) => {
   /* All optimizations are needed to work completely on this input */
   assertAnf(
     "test_optimizations_work_together",
-    "/* grainc-flags --experimental-wasm-tail-call */ {\n    let x = 5;\n    let foo = ((y) => {y});\n    let y = (3, 5);\n    foo(3) + x}",
+    "{\n    let x = 5;\n    let foo = ((y) => {y});\n    let y = (3, 5);\n    foo(3) + x}",
     {
       open Grain_typed;
       let plus = Ident.create("+");
@@ -414,7 +414,6 @@ describe("optimizations", ({test, testSkip}) => {
   // Removal of manual memory management calls
   assertAnf(
     "test_manual_gc_calls_removed",
-    ~config_fn=() => {Grain_utils.Config.experimental_tail_call := true},
     {|
       /* grainc-flags --no-gc */
       include "runtime/unsafe/memory"


### PR DESCRIPTION
This pr enables tail calls by default it adds the cli argument `--no-wasm-tail-call` and removes the `--experimental-wasm-tail-calls` cli argument. 

This is marked as a draft because in #1587 it is noted that there are some cases where tail calls currently leak which need to be fixed before this is default.

closes: #1587