### PR TITLE
feat(compiler)!: Include Option and Result as language-supplied types

### DIFF
--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -15,7 +15,7 @@ arrays › array_access
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,7 +44,7 @@ arrays › array_access
     (local.set $0
      (block $compile_block.10 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -77,7 +77,7 @@ arrays › array_access
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ arrays › array_access
         (i32.const 1)
        )
        (local.set $2
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (block $resolve_idx.8
         (if
@@ -149,7 +149,7 @@ arrays › array_access
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
@@ -149,7 +149,7 @@ arrays › array_access5
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access5
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access5
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -15,7 +15,7 @@ arrays › array_access4
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,7 +44,7 @@ arrays › array_access4
     (local.set $0
      (block $compile_block.10 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -77,7 +77,7 @@ arrays › array_access4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ arrays › array_access4
         (i32.const -3)
        )
        (local.set $2
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (block $resolve_idx.8
         (if
@@ -149,7 +149,7 @@ arrays › array_access4
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access4
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access4
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -15,7 +15,7 @@ arrays › array_access2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,7 +44,7 @@ arrays › array_access2
     (local.set $0
      (block $compile_block.10 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -77,7 +77,7 @@ arrays › array_access2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ arrays › array_access2
         (i32.const 3)
        )
        (local.set $2
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (block $resolve_idx.8
         (if
@@ -149,7 +149,7 @@ arrays › array_access2
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access2
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access2
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -15,7 +15,7 @@ arrays › array_access3
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,7 +44,7 @@ arrays › array_access3
     (local.set $0
      (block $compile_block.10 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -77,7 +77,7 @@ arrays › array_access3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ arrays › array_access3
         (i32.const 5)
        )
        (local.set $2
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (block $resolve_idx.8
         (if
@@ -149,7 +149,7 @@ arrays › array_access3
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access3
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access3
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -15,7 +15,7 @@ arrays › array_access5
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/exception\" \"panicWithException\" (func $panicWithException_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,7 +44,7 @@ arrays › array_access5
     (local.set $0
      (block $compile_block.10 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_array.1 (result i32)
@@ -77,7 +77,7 @@ arrays › array_access5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ arrays › array_access5
         (i32.const -5)
        )
        (local.set $2
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (block $resolve_idx.8
         (if
@@ -149,7 +149,7 @@ arrays › array_access5
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 45)
+               (i32.const 49)
               )
               (i32.store offset=16
                (local.get $0)
@@ -183,7 +183,7 @@ arrays › array_access5
               )
               (i32.store offset=12
                (local.get $0)
-               (i32.const 47)
+               (i32.const 51)
               )
               (i32.store offset=16
                (local.get $0)
@@ -249,7 +249,7 @@ arrays › array_access5
             )
             (i32.store offset=12
              (local.get $0)
-             (i32.const 45)
+             (i32.const 49)
             )
             (i32.store offset=16
              (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const -33)
        (i32.const 35)

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › land4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1131
+      (call $&_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1131)
+        (global.get $&_1129)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lxor1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1131
+      (call $^_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1131)
+        (global.get $^_1129)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lor1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1131
+      (call $|_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1131)
+        (global.get $|_1129)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo6
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo6
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const 35)
        (i32.const 35)

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -10,12 +10,12 @@ basic functionality › precedence3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1134 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1132 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,10 +48,10 @@ basic functionality › precedence3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $%_1134
+          (call $%_1132
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $%_1134)
+            (global.get $%_1132)
            )
            (i32.const 9)
            (i32.const 13)
@@ -66,10 +66,10 @@ basic functionality › precedence3
        (block $do_backpatches.1
        )
       )
-      (call $+_1131
+      (call $+_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1131)
+        (global.get $+_1129)
        )
        (i32.const 7)
        (call $incRef_0

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsl1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lsl1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $<<_1131
+      (call $<<_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $<<_1131)
+        (global.get $<<_1129)
        )
        (i32.const 15)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -11,18 +11,18 @@ basic functionality › unsafe_wasm_globals
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F64_VAL\" (global $_F64_VAL_1165 (mut f64)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printF64\" (global $printF64_1164 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F32_VAL\" (global $_F32_VAL_1163 (mut f32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printF32\" (global $printF32_1162 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I64_VAL\" (global $_I64_VAL_1161 (mut i64)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printI64\" (global $printI64_1160 (mut i32)))
- (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I32_VAL\" (global $_I32_VAL_1159 (mut i32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printI32\" (global $printI32_1158 (mut i32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"printF64\" (func $printF64_1164 (param i32 f64) (result i32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"printF32\" (func $printF32_1162 (param i32 f32) (result i32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"printI64\" (func $printI64_1160 (param i32 i64) (result i32)))
- (import \"GRAIN$MODULE$runtime/debugPrint\" \"printI32\" (func $printI32_1158 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F64_VAL\" (global $_F64_VAL_1163 (mut f64)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printF64\" (global $printF64_1162 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_F32_VAL\" (global $_F32_VAL_1161 (mut f32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printF32\" (global $printF32_1160 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I64_VAL\" (global $_I64_VAL_1159 (mut i64)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printI64\" (global $printI64_1158 (mut i32)))
+ (import \"GRAIN$MODULE$unsafeWasmGlobalsExports\" \"GRAIN$EXPORT$_I32_VAL\" (global $_I32_VAL_1157 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"GRAIN$EXPORT$printI32\" (global $printI32_1156 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"printF64\" (func $printF64_1162 (param i32 f64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"printF32\" (func $printF32_1160 (param i32 f32) (result i32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"printI64\" (func $printI64_1158 (param i32 i64) (result i32)))
+ (import \"GRAIN$MODULE$runtime/debugPrint\" \"printI32\" (func $printI32_1156 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -49,26 +49,26 @@ basic functionality › unsafe_wasm_globals
   (return
    (block $compile_block.1 (result i32)
     (drop
-     (call $printI32_1158
-      (global.get $printI32_1158)
-      (global.get $_I32_VAL_1159)
+     (call $printI32_1156
+      (global.get $printI32_1156)
+      (global.get $_I32_VAL_1157)
      )
     )
     (drop
-     (call $printI64_1160
-      (global.get $printI64_1160)
-      (global.get $_I64_VAL_1161)
+     (call $printI64_1158
+      (global.get $printI64_1158)
+      (global.get $_I64_VAL_1159)
      )
     )
     (drop
-     (call $printF32_1162
-      (global.get $printF32_1162)
-      (global.get $_F32_VAL_1163)
+     (call $printF32_1160
+      (global.get $printF32_1160)
+      (global.get $_F32_VAL_1161)
      )
     )
-    (call $printF64_1164
-     (global.get $printF64_1164)
-     (global.get $_F64_VAL_1165)
+    (call $printF64_1162
+     (global.get $printF64_1162)
+     (global.get $_F64_VAL_1163)
     )
    )
   )

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -11,11 +11,11 @@ basic functionality › comp22
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -106,7 +106,7 @@ basic functionality › comp22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -151,7 +151,7 @@ basic functionality › comp22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -244,7 +244,7 @@ basic functionality › comp22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -289,7 +289,7 @@ basic functionality › comp22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -325,10 +325,10 @@ basic functionality › comp22
        (block $do_backpatches.17
        )
       )
-      (call $isnt_1131
+      (call $isnt_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1131)
+        (global.get $isnt_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › land1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1131
+      (call $&_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1131)
+        (global.get $&_1129)
        )
        (i32.const 3)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › orshort2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › orshort2
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1131
+       (call $print_1129
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1131)
+         (global.get $print_1129)
         )
         (i32.const 3)
        )

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -10,12 +10,12 @@ basic functionality › precedence4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1133 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1133 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,10 +48,10 @@ basic functionality › precedence4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $%_1133
+          (call $%_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $%_1133)
+            (global.get $%_1131)
            )
            (i32.const 9)
            (i32.const 13)
@@ -66,10 +66,10 @@ basic functionality › precedence4
        (block $do_backpatches.1
        )
       )
-      (call $+_1131
+      (call $+_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1131)
+        (global.get $+_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsl2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<<\" (global $<<_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"<<\" (func $<<_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lsl2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $<<_1131
+      (call $<<_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $<<_1131)
+        (global.get $<<_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › comp17
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › comp17
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $isnt_1131
+      (call $isnt_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1131)
+        (global.get $isnt_1129)
        )
        (i32.const 2147483646)
        (i32.const -2)

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › complex2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › complex2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $print_1131
+      (call $print_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1131)
+        (global.get $print_1129)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -11,11 +11,11 @@ basic functionality › comp20
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -72,7 +72,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -117,7 +117,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -173,7 +173,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -229,7 +229,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -274,7 +274,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -330,7 +330,7 @@ basic functionality › comp20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -363,10 +363,10 @@ basic functionality › comp20
        (block $do_backpatches.17
        )
       )
-      (call $isnt_1131
+      (call $isnt_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1131)
+        (global.get $isnt_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lor3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1131
+      (call $|_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1131)
+        (global.get $|_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › decr_3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1131
+      (call $decr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1131)
+        (global.get $decr_1129)
        )
        (i32.const 1)
       )

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -11,13 +11,13 @@ basic functionality › func_shadow
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1136 (param i32 i32) (result i32)))
- (global $foo_1133 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
  (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -25,7 +25,7 @@ basic functionality › func_shadow
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -73,7 +73,7 @@ basic functionality › func_shadow
    )
   )
  )
- (func $foo_1133 (param $0 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -144,10 +144,83 @@ basic functionality › func_shadow
     (local.set $0
      (block $compile_block.17 (result i32)
       (block $compile_store.9
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.7 (result i32)
+           (i32.store
+            (local.tee $0
+             (call $malloc_0
+              (global.get $GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+            )
+            (i32.const 6)
+           )
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 1)
+           )
+           (i32.store offset=8
+            (local.get $0)
+            (i32.const -1)
+           )
+           (i32.store offset=12
+            (local.get $0)
+            (i32.const 0)
+           )
+           (local.get $0)
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (global.get $foo_1129)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.8
+        (local.set $0
+         (global.get $foo_1129)
+        )
+       )
+      )
+      (block $compile_store.11
+       (local.set $6
+        (tuple.extract 0
+         (tuple.make
+          (call $foo_1129
+           (call $incRef_0
+            (global.get $GRAIN$EXPORT$incRef_0)
+            (global.get $foo_1129)
+           )
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (local.get $6)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.10
+       )
+      )
+      (drop
+       (call $print_1134
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (global.get $print_1134)
+        )
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (local.get $6)
+        )
+       )
+      )
+      (block $compile_store.14
+       (global.set $foo_1131
+        (tuple.extract 0
+         (tuple.make
+          (block $allocate_closure.12 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -178,82 +251,9 @@ basic functionality › func_shadow
          )
         )
        )
-       (block $do_backpatches.8
-        (local.set $0
-         (global.get $foo_1131)
-        )
-       )
-      )
-      (block $compile_store.11
-       (local.set $6
-        (tuple.extract 0
-         (tuple.make
-          (call $foo_1131
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1131)
-           )
-          )
-          (call $decRef_0
-           (global.get $GRAIN$EXPORT$decRef_0)
-           (local.get $6)
-          )
-         )
-        )
-       )
-       (block $do_backpatches.10
-       )
-      )
-      (drop
-       (call $print_1136
-        (call $incRef_0
-         (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1136)
-        )
-        (call $incRef_0
-         (global.get $GRAIN$EXPORT$incRef_0)
-         (local.get $6)
-        )
-       )
-      )
-      (block $compile_store.14
-       (global.set $foo_1133
-        (tuple.extract 0
-         (tuple.make
-          (block $allocate_closure.12 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
-          (call $decRef_0
-           (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1133)
-          )
-         )
-        )
-       )
        (block $do_backpatches.13
         (local.set $0
-         (global.get $foo_1133)
+         (global.get $foo_1131)
         )
        )
       )
@@ -261,10 +261,10 @@ basic functionality › func_shadow
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $foo_1133
+          (call $foo_1131
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1133)
+            (global.get $foo_1131)
            )
           )
           (call $decRef_0
@@ -277,10 +277,10 @@ basic functionality › func_shadow
        (block $do_backpatches.15
        )
       )
-      (call $print_1136
+      (call $print_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1136)
+        (global.get $print_1134)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo5
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo5
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const 35)
        (i32.const -33)

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -11,7 +11,7 @@ basic functionality › if_one_sided6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -40,13 +40,13 @@ basic functionality › if_one_sided6
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -62,13 +62,13 @@ basic functionality › if_one_sided6
         )
         (block $compile_block.4 (result i32)
          (block $compile_set.3 (result i32)
-          (global.set $x_1131
+          (global.set $x_1129
            (tuple.extract 0
             (tuple.make
              (i32.const 11)
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $x_1131)
+              (global.get $x_1129)
              )
             )
            )
@@ -83,7 +83,7 @@ basic functionality › if_one_sided6
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1131)
+       (global.get $x_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › binop6
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › binop6
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const 19)
        (i32.const 11)

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -14,7 +14,7 @@ basic functionality › block_no_expression
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $f_1131 (mut i32) (i32.const 0))
+ (global $f_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -22,7 +22,7 @@ basic functionality › block_no_expression
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $f_1131 (param $0 i32) (result i32)
+ (func $f_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -67,7 +67,7 @@ basic functionality › block_no_expression
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $f_1131
+       (global.set $f_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -96,21 +96,21 @@ basic functionality › block_no_expression
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $f_1131)
+           (global.get $f_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $f_1131)
+         (global.get $f_1129)
         )
        )
       )
-      (call $f_1131
+      (call $f_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $f_1131)
+        (global.get $f_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -9,7 +9,7 @@ basic functionality › if_one_sided5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,13 +38,13 @@ basic functionality › if_one_sided5
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.2
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -53,13 +53,13 @@ basic functionality › if_one_sided5
        )
       )
       (block $compile_set.3 (result i32)
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 11)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lor2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1131
+      (call $|_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1131)
+        (global.get $|_1129)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › land2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1131
+      (call $&_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1131)
+        (global.get $&_1129)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -11,12 +11,12 @@ basic functionality › pattern_match_unsafe_wasm
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1143 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1141 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1143 (param i32 i32) (result i32)))
- (global $test_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1141 (param i32 i32) (result i32)))
+ (global $test_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ basic functionality › pattern_match_unsafe_wasm
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $test_1131 (param $0 i32) (result i32)
+ (func $test_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -78,7 +78,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
       (drop
-       (call $foo_1132
+       (call $foo_1130
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
          (local.get $7)
@@ -87,7 +87,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
       (drop
-       (call $foo_1132
+       (call $foo_1130
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
          (local.get $7)
@@ -96,7 +96,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
       (drop
-       (call $foo_1132
+       (call $foo_1130
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
          (local.get $7)
@@ -105,7 +105,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
       )
       (drop
-       (call $foo_1132
+       (call $foo_1130
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
          (local.get $7)
@@ -113,7 +113,7 @@ basic functionality › pattern_match_unsafe_wasm
         (i32.const 8)
        )
       )
-      (call $foo_1132
+      (call $foo_1130
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $7)
@@ -138,7 +138,7 @@ basic functionality › pattern_match_unsafe_wasm
    )
   )
  )
- (func $foo_1132 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1130 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -395,10 +395,10 @@ basic functionality › pattern_match_unsafe_wasm
                        (block $do_backpatches.40
                        )
                       )
-                      (call $print_1143
+                      (call $print_1141
                        (call $incRef_0
                         (global.get $GRAIN$EXPORT$incRef_0)
-                        (global.get $print_1143)
+                        (global.get $print_1141)
                        )
                        (call $incRef_0
                         (global.get $GRAIN$EXPORT$incRef_0)
@@ -411,10 +411,10 @@ basic functionality › pattern_match_unsafe_wasm
                   )
                   (br $switch.32_outer
                    (block $compile_block.38 (result i32)
-                    (call $print_1143
+                    (call $print_1141
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $print_1143)
+                      (global.get $print_1141)
                      )
                      (i32.const 13)
                     )
@@ -424,10 +424,10 @@ basic functionality › pattern_match_unsafe_wasm
                 )
                 (br $switch.32_outer
                  (block $compile_block.37 (result i32)
-                  (call $print_1143
+                  (call $print_1141
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $print_1143)
+                    (global.get $print_1141)
                    )
                    (i32.const 11)
                   )
@@ -437,10 +437,10 @@ basic functionality › pattern_match_unsafe_wasm
               )
               (br $switch.32_outer
                (block $compile_block.36 (result i32)
-                (call $print_1143
+                (call $print_1141
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $print_1143)
+                  (global.get $print_1141)
                  )
                  (i32.const 9)
                 )
@@ -450,10 +450,10 @@ basic functionality › pattern_match_unsafe_wasm
             )
             (br $switch.32_outer
              (block $compile_block.35 (result i32)
-              (call $print_1143
+              (call $print_1141
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $print_1143)
+                (global.get $print_1141)
                )
                (i32.const 7)
               )
@@ -463,10 +463,10 @@ basic functionality › pattern_match_unsafe_wasm
           )
           (br $switch.32_outer
            (block $compile_block.34 (result i32)
-            (call $print_1143
+            (call $print_1141
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $print_1143)
+              (global.get $print_1141)
              )
              (i32.const 5)
             )
@@ -476,10 +476,10 @@ basic functionality › pattern_match_unsafe_wasm
         )
         (br $switch.32_outer
          (block $compile_block.33 (result i32)
-          (call $print_1143
+          (call $print_1141
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $print_1143)
+            (global.get $print_1141)
            )
            (i32.const 3)
           )
@@ -526,7 +526,7 @@ basic functionality › pattern_match_unsafe_wasm
     (local.set $0
      (block $compile_block.49 (result i32)
       (block $compile_store.48
-       (global.set $test_1131
+       (global.set $test_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.46 (result i32)
@@ -555,21 +555,21 @@ basic functionality › pattern_match_unsafe_wasm
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $test_1131)
+           (global.get $test_1129)
           )
          )
         )
        )
        (block $do_backpatches.47
         (local.set $0
-         (global.get $test_1131)
+         (global.get $test_1129)
         )
        )
       )
-      (call $test_1131
+      (call $test_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $test_1131)
+        (global.get $test_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › asr1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › asr1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>_1131
+      (call $>>_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>_1131)
+        (global.get $>>_1129)
        )
        (i32.const 359)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -103,7 +103,7 @@ basic functionality › comp21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -148,7 +148,7 @@ basic functionality › comp21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -241,7 +241,7 @@ basic functionality › comp21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -286,7 +286,7 @@ basic functionality › comp21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lxor3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1131
+      (call $^_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1131)
+        (global.get $^_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › incr_3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1131
+      (call $incr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1131)
+        (global.get $incr_1129)
        )
        (i32.const -1)
       )

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -9,7 +9,7 @@ basic functionality › if_one_sided3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,13 +38,13 @@ basic functionality › if_one_sided3
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.2
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -53,13 +53,13 @@ basic functionality › if_one_sided3
        )
       )
       (block $compile_set.3 (result i32)
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 5)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
@@ -11,11 +11,11 @@ basic functionality › bigint_1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -78,10 +78,10 @@ basic functionality › bigint_1
        (block $do_backpatches.2
        )
       )
-      (call $+_1131
+      (call $+_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1131)
+        (global.get $+_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lxor2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1131
+      (call $^_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1131)
+        (global.get $^_1129)
        )
        (i32.const 3)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › if_one_sided
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1133 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › if_one_sided
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $print_1135
+      (call $print_1133
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1135)
+        (global.get $print_1133)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lxor4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$^\" (global $^_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"^\" (func $^_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lxor4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $^_1131
+      (call $^_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $^_1131)
+        (global.get $^_1129)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › complex1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › complex1
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 7)
        )

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsr2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lsr2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>>_1131
+      (call $>>>_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>>_1131)
+        (global.get $>>>_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -9,10 +9,10 @@ basic functionality › toplevel_statements
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -41,46 +41,46 @@ basic functionality › toplevel_statements
     (local.set $0
      (block $compile_block.2 (result i32)
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 3)
        )
       )
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 5)
        )
       )
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 7)
        )
       )
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 9)
        )
       )
       (drop
-       (call $print_1138
+       (call $print_1136
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1138)
+         (global.get $print_1136)
         )
         (i32.const 11)
        )

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lsr1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>>\" (global $>>>_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>>\" (func $>>>_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lsr1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>>_1131
+      (call $>>>_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>>_1131)
+        (global.get $>>>_1129)
        )
        (i32.const 15)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › incr_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1131
+      (call $incr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1131)
+        (global.get $incr_1129)
        )
        (i32.const 5)
       )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › incr_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$incr\" (global $incr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"incr\" (func $incr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › incr_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $incr_1131
+      (call $incr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $incr_1131)
+        (global.get $incr_1129)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const -33)
        (i32.const -7)

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › lor4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$|\" (global $|_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"|\" (func $|_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › lor4
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $|_1131
+      (call $|_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $|_1131)
+        (global.get $|_1129)
        )
        (i32.const 1)
        (i32.const 1)

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › int64_pun_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › int64_pun_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $*_1131
+      (call $*_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $*_1131)
+        (global.get $*_1129)
        )
        (i32.const 19999999)
        (i32.const 199999999)

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › decr_1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1131
+      (call $decr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1131)
+        (global.get $decr_1129)
        )
        (i32.const 5)
       )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › andshort1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › andshort1
     (local.set $0
      (block $compile_block.1 (result i32)
       (drop
-       (call $print_1131
+       (call $print_1129
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1131)
+         (global.get $print_1129)
         )
         (i32.const 3)
        )

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo1
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const -33)
        (i32.const 9)

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › land3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$&\" (global $&_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"&\" (func $&_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › land3
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $&_1131
+      (call $&_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $&_1131)
+        (global.get $&_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › comp18
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$isnt\" (global $isnt_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"isnt\" (func $isnt_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › comp18
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $isnt_1131
+      (call $isnt_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $isnt_1131)
+        (global.get $isnt_1129)
        )
        (i32.const 9)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -11,7 +11,7 @@ basic functionality › if_one_sided4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -40,13 +40,13 @@ basic functionality › if_one_sided4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 3)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -62,13 +62,13 @@ basic functionality › if_one_sided4
         )
         (block $compile_block.4 (result i32)
          (block $compile_set.3 (result i32)
-          (global.set $x_1131
+          (global.set $x_1129
            (tuple.extract 0
             (tuple.make
              (i32.const 5)
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
-              (global.get $x_1131)
+              (global.get $x_1129)
              )
             )
            )
@@ -83,7 +83,7 @@ basic functionality › if_one_sided4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1131)
+       (global.get $x_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › asr2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>>\" (global $>>_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \">>\" (func $>>_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › asr2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $>>_1131
+      (call $>>_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $>>_1131)
+        (global.get $>>_1129)
        )
        (i32.const 1)
        (i32.const 3)

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › modulo2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$%\" (global $%_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"%\" (func $%_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › modulo2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $%_1131
+      (call $%_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $%_1131)
+        (global.get $%_1129)
        )
        (i32.const 35)
        (i32.const -7)

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -8,9 +8,9 @@ basic functionality › decr_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$decr\" (global $decr_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1131 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"decr\" (func $decr_1129 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -38,10 +38,10 @@ basic functionality › decr_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $decr_1131
+      (call $decr_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $decr_1131)
+        (global.get $decr_1129)
        )
        (i32.const 11)
       )

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -69,7 +69,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -114,7 +114,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -170,7 +170,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -226,7 +226,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -271,7 +271,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -327,7 +327,7 @@ basic functionality › comp19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -9,9 +9,9 @@ basic functionality › int64_pun_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ basic functionality › int64_pun_2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $-_1131
+      (call $-_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $-_1131)
+        (global.get $-_1129)
        )
        (i32.const -199999997)
        (i32.const 1999999999)

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -11,23 +11,23 @@ basic functionality › func_shadow_and_indirect_call
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1139 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1137 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1139 (param i32 i32) (result i32)))
- (global $foo_1137 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1137 (param i32 i32) (result i32)))
  (global $foo_1135 (mut i32) (i32.const 0))
  (global $foo_1133 (mut i32) (i32.const 0))
  (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1148)
+ (elem $elem (global.get $relocBase_0) $func_1146)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -75,7 +75,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $foo_1133 (param $0 i32) (result i32)
+ (func $foo_1131 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -123,7 +123,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $foo_1135 (param $0 i32) (result i32)
+ (func $foo_1133 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -178,7 +178,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $func_1148 (param $0 i32) (result i32)
+ (func $func_1146 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -250,10 +250,83 @@ basic functionality › func_shadow_and_indirect_call
     (local.set $0
      (block $compile_block.31 (result i32)
       (block $compile_store.15
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.13 (result i32)
+           (i32.store
+            (local.tee $0
+             (call $malloc_0
+              (global.get $GRAIN$EXPORT$malloc_0)
+              (i32.const 16)
+             )
+            )
+            (i32.const 6)
+           )
+           (i32.store offset=4
+            (local.get $0)
+            (i32.const 1)
+           )
+           (i32.store offset=8
+            (local.get $0)
+            (i32.const -1)
+           )
+           (i32.store offset=12
+            (local.get $0)
+            (i32.const 0)
+           )
+           (local.get $0)
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (global.get $foo_1129)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.14
+        (local.set $0
+         (global.get $foo_1129)
+        )
+       )
+      )
+      (block $compile_store.17
+       (local.set $6
+        (tuple.extract 0
+         (tuple.make
+          (call $foo_1129
+           (call $incRef_0
+            (global.get $GRAIN$EXPORT$incRef_0)
+            (global.get $foo_1129)
+           )
+          )
+          (call $decRef_0
+           (global.get $GRAIN$EXPORT$decRef_0)
+           (local.get $6)
+          )
+         )
+        )
+       )
+       (block $do_backpatches.16
+       )
+      )
+      (drop
+       (call $print_1137
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (global.get $print_1137)
+        )
+        (call $incRef_0
+         (global.get $GRAIN$EXPORT$incRef_0)
+         (local.get $6)
+        )
+       )
+      )
+      (block $compile_store.20
+       (global.set $foo_1131
+        (tuple.extract 0
+         (tuple.make
+          (block $allocate_closure.18 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -284,14 +357,14 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.14
+       (block $do_backpatches.19
         (local.set $0
          (global.get $foo_1131)
         )
        )
       )
-      (block $compile_store.17
-       (local.set $6
+      (block $compile_store.22
+       (local.set $7
         (tuple.extract 0
          (tuple.make
           (call $foo_1131
@@ -302,31 +375,31 @@ basic functionality › func_shadow_and_indirect_call
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (local.get $6)
+           (local.get $7)
           )
          )
         )
        )
-       (block $do_backpatches.16
+       (block $do_backpatches.21
        )
       )
       (drop
-       (call $print_1139
+       (call $print_1137
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1139)
+         (global.get $print_1137)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (local.get $6)
+         (local.get $7)
         )
        )
       )
-      (block $compile_store.20
+      (block $compile_store.25
        (global.set $foo_1133
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.18 (result i32)
+          (block $allocate_closure.23 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -357,14 +430,14 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.19
+       (block $do_backpatches.24
         (local.set $0
          (global.get $foo_1133)
         )
        )
       )
-      (block $compile_store.22
-       (local.set $7
+      (block $compile_store.27
+       (global.set $foo_1135
         (tuple.extract 0
          (tuple.make
           (call $foo_1133
@@ -375,80 +448,7 @@ basic functionality › func_shadow_and_indirect_call
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (local.get $7)
-          )
-         )
-        )
-       )
-       (block $do_backpatches.21
-       )
-      )
-      (drop
-       (call $print_1139
-        (call $incRef_0
-         (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1139)
-        )
-        (call $incRef_0
-         (global.get $GRAIN$EXPORT$incRef_0)
-         (local.get $7)
-        )
-       )
-      )
-      (block $compile_store.25
-       (global.set $foo_1135
-        (tuple.extract 0
-         (tuple.make
-          (block $allocate_closure.23 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
-          (call $decRef_0
-           (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1135)
-          )
-         )
-        )
-       )
-       (block $do_backpatches.24
-        (local.set $0
-         (global.get $foo_1135)
-        )
-       )
-      )
-      (block $compile_store.27
-       (global.set $foo_1137
-        (tuple.extract 0
-         (tuple.make
-          (call $foo_1135
-           (call $incRef_0
-            (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1135)
-           )
-          )
-          (call $decRef_0
-           (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1137)
           )
          )
         )
@@ -464,7 +464,7 @@ basic functionality › func_shadow_and_indirect_call
            (local.set $0
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $foo_1137)
+             (global.get $foo_1135)
             )
            )
            (call_indirect (type $i32_=>_i32)
@@ -484,10 +484,10 @@ basic functionality › func_shadow_and_indirect_call
        (block $do_backpatches.29
        )
       )
-      (call $print_1139
+      (call $print_1137
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1139)
+        (global.get $print_1137)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_subtraction1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,7 +47,7 @@ boxes › box_subtraction1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -72,7 +72,7 @@ boxes › box_subtraction1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -87,7 +87,7 @@ boxes › box_subtraction1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -104,10 +104,10 @@ boxes › box_subtraction1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -127,7 +127,7 @@ boxes › box_subtraction1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -137,7 +137,7 @@ boxes › box_subtraction1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_multiplication2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,7 +48,7 @@ boxes › box_multiplication2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -73,7 +73,7 @@ boxes › box_multiplication2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -88,7 +88,7 @@ boxes › box_multiplication2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -105,10 +105,10 @@ boxes › box_multiplication2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $*_1135
+          (call $*_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1135)
+            (global.get $*_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -130,7 +130,7 @@ boxes › box_multiplication2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1131)
+          (global.get $b_1129)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -140,7 +140,7 @@ boxes › box_multiplication2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1131)
+              (global.get $b_1129)
              )
             )
            )
@@ -155,7 +155,7 @@ boxes › box_multiplication2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_division2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,7 +48,7 @@ boxes › box_division2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -73,7 +73,7 @@ boxes › box_division2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -88,7 +88,7 @@ boxes › box_division2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -105,10 +105,10 @@ boxes › box_division2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $/_1135
+          (call $/_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1135)
+            (global.get $/_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -130,7 +130,7 @@ boxes › box_division2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1131)
+          (global.get $b_1129)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -140,7 +140,7 @@ boxes › box_division2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1131)
+              (global.get $b_1129)
              )
             )
            )
@@ -155,7 +155,7 @@ boxes › box_division2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_addition2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,7 +48,7 @@ boxes › box_addition2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -73,7 +73,7 @@ boxes › box_addition2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -88,7 +88,7 @@ boxes › box_addition2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -105,10 +105,10 @@ boxes › box_addition2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $+_1135
+          (call $+_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1135)
+            (global.get $+_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -130,7 +130,7 @@ boxes › box_addition2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1131)
+          (global.get $b_1129)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -140,7 +140,7 @@ boxes › box_addition2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1131)
+              (global.get $b_1129)
              )
             )
            )
@@ -155,7 +155,7 @@ boxes › box_addition2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_division1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,7 +47,7 @@ boxes › box_division1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -72,7 +72,7 @@ boxes › box_division1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -87,7 +87,7 @@ boxes › box_division1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -104,10 +104,10 @@ boxes › box_division1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $/_1135
+          (call $/_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1135)
+            (global.get $/_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -127,7 +127,7 @@ boxes › box_division1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -137,7 +137,7 @@ boxes › box_division1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_subtraction2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -48,7 +48,7 @@ boxes › box_subtraction2
     (local.set $0
      (block $compile_block.11 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -73,7 +73,7 @@ boxes › box_subtraction2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -88,7 +88,7 @@ boxes › box_subtraction2
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -105,10 +105,10 @@ boxes › box_subtraction2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -130,7 +130,7 @@ boxes › box_subtraction2
        (local.set $8
         (block $MTupleSet.8 (result i32)
          (i32.store offset=8
-          (global.get $b_1131)
+          (global.get $b_1129)
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -140,7 +140,7 @@ boxes › box_subtraction2
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $b_1131)
+              (global.get $b_1129)
              )
             )
            )
@@ -155,7 +155,7 @@ boxes › box_subtraction2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_addition1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,7 +47,7 @@ boxes › box_addition1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -72,7 +72,7 @@ boxes › box_addition1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -87,7 +87,7 @@ boxes › box_addition1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -104,10 +104,10 @@ boxes › box_addition1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $+_1135
+          (call $+_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1135)
+            (global.get $+_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -127,7 +127,7 @@ boxes › box_addition1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -137,7 +137,7 @@ boxes › box_addition1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
          )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -11,12 +11,12 @@ boxes › box_multiplication1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,7 +47,7 @@ boxes › box_multiplication1
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -72,7 +72,7 @@ boxes › box_multiplication1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -87,7 +87,7 @@ boxes › box_multiplication1
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
           (call $decRef_0
@@ -104,10 +104,10 @@ boxes › box_multiplication1
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (call $*_1135
+          (call $*_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1135)
+            (global.get $*_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -127,7 +127,7 @@ boxes › box_multiplication1
       )
       (block $MTupleSet.8 (result i32)
        (i32.store offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -137,7 +137,7 @@ boxes › box_multiplication1
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (i32.load offset=8
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
           )
          )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -50,7 +50,7 @@ enums › adt_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899347051)
+       (i64.const 85899347049)
       )
       (i64.store offset=32
        (local.get $0)
@@ -127,7 +127,7 @@ enums › adt_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -10,11 +10,11 @@ enums › enum_recursive_data_definition
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1149 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1147 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1149 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1147 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -56,7 +56,7 @@ enums › enum_recursive_data_definition
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 85899347052)
+       (i64.const 85899347050)
       )
       (i64.store offset=32
        (local.get $0)
@@ -80,7 +80,7 @@ enums › enum_recursive_data_definition
       )
       (i64.store offset=72
        (local.get $0)
-       (i64.const 85899347051)
+       (i64.const 85899347049)
       )
       (i64.store offset=80
        (local.get $0)
@@ -234,7 +234,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -279,7 +279,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -338,7 +338,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -383,7 +383,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -442,7 +442,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -501,7 +501,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -546,7 +546,7 @@ enums › enum_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -582,10 +582,10 @@ enums › enum_recursive_data_definition
        (block $do_backpatches.28
        )
       )
-      (call $print_1149
+      (call $print_1147
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1149)
+        (global.get $print_1147)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -54,7 +54,7 @@ exceptions › exception_4
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 12884903019)
+       (i64.const 12884903017)
       )
       (i64.store offset=40
        (local.get $0)
@@ -62,7 +62,7 @@ exceptions › exception_4
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 4861902979092)
+       (i64.const 4853313044500)
       )
       (i64.store offset=56
        (local.get $0)
@@ -127,7 +127,7 @@ exceptions › exception_4
        )
        (i32.store offset=12
         (local.get $0)
-        (i32.const 2265)
+        (i32.const 2261)
        )
        (i32.store offset=16
         (local.get $0)

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -54,7 +54,7 @@ exceptions › exception_2
       )
       (i64.store offset=32
        (local.get $0)
-       (i64.const 12884903019)
+       (i64.const 12884903017)
       )
       (i64.store offset=40
        (local.get $0)
@@ -115,7 +115,7 @@ exceptions › exception_2
        )
        (i32.store offset=12
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=16
         (local.get $0)

--- a/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
+++ b/compiler/test/__snapshots__/exports.40fa3869.0.snapshot
@@ -11,21 +11,21 @@ exports › export_start_function
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1135 (param i32 i32) (result i32)))
- (global $_start_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1133 (param i32 i32) (result i32)))
+ (global $_start_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"_start\" (func $_start_1131))
- (export \"GRAIN$EXPORT$_start\" (global $_start_1131))
+ (export \"_start\" (func $_start_1129))
+ (export \"GRAIN$EXPORT$_start\" (global $_start_1129))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $_start_1131 (param $0 i32) (result i32)
+ (func $_start_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -75,10 +75,10 @@ exports › export_start_function
        (block $do_backpatches.2
        )
       )
-      (call $print_1135
+      (call $print_1133
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1135)
+        (global.get $print_1133)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -159,10 +159,10 @@ exports › export_start_function
        )
       )
       (drop
-       (call $print_1135
+       (call $print_1133
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $print_1135)
+         (global.get $print_1133)
         )
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
@@ -171,7 +171,7 @@ exports › export_start_function
        )
       )
       (block $compile_store.11
-       (global.set $_start_1131
+       (global.set $_start_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.9 (result i32)
@@ -200,14 +200,14 @@ exports › export_start_function
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $_start_1131)
+           (global.get $_start_1129)
           )
          )
         )
        )
        (block $do_backpatches.10
         (local.set $0
-         (global.get $_start_1131)
+         (global.get $_start_1129)
         )
        )
       )

--- a/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
+++ b/compiler/test/__snapshots__/exports.6ebe81b3.0.snapshot
@@ -8,7 +8,7 @@ exports › export7
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ exports › export7
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1140)
+       (global.get $x_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a2013f43.0.snapshot
@@ -12,17 +12,17 @@ exports › let_rec_export
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
- (export \"foo\" (func $foo_1131))
- (export \"GRAIN$EXPORT$foo\" (global $foo_1131))
+ (export \"foo\" (func $foo_1129))
+ (export \"GRAIN$EXPORT$foo\" (global $foo_1129))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -72,7 +72,7 @@ exports › let_rec_export
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -101,14 +101,14 @@ exports › let_rec_export
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )

--- a/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
+++ b/compiler/test/__snapshots__/exports.a24038e5.0.snapshot
@@ -8,7 +8,7 @@ exports › export4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$onlyXExported\" \"GRAIN$EXPORT$x\" (global $x_1134 (mut i32)))
+ (import \"GRAIN$MODULE$onlyXExported\" \"GRAIN$EXPORT$x\" (global $x_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ exports › export4
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1134)
+       (global.get $x_1132)
       )
      )
     )

--- a/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d0b9a66c.0.snapshot
@@ -8,10 +8,10 @@ exports › export9
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ exports › export9
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1140
+      (call $y_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1140)
+        (global.get $y_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $z_1141)
+        (global.get $z_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/exports.d19c8510.0.snapshot
+++ b/compiler/test/__snapshots__/exports.d19c8510.0.snapshot
@@ -10,21 +10,21 @@ exports › export12
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1180 (mut i32)))
- (import \"GRAIN$MODULE$exposedType\" \"GRAIN$EXPORT$apply\" (global $apply_1178 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1178 (mut i32)))
+ (import \"GRAIN$MODULE$exposedType\" \"GRAIN$EXPORT$apply\" (global $apply_1176 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1180 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exposedType\" \"apply\" (func $apply_1178 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1178 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exposedType\" \"apply\" (func $apply_1176 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1179)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1177)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1179 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1177 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -70,10 +70,10 @@ exports › export12
        (block $do_backpatches.2
        )
       )
-      (call $print_1180
+      (call $print_1178
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1180)
+        (global.get $print_1178)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -169,10 +169,10 @@ exports › export12
         )
        )
       )
-      (call $apply_1178
+      (call $apply_1176
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $apply_1178)
+        (global.get $apply_1176)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
+++ b/compiler/test/__snapshots__/exports.de3bf2b8.0.snapshot
@@ -10,13 +10,13 @@ exports › export8
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1143 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1141 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1139 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1143 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1141 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1138 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -49,10 +49,10 @@ exports › export8
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $y_1143
+          (call $y_1141
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $y_1143)
+            (global.get $y_1141)
            )
            (i32.const 9)
           )
@@ -66,14 +66,14 @@ exports › export8
        (block $do_backpatches.1
        )
       )
-      (call $+_1140
+      (call $+_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1140)
+        (global.get $+_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1141)
+        (global.get $x_1139)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -14,7 +14,7 @@ functions › dup_func
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1135 (mut i32) (i32.const 0))
+ (global $foo_1133 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -22,7 +22,7 @@ functions › dup_func
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1135 (param $0 i32) (result i32)
+ (func $foo_1133 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -72,7 +72,7 @@ functions › dup_func
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1135
+       (global.set $foo_1133
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -101,21 +101,21 @@ functions › dup_func
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1135)
+           (global.get $foo_1133)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1135)
+         (global.get $foo_1133)
         )
        )
       )
-      (call $foo_1135
+      (call $foo_1133
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1135)
+        (global.get $foo_1133)
        )
       )
      )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -11,12 +11,12 @@ functions › shorthand_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › shorthand_4
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -37,10 +37,10 @@ functions › shorthand_4
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1133
+        (call $+_1131
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1133)
+          (global.get $+_1131)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -90,7 +90,7 @@ functions › shorthand_4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -119,21 +119,21 @@ functions › shorthand_4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -13,7 +13,7 @@ functions › shorthand_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -21,7 +21,7 @@ functions › shorthand_1
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -80,7 +80,7 @@ functions › shorthand_1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -109,21 +109,21 @@ functions › shorthand_1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -11,11 +11,11 @@ functions › lam_destructure_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -23,7 +23,7 @@ functions › lam_destructure_5
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1136 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $lam_lambda_1134 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -338,10 +338,10 @@ functions › lam_destructure_5
          (local.set $19
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -366,10 +366,10 @@ functions › lam_destructure_5
          (local.set $20
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -394,10 +394,10 @@ functions › lam_destructure_5
          (local.set $21
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -418,10 +418,10 @@ functions › lam_destructure_5
          (block $do_backpatches.30
          )
         )
-        (call $+_1137
+        (call $+_1135
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1137)
+          (global.get $+_1135)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -681,7 +681,7 @@ functions › lam_destructure_5
        (block $do_backpatches.41
        )
       )
-      (call $lam_lambda_1136
+      (call $lam_lambda_1134
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -13,7 +13,7 @@ functions › lambda_pat_any
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -21,7 +21,7 @@ functions › lambda_pat_any
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $x_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $x_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -78,7 +78,7 @@ functions › lambda_pat_any
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.5
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -107,14 +107,14 @@ functions › lambda_pat_any
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $x_1131)
+         (global.get $x_1129)
         )
        )
       )
@@ -152,10 +152,10 @@ functions › lambda_pat_any
        (block $do_backpatches.7
        )
       )
-      (call $x_1131
+      (call $x_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1131)
+        (global.get $x_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -11,20 +11,20 @@ functions › curried_func
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
- (global $add_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
+ (global $add_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1141)
+ (elem $elem (global.get $relocBase_0) $func_1139)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $add_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $add_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -92,7 +92,7 @@ functions › curried_func
    )
   )
  )
- (func $func_1141 (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1139 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -105,10 +105,10 @@ functions › curried_func
      (tuple.extract 0
       (tuple.make
        (block $compile_block.4 (result i32)
-        (call $+_1134
+        (call $+_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1134)
+          (global.get $+_1132)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -164,7 +164,7 @@ functions › curried_func
     (local.set $0
      (block $compile_block.12 (result i32)
       (block $compile_store.8
-       (global.set $add_1131
+       (global.set $add_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.6 (result i32)
@@ -193,14 +193,14 @@ functions › curried_func
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $add_1131)
+           (global.get $add_1129)
           )
          )
         )
        )
        (block $do_backpatches.7
         (local.set $0
-         (global.get $add_1131)
+         (global.get $add_1129)
         )
        )
       )
@@ -208,10 +208,10 @@ functions › curried_func
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $add_1131
+          (call $add_1129
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $add_1131)
+            (global.get $add_1129)
            )
            (i32.const 5)
           )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -12,27 +12,27 @@ functions › func_recursive_closure
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1157 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1152 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1155 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1150 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1140 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1157 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1152 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
- (global $truc_1134 (mut i32) (i32.const 0))
- (global $makeAdder_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1155 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1150 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1140 (param i32 i32 i32) (result i32)))
+ (global $truc_1132 (mut i32) (i32.const 0))
+ (global $makeAdder_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $func_1165)
+ (elem $elem (global.get $relocBase_0) $func_1163)
  (export \"memory\" (memory $0))
- (export \"truc\" (func $truc_1134))
- (export \"GRAIN$EXPORT$truc\" (global $truc_1134))
+ (export \"truc\" (func $truc_1132))
+ (export \"GRAIN$EXPORT$truc\" (global $truc_1132))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $makeAdder_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $makeAdder_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -100,7 +100,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $truc_1134 (param $0 i32) (result i32)
+ (func $truc_1132 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -155,7 +155,7 @@ functions › func_recursive_closure
           )
          )
         )
-        (call $foo_1135
+        (call $foo_1133
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
           (local.get $7)
@@ -183,7 +183,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $func_1165 (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1163 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -196,10 +196,10 @@ functions › func_recursive_closure
      (tuple.extract 0
       (tuple.make
        (block $compile_block.9 (result i32)
-        (call $+_1142
+        (call $+_1140
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1142)
+          (global.get $+_1140)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -233,7 +233,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $foo_1135 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1133 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -255,10 +255,10 @@ functions › func_recursive_closure
          (local.set $8
           (tuple.extract 0
            (tuple.make
-            (call $makeAdder_1131
+            (call $makeAdder_1129
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $makeAdder_1131)
+              (global.get $makeAdder_1129)
              )
              (i32.const 3)
             )
@@ -329,10 +329,10 @@ functions › func_recursive_closure
         )
         (block $compile_store.17
          (local.set $11
-          (call $==_1152
+          (call $==_1150
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1152)
+            (global.get $==_1150)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -355,10 +355,10 @@ functions › func_recursive_closure
          (block $compile_block.25 (result i32)
           (block $compile_store.20
            (local.set $12
-            (call $==_1152
+            (call $==_1150
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $==_1152)
+              (global.get $==_1150)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -376,7 +376,7 @@ functions › func_recursive_closure
             (i32.const 31)
            )
            (block $compile_block.21 (result i32)
-            (call $bar_1138
+            (call $bar_1136
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (local.get $9)
@@ -389,10 +389,10 @@ functions › func_recursive_closure
              (local.set $10
               (tuple.extract 0
                (tuple.make
-                (call $-_1157
+                (call $-_1155
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $-_1157)
+                  (global.get $-_1155)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -410,7 +410,7 @@ functions › func_recursive_closure
              (block $do_backpatches.22
              )
             )
-            (call $foo_1135
+            (call $foo_1133
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (local.get $0)
@@ -463,7 +463,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $bar_1138 (param $0 i32) (param $1 i32) (result i32)
+ (func $bar_1136 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -482,7 +482,7 @@ functions › func_recursive_closure
          (local.set $8
           (tuple.extract 0
            (tuple.make
-            (call $foo_1135
+            (call $foo_1133
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
               (i32.load offset=16
@@ -532,10 +532,10 @@ functions › func_recursive_closure
          (block $do_backpatches.31
          )
         )
-        (call $+_1142
+        (call $+_1140
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1142)
+          (global.get $+_1140)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -600,7 +600,7 @@ functions › func_recursive_closure
     (local.set $0
      (block $compile_block.41 (result i32)
       (block $compile_store.37
-       (global.set $makeAdder_1131
+       (global.set $makeAdder_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.35 (result i32)
@@ -629,19 +629,19 @@ functions › func_recursive_closure
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $makeAdder_1131)
+           (global.get $makeAdder_1129)
           )
          )
         )
        )
        (block $do_backpatches.36
         (local.set $0
-         (global.get $makeAdder_1131)
+         (global.get $makeAdder_1129)
         )
        )
       )
       (block $compile_store.40
-       (global.set $truc_1134
+       (global.set $truc_1132
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.38 (result i32)
@@ -670,21 +670,21 @@ functions › func_recursive_closure
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $truc_1134)
+           (global.get $truc_1132)
           )
          )
         )
        )
        (block $do_backpatches.39
         (local.set $0
-         (global.get $truc_1134)
+         (global.get $truc_1132)
         )
        )
       )
-      (call $truc_1134
+      (call $truc_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $truc_1134)
+        (global.get $truc_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -20,7 +20,7 @@ functions › app_1
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1132 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1130 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -120,7 +120,7 @@ functions › app_1
         )
        )
       )
-      (call $lam_lambda_1132
+      (call $lam_lambda_1130
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -13,7 +13,7 @@ functions › shorthand_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -21,7 +21,7 @@ functions › shorthand_3
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -80,7 +80,7 @@ functions › shorthand_3
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -109,21 +109,21 @@ functions › shorthand_3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -11,11 +11,11 @@ functions › lam_destructure_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -23,7 +23,7 @@ functions › lam_destructure_3
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1134 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1132 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -218,10 +218,10 @@ functions › lam_destructure_3
          (local.set $14
           (tuple.extract 0
            (tuple.make
-            (call $+_1135
+            (call $+_1133
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1135)
+              (global.get $+_1133)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -242,10 +242,10 @@ functions › lam_destructure_3
          (block $do_backpatches.16
          )
         )
-        (call $+_1135
+        (call $+_1133
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1135)
+          (global.get $+_1133)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -424,7 +424,7 @@ functions › lam_destructure_3
        (block $do_backpatches.24
        )
       )
-      (call $lam_lambda_1134
+      (call $lam_lambda_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -11,11 +11,11 @@ functions › lam_destructure_7
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1136 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -23,7 +23,7 @@ functions › lam_destructure_7
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1135 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1133 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -299,10 +299,10 @@ functions › lam_destructure_7
          (local.set $17
           (tuple.extract 0
            (tuple.make
-            (call $+_1136
+            (call $+_1134
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1136)
+              (global.get $+_1134)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -327,10 +327,10 @@ functions › lam_destructure_7
          (local.set $18
           (tuple.extract 0
            (tuple.make
-            (call $+_1136
+            (call $+_1134
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1136)
+              (global.get $+_1134)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -351,10 +351,10 @@ functions › lam_destructure_7
          (block $do_backpatches.25
          )
         )
-        (call $+_1136
+        (call $+_1134
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1136)
+          (global.get $+_1134)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -599,7 +599,7 @@ functions › lam_destructure_7
        (block $do_backpatches.36
        )
       )
-      (call $lam_lambda_1135
+      (call $lam_lambda_1133
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -11,12 +11,12 @@ functions › shorthand_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1131 (param i32 i32 i32) (result i32)))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › shorthand_2
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -37,10 +37,10 @@ functions › shorthand_2
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1133
+        (call $+_1131
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1133)
+          (global.get $+_1131)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -90,7 +90,7 @@ functions › shorthand_2
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -119,21 +119,21 @@ functions › shorthand_2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (i32.const 3)
       )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -11,12 +11,12 @@ functions › lam_destructure_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › lam_destructure_4
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -219,10 +219,10 @@ functions › lam_destructure_4
          (local.set $14
           (tuple.extract 0
            (tuple.make
-            (call $+_1135
+            (call $+_1133
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1135)
+              (global.get $+_1133)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -243,10 +243,10 @@ functions › lam_destructure_4
          (block $do_backpatches.16
          )
         )
-        (call $+_1135
+        (call $+_1133
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1135)
+          (global.get $+_1133)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -342,7 +342,7 @@ functions › lam_destructure_4
     (local.set $0
      (block $compile_block.26 (result i32)
       (block $compile_store.22
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.20 (result i32)
@@ -371,14 +371,14 @@ functions › lam_destructure_4
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.21
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
@@ -424,10 +424,10 @@ functions › lam_destructure_4
        (block $do_backpatches.24
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -11,12 +11,12 @@ functions › lam_destructure_8
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1136 (param i32 i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › lam_destructure_8
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -300,10 +300,10 @@ functions › lam_destructure_8
          (local.set $17
           (tuple.extract 0
            (tuple.make
-            (call $+_1136
+            (call $+_1134
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1136)
+              (global.get $+_1134)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -328,10 +328,10 @@ functions › lam_destructure_8
          (local.set $18
           (tuple.extract 0
            (tuple.make
-            (call $+_1136
+            (call $+_1134
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1136)
+              (global.get $+_1134)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -352,10 +352,10 @@ functions › lam_destructure_8
          (block $do_backpatches.25
          )
         )
-        (call $+_1136
+        (call $+_1134
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1136)
+          (global.get $+_1134)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -476,7 +476,7 @@ functions › lam_destructure_8
     (local.set $0
      (block $compile_block.38 (result i32)
       (block $compile_store.31
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.29 (result i32)
@@ -505,14 +505,14 @@ functions › lam_destructure_8
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.30
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
@@ -599,10 +599,10 @@ functions › lam_destructure_8
        (block $do_backpatches.36
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -20,7 +20,7 @@ functions › lam_destructure_1
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -152,7 +152,7 @@ functions › lam_destructure_1
        (block $do_backpatches.7
        )
       )
-      (call $lam_lambda_1131
+      (call $lam_lambda_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
         (local.get $6)

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -13,7 +13,7 @@ functions › lam_destructure_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -21,7 +21,7 @@ functions › lam_destructure_2
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -78,7 +78,7 @@ functions › lam_destructure_2
     (local.set $0
      (block $compile_block.9 (result i32)
       (block $compile_store.5
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -107,14 +107,14 @@ functions › lam_destructure_2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
@@ -152,10 +152,10 @@ functions › lam_destructure_2
        (block $do_backpatches.7
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -15,13 +15,13 @@ functions › func_record_associativity2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1141)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1139)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1141 (param $0 i32) (result i32)
+ (func $lam_lambda_1139 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -79,7 +79,7 @@ functions › func_record_associativity2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -91,7 +91,7 @@ functions › func_record_associativity2
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 68719477868)
+       (i64.const 68719477866)
       )
       (i64.store offset=56
        (local.get $0)
@@ -206,7 +206,7 @@ functions › func_record_associativity2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -254,7 +254,7 @@ functions › func_record_associativity2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -11,12 +11,12 @@ functions › fn_trailing_comma
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1134 (param i32 i32 i32) (result i32)))
- (global $testFn_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1132 (param i32 i32 i32) (result i32)))
+ (global $testFn_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › fn_trailing_comma
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $testFn_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $testFn_1129 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37,10 +37,10 @@ functions › fn_trailing_comma
      (tuple.extract 0
       (tuple.make
        (block $compile_block.1 (result i32)
-        (call $+_1134
+        (call $+_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1134)
+          (global.get $+_1132)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -99,7 +99,7 @@ functions › fn_trailing_comma
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $testFn_1131
+       (global.set $testFn_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -128,21 +128,21 @@ functions › fn_trailing_comma
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $testFn_1131)
+           (global.get $testFn_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $testFn_1131)
+         (global.get $testFn_1129)
         )
        )
       )
-      (call $testFn_1131
+      (call $testFn_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $testFn_1131)
+        (global.get $testFn_1129)
        )
        (i32.const 5)
        (i32.const 7)

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -11,12 +11,12 @@ functions › lam_destructure_6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
- (global $foo_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
+ (global $foo_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -24,7 +24,7 @@ functions › lam_destructure_6
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $foo_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $foo_1129 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -339,10 +339,10 @@ functions › lam_destructure_6
          (local.set $19
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -367,10 +367,10 @@ functions › lam_destructure_6
          (local.set $20
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -395,10 +395,10 @@ functions › lam_destructure_6
          (local.set $21
           (tuple.extract 0
            (tuple.make
-            (call $+_1137
+            (call $+_1135
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1137)
+              (global.get $+_1135)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -419,10 +419,10 @@ functions › lam_destructure_6
          (block $do_backpatches.30
          )
         )
-        (call $+_1137
+        (call $+_1135
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $+_1137)
+          (global.get $+_1135)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -561,7 +561,7 @@ functions › lam_destructure_6
     (local.set $0
      (block $compile_block.43 (result i32)
       (block $compile_store.36
-       (global.set $foo_1131
+       (global.set $foo_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.34 (result i32)
@@ -590,14 +590,14 @@ functions › lam_destructure_6
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1131)
+           (global.get $foo_1129)
           )
          )
         )
        )
        (block $do_backpatches.35
         (local.set $0
-         (global.get $foo_1131)
+         (global.get $foo_1129)
         )
        )
       )
@@ -681,10 +681,10 @@ functions › lam_destructure_6
        (block $do_backpatches.41
        )
       )
-      (call $foo_1131
+      (call $foo_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1131)
+        (global.get $foo_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -15,13 +15,13 @@ functions › func_record_associativity1
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1137)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1135)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1137 (param $0 i32) (result i32)
+ (func $lam_lambda_1135 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -79,7 +79,7 @@ functions › func_record_associativity1
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -192,7 +192,7 @@ functions › func_record_associativity1
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0706ac31.0.snapshot
@@ -64,7 +64,7 @@ imports › import_all_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -105,7 +105,7 @@ imports › import_all_constructor
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0b2049ee.0.snapshot
@@ -8,7 +8,7 @@ imports › import_some
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_some
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1140)
+       (global.get $x_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.0e53f2e1.0.snapshot
@@ -8,7 +8,7 @@ imports › import_all_except_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$z\" (global $z_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_all_except_multiple
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $z_1140)
+       (global.get $z_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.259f419e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.259f419e.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$../test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$../test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_relative_path1
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1140)
+       (global.get $x_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.2f957040.0.snapshot
+++ b/compiler/test/__snapshots__/imports.2f957040.0.snapshot
@@ -10,11 +10,11 @@ imports › import_alias_multiple_constructor
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -67,7 +67,7 @@ imports › import_alias_multiple_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -112,7 +112,7 @@ imports › import_alias_multiple_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -145,10 +145,10 @@ imports › import_alias_multiple_constructor
        (block $do_backpatches.5
        )
       )
-      (call $sum_1138
+      (call $sum_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1138)
+        (global.get $sum_1136)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.45beae05.0.snapshot
+++ b/compiler/test/__snapshots__/imports.45beae05.0.snapshot
@@ -55,7 +55,7 @@ imports › annotation_across_import
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4ac5b2fd.0.snapshot
@@ -8,10 +8,10 @@ imports › import_alias_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $x_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $x_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ imports › import_alias_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $x_1140
+      (call $x_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1140)
+        (global.get $x_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1141)
+        (global.get $y_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
+++ b/compiler/test/__snapshots__/imports.4edfc4fd.0.snapshot
@@ -8,7 +8,7 @@ imports › import_alias
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_alias
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $y_1140)
+       (global.get $y_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.54ae58d4.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple_trailing
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ imports › import_some_multiple_trailing
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1140
+      (call $y_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1140)
+        (global.get $y_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1141)
+        (global.get $x_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.59fd966e.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ imports › import_some_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1140
+      (call $y_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1140)
+        (global.get $y_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1141)
+        (global.get $x_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.644a1413.0.snapshot
+++ b/compiler/test/__snapshots__/imports.644a1413.0.snapshot
@@ -9,12 +9,12 @@ imports › import_relative_path4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1136 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1136 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,10 +47,10 @@ imports › import_relative_path4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $bar_1136
+          (call $bar_1134
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $bar_1136)
+            (global.get $bar_1134)
            )
            (i32.const 5)
           )
@@ -64,10 +64,10 @@ imports › import_relative_path4
        (block $do_backpatches.1
        )
       )
-      (call $print_1134
+      (call $print_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1134)
+        (global.get $print_1132)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7cdfb4de.0.snapshot
@@ -55,7 +55,7 @@ imports › import_all_except_constructor
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
+++ b/compiler/test/__snapshots__/imports.7fc65fd4.0.snapshot
@@ -64,7 +64,7 @@ imports › import_some_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -105,7 +105,7 @@ imports › import_some_constructor
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
+++ b/compiler/test/__snapshots__/imports.8c14f403.0.snapshot
@@ -8,7 +8,7 @@ imports › import_module
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_module
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1140)
+       (global.get $x_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.91b07561.0.snapshot
+++ b/compiler/test/__snapshots__/imports.91b07561.0.snapshot
@@ -8,10 +8,10 @@ imports › import_module2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ imports › import_module2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1140
+      (call $y_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1140)
+        (global.get $y_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1141)
+        (global.get $x_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
+++ b/compiler/test/__snapshots__/imports.a3a21ec1.0.snapshot
@@ -64,7 +64,7 @@ imports › import_same_module_unify2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -105,7 +105,7 @@ imports › import_same_module_unify2
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
+++ b/compiler/test/__snapshots__/imports.b31f1d0e.0.snapshot
@@ -9,9 +9,9 @@ imports › import_with_export_multiple
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$sameExport\" \"GRAIN$EXPORT$foo\" (global $foo_1134 (mut i32)))
+ (import \"GRAIN$MODULE$sameExport\" \"GRAIN$EXPORT$foo\" (global $foo_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$sameExport\" \"foo\" (func $foo_1134 (param i32) (result i32)))
+ (import \"GRAIN$MODULE$sameExport\" \"foo\" (func $foo_1132 (param i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,10 +39,10 @@ imports › import_with_export_multiple
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $foo_1134
+      (call $foo_1132
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1134)
+        (global.get $foo_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.c06afb4d.0.snapshot
@@ -64,7 +64,7 @@ imports › import_same_module_unify
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -105,7 +105,7 @@ imports › import_same_module_unify
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.cc67676f.0.snapshot
@@ -10,11 +10,11 @@ imports › import_all_except_multiple_constructor
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -66,7 +66,7 @@ imports › import_all_except_multiple_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -88,10 +88,10 @@ imports › import_all_except_multiple_constructor
        (block $do_backpatches.2
        )
       )
-      (call $sum_1138
+      (call $sum_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1138)
+        (global.get $sum_1136)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
+++ b/compiler/test/__snapshots__/imports.daf4add5.0.snapshot
@@ -8,10 +8,10 @@ imports › import_some_multiple_trailing2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1141 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1140 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1139 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$y\" (global $y_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1140 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"y\" (func $y_1138 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -39,14 +39,14 @@ imports › import_some_multiple_trailing2
    (block $cleanup_locals.2 (result i32)
     (local.set $0
      (block $compile_block.1 (result i32)
-      (call $y_1140
+      (call $y_1138
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $y_1140)
+        (global.get $y_1138)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $x_1141)
+        (global.get $x_1139)
        )
       )
      )

--- a/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
+++ b/compiler/test/__snapshots__/imports.dd1aa173.0.snapshot
@@ -10,11 +10,11 @@ imports › import_alias_constructor
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -66,7 +66,7 @@ imports › import_alias_constructor
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -88,10 +88,10 @@ imports › import_alias_constructor
        (block $do_backpatches.2
        )
       )
-      (call $sum_1138
+      (call $sum_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1138)
+        (global.get $sum_1136)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/imports.e295854d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e295854d.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$../../test/test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1140 (mut i32)))
+ (import \"GRAIN$MODULE$../../test/test-libs/exportStar\" \"GRAIN$EXPORT$x\" (global $x_1138 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_relative_path2
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $x_1140)
+       (global.get $x_1138)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
+++ b/compiler/test/__snapshots__/imports.e92f584f.0.snapshot
@@ -8,7 +8,7 @@ imports › import_relative_path3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$nested/nested\" \"GRAIN$EXPORT$j\" (global $j_1134 (mut i32)))
+ (import \"GRAIN$MODULE$nested/nested\" \"GRAIN$EXPORT$j\" (global $j_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
@@ -39,7 +39,7 @@ imports › import_relative_path3
      (block $compile_block.1 (result i32)
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $j_1134)
+       (global.get $j_1132)
       )
      )
     )

--- a/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f36bd08d.0.snapshot
@@ -10,7 +10,7 @@ imports › import_muliple_modules
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1148 (mut i32)))
+ (import \"GRAIN$MODULE$exportStar\" \"GRAIN$EXPORT$x\" (global $x_1146 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
@@ -65,7 +65,7 @@ imports › import_muliple_modules
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -106,7 +106,7 @@ imports › import_muliple_modules
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)
@@ -120,7 +120,7 @@ imports › import_muliple_modules
         (local.get $0)
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)
-         (global.get $x_1148)
+         (global.get $x_1146)
         )
        )
        (i32.store offset=24

--- a/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
+++ b/compiler/test/__snapshots__/imports.f4cfe044.0.snapshot
@@ -10,11 +10,11 @@ imports › import_some_mixed
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1138 (mut i32)))
+ (import \"GRAIN$MODULE$tlists\" \"GRAIN$EXPORT$sum\" (global $sum_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1138 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists\" \"sum\" (func $sum_1136 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -67,7 +67,7 @@ imports › import_some_mixed
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -112,7 +112,7 @@ imports › import_some_mixed
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -145,10 +145,10 @@ imports › import_some_mixed
        (block $do_backpatches.5
        )
       )
-      (call $sum_1138
+      (call $sum_1136
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $sum_1138)
+        (global.get $sum_1136)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,13 +44,13 @@ let mut › let-mut_division1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -62,14 +62,14 @@ let mut › let-mut_division1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1135
+          (call $/_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1135)
+            (global.get $/_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -84,7 +84,7 @@ let mut › let-mut_division1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -93,7 +93,7 @@ let mut › let-mut_division1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_multiplication2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_multiplication2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1135
+          (call $*_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1135)
+            (global.get $*_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_multiplication2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_multiplication2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_multiplication2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -13,7 +13,7 @@ let mut › let-mut3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -42,7 +42,7 @@ let mut › let-mut3
     (local.set $0
      (block $compile_block.4 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -67,7 +67,7 @@ let mut › let-mut3
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -78,7 +78,7 @@ let mut › let-mut3
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $b_1131)
+        (global.get $b_1129)
        )
       )
      )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_division3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_division3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1135
+          (call $/_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1135)
+            (global.get $/_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_division3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_division3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_division3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut5
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut5
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 3)
           )
@@ -87,7 +87,7 @@ let mut › let-mut5
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut5
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut5
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -13,7 +13,7 @@ let mut › let-mut2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -81,7 +81,7 @@ let mut › let-mut2
        )
       )
       (block $compile_store.6
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -113,7 +113,7 @@ let mut › let-mut2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -123,7 +123,7 @@ let mut › let-mut2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,13 +44,13 @@ let mut › let-mut_multiplication1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -62,14 +62,14 @@ let mut › let-mut_multiplication1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1135
+          (call $*_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1135)
+            (global.get $*_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -84,7 +84,7 @@ let mut › let-mut_multiplication1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -93,7 +93,7 @@ let mut › let-mut_multiplication1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_multiplication3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$*\" (global $*_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"*\" (func $*_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_multiplication3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_multiplication3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $*_1135
+          (call $*_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $*_1135)
+            (global.get $*_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_multiplication3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_multiplication3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_multiplication3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -11,7 +11,7 @@ let mut › let-mut4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -41,13 +41,13 @@ let mut › let-mut4
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -58,13 +58,13 @@ let mut › let-mut4
       (block $compile_store.5
        (local.set $6
         (block $compile_set.3 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (i32.const 7)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -77,7 +77,7 @@ let mut › let-mut4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,13 +44,13 @@ let mut › let-mut_subtraction1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -62,14 +62,14 @@ let mut › let-mut_subtraction1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -84,7 +84,7 @@ let mut › let-mut_subtraction1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -93,7 +93,7 @@ let mut › let-mut_subtraction1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_subtraction2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_subtraction2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_subtraction2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_subtraction2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_subtraction2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_addition2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_addition2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1135
+          (call $+_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1135)
+            (global.get $+_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_addition2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_addition2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_addition2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition1
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -44,13 +44,13 @@ let mut › let-mut_addition1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -62,14 +62,14 @@ let mut › let-mut_addition1
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1135
+          (call $+_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1135)
+            (global.get $+_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -84,7 +84,7 @@ let mut › let-mut_addition1
        )
       )
       (block $compile_set.5 (result i32)
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (call $incRef_0
@@ -93,7 +93,7 @@ let mut › let-mut_addition1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_subtraction3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_subtraction3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_subtraction3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $-_1135
+          (call $-_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $-_1135)
+            (global.get $-_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_subtraction3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_subtraction3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_subtraction3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_addition3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_addition3
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_addition3
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $+_1135
+          (call $+_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1135)
+            (global.get $+_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_addition3
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_addition3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_addition3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -10,11 +10,11 @@ let mut › let-mut_division2
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1135 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$/\" (global $/_1133 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1135 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"/\" (func $/_1133 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -45,13 +45,13 @@ let mut › let-mut_division2
     (local.set $0
      (block $compile_block.8 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 153)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -63,14 +63,14 @@ let mut › let-mut_division2
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (call $/_1135
+          (call $/_1133
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $/_1135)
+            (global.get $/_1133)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $b_1131)
+            (global.get $b_1129)
            )
            (i32.const 39)
           )
@@ -87,7 +87,7 @@ let mut › let-mut_division2
       (block $compile_store.7
        (local.set $7
         (block $compile_set.5 (result i32)
-         (global.set $b_1131
+         (global.set $b_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -96,7 +96,7 @@ let mut › let-mut_division2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1131)
+             (global.get $b_1129)
             )
            )
           )
@@ -109,7 +109,7 @@ let mut › let-mut_division2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -11,7 +11,7 @@ let mut › let-mut1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -40,13 +40,13 @@ let mut › let-mut1
     (local.set $0
      (block $compile_block.3 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 9)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -56,7 +56,7 @@ let mut › let-mut1
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -67,7 +67,7 @@ lists › list_spread
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -112,7 +112,7 @@ lists › list_spread
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -168,7 +168,7 @@ lists › list_spread
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -224,7 +224,7 @@ lists › list_spread
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -276,7 +276,7 @@ lists › list_spread
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2653)
+        (i32.const 2651)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -66,7 +66,7 @@ lists › list1_trailing_space
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -111,7 +111,7 @@ lists › list1_trailing_space
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -167,7 +167,7 @@ lists › list1_trailing_space
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -219,7 +219,7 @@ lists › list1_trailing_space
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2653)
+        (i32.const 2651)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -66,7 +66,7 @@ lists › list1_trailing
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -111,7 +111,7 @@ lists › list1_trailing
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -167,7 +167,7 @@ lists › list1_trailing
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -219,7 +219,7 @@ lists › list1_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2653)
+        (i32.const 2651)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -11,17 +11,17 @@ loops › loop2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1146 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1143 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1141 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1146 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1143 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1138 (param i32 i32 i32) (result i32)))
- (global $count_1132 (mut i32) (i32.const 0))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1141 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1136 (param i32 i32 i32) (result i32)))
+ (global $count_1130 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -56,7 +56,7 @@ loops › loop2
     (local.set $0
      (block $compile_block.29 (result i32)
       (block $compile_store.3
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -81,7 +81,7 @@ loops › loop2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -90,7 +90,7 @@ loops › loop2
        )
       )
       (block $compile_store.6
-       (global.set $count_1132
+       (global.set $count_1130
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -115,7 +115,7 @@ loops › loop2
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1132)
+           (global.get $count_1130)
           )
          )
         )
@@ -142,7 +142,7 @@ loops › loop2
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
                       (i32.load offset=8
-                       (global.get $b_1131)
+                       (global.get $b_1129)
                       )
                      )
                      (call $decRef_0
@@ -155,10 +155,10 @@ loops › loop2
                   (block $do_backpatches.10
                   )
                  )
-                 (call $>_1146
+                 (call $>_1144
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1146)
+                   (global.get $>_1144)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
@@ -182,7 +182,7 @@ loops › loop2
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
                     (i32.load offset=8
-                     (global.get $b_1131)
+                     (global.get $b_1129)
                     )
                    )
                    (call $decRef_0
@@ -199,10 +199,10 @@ loops › loop2
                 (local.set $7
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1138
+                   (call $-_1136
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1138)
+                     (global.get $-_1136)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
@@ -224,7 +224,7 @@ loops › loop2
                 (local.set $11
                  (block $MTupleSet.17 (result i32)
                   (i32.store offset=8
-                   (global.get $b_1131)
+                   (global.get $b_1129)
                    (tuple.extract 0
                     (tuple.make
                      (call $incRef_0
@@ -234,7 +234,7 @@ loops › loop2
                      (call $decRef_0
                       (global.get $GRAIN$EXPORT$decRef_0)
                       (i32.load offset=8
-                       (global.get $b_1131)
+                       (global.get $b_1129)
                       )
                      )
                     )
@@ -253,7 +253,7 @@ loops › loop2
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
                     (i32.load offset=8
-                     (global.get $count_1132)
+                     (global.get $count_1130)
                     )
                    )
                    (call $decRef_0
@@ -270,10 +270,10 @@ loops › loop2
                 (local.set $9
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1143
+                   (call $+_1141
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1143)
+                     (global.get $+_1141)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
@@ -293,7 +293,7 @@ loops › loop2
                )
                (block $MTupleSet.24 (result i32)
                 (i32.store offset=8
-                 (global.get $count_1132)
+                 (global.get $count_1130)
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -303,7 +303,7 @@ loops › loop2
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
                     (i32.load offset=8
-                     (global.get $count_1132)
+                     (global.get $count_1130)
                     )
                    )
                   )
@@ -327,7 +327,7 @@ loops › loop2
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (i32.load offset=8
-        (global.get $count_1132)
+        (global.get $count_1130)
        )
       )
      )

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -10,16 +10,16 @@ loops › loop5
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>=\" (global $>=_1144 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1142 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>=\" (global $>=_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">=\" (func $>=_1144 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1142 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1138 (param i32 i32 i32) (result i32)))
- (global $count_1132 (mut i32) (i32.const 0))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">=\" (func $>=_1142 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1136 (param i32 i32 i32) (result i32)))
+ (global $count_1130 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -51,13 +51,13 @@ loops › loop5
     (local.set $0
      (block $compile_block.21 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 25)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -66,13 +66,13 @@ loops › loop5
        )
       )
       (block $compile_store.4
-       (global.set $count_1132
+       (global.set $count_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 1)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1132)
+           (global.get $count_1130)
           )
          )
         )
@@ -96,14 +96,14 @@ loops › loop5
                   (local.set $6
                    (tuple.extract 0
                     (tuple.make
-                     (call $-_1142
+                     (call $-_1140
                       (call $incRef_0
                        (global.get $GRAIN$EXPORT$incRef_0)
-                       (global.get $-_1142)
+                       (global.get $-_1140)
                       )
                       (call $incRef_0
                        (global.get $GRAIN$EXPORT$incRef_0)
-                       (global.get $b_1131)
+                       (global.get $b_1129)
                       )
                       (i32.const 3)
                      )
@@ -120,7 +120,7 @@ loops › loop5
                  (block $compile_store.12
                   (local.set $8
                    (block $compile_set.10 (result i32)
-                    (global.set $b_1131
+                    (global.set $b_1129
                      (tuple.extract 0
                       (tuple.make
                        (call $incRef_0
@@ -129,7 +129,7 @@ loops › loop5
                        )
                        (call $decRef_0
                         (global.get $GRAIN$EXPORT$decRef_0)
-                        (global.get $b_1131)
+                        (global.get $b_1129)
                        )
                       )
                      )
@@ -140,14 +140,14 @@ loops › loop5
                   (block $do_backpatches.11
                   )
                  )
-                 (call $>=_1144
+                 (call $>=_1142
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>=_1144)
+                   (global.get $>=_1142)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1131)
+                   (global.get $b_1129)
                   )
                   (i32.const 1)
                  )
@@ -164,14 +164,14 @@ loops › loop5
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1138
+                   (call $+_1136
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1138)
+                     (global.get $+_1136)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $count_1132)
+                     (global.get $count_1130)
                     )
                     (i32.const 3)
                    )
@@ -186,7 +186,7 @@ loops › loop5
                 )
                )
                (block $compile_set.16 (result i32)
-                (global.set $count_1132
+                (global.set $count_1130
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -195,7 +195,7 @@ loops › loop5
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $count_1132)
+                    (global.get $count_1130)
                    )
                   )
                  )
@@ -217,7 +217,7 @@ loops › loop5
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $count_1132)
+       (global.get $count_1130)
       )
      )
     )

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -10,13 +10,13 @@ loops › loop3
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1138 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1136 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1134 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1138 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1136 (param i32 i32 i32) (result i32)))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1136 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1134 (param i32 i32 i32) (result i32)))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -47,13 +47,13 @@ loops › loop3
     (local.set $0
      (block $compile_block.14 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 7)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -73,14 +73,14 @@ loops › loop3
               (i32.eqz
                (i32.shr_u
                 (block $compile_block.6 (result i32)
-                 (call $>_1138
+                 (call $>_1136
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1138)
+                   (global.get $>_1136)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1131)
+                   (global.get $b_1129)
                   )
                   (i32.const 1)
                  )
@@ -97,14 +97,14 @@ loops › loop3
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1136
+                   (call $-_1134
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1136)
+                     (global.get $-_1134)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $b_1131)
+                     (global.get $b_1129)
                     )
                     (i32.const 3)
                    )
@@ -119,7 +119,7 @@ loops › loop3
                 )
                )
                (block $compile_set.9 (result i32)
-                (global.set $b_1131
+                (global.set $b_1129
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -128,7 +128,7 @@ loops › loop3
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $b_1131)
+                    (global.get $b_1129)
                    )
                   )
                  )
@@ -150,7 +150,7 @@ loops › loop3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $b_1131)
+       (global.get $b_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -10,16 +10,16 @@ loops › loop4
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1144 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1138 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1142 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1140 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1144 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1138 (param i32 i32 i32) (result i32)))
- (global $count_1132 (mut i32) (i32.const 0))
- (global $b_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1142 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1140 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1136 (param i32 i32 i32) (result i32)))
+ (global $count_1130 (mut i32) (i32.const 0))
+ (global $b_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -51,13 +51,13 @@ loops › loop4
     (local.set $0
      (block $compile_block.21 (result i32)
       (block $compile_store.2
-       (global.set $b_1131
+       (global.set $b_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 25)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1131)
+           (global.get $b_1129)
           )
          )
         )
@@ -66,13 +66,13 @@ loops › loop4
        )
       )
       (block $compile_store.4
-       (global.set $count_1132
+       (global.set $count_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 1)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $count_1132)
+           (global.get $count_1130)
           )
          )
         )
@@ -92,14 +92,14 @@ loops › loop4
               (i32.eqz
                (i32.shr_u
                 (block $compile_block.8 (result i32)
-                 (call $>_1144
+                 (call $>_1142
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $>_1144)
+                   (global.get $>_1142)
                   )
                   (call $incRef_0
                    (global.get $GRAIN$EXPORT$incRef_0)
-                   (global.get $b_1131)
+                   (global.get $b_1129)
                   )
                   (i32.const 1)
                  )
@@ -116,14 +116,14 @@ loops › loop4
                 (local.set $6
                  (tuple.extract 0
                   (tuple.make
-                   (call $-_1138
+                   (call $-_1136
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $-_1138)
+                     (global.get $-_1136)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $b_1131)
+                     (global.get $b_1129)
                     )
                     (i32.const 3)
                    )
@@ -140,7 +140,7 @@ loops › loop4
                (block $compile_store.13
                 (local.set $8
                  (block $compile_set.11 (result i32)
-                  (global.set $b_1131
+                  (global.set $b_1129
                    (tuple.extract 0
                     (tuple.make
                      (call $incRef_0
@@ -149,7 +149,7 @@ loops › loop4
                      )
                      (call $decRef_0
                       (global.get $GRAIN$EXPORT$decRef_0)
-                      (global.get $b_1131)
+                      (global.get $b_1129)
                      )
                     )
                    )
@@ -164,14 +164,14 @@ loops › loop4
                 (local.set $7
                  (tuple.extract 0
                   (tuple.make
-                   (call $+_1142
+                   (call $+_1140
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $+_1142)
+                     (global.get $+_1140)
                     )
                     (call $incRef_0
                      (global.get $GRAIN$EXPORT$incRef_0)
-                     (global.get $count_1132)
+                     (global.get $count_1130)
                     )
                     (i32.const 3)
                    )
@@ -186,7 +186,7 @@ loops › loop4
                 )
                )
                (block $compile_set.16 (result i32)
-                (global.set $count_1132
+                (global.set $count_1130
                  (tuple.extract 0
                   (tuple.make
                    (call $incRef_0
@@ -195,7 +195,7 @@ loops › loop4
                    )
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
-                    (global.get $count_1132)
+                    (global.get $count_1130)
                    )
                   )
                  )
@@ -217,7 +217,7 @@ loops › loop4
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $count_1132)
+       (global.get $count_1130)
       )
      )
     )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -14,7 +14,7 @@ optimizations › trs1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $f1_1131 (mut i32) (i32.const 0))
+ (global $f1_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -22,7 +22,7 @@ optimizations › trs1
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $f1_1131 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $f1_1129 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -87,7 +87,7 @@ optimizations › trs1
     (local.set $0
      (block $compile_block.6 (result i32)
       (block $compile_store.5
-       (global.set $f1_1131
+       (global.set $f1_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_closure.3 (result i32)
@@ -116,21 +116,21 @@ optimizations › trs1
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $f1_1131)
+           (global.get $f1_1129)
           )
          )
         )
        )
        (block $do_backpatches.4
         (local.set $0
-         (global.get $f1_1131)
+         (global.get $f1_1129)
         )
        )
       )
-      (call $f1_1131
+      (call $f1_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $f1_1131)
+        (global.get $f1_1129)
        )
        (i32.const 3)
        (i32.const 5)

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -11,13 +11,13 @@ optimizations › test_dead_branch_elimination_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
- (global $y_1132 (mut i32) (i32.const 0))
- (global $x_1131 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
+ (global $y_1130 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -50,7 +50,7 @@ optimizations › test_dead_branch_elimination_5
     (local.set $0
      (block $compile_block.17 (result i32)
       (block $compile_store.3
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.1 (result i32)
@@ -75,7 +75,7 @@ optimizations › test_dead_branch_elimination_5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -84,7 +84,7 @@ optimizations › test_dead_branch_elimination_5
        )
       )
       (block $compile_store.6
-       (global.set $y_1132
+       (global.set $y_1130
         (tuple.extract 0
          (tuple.make
           (block $allocate_tuple.4 (result i32)
@@ -109,7 +109,7 @@ optimizations › test_dead_branch_elimination_5
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $y_1132)
+           (global.get $y_1130)
           )
          )
         )
@@ -121,14 +121,14 @@ optimizations › test_dead_branch_elimination_5
        (local.set $8
         (block $MTupleSet.7 (result i32)
          (i32.store offset=8
-          (global.get $x_1131)
+          (global.get $x_1129)
           (tuple.extract 0
            (tuple.make
             (i32.const 7)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $x_1131)
+              (global.get $x_1129)
              )
             )
            )
@@ -144,14 +144,14 @@ optimizations › test_dead_branch_elimination_5
        (local.set $9
         (block $MTupleSet.10 (result i32)
          (i32.store offset=8
-          (global.get $y_1132)
+          (global.get $y_1130)
           (tuple.extract 0
            (tuple.make
             (i32.const 9)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (i32.load offset=8
-              (global.get $y_1132)
+              (global.get $y_1130)
              )
             )
            )
@@ -170,7 +170,7 @@ optimizations › test_dead_branch_elimination_5
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $x_1131)
+            (global.get $x_1129)
            )
           )
           (call $decRef_0
@@ -190,7 +190,7 @@ optimizations › test_dead_branch_elimination_5
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
            (i32.load offset=8
-            (global.get $y_1132)
+            (global.get $y_1130)
            )
           )
           (call $decRef_0
@@ -203,10 +203,10 @@ optimizations › test_dead_branch_elimination_5
        (block $do_backpatches.15
        )
       )
-      (call $+_1144
+      (call $+_1142
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1144)
+        (global.get $+_1142)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ pattern matching › record_match_3
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -143,7 +143,7 @@ pattern matching › record_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -311,10 +311,10 @@ pattern matching › record_match_3
         )
         (br $switch.16_outer
          (block $compile_block.17 (result i32)
-          (call $+_1144
+          (call $+_1142
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1144)
+            (global.get $+_1142)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -54,7 +54,7 @@ pattern matching › adt_match_deep
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -128,7 +128,7 @@ pattern matching › adt_match_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -173,7 +173,7 @@ pattern matching › adt_match_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -218,7 +218,7 @@ pattern matching › adt_match_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1171 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1169 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1171 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1169 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -95,7 +95,7 @@ pattern matching › tuple_match_deep4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -140,7 +140,7 @@ pattern matching › tuple_match_deep4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -1019,10 +1019,10 @@ pattern matching › tuple_match_deep4
                  (local.set $21
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1171
+                    (call $+_1169
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1171)
+                      (global.get $+_1169)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1047,10 +1047,10 @@ pattern matching › tuple_match_deep4
                  (local.set $22
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1171
+                    (call $+_1169
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1171)
+                      (global.get $+_1169)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1071,10 +1071,10 @@ pattern matching › tuple_match_deep4
                  (block $do_backpatches.102
                  )
                 )
-                (call $+_1171
+                (call $+_1169
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1171)
+                  (global.get $+_1169)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1095,10 +1095,10 @@ pattern matching › tuple_match_deep4
                (local.set $21
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1171
+                  (call $+_1169
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1171)
+                    (global.get $+_1169)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1119,10 +1119,10 @@ pattern matching › tuple_match_deep4
                (block $do_backpatches.97
                )
               )
-              (call $+_1171
+              (call $+_1169
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1171)
+                (global.get $+_1169)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1139,10 +1139,10 @@ pattern matching › tuple_match_deep4
           )
           (br $switch.94_outer
            (block $compile_block.96 (result i32)
-            (call $+_1171
+            (call $+_1169
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1171)
+              (global.get $+_1169)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › adt_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1165 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1165 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -90,7 +90,7 @@ pattern matching › adt_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -135,7 +135,7 @@ pattern matching › adt_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -191,7 +191,7 @@ pattern matching › adt_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -247,7 +247,7 @@ pattern matching › adt_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -897,10 +897,10 @@ pattern matching › adt_match_4
                  (local.set $16
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1167
+                    (call $+_1165
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1167)
+                      (global.get $+_1165)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -921,10 +921,10 @@ pattern matching › adt_match_4
                  (block $do_backpatches.85
                  )
                 )
-                (call $+_1167
+                (call $+_1165
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1167)
+                  (global.get $+_1165)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -941,10 +941,10 @@ pattern matching › adt_match_4
             )
             (br $switch.81_outer
              (block $compile_block.84 (result i32)
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
@@ -8,9 +8,9 @@ pattern matching › low_level_constant_match_2
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -188,10 +188,10 @@ pattern matching › low_level_constant_match_2
       )
       (block $compile_store.24
        (local.set $9
-        (call $print_1134
+        (call $print_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $print_1134)
+          (global.get $print_1132)
          )
          (local.get $8)
         )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -54,7 +54,7 @@ pattern matching › record_match_2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -173,7 +173,7 @@ pattern matching › record_match_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1143 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1141 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1143 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1141 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -267,10 +267,10 @@ pattern matching › guarded_match_2
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1143
+        (call $==_1141
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1143)
+          (global.get $==_1141)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
@@ -8,9 +8,9 @@ pattern matching › low_level_constant_match_3
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -188,10 +188,10 @@ pattern matching › low_level_constant_match_3
       )
       (block $compile_store.24
        (local.set $9
-        (call $print_1134
+        (call $print_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $print_1134)
+          (global.get $print_1132)
          )
          (local.get $8)
         )

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1149 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1147 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1149 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1147 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -415,10 +415,10 @@ pattern matching › tuple_match_deep
            (local.set $17
             (tuple.extract 0
              (tuple.make
-              (call $+_1149
+              (call $+_1147
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1149)
+                (global.get $+_1147)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -443,10 +443,10 @@ pattern matching › tuple_match_deep
            (local.set $18
             (tuple.extract 0
              (tuple.make
-              (call $+_1149
+              (call $+_1147
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1149)
+                (global.get $+_1147)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -467,10 +467,10 @@ pattern matching › tuple_match_deep
            (block $do_backpatches.32
            )
           )
-          (call $+_1149
+          (call $+_1147
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1149)
+            (global.get $+_1147)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -54,7 +54,7 @@ pattern matching › record_match_1
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -173,7 +173,7 @@ pattern matching › record_match_1
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
@@ -76,7 +76,7 @@ pattern matching › alias_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)
@@ -441,7 +441,7 @@ pattern matching › alias_match_5
                )
                (i32.store offset=8
                 (local.get $0)
-                (i32.const 2659)
+                (i32.const 7)
                )
                (i32.store offset=12
                 (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1143 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ pattern matching › record_match_4
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -146,7 +146,7 @@ pattern matching › record_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -375,10 +375,10 @@ pattern matching › record_match_4
            (local.set $13
             (tuple.extract 0
              (tuple.make
-              (call $+_1145
+              (call $+_1143
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1145)
+                (global.get $+_1143)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -399,10 +399,10 @@ pattern matching › record_match_4
            (block $do_backpatches.22
            )
           )
-          (call $+_1145
+          (call $+_1143
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1145)
+            (global.get $+_1143)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep6
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1175 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1173 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1175 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1173 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -97,7 +97,7 @@ pattern matching › tuple_match_deep6
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -142,7 +142,7 @@ pattern matching › tuple_match_deep6
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -198,7 +198,7 @@ pattern matching › tuple_match_deep6
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -254,7 +254,7 @@ pattern matching › tuple_match_deep6
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -1133,10 +1133,10 @@ pattern matching › tuple_match_deep6
                  (local.set $23
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1175
+                    (call $+_1173
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1175)
+                      (global.get $+_1173)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1161,10 +1161,10 @@ pattern matching › tuple_match_deep6
                  (local.set $24
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1175
+                    (call $+_1173
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1175)
+                      (global.get $+_1173)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1185,10 +1185,10 @@ pattern matching › tuple_match_deep6
                  (block $do_backpatches.108
                  )
                 )
-                (call $+_1175
+                (call $+_1173
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1175)
+                  (global.get $+_1173)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1209,10 +1209,10 @@ pattern matching › tuple_match_deep6
                (local.set $23
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1175
+                  (call $+_1173
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1175)
+                    (global.get $+_1173)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1233,10 +1233,10 @@ pattern matching › tuple_match_deep6
                (block $do_backpatches.103
                )
               )
-              (call $+_1175
+              (call $+_1173
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1175)
+                (global.get $+_1173)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1253,10 +1253,10 @@ pattern matching › tuple_match_deep6
           )
           (br $switch.100_outer
            (block $compile_block.102 (result i32)
-            (call $+_1175
+            (call $+_1173
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1175)
+              (global.get $+_1173)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1169 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1169 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -94,7 +94,7 @@ pattern matching › tuple_match_deep3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -962,10 +962,10 @@ pattern matching › tuple_match_deep3
                  (local.set $20
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1169
+                    (call $+_1167
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1169)
+                      (global.get $+_1167)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -990,10 +990,10 @@ pattern matching › tuple_match_deep3
                  (local.set $21
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1169
+                    (call $+_1167
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1169)
+                      (global.get $+_1167)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1014,10 +1014,10 @@ pattern matching › tuple_match_deep3
                  (block $do_backpatches.99
                  )
                 )
-                (call $+_1169
+                (call $+_1167
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1169)
+                  (global.get $+_1167)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1038,10 +1038,10 @@ pattern matching › tuple_match_deep3
                (local.set $20
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1169
+                  (call $+_1167
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1169)
+                    (global.get $+_1167)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1062,10 +1062,10 @@ pattern matching › tuple_match_deep3
                (block $do_backpatches.94
                )
               )
-              (call $+_1169
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1169)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1082,10 +1082,10 @@ pattern matching › tuple_match_deep3
           )
           (br $switch.91_outer
            (block $compile_block.93 (result i32)
-            (call $+_1169
+            (call $+_1167
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1169)
+              (global.get $+_1167)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › adt_match_1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1161 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1159 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1161 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1159 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -87,7 +87,7 @@ pattern matching › adt_match_1
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -726,10 +726,10 @@ pattern matching › adt_match_1
                  (local.set $13
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1161
+                    (call $+_1159
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1161)
+                      (global.get $+_1159)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -750,10 +750,10 @@ pattern matching › adt_match_1
                  (block $do_backpatches.76
                  )
                 )
-                (call $+_1161
+                (call $+_1159
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1161)
+                  (global.get $+_1159)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -770,10 +770,10 @@ pattern matching › adt_match_1
             )
             (br $switch.72_outer
              (block $compile_block.75 (result i32)
-              (call $+_1161
+              (call $+_1159
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1161)
+                (global.get $+_1159)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1165 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1165 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -784,10 +784,10 @@ pattern matching › tuple_match_deep2
            (local.set $29
             (tuple.extract 0
              (tuple.make
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -812,10 +812,10 @@ pattern matching › tuple_match_deep2
            (local.set $30
             (tuple.extract 0
              (tuple.make
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -840,10 +840,10 @@ pattern matching › tuple_match_deep2
            (local.set $31
             (tuple.extract 0
              (tuple.make
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -868,10 +868,10 @@ pattern matching › tuple_match_deep2
            (local.set $32
             (tuple.extract 0
              (tuple.make
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -896,10 +896,10 @@ pattern matching › tuple_match_deep2
            (local.set $33
             (tuple.extract 0
              (tuple.make
-              (call $+_1167
+              (call $+_1165
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1167)
+                (global.get $+_1165)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -920,10 +920,10 @@ pattern matching › tuple_match_deep2
            (block $do_backpatches.68
            )
           )
-          (call $+_1167
+          (call $+_1165
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1167)
+            (global.get $+_1165)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -54,7 +54,7 @@ pattern matching › record_match_deep
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -66,7 +66,7 @@ pattern matching › record_match_deep
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 68719477868)
+       (i64.const 68719477866)
       )
       (i64.store offset=56
        (local.get $0)
@@ -136,7 +136,7 @@ pattern matching › record_match_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -181,7 +181,7 @@ pattern matching › record_match_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
@@ -8,9 +8,9 @@ pattern matching › low_level_constant_match_4
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -188,10 +188,10 @@ pattern matching › low_level_constant_match_4
       )
       (block $compile_store.24
        (local.set $9
-        (call $print_1134
+        (call $print_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $print_1134)
+          (global.get $print_1132)
          )
          (local.get $8)
         )

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1142 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -268,10 +268,10 @@ pattern matching › guarded_match_4
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1144
+        (call $==_1142
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1144)
+          (global.get $==_1142)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -291,10 +291,10 @@ pattern matching › guarded_match_4
           (i32.const 31)
          )
          (block $compile_block.21 (result i32)
-          (call $==_1144
+          (call $==_1142
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1144)
+            (global.get $==_1142)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_1
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1143 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1141 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1143 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1141 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -267,10 +267,10 @@ pattern matching › guarded_match_1
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1143
+        (call $==_1141
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1143)
+          (global.get $==_1141)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › adt_match_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1163 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1161 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1163 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1161 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -88,7 +88,7 @@ pattern matching › adt_match_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -133,7 +133,7 @@ pattern matching › adt_match_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -783,10 +783,10 @@ pattern matching › adt_match_2
                  (local.set $14
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1163
+                    (call $+_1161
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1163)
+                      (global.get $+_1161)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -807,10 +807,10 @@ pattern matching › adt_match_2
                  (block $do_backpatches.79
                  )
                 )
-                (call $+_1163
+                (call $+_1161
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1163)
+                  (global.get $+_1161)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -827,10 +827,10 @@ pattern matching › adt_match_2
             )
             (br $switch.75_outer
              (block $compile_block.78 (result i32)
-              (call $+_1163
+              (call $+_1161
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1163)
+                (global.get $+_1161)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › guarded_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1142 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -268,10 +268,10 @@ pattern matching › guarded_match_3
       )
       (block $compile_store.20
        (local.set $13
-        (call $==_1144
+        (call $==_1142
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $==_1144)
+          (global.get $==_1142)
          )
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -291,10 +291,10 @@ pattern matching › guarded_match_3
           (i32.const 31)
          )
          (block $compile_block.21 (result i32)
-          (call $==_1144
+          (call $==_1142
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $==_1144)
+            (global.get $==_1142)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
@@ -8,9 +8,9 @@ pattern matching › low_level_constant_match_1
  (import \"_grainEnv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_grainEnv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1134 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1132 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1134 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1132 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -194,10 +194,10 @@ pattern matching › low_level_constant_match_1
       )
       (block $compile_store.24
        (local.set $9
-        (call $print_1134
+        (call $print_1132
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
-          (global.get $print_1134)
+          (global.get $print_1132)
          )
          (local.get $8)
         )

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › adt_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1165 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1163 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1165 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1163 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -89,7 +89,7 @@ pattern matching › adt_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -134,7 +134,7 @@ pattern matching › adt_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -190,7 +190,7 @@ pattern matching › adt_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -840,10 +840,10 @@ pattern matching › adt_match_3
                  (local.set $15
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1165
+                    (call $+_1163
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1165)
+                      (global.get $+_1163)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -864,10 +864,10 @@ pattern matching › adt_match_3
                  (block $do_backpatches.82
                  )
                 )
-                (call $+_1165
+                (call $+_1163
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1165)
+                  (global.get $+_1163)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -884,10 +884,10 @@ pattern matching › adt_match_3
             )
             (br $switch.78_outer
              (block $compile_block.81 (result i32)
-              (call $+_1165
+              (call $+_1163
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1165)
+                (global.get $+_1163)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
@@ -74,7 +74,7 @@ pattern matching › alias_match_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › adt_match_5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1169 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1169 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1167 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -91,7 +91,7 @@ pattern matching › adt_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -136,7 +136,7 @@ pattern matching › adt_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -192,7 +192,7 @@ pattern matching › adt_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -248,7 +248,7 @@ pattern matching › adt_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -304,7 +304,7 @@ pattern matching › adt_match_5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -954,10 +954,10 @@ pattern matching › adt_match_5
                  (local.set $17
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1169
+                    (call $+_1167
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1169)
+                      (global.get $+_1167)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -978,10 +978,10 @@ pattern matching › adt_match_5
                  (block $do_backpatches.88
                  )
                 )
-                (call $+_1169
+                (call $+_1167
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1169)
+                  (global.get $+_1167)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -998,10 +998,10 @@ pattern matching › adt_match_5
             )
             (br $switch.84_outer
              (block $compile_block.87 (result i32)
-              (call $+_1169
+              (call $+_1167
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1169)
+                (global.get $+_1167)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep5
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1173 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1171 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1173 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1171 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -96,7 +96,7 @@ pattern matching › tuple_match_deep5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -141,7 +141,7 @@ pattern matching › tuple_match_deep5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -197,7 +197,7 @@ pattern matching › tuple_match_deep5
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -1076,10 +1076,10 @@ pattern matching › tuple_match_deep5
                  (local.set $22
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1173
+                    (call $+_1171
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1173)
+                      (global.get $+_1171)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1104,10 +1104,10 @@ pattern matching › tuple_match_deep5
                  (local.set $23
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1173
+                    (call $+_1171
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1173)
+                      (global.get $+_1171)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1128,10 +1128,10 @@ pattern matching › tuple_match_deep5
                  (block $do_backpatches.105
                  )
                 )
-                (call $+_1173
+                (call $+_1171
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1173)
+                  (global.get $+_1171)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1152,10 +1152,10 @@ pattern matching › tuple_match_deep5
                (local.set $22
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1173
+                  (call $+_1171
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1173)
+                    (global.get $+_1171)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1176,10 +1176,10 @@ pattern matching › tuple_match_deep5
                (block $do_backpatches.100
                )
               )
-              (call $+_1173
+              (call $+_1171
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1173)
+                (global.get $+_1171)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1196,10 +1196,10 @@ pattern matching › tuple_match_deep5
           )
           (br $switch.97_outer
            (block $compile_block.99 (result i32)
-            (call $+_1173
+            (call $+_1171
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1173)
+              (global.get $+_1171)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -12,12 +12,12 @@ pattern matching › constant_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"GRAIN$EXPORT$equal\" (global $GRAIN$EXPORT$equal_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/equal\" \"equal\" (func $equal_0 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1144 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1142 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -287,10 +287,10 @@ pattern matching › constant_match_4
           )
           (block $compile_store.22
            (local.set $14
-            (call $==_1144
+            (call $==_1142
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $==_1144)
+              (global.get $==_1142)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -383,10 +383,10 @@ pattern matching › constant_match_4
               )
               (block $compile_store.30
                (local.set $16
-                (call $==_1144
+                (call $==_1142
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $==_1144)
+                  (global.get $==_1142)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › tuple_match_deep7
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1177 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1175 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1177 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1175 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -98,7 +98,7 @@ pattern matching › tuple_match_deep7
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -143,7 +143,7 @@ pattern matching › tuple_match_deep7
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -199,7 +199,7 @@ pattern matching › tuple_match_deep7
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -255,7 +255,7 @@ pattern matching › tuple_match_deep7
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -311,7 +311,7 @@ pattern matching › tuple_match_deep7
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -1190,10 +1190,10 @@ pattern matching › tuple_match_deep7
                  (local.set $24
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1177
+                    (call $+_1175
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1177)
+                      (global.get $+_1175)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1218,10 +1218,10 @@ pattern matching › tuple_match_deep7
                  (local.set $25
                   (tuple.extract 0
                    (tuple.make
-                    (call $+_1177
+                    (call $+_1175
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
-                      (global.get $+_1177)
+                      (global.get $+_1175)
                      )
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -1242,10 +1242,10 @@ pattern matching › tuple_match_deep7
                  (block $do_backpatches.111
                  )
                 )
-                (call $+_1177
+                (call $+_1175
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
-                  (global.get $+_1177)
+                  (global.get $+_1175)
                  )
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -1266,10 +1266,10 @@ pattern matching › tuple_match_deep7
                (local.set $24
                 (tuple.extract 0
                  (tuple.make
-                  (call $+_1177
+                  (call $+_1175
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
-                    (global.get $+_1177)
+                    (global.get $+_1175)
                    )
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -1290,10 +1290,10 @@ pattern matching › tuple_match_deep7
                (block $do_backpatches.106
                )
               )
-              (call $+_1177
+              (call $+_1175
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1177)
+                (global.get $+_1175)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -1310,10 +1310,10 @@ pattern matching › tuple_match_deep7
           )
           (br $switch.103_outer
            (block $compile_block.105 (result i32)
-            (call $+_1177
+            (call $+_1175
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
-              (global.get $+_1177)
+              (global.get $+_1175)
              )
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
@@ -79,7 +79,7 @@ pattern matching › or_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -124,7 +124,7 @@ pattern matching › or_match_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
@@ -74,7 +74,7 @@ pattern matching › or_match_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/records.012b017b.0.snapshot
+++ b/compiler/test/__snapshots__/records.012b017b.0.snapshot
@@ -50,7 +50,7 @@ records › record_spread_2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -11,11 +11,11 @@ records › record_get_multiple
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1135 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1137 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1135 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ records › record_get_multiple
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -133,7 +133,7 @@ records › record_get_multiple
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -199,10 +199,10 @@ records › record_get_multiple
        (block $do_backpatches.8
        )
       )
-      (call $+_1137
+      (call $+_1135
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1137)
+        (global.get $+_1135)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -50,7 +50,7 @@ records › record_definition_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -111,7 +111,7 @@ records › record_definition_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1132 (mut i32) (i32.const 0))
+ (global $foo_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -55,7 +55,7 @@ records › record_destruct_1
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -173,7 +173,7 @@ records › record_destruct_1
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -207,13 +207,13 @@ records › record_destruct_1
        )
       )
       (block $compile_store.10
-       (global.set $foo_1132
+       (global.set $foo_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1130)
           )
          )
         )
@@ -245,7 +245,7 @@ records › record_destruct_1
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.13 (result i32)
-         (global.set $foo_1132
+         (global.set $foo_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -254,7 +254,7 @@ records › record_destruct_1
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $foo_1132)
+             (global.get $foo_1130)
             )
            )
           )
@@ -265,7 +265,7 @@ records › record_destruct_1
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $foo_1132)
+       (global.get $foo_1130)
       )
      )
     )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -11,14 +11,14 @@ records › record_destruct_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
- (global $bar_1133 (mut i32) (i32.const 0))
- (global $foo_1132 (mut i32) (i32.const 0))
- (global $baz_1134 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1143 (param i32 i32 i32) (result i32)))
+ (global $bar_1131 (mut i32) (i32.const 0))
+ (global $foo_1130 (mut i32) (i32.const 0))
+ (global $baz_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -60,7 +60,7 @@ records › record_destruct_4
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -146,7 +146,7 @@ records › record_destruct_4
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -177,13 +177,13 @@ records › record_destruct_4
        )
       )
       (block $compile_store.7
-       (global.set $foo_1132
+       (global.set $foo_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1130)
           )
          )
         )
@@ -192,13 +192,13 @@ records › record_destruct_4
        )
       )
       (block $compile_store.9
-       (global.set $bar_1133
+       (global.set $bar_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $bar_1133)
+           (global.get $bar_1131)
           )
          )
         )
@@ -207,13 +207,13 @@ records › record_destruct_4
        )
       )
       (block $compile_store.11
-       (global.set $baz_1134
+       (global.set $baz_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $baz_1134)
+           (global.get $baz_1132)
           )
          )
         )
@@ -285,7 +285,7 @@ records › record_destruct_4
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $baz_1134
+         (global.set $baz_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -294,7 +294,7 @@ records › record_destruct_4
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $baz_1134)
+             (global.get $baz_1132)
             )
            )
           )
@@ -307,7 +307,7 @@ records › record_destruct_4
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $bar_1133
+         (global.set $bar_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -316,7 +316,7 @@ records › record_destruct_4
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $bar_1133)
+             (global.get $bar_1131)
             )
            )
           )
@@ -329,7 +329,7 @@ records › record_destruct_4
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.20 (result i32)
-         (global.set $foo_1132
+         (global.set $foo_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -338,7 +338,7 @@ records › record_destruct_4
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $foo_1132)
+             (global.get $foo_1130)
             )
            )
           )
@@ -351,18 +351,18 @@ records › record_destruct_4
        (local.set $10
         (tuple.extract 0
          (tuple.make
-          (call $+_1145
+          (call $+_1143
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1145)
+            (global.get $+_1143)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1132)
+            (global.get $foo_1130)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $bar_1133)
+            (global.get $bar_1131)
            )
           )
           (call $decRef_0
@@ -375,10 +375,10 @@ records › record_destruct_4
        (block $do_backpatches.21
        )
       )
-      (call $+_1145
+      (call $+_1143
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1145)
+        (global.get $+_1143)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -386,7 +386,7 @@ records › record_destruct_4
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $baz_1134)
+        (global.get $baz_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -50,7 +50,7 @@ records › record_value_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -111,7 +111,7 @@ records › record_value_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -54,7 +54,7 @@ records › record_recursive_data_definition
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477868)
+       (i64.const 68719477866)
       )
       (i64.store offset=32
        (local.get $0)
@@ -66,7 +66,7 @@ records › record_recursive_data_definition
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=56
        (local.get $0)
@@ -138,7 +138,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)
@@ -183,7 +183,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -231,7 +231,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)
@@ -276,7 +276,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -324,7 +324,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)
@@ -402,7 +402,7 @@ records › record_recursive_data_definition
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2659)
+            (i32.const 7)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_mixed_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_mixed_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $bar_1132 (mut i32) (i32.const 0))
+ (global $bar_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -55,7 +55,7 @@ records › record_destruct_2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -173,7 +173,7 @@ records › record_destruct_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -207,13 +207,13 @@ records › record_destruct_2
        )
       )
       (block $compile_store.10
-       (global.set $bar_1132
+       (global.set $bar_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $bar_1132)
+           (global.get $bar_1130)
           )
          )
         )
@@ -245,7 +245,7 @@ records › record_destruct_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.13 (result i32)
-         (global.set $bar_1132
+         (global.set $bar_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -254,7 +254,7 @@ records › record_destruct_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $bar_1132)
+             (global.get $bar_1130)
             )
            )
           )
@@ -265,7 +265,7 @@ records › record_destruct_2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $bar_1132)
+       (global.get $bar_1130)
       )
      )
     )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -111,7 +111,7 @@ records › record_pun_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -13,7 +13,7 @@ records › record_destruct_deep
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $foo_1133 (mut i32) (i32.const 0))
+ (global $foo_1131 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -55,7 +55,7 @@ records › record_destruct_deep
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -67,7 +67,7 @@ records › record_destruct_deep
       )
       (i64.store offset=48
        (local.get $0)
-       (i64.const 68719477868)
+       (i64.const 68719477866)
       )
       (i64.store offset=56
        (local.get $0)
@@ -136,7 +136,7 @@ records › record_destruct_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -181,7 +181,7 @@ records › record_destruct_deep
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)
@@ -207,13 +207,13 @@ records › record_destruct_deep
        )
       )
       (block $compile_store.10
-       (global.set $foo_1133
+       (global.set $foo_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1133)
+           (global.get $foo_1131)
           )
          )
         )
@@ -265,7 +265,7 @@ records › record_destruct_deep
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.15 (result i32)
-         (global.set $foo_1133
+         (global.set $foo_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -274,7 +274,7 @@ records › record_destruct_deep
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $foo_1133)
+             (global.get $foo_1131)
             )
            )
           )
@@ -285,7 +285,7 @@ records › record_destruct_deep
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $foo_1133)
+       (global.get $foo_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -11,13 +11,13 @@ records › record_destruct_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1144 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1142 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1144 (param i32 i32 i32) (result i32)))
- (global $bar_1133 (mut i32) (i32.const 0))
- (global $foo_1132 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1142 (param i32 i32 i32) (result i32)))
+ (global $bar_1131 (mut i32) (i32.const 0))
+ (global $foo_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -59,7 +59,7 @@ records › record_destruct_3
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -143,7 +143,7 @@ records › record_destruct_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -174,13 +174,13 @@ records › record_destruct_3
        )
       )
       (block $compile_store.7
-       (global.set $foo_1132
+       (global.set $foo_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1130)
           )
          )
         )
@@ -189,13 +189,13 @@ records › record_destruct_3
        )
       )
       (block $compile_store.9
-       (global.set $bar_1133
+       (global.set $bar_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $bar_1133)
+           (global.get $bar_1131)
           )
          )
         )
@@ -247,7 +247,7 @@ records › record_destruct_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.14 (result i32)
-         (global.set $bar_1133
+         (global.set $bar_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -256,7 +256,7 @@ records › record_destruct_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $bar_1133)
+             (global.get $bar_1131)
             )
            )
           )
@@ -269,7 +269,7 @@ records › record_destruct_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.15 (result i32)
-         (global.set $foo_1132
+         (global.set $foo_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -278,7 +278,7 @@ records › record_destruct_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $foo_1132)
+             (global.get $foo_1130)
             )
            )
           )
@@ -287,18 +287,18 @@ records › record_destruct_3
         )
        )
       )
-      (call $+_1144
+      (call $+_1142
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1144)
+        (global.get $+_1142)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $foo_1132)
+        (global.get $foo_1130)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $bar_1133)
+        (global.get $bar_1131)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -54,7 +54,7 @@ records › record_get_multilevel
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -74,7 +74,7 @@ records › record_get_multilevel
       )
       (i64.store offset=64
        (local.get $0)
-       (i64.const 68719477868)
+       (i64.const 68719477866)
       )
       (i64.store offset=72
        (local.get $0)
@@ -142,7 +142,7 @@ records › record_get_multilevel
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -191,7 +191,7 @@ records › record_get_multilevel
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2265)
+            (i32.const 2261)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -54,7 +54,7 @@ records › record_multiple_fields_definition_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -166,7 +166,7 @@ records › record_multiple_fields_definition_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -54,7 +54,7 @@ records › record_get_2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -120,7 +120,7 @@ records › record_get_2
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_mixed
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_mixed
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -11,14 +11,14 @@ records › record_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1145 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1143 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1145 (param i32 i32 i32) (result i32)))
- (global $bar_1133 (mut i32) (i32.const 0))
- (global $foo_1132 (mut i32) (i32.const 0))
- (global $baz_1134 (mut i32) (i32.const 0))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1143 (param i32 i32 i32) (result i32)))
+ (global $bar_1131 (mut i32) (i32.const 0))
+ (global $foo_1130 (mut i32) (i32.const 0))
+ (global $baz_1132 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -60,7 +60,7 @@ records › record_destruct_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -146,7 +146,7 @@ records › record_destruct_trailing
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -177,13 +177,13 @@ records › record_destruct_trailing
        )
       )
       (block $compile_store.7
-       (global.set $foo_1132
+       (global.set $foo_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $foo_1132)
+           (global.get $foo_1130)
           )
          )
         )
@@ -192,13 +192,13 @@ records › record_destruct_trailing
        )
       )
       (block $compile_store.9
-       (global.set $bar_1133
+       (global.set $bar_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $bar_1133)
+           (global.get $bar_1131)
           )
          )
         )
@@ -207,13 +207,13 @@ records › record_destruct_trailing
        )
       )
       (block $compile_store.11
-       (global.set $baz_1134
+       (global.set $baz_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $baz_1134)
+           (global.get $baz_1132)
           )
          )
         )
@@ -285,7 +285,7 @@ records › record_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $baz_1134
+         (global.set $baz_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -294,7 +294,7 @@ records › record_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $baz_1134)
+             (global.get $baz_1132)
             )
            )
           )
@@ -307,7 +307,7 @@ records › record_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $bar_1133
+         (global.set $bar_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -316,7 +316,7 @@ records › record_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $bar_1133)
+             (global.get $bar_1131)
             )
            )
           )
@@ -329,7 +329,7 @@ records › record_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.20 (result i32)
-         (global.set $foo_1132
+         (global.set $foo_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -338,7 +338,7 @@ records › record_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $foo_1132)
+             (global.get $foo_1130)
             )
            )
           )
@@ -351,18 +351,18 @@ records › record_destruct_trailing
        (local.set $10
         (tuple.extract 0
          (tuple.make
-          (call $+_1145
+          (call $+_1143
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1145)
+            (global.get $+_1143)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $foo_1132)
+            (global.get $foo_1130)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $bar_1133)
+            (global.get $bar_1131)
            )
           )
           (call $decRef_0
@@ -375,10 +375,10 @@ records › record_destruct_trailing
        (block $do_backpatches.21
        )
       )
-      (call $+_1145
+      (call $+_1143
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1145)
+        (global.get $+_1143)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -386,7 +386,7 @@ records › record_destruct_trailing
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $baz_1134)
+        (global.get $baz_1132)
        )
       )
      )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_mixed_2
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_mixed_2
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -54,7 +54,7 @@ records › record_multiple_fields_both_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -166,7 +166,7 @@ records › record_multiple_fields_both_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -50,7 +50,7 @@ records › record_both_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -111,7 +111,7 @@ records › record_both_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_multiple
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_multiple
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_multiple_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_multiple_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -54,7 +54,7 @@ records › record_multiple_fields_value_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -166,7 +166,7 @@ records › record_multiple_fields_value_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -50,7 +50,7 @@ records › record_pun_mixed_2_trailing
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -119,7 +119,7 @@ records › record_pun_mixed_2_trailing
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2263)
+        (i32.const 2259)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_20
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ stdlib › stdlib_equal_20
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -176,7 +176,7 @@ stdlib › stdlib_equal_20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -266,7 +266,7 @@ stdlib › stdlib_equal_20
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_20
        (block $do_backpatches.13
        )
       )
-      (call $==_1133
+      (call $==_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1133)
+        (global.get $==_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_18
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -113,10 +113,10 @@ stdlib › stdlib_equal_18
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -66,7 +66,7 @@ stdlib › stdlib_cons
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -111,7 +111,7 @@ stdlib › stdlib_cons
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -167,7 +167,7 @@ stdlib › stdlib_cons
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -219,7 +219,7 @@ stdlib › stdlib_cons
        )
        (i32.store offset=8
         (local.get $0)
-        (i32.const 2653)
+        (i32.const 2651)
        )
        (i32.store offset=12
         (local.get $0)

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_19
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ stdlib › stdlib_equal_19
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -176,7 +176,7 @@ stdlib › stdlib_equal_19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -266,7 +266,7 @@ stdlib › stdlib_equal_19
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_19
        (block $do_backpatches.13
        )
       )
-      (call $==_1133
+      (call $==_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1133)
+        (global.get $==_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_16
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -113,10 +113,10 @@ stdlib › stdlib_equal_16
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_12
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -137,10 +137,10 @@ stdlib › stdlib_equal_12
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_21
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ stdlib › stdlib_equal_21
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -176,7 +176,7 @@ stdlib › stdlib_equal_21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -266,7 +266,7 @@ stdlib › stdlib_equal_21
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_21
        (block $do_backpatches.13
        )
       )
-      (call $==_1133
+      (call $==_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1133)
+        (global.get $==_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_15
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -109,10 +109,10 @@ stdlib › stdlib_equal_15
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_14
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -109,10 +109,10 @@ stdlib › stdlib_equal_14
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -74,7 +74,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -119,7 +119,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -175,7 +175,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -231,7 +231,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -287,7 +287,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -332,7 +332,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -388,7 +388,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -444,7 +444,7 @@ stdlib › stdlib_equal_3
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2653)
+            (i32.const 2651)
            )
            (i32.store offset=12
             (local.get $0)
@@ -477,10 +477,10 @@ stdlib › stdlib_equal_3
        (block $do_backpatches.23
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_11
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -117,10 +117,10 @@ stdlib › stdlib_equal_11
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_9
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -109,10 +109,10 @@ stdlib › stdlib_equal_9
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_2
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1169 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1167 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1169 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1167 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -121,10 +121,10 @@ stdlib › stdlib_equal_2
        (block $do_backpatches.5
        )
       )
-      (call $==_1169
+      (call $==_1167
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1169)
+        (global.get $==_1167)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_22
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1133 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1131 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1133 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1131 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -57,7 +57,7 @@ stdlib › stdlib_equal_22
       )
       (i64.store offset=24
        (local.get $0)
-       (i64.const 68719477867)
+       (i64.const 68719477865)
       )
       (i64.store offset=32
        (local.get $0)
@@ -176,7 +176,7 @@ stdlib › stdlib_equal_22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -266,7 +266,7 @@ stdlib › stdlib_equal_22
            )
            (i32.store offset=8
             (local.get $0)
-            (i32.const 2263)
+            (i32.const 2259)
            )
            (i32.store offset=12
             (local.get $0)
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_22
        (block $do_backpatches.13
        )
       )
-      (call $==_1133
+      (call $==_1131
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1133)
+        (global.get $==_1131)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_10
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -113,10 +113,10 @@ stdlib › stdlib_equal_10
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_13
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -105,10 +105,10 @@ stdlib › stdlib_equal_13
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_8
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -105,10 +105,10 @@ stdlib › stdlib_equal_8
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_17
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1251 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1249 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1251 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1249 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -113,10 +113,10 @@ stdlib › stdlib_equal_17
        (block $do_backpatches.5
        )
       )
-      (call $==_1251
+      (call $==_1249
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1251)
+        (global.get $==_1249)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -11,11 +11,11 @@ strings › concat
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$++\" (global $++_1131 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$++\" (global $++_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"++\" (func $++_1131 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"++\" (func $++_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -113,10 +113,10 @@ strings › concat
        (block $do_backpatches.5
        )
       )
-      (call $++_1131
+      (call $++_1129
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $++_1131)
+        (global.get $++_1129)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -13,10 +13,10 @@ tuples › nested_tup_3
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1134 (mut i32) (i32.const 0))
- (global $a_1133 (mut i32) (i32.const 0))
- (global $y_1132 (mut i32) (i32.const 0))
- (global $x_1131 (mut i32) (i32.const 0))
+ (global $b_1132 (mut i32) (i32.const 0))
+ (global $a_1131 (mut i32) (i32.const 0))
+ (global $y_1130 (mut i32) (i32.const 0))
+ (global $x_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -173,13 +173,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.11
-       (global.set $x_1131
+       (global.set $x_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $x_1131)
+           (global.get $x_1129)
           )
          )
         )
@@ -188,13 +188,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.13
-       (global.set $y_1132
+       (global.set $y_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $y_1132)
+           (global.get $y_1130)
           )
          )
         )
@@ -246,7 +246,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $y_1132
+         (global.set $y_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -255,7 +255,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $y_1132)
+             (global.get $y_1130)
             )
            )
           )
@@ -268,7 +268,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $x_1131
+         (global.set $x_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -277,7 +277,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $x_1131)
+             (global.get $x_1129)
             )
            )
           )
@@ -292,7 +292,7 @@ tuples › nested_tup_3
          (tuple.make
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
-           (global.get $y_1132)
+           (global.get $y_1130)
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
@@ -305,13 +305,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.23
-       (global.set $a_1133
+       (global.set $a_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1133)
+           (global.get $a_1131)
           )
          )
         )
@@ -320,13 +320,13 @@ tuples › nested_tup_3
        )
       )
       (block $compile_store.25
-       (global.set $b_1134
+       (global.set $b_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1134)
+           (global.get $b_1132)
           )
          )
         )
@@ -378,7 +378,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.30 (result i32)
-         (global.set $b_1134
+         (global.set $b_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -387,7 +387,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1134)
+             (global.get $b_1132)
             )
            )
           )
@@ -400,7 +400,7 @@ tuples › nested_tup_3
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.31 (result i32)
-         (global.set $a_1133
+         (global.set $a_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -409,7 +409,7 @@ tuples › nested_tup_3
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1133)
+             (global.get $a_1131)
             )
            )
           )
@@ -420,7 +420,7 @@ tuples › nested_tup_3
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $a_1133)
+       (global.get $a_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -13,8 +13,8 @@ tuples › nested_tup_1
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $b_1132 (mut i32) (i32.const 0))
- (global $a_1131 (mut i32) (i32.const 0))
+ (global $b_1130 (mut i32) (i32.const 0))
+ (global $a_1129 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -168,13 +168,13 @@ tuples › nested_tup_1
        )
       )
       (block $compile_store.11
-       (global.set $a_1131
+       (global.set $a_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1131)
+           (global.get $a_1129)
           )
          )
         )
@@ -183,13 +183,13 @@ tuples › nested_tup_1
        )
       )
       (block $compile_store.13
-       (global.set $b_1132
+       (global.set $b_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1132)
+           (global.get $b_1130)
           )
          )
         )
@@ -241,7 +241,7 @@ tuples › nested_tup_1
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $b_1132
+         (global.set $b_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -250,7 +250,7 @@ tuples › nested_tup_1
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1132)
+             (global.get $b_1130)
             )
            )
           )
@@ -263,7 +263,7 @@ tuples › nested_tup_1
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $a_1131
+         (global.set $a_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -272,7 +272,7 @@ tuples › nested_tup_1
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1131)
+             (global.get $a_1129)
             )
            )
           )
@@ -283,7 +283,7 @@ tuples › nested_tup_1
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $a_1131)
+       (global.get $a_1129)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
@@ -13,9 +13,9 @@ tuples › tup1_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1131 (mut i32) (i32.const 0))
- (global $c_1133 (mut i32) (i32.const 0))
- (global $b_1132 (mut i32) (i32.const 0))
+ (global $a_1129 (mut i32) (i32.const 0))
+ (global $c_1131 (mut i32) (i32.const 0))
+ (global $b_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -90,13 +90,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.5
-       (global.set $a_1131
+       (global.set $a_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1131)
+           (global.get $a_1129)
           )
          )
         )
@@ -105,13 +105,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.7
-       (global.set $b_1132
+       (global.set $b_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1132)
+           (global.get $b_1130)
           )
          )
         )
@@ -120,13 +120,13 @@ tuples › tup1_destruct_trailing
        )
       )
       (block $compile_store.9
-       (global.set $c_1133
+       (global.set $c_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1133)
+           (global.get $c_1131)
           )
          )
         )
@@ -198,7 +198,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.16 (result i32)
-         (global.set $c_1133
+         (global.set $c_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -207,7 +207,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1133)
+             (global.get $c_1131)
             )
            )
           )
@@ -220,7 +220,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.17 (result i32)
-         (global.set $b_1132
+         (global.set $b_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -229,7 +229,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1132)
+             (global.get $b_1130)
             )
            )
           )
@@ -242,7 +242,7 @@ tuples › tup1_destruct_trailing
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $a_1131
+         (global.set $a_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -251,7 +251,7 @@ tuples › tup1_destruct_trailing
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1131)
+             (global.get $a_1129)
             )
            )
           )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -13,10 +13,10 @@ tuples › big_tup_access
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1131 (mut i32) (i32.const 0))
- (global $d_1134 (mut i32) (i32.const 0))
- (global $c_1133 (mut i32) (i32.const 0))
- (global $b_1132 (mut i32) (i32.const 0))
+ (global $a_1129 (mut i32) (i32.const 0))
+ (global $d_1132 (mut i32) (i32.const 0))
+ (global $c_1131 (mut i32) (i32.const 0))
+ (global $b_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -96,13 +96,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.5
-       (global.set $a_1131
+       (global.set $a_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1131)
+           (global.get $a_1129)
           )
          )
         )
@@ -111,13 +111,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.7
-       (global.set $b_1132
+       (global.set $b_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1132)
+           (global.get $b_1130)
           )
          )
         )
@@ -126,13 +126,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.9
-       (global.set $c_1133
+       (global.set $c_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1133)
+           (global.get $c_1131)
           )
          )
         )
@@ -141,13 +141,13 @@ tuples › big_tup_access
        )
       )
       (block $compile_store.11
-       (global.set $d_1134
+       (global.set $d_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $d_1134)
+           (global.get $d_1132)
           )
          )
         )
@@ -239,7 +239,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.20 (result i32)
-         (global.set $d_1134
+         (global.set $d_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -248,7 +248,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $d_1134)
+             (global.get $d_1132)
             )
            )
           )
@@ -261,7 +261,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.21 (result i32)
-         (global.set $c_1133
+         (global.set $c_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -270,7 +270,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1133)
+             (global.get $c_1131)
             )
            )
           )
@@ -283,7 +283,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.22 (result i32)
-         (global.set $b_1132
+         (global.set $b_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -292,7 +292,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1132)
+             (global.get $b_1130)
             )
            )
           )
@@ -305,7 +305,7 @@ tuples › big_tup_access
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.23 (result i32)
-         (global.set $a_1131
+         (global.set $a_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -314,7 +314,7 @@ tuples › big_tup_access
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1131)
+             (global.get $a_1129)
             )
            )
           )
@@ -325,7 +325,7 @@ tuples › big_tup_access
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $c_1133)
+       (global.get $c_1131)
       )
      )
     )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -13,10 +13,10 @@ tuples › nested_tup_2
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (global $a_1131 (mut i32) (i32.const 0))
- (global $d_1134 (mut i32) (i32.const 0))
- (global $c_1133 (mut i32) (i32.const 0))
- (global $b_1132 (mut i32) (i32.const 0))
+ (global $a_1129 (mut i32) (i32.const 0))
+ (global $d_1132 (mut i32) (i32.const 0))
+ (global $c_1131 (mut i32) (i32.const 0))
+ (global $b_1130 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -173,13 +173,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.11
-       (global.set $a_1131
+       (global.set $a_1129
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $a_1131)
+           (global.get $a_1129)
           )
          )
         )
@@ -188,13 +188,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.13
-       (global.set $b_1132
+       (global.set $b_1130
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $b_1132)
+           (global.get $b_1130)
           )
          )
         )
@@ -246,7 +246,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.18 (result i32)
-         (global.set $b_1132
+         (global.set $b_1130
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -255,7 +255,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $b_1132)
+             (global.get $b_1130)
             )
            )
           )
@@ -268,7 +268,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.19 (result i32)
-         (global.set $a_1131
+         (global.set $a_1129
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -277,7 +277,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $a_1131)
+             (global.get $a_1129)
             )
            )
           )
@@ -292,7 +292,7 @@ tuples › nested_tup_2
          (tuple.make
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
-           (global.get $b_1132)
+           (global.get $b_1130)
           )
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
@@ -305,13 +305,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.23
-       (global.set $c_1133
+       (global.set $c_1131
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $c_1133)
+           (global.get $c_1131)
           )
          )
         )
@@ -320,13 +320,13 @@ tuples › nested_tup_2
        )
       )
       (block $compile_store.25
-       (global.set $d_1134
+       (global.set $d_1132
         (tuple.extract 0
          (tuple.make
           (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
-           (global.get $d_1134)
+           (global.get $d_1132)
           )
          )
         )
@@ -378,7 +378,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.30 (result i32)
-         (global.set $d_1134
+         (global.set $d_1132
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -387,7 +387,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $d_1134)
+             (global.get $d_1132)
             )
            )
           )
@@ -400,7 +400,7 @@ tuples › nested_tup_2
        (call $decRef_0
         (global.get $GRAIN$EXPORT$decRef_0)
         (block $compile_set.31 (result i32)
-         (global.set $c_1133
+         (global.set $c_1131
           (tuple.extract 0
            (tuple.make
             (call $incRef_0
@@ -409,7 +409,7 @@ tuples › nested_tup_2
             )
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
-             (global.get $c_1133)
+             (global.get $c_1131)
             )
            )
           )
@@ -420,7 +420,7 @@ tuples › nested_tup_2
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $d_1134)
+       (global.get $d_1132)
       )
      )
     )

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -53,27 +53,6 @@ export enum List<a> {
 }
 
 /**
- * Grain's type representing something that may or may not contain data.
- * Think of this like a better, type-safe "null".
- *
- * @since v0.2.0
- */
-export enum Option<a> {
-  Some(a),
-  None,
-}
-
-/**
- * Grain's type representing the result of something that might error.
- *
- * @since v0.2.0
- */
-export enum Result<t, e> {
-  Ok(t),
-  Err(e),
-}
-
-/**
  * @section Boolean operations: Infix functions for working with Boolean values.
  */
 

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -28,29 +28,6 @@ enum List<a> {
 
 The type of Grain lists.
 
-### Pervasives.**Option**
-
-```grain
-enum Option<a> {
-  Some(a),
-  None,
-}
-```
-
-Grain's type representing something that may or may not contain data.
-Think of this like a better, type-safe "null".
-
-### Pervasives.**Result**
-
-```grain
-enum Result<t, e> {
-  Ok(t),
-  Err(e),
-}
-```
-
-Grain's type representing the result of something that might error.
-
 ## Boolean operations
 
 Infix functions for working with Boolean values.

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -11,11 +11,6 @@ import foreign wasm fd_write: (
 
 primitive unreachable: () -> a = "@unreachable"
 
-enum Option<a> {
-  Some(a),
-  None,
-}
-
 export let mut printers = 0n
 
 // These functions are dangerous because they leak runtime memory and perform

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -1,9 +1,3 @@
-### Exception.**Option**
-
-```grain
-type Option<a>
-```
-
 ### Exception.**printers**
 
 ```grain

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -25,7 +25,11 @@ import Memory from "runtime/unsafe/memory"
 import Tags from "runtime/unsafe/tags"
 import NumberUtils from "runtime/numberUtils"
 
-import { allocateString, allocateArray } from "runtime/dataStructures"
+import {
+  allocateString,
+  allocateArray,
+  untagSimpleNumber,
+} from "runtime/dataStructures"
 
 import foreign wasm fd_write: (
   WasmI32,
@@ -37,6 +41,7 @@ import foreign wasm fd_write: (
 primitive (!): Bool -> Bool = "@not"
 primitive (&&): (Bool, Bool) -> Bool = "@and"
 primitive (||): (Bool, Bool) -> Bool = "@or"
+primitive builtinId: String -> Number = "@builtin.id"
 
 enum StringList {
   [],
@@ -68,32 +73,60 @@ let findTypeMetadata = typeId => {
 }
 
 @unsafe
+let _OPTION_ID = untagSimpleNumber(builtinId("Option"))
+@unsafe
+let _RESULT_ID = untagSimpleNumber(builtinId("Result"))
+
+let _SOME = "Some"
+let _NONE = "None"
+let _OK = "Ok"
+let _ERR = "Err"
+
+@unsafe
 let getVariantName = variant => {
   let typeId = WasmI32.load(variant, 8n) >> 1n
   let variantId = WasmI32.load(variant, 12n) >> 1n
 
-  let mut block = findTypeMetadata(typeId)
-
-  if (block == -1n) {
-    -1n
-  } else {
-    let sectionLength = WasmI32.load(block, 0n)
-    block += 8n
-
-    let end = block + sectionLength
-    let mut result = -1n
-    while (block < end) {
-      if (WasmI32.load(block, 4n) == variantId) {
-        let length = WasmI32.load(block, 8n)
-        let str = allocateString(length)
-        Memory.copy(str + 8n, block + 12n, length)
-        result = str
-        break
+  match (typeId) {
+    id when id == _OPTION_ID => {
+      if (variantId == 0n) {
+        Memory.incRef(WasmI32.fromGrain(_SOME))
+      } else {
+        Memory.incRef(WasmI32.fromGrain(_NONE))
       }
-      block += WasmI32.load(block, 0n)
-    }
+    },
+    id when id == _RESULT_ID => {
+      if (variantId == 0n) {
+        Memory.incRef(WasmI32.fromGrain(_OK))
+      } else {
+        Memory.incRef(WasmI32.fromGrain(_ERR))
+      }
+    },
+    _ => {
+      let mut block = findTypeMetadata(typeId)
 
-    result
+      if (block == -1n) {
+        -1n
+      } else {
+        let sectionLength = WasmI32.load(block, 0n)
+        block += 8n
+
+        let end = block + sectionLength
+        let mut result = -1n
+        while (block < end) {
+          if (WasmI32.load(block, 4n) == variantId) {
+            let length = WasmI32.load(block, 8n)
+            let str = allocateString(length)
+            Memory.copy(str + 8n, block + 12n, length)
+            result = str
+            break
+          }
+          block += WasmI32.load(block, 0n)
+        }
+
+        result
+      }
+    },
   }
 }
 


### PR DESCRIPTION
Closes #1049 

The snapshot changes are because Option/Result were removed from Pervasives, which everything depends on so IDs are all now two lower.