### PR TITLE
chore(compiler): Move constants from compcore into comp_utils

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -3,6 +3,12 @@ open Binaryen;
 open Grain_typed;
 open Grain_utils;
 
+let grain_main = "_gmain";
+let grain_type_metadata = "_gtype_metadata";
+let grain_start = "_start";
+let grain_env_name = "_grainEnv";
+let grain_global_function_table = "tbl";
+
 let wasm_type =
   fun
   | Types.Managed
@@ -88,8 +94,6 @@ let load =
   Expression.Load.make(~signed, wasm_mod, sz, offset, align, ty, ptr);
 };
 
-let grain_env_name = "_grainEnv";
-
 let is_grain_env = str => grain_env_name == str;
 
 let get_exported_names = (~function_names=?, ~global_names=?, wasm_mod) => {
@@ -130,8 +134,6 @@ let type_of_repr = repr => {
     }
   );
 };
-
-let global_function_table = "tbl";
 
 let write_universal_exports =
     (wasm_mod, {Cmi_format.cmi_sign}, exported_names) => {
@@ -197,7 +199,7 @@ let write_universal_exports =
                   );
                 Expression.Call_indirect.make(
                   wasm_mod,
-                  global_function_table,
+                  grain_global_function_table,
                   func_ptr,
                   arguments,
                   call_arg_types,

--- a/compiler/src/codegen/comp_utils.rei
+++ b/compiler/src/codegen/comp_utils.rei
@@ -1,0 +1,69 @@
+open Mashtree;
+open Binaryen;
+open Grain_typed;
+
+let grain_main: string;
+let grain_type_metadata: string;
+let grain_start: string;
+let grain_env_name: string;
+let grain_global_function_table: string;
+
+let wasm_type: Types.allocation_type => Type.t;
+
+let encoded_int32: int => int;
+let const_int32: int => Literal.t;
+let const_int64: int => Literal.t;
+let const_float32: float => Literal.t;
+let const_float64: float => Literal.t;
+
+/* These are like the above 'const' functions, but take inputs
+   of the underlying types instead */
+let wrap_int32: int32 => Literal.t;
+let wrap_int64: int64 => Literal.t;
+let wrap_float32: float => Literal.t;
+let wrap_float64: float => Literal.t;
+
+let compile_const: constant => Literal.t;
+
+let const_true: unit => Literal.t;
+let const_false: unit => Literal.t;
+let const_void: unit => Literal.t;
+
+let store:
+  (
+    ~ty: Type.t=?,
+    ~align: int=?,
+    ~offset: int=?,
+    ~sz: int=?,
+    Module.t,
+    Expression.t,
+    Expression.t
+  ) =>
+  Expression.t;
+
+let load:
+  (
+    ~ty: Type.t=?,
+    ~align: int=?,
+    ~offset: int=?,
+    ~sz: int=?,
+    ~signed: bool=?,
+    Module.t,
+    Expression.t
+  ) =>
+  Expression.t;
+
+let is_grain_env: string => bool;
+
+let get_exported_names:
+  (
+    ~function_names: Hashtbl.t(string, string)=?,
+    ~global_names: Hashtbl.t(string, string)=?,
+    Module.t
+  ) =>
+  Hashtbl.t(string, string);
+
+let write_universal_exports:
+  (Module.t, Cmi_format.cmi_infos, Hashtbl.t(string, string)) => unit;
+
+let compiling_wasi_polyfill: option(string) => bool;

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -80,10 +80,6 @@ let equal_closure_ident = Ident.create_persistent("GRAIN$EXPORT$equal");
 let console_mod = "console";
 let tracepoint_ident = Ident.create_persistent("tracepoint");
 
-let grain_main = "_gmain";
-let grain_type_metadata = "_gtype_metadata";
-let grain_start = "_start";
-
 let required_global_imports = [
   {
     mimp_id: reloc_base,
@@ -1604,7 +1600,7 @@ let call_lambda =
         set_swap(wasm_mod, env, 0, compiled_func()),
         instr(
           wasm_mod,
-          global_function_table,
+          grain_global_function_table,
           load(~offset=8, wasm_mod, get_func_swap()),
           args,
           Type.create @@
@@ -3488,9 +3484,9 @@ let compile_imports = (wasm_mod, env, {imports}) => {
   Import.add_memory_import(wasm_mod, "mem", grain_env_mod, "mem", false);
   Import.add_table_import(
     wasm_mod,
-    global_function_table,
+    grain_global_function_table,
     grain_env_mod,
-    global_function_table,
+    grain_global_function_table,
   );
 };
 
@@ -3562,7 +3558,7 @@ let compile_exports = (wasm_mod, env, {imports, exports, globals}) => {
 let compile_tables = (wasm_mod, env, {function_table_elements}) => {
   Table.add_active_element_segment(
     wasm_mod,
-    global_function_table,
+    grain_global_function_table,
     "elem",
     function_table_elements,
     Expression.Global_get.make(

--- a/compiler/src/codegen/compcore.rei
+++ b/compiler/src/codegen/compcore.rei
@@ -3,10 +3,6 @@ open Grain_middle_end;
 open Mashtree;
 open Binaryen;
 
-let grain_main: string;
-let grain_type_metadata: string;
-let grain_start: string;
-
 type codegen_env = {
   name: option(string),
   num_args: int,

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -195,7 +195,7 @@ let rec globalize_names = (~function_names, ~global_names, ~label_names, expr) =
 
     Expression.Call_indirect.set_table(
       expr,
-      Comp_utils.global_function_table,
+      Comp_utils.grain_global_function_table,
     );
 
     let num_operands = Expression.Call_indirect.get_num_operands(expr);
@@ -496,7 +496,7 @@ let link_all = (linked_mod, dependencies, signature) => {
       ignore @@
       Table.add_active_element_segment(
         linked_mod,
-        Comp_utils.global_function_table,
+        Comp_utils.grain_global_function_table,
         new_name,
         elems,
         Expression.Const.make(
@@ -525,7 +525,7 @@ let link_all = (linked_mod, dependencies, signature) => {
   ignore @@
   Table.add_table(
     linked_mod,
-    Comp_utils.global_function_table,
+    Comp_utils.grain_global_function_table,
     table_offset^,
     -1,
     Type.funcref,
@@ -555,7 +555,7 @@ let link_all = (linked_mod, dependencies, signature) => {
             linked_mod,
             Hashtbl.find(
               Hashtbl.find(exported_names, dep),
-              Compcore.grain_type_metadata,
+              Comp_utils.grain_type_metadata,
             ),
             [],
             Type.none,
@@ -568,7 +568,7 @@ let link_all = (linked_mod, dependencies, signature) => {
                 linked_mod,
                 Hashtbl.find(
                   Hashtbl.find(exported_names, dep),
-                  Compcore.grain_main,
+                  Comp_utils.grain_main,
                 ),
                 [],
                 Type.int32,
@@ -594,7 +594,7 @@ let link_all = (linked_mod, dependencies, signature) => {
       dependencies @ [main],
     );
 
-  let start_name = gensym(Compcore.grain_start);
+  let start_name = gensym(Comp_utils.grain_start);
   let start =
     Function.add_function(
       linked_mod,
@@ -609,7 +609,7 @@ let link_all = (linked_mod, dependencies, signature) => {
     Function.set_start(linked_mod, start);
   } else {
     ignore @@
-    Export.add_function_export(linked_mod, start_name, Compcore.grain_start);
+    Export.add_function_export(linked_mod, start_name, Comp_utils.grain_start);
   };
 };
 


### PR DESCRIPTION
This is a refactor that needs to happen prior to binaryen 110 because we want to make a constant for the memory and we'd end up with a dependency cycle with compcore and comp_utils.