### PR TITLE
chore(compiler): Update binaryen.ml to v0.20.1

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -31,7 +31,7 @@
     "check-format": "dune build @fmt"
   },
   "dependencies": {
-    "@grain/binaryen.ml": ">= 0.19.0 < 0.20.0",
+    "@grain/binaryen.ml": ">= 0.20.1 < 0.21.0",
     "@opam/cmdliner": ">= 1.1.1",
     "@opam/dune": ">= 3.6.1 < 4.0.0",
     "@opam/dune-build-info": ">= 3.6.1 < 4.0.0",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0c6c853d75ad5414ceef6d785adaa70e",
+  "checksum": "b568bc63e0c96535498218378ab30dac",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@github:phated/ocaml:package.json#a25997805f1ce225f23c0321e827c0d503896017@d41d8cd9": {
@@ -274,20 +274,20 @@
         "ocaml@github:phated/ocaml:package.json#a25997805f1ce225f23c0321e827c0d503896017@d41d8cd9"
       ]
     },
-    "@opam/utop@opam:2.12.0@41cf0331": {
-      "id": "@opam/utop@opam:2.12.0@41cf0331",
+    "@opam/utop@opam:2.12.1@8af80d05": {
+      "id": "@opam/utop@opam:2.12.1@8af80d05",
       "name": "@opam/utop",
-      "version": "opam:2.12.0",
+      "version": "opam:2.12.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/ad/ad19c859a783bec573cd91e810c54d0e6b70f339d0a4fed55ec672ae408aa1ea#sha256:ad19c859a783bec573cd91e810c54d0e6b70f339d0a4fed55ec672ae408aa1ea",
-          "archive:https://github.com/ocaml-community/utop/releases/download/2.12.0/utop-2.12.0.tbz#sha256:ad19c859a783bec573cd91e810c54d0e6b70f339d0a4fed55ec672ae408aa1ea"
+          "archive:https://opam.ocaml.org/cache/sha256/67/67a4b7a54138458e50ee4791515490bb392291ec1680cfac44b81c47ef1b2253#sha256:67a4b7a54138458e50ee4791515490bb392291ec1680cfac44b81c47ef1b2253",
+          "archive:https://github.com/ocaml-community/utop/releases/download/2.12.1/utop-2.12.1.tbz#sha256:67a4b7a54138458e50ee4791515490bb392291ec1680cfac44b81c47ef1b2253"
         ],
         "opam": {
           "name": "utop",
-          "version": "2.12.0",
-          "path": "esy.lock/opam/utop.2.12.0"
+          "version": "2.12.1",
+          "path": "esy.lock/opam/utop.2.12.1"
         }
       },
       "overrides": [],
@@ -2310,14 +2310,14 @@
         "@opam/bigstringaf@opam:0.9.1@e6f2e882"
       ]
     },
-    "@grain/libbinaryen@109.0.1@d41d8cd9": {
-      "id": "@grain/libbinaryen@109.0.1@d41d8cd9",
+    "@grain/libbinaryen@110.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@110.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "109.0.1",
+      "version": "110.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-109.0.1.tgz#sha1:c02ddf08f8b8c50713d3223c05c2d9b6f1d71005"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-110.0.0.tgz#sha1:1b4dd06b78461f32682998a30ad54a75add29848"
         ]
       },
       "overrides": [],
@@ -2355,7 +2355,7 @@
         "@opam/dune-build-info@opam:3.7.1@adf0d411",
         "@opam/dune@opam:3.7.1@40db2f22",
         "@opam/cmdliner@opam:1.2.0@b0c6143c",
-        "@grain/binaryen.ml@0.19.0@d41d8cd9"
+        "@grain/binaryen.ml@0.20.1@d41d8cd9"
       ],
       "devDependencies": [
         "@reason-native/rely@github:reasonml/reason-native:rely.json#0ed854f986256e52e59aeecfa90e9af60f105b15@d41d8cd9",
@@ -2364,14 +2364,14 @@
       ],
       "installConfig": { "pnp": false }
     },
-    "@grain/binaryen.ml@0.19.0@d41d8cd9": {
-      "id": "@grain/binaryen.ml@0.19.0@d41d8cd9",
+    "@grain/binaryen.ml@0.20.1@d41d8cd9": {
+      "id": "@grain/binaryen.ml@0.20.1@d41d8cd9",
       "name": "@grain/binaryen.ml",
-      "version": "0.19.0",
+      "version": "0.20.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.19.0.tgz#sha1:158f7ba00494171cf6392059c8f3478c492947aa"
+          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.20.1.tgz#sha1:ea311d7e4a1e95682311b62df7b5e614475eded0"
         ]
       },
       "overrides": [],
@@ -2379,7 +2379,7 @@
         "ocaml@github:phated/ocaml:package.json#a25997805f1ce225f23c0321e827c0d503896017@d41d8cd9",
         "@opam/dune-configurator@opam:3.7.1@32ab7c21",
         "@opam/dune@opam:3.7.1@40db2f22",
-        "@grain/libbinaryen@109.0.1@d41d8cd9"
+        "@grain/libbinaryen@110.0.0@d41d8cd9"
       ],
       "devDependencies": [],
       "installConfig": { "pnp": false }
@@ -2413,7 +2413,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:phated/ocaml:package.json#a25997805f1ce225f23c0321e827c0d503896017@d41d8cd9",
-        "@opam/utop@opam:2.12.0@41cf0331", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/utop@opam:2.12.1@8af80d05", "@opam/result@opam:1.5@1c6a6533",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocamlfind@opam:1.9.6@da5169c7",
         "@opam/merlin-extend@opam:0.6.1@7d979feb",

--- a/compiler/esy.lock/opam/utop.2.12.1/opam
+++ b/compiler/esy.lock/opam/utop.2.12.1/opam
@@ -34,10 +34,10 @@ and more.  It integrates with the Tuareg mode in Emacs.
 """
 url {
   src:
-    "https://github.com/ocaml-community/utop/releases/download/2.12.0/utop-2.12.0.tbz"
+    "https://github.com/ocaml-community/utop/releases/download/2.12.1/utop-2.12.1.tbz"
   checksum: [
-    "sha256=ad19c859a783bec573cd91e810c54d0e6b70f339d0a4fed55ec672ae408aa1ea"
-    "sha512=cd55cfb49178bec60b39df5b15df9090d9a316b81ddd5e564daaaa04c3c896c2e1ccf24a15ebce5b41ad3e22db56cfc95cc3f1a6808ee8e09f1c685284cdfb71"
+    "sha256=67a4b7a54138458e50ee4791515490bb392291ec1680cfac44b81c47ef1b2253"
+    "sha512=a3957684b5124227ff5c18aa3221aa3cdfdffce345df49db7ac84005012bcdda6e12ad00466f592f3b42ead50626fc250713a91ca4500b7ab2e89b15d96a3f84"
   ]
 }
-x-commit-hash: "c50173caf9b147eae637cb44e302e2077778afb4"
+x-commit-hash: "ba0e2c7fffab33cf78e2f6e4c346f65e7c0949ae"

--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -7,6 +7,8 @@ let grain_main = "_gmain";
 let grain_start = "_start";
 let grain_env_name = "_genv";
 let grain_global_function_table = "tbl";
+// TODO(#): Use a more descriptive name once we get fixes into Binaryen
+let grain_memory = "0";
 
 let wasm_type =
   fun
@@ -114,7 +116,16 @@ let store = (~ty=Type.int32, ~align=?, ~offset=0, ~sz=?, wasm_mod, ptr, arg) => 
       sz,
     );
   let align = Option.value(~default=sz, align);
-  Expression.Store.make(wasm_mod, sz, offset, align, ptr, arg, ty);
+  Expression.Store.make(
+    wasm_mod,
+    sz,
+    offset,
+    align,
+    ptr,
+    arg,
+    ty,
+    grain_memory,
+  );
 };
 
 let load =
@@ -130,7 +141,16 @@ let load =
       sz,
     );
   let align = Option.value(~default=sz, align);
-  Expression.Load.make(~signed, wasm_mod, sz, offset, align, ty, ptr);
+  Expression.Load.make(
+    ~signed,
+    wasm_mod,
+    sz,
+    offset,
+    align,
+    ty,
+    ptr,
+    grain_memory,
+  );
 };
 
 let is_grain_env = str => grain_env_name == str;
@@ -235,6 +255,7 @@ let write_universal_exports =
                     2,
                     Type.int32,
                     get_closure(),
+                    grain_memory,
                   );
                 Expression.Call_indirect.make(
                   wasm_mod,

--- a/compiler/src/codegen/comp_utils.rei
+++ b/compiler/src/codegen/comp_utils.rei
@@ -6,6 +6,7 @@ let grain_main: string;
 let grain_start: string;
 let grain_env_name: string;
 let grain_global_function_table: string;
+let grain_memory: string;
 
 let wasm_type: Types.allocation_type => Type.t;
 

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -2176,7 +2176,8 @@ let compile_prim0 = (wasm_mod, env, p0): Expression.t => {
     allocate_alt_num_uninitialized(wasm_mod, env, Uint32Type)
   | AllocateUint64 =>
     allocate_alt_num_uninitialized(wasm_mod, env, Uint64Type)
-  | WasmMemorySize => Expression.Memory_size.make(wasm_mod)
+  | WasmMemorySize =>
+    Expression.Memory_size.make(wasm_mod, grain_memory, false)
   | Unreachable => Expression.Unreachable.make(wasm_mod)
   | HeapStart => get_runtime_heap_start(wasm_mod)
   };
@@ -2285,7 +2286,8 @@ let compile_prim1 = (wasm_mod, env, p1, arg, loc): Expression.t => {
     // no-op
     compile_imm(wasm_mod, env, arg)
   | WasmToGrain => compiled_arg // no-op
-  | WasmMemoryGrow => Expression.Memory_grow.make(wasm_mod, compiled_arg)
+  | WasmMemoryGrow =>
+    Expression.Memory_grow.make(wasm_mod, compiled_arg, grain_memory, false)
   | WasmUnaryI32({wasm_op, ret_type})
   | WasmUnaryI64({wasm_op, ret_type})
   | WasmUnaryF32({wasm_op, ret_type})
@@ -2472,6 +2474,8 @@ let compile_primn = (wasm_mod, env: codegen_env, p, args): Expression.t => {
           compile_imm(wasm_mod, env, List.nth(args, 0)),
           compile_imm(wasm_mod, env, List.nth(args, 1)),
           compile_imm(wasm_mod, env, List.nth(args, 2)),
+          grain_memory,
+          grain_memory,
         ),
         Expression.Const.make(wasm_mod, const_void()),
       ],
@@ -2486,6 +2490,7 @@ let compile_primn = (wasm_mod, env: codegen_env, p, args): Expression.t => {
           compile_imm(wasm_mod, env, List.nth(args, 0)),
           compile_imm(wasm_mod, env, List.nth(args, 1)),
           compile_imm(wasm_mod, env, List.nth(args, 2)),
+          grain_memory,
         ),
         Expression.Const.make(wasm_mod, const_void()),
       ],
@@ -3527,7 +3532,15 @@ let compile_wasm_module = (~env=?, ~name=?, prog) => {
       Option.is_none(Grain_utils.Config.memory_base^),
     );
   let _ =
-    Memory.set_memory(wasm_mod, 0, Memory.unlimited, "memory", [], false);
+    Memory.set_memory(
+      wasm_mod,
+      0,
+      Memory.unlimited,
+      "memory",
+      [],
+      false,
+      grain_memory,
+    );
 
   let compile_all = () => {
     ignore @@ compile_globals(wasm_mod, env, prog);

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -271,8 +271,6 @@ let rec globalize_names = (~function_names, ~global_names, ~label_names, expr) =
   | RefTest
   | RefCast
   | BrOn
-  | RttCanon
-  | RttSub
   | StructNew
   | StructGet
   | StructSet

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -689,9 +689,16 @@ let link_all = (linked_mod, dependencies, signature) => {
     "memory",
     data_segments,
     false,
+    Comp_utils.grain_memory,
   );
   if (Config.import_memory^) {
-    Import.add_memory_import(linked_mod, "memory", "env", "memory", false);
+    Import.add_memory_import(
+      linked_mod,
+      Comp_utils.grain_memory,
+      "env",
+      "memory",
+      false,
+    );
   };
 
   let starts =


### PR DESCRIPTION
This updates to binaryen 110 using our binaryen.ml bindings v0.20.1 - the big change is that binaryen requires all APIs to use an internal memory name when interacting with memories. This is to support multi-memory, I believe. However, we found a bunch of problems and/or bugs with their implementation that we need to raise upstream.

This currently has workarounds for the issues but relies on us dropping the js-runner in #1585. It also is built upon my cleanup in #1598 