### PR TITLE
fix(stdlib): Allow destructuring of TypedPath tuple

### DIFF
--- a/compiler/test/stdlib/path.test.gr
+++ b/compiler/test/stdlib/path.test.gr
@@ -269,3 +269,12 @@ assert Path.ancestry(fs("../dir1"), fs("./dir2")) == Ok(Path.NoLineage)
 assert Path.ancestry(fs("./dir1"), fs("../../dir2")) == Ok(Path.NoLineage)
 assert Path.ancestry(fs("./dir1"), fs("/dir2")) == Err(Path.DifferentBases)
 assert Path.ancestry(fs("C:/dir1"), fs("/dir2")) == Err(Path.DifferentRoots)
+
+// can destructure TypedPath tuple
+match (fs("./dir1/dir2/dir3")) {
+  Path.RelativeFile(x) => {
+    let (base, fileType, pathArray) = x
+    assert pathArray == ["dir3", "dir2", "dir1"]
+  },
+  _ => fail "not a relative file",
+}

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -130,7 +130,7 @@ record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
+export type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
 /**
  * Represents a system path.
  */


### PR DESCRIPTION
@alex-snezhko I was having some trouble destructuring TypedPath tuples due to type errors. 

I found by exporting: `export type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),` I'm able to destructure it fine now. Is it okay to expose this? Or were you wanting consumers to always interact with Path using provided functions?

```js
match (Path.fromString("./dir1/dir2/dir3")) {
  Path.RelativeFile(x) => {
    let (base, fileType, pathArray) = x           // type error here
    assert pathArray == ["dir3", "dir2", "dir1"]
  },
  _ => fail "not a relative file",
}
```

```
This expression has type Path.TypedPath<Path.Relative, Path.File>
but an expression was expected of type (a, b, c)
```
