### PR TITLE
fix(compiler): Properly handle parsing return of negative number

### DIFF
--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -63,7 +63,7 @@ module Grain_parsing = struct end
 %left INFIX_110 DASH
 %left INFIX_120 STAR SLASH
 
-%right SEMI EOL COMMA DOT COLON LPAREN RETURN
+%right SEMI EOL COMMA DOT COLON LPAREN
 
 %nonassoc _if
 %nonassoc ELSE
@@ -531,7 +531,8 @@ stmt_expr:
   | THROW expr { Exp.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "throw"]) [$2] }
   | ASSERT expr { Exp.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "assert"]) [$2] }
   | FAIL expr { Exp.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "fail"]) [$2] }
-  | RETURN ioption(expr) { Exp.return ~loc:(to_loc $loc) $2 }
+  // allow DASH to cause a shift instead of the usual reduction of the left side for subtraction
+  | RETURN ioption(expr) %prec _below_infix { Exp.return ~loc:(to_loc $loc) $2 }
   | CONTINUE { Exp.continue ~loc:(to_loc $loc) () }
   | BREAK { Exp.break ~loc:(to_loc $loc) () }
 

--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -216,4 +216,19 @@ describe("parsing", ({test, testSkip}) => {
       prog_loc: Location.dummy_loc,
     },
   );
+  assertParse(
+    "regression_issue_1609",
+    "return -1",
+    {
+      statements: [
+        Top.expr(
+          Exp.return(
+            Some(Exp.constant(PConstNumber(PConstNumberInt("-1")))),
+          ),
+        ),
+      ],
+      comments: [],
+      prog_loc: Location.dummy_loc,
+    },
+  );
 });


### PR DESCRIPTION
Fixes #1609 

Since subtraction is left-associative and return statements are not required to have an expression, parsing `return -1` was causing the `return` itself to be treated as an expression, in the same way that typing `foo(5) - 4` would cause the parser to reduce `foo(5)` to a function call before attempting to parse subtraction.

Thanks @alex-snezhko for the report 🙂