### PR TITLE
chore(stdlib): Utilize early return in more of the stdlib

### DIFF
--- a/stdlib/runtime/bigint.gr
+++ b/stdlib/runtime/bigint.gr
@@ -394,14 +394,12 @@ export let eqz = (num: WasmI32) => {
   let (!=) = WasmI64.ne
   let (-) = WasmI32.sub
   let (>=) = WasmI32.geS
-  let mut result = 1n
   for (let mut i = numLimbs - 1n; i >= 0n; i -= 1n) {
     if (getLimb(num, i) != 0N) {
-      result = 0n
-      break
+      return false
     }
   }
-  WasmI32.ne(result, 0n)
+  return true
 }
 
 @unsafe
@@ -574,23 +572,20 @@ let cmpUnsignedI64 = (num1: WasmI32, num2: WasmI64) => {
   let delta = num1Limbs - num2Limbs
   let num2abs = if (WasmI64.ltS(num2, 0N)) WasmI64.mul(-1N, num2) else num2
   if (delta != 0n) {
-    delta
-  } else {
-    // num1 and num2 have the same size. Compare all limbs, high to low
-    let mut result = 0n
-    for (let mut i = num1Limbs - 1n; i >= 0n; i -= 1n) {
-      let limb1 = getLimb(num1, i)
-      let limb2 = if (i == 0n) num2abs else 0N
-      if (WasmI64.ltU(limb1, limb2)) {
-        result = -1n
-        break
-      } else if (WasmI64.ltU(limb2, limb1)) {
-        result = 1n
-        break
-      }
-    }
-    result
+    return delta
   }
+  // num1 and num2 have the same size. Compare all limbs, high to low
+  for (let mut i = num1Limbs - 1n; i >= 0n; i -= 1n) {
+    let limb1 = getLimb(num1, i)
+    let limb2 = if (i == 0n) num2abs else 0N
+    if (WasmI64.ltU(limb1, limb2)) {
+      return -1n
+    } else if (WasmI64.ltU(limb2, limb1)) {
+      return 1n
+    }
+  }
+
+  return 0n
 }
 
 @unsafe
@@ -646,23 +641,19 @@ let cmpUnsigned = (num1: WasmI32, num2: WasmI32) => {
   let num2Limbs = getSize(num2)
   let delta = num1Limbs - num2Limbs
   if (delta != 0n) {
-    delta
-  } else {
-    // num1 and num2 have the same size. Compare all limbs, high to low
-    let mut result = 0n
-    for (let mut i = num1Limbs - 1n; i >= 0n; i -= 1n) {
-      let limb1 = getLimb(num1, i)
-      let limb2 = getLimb(num2, i)
-      if (WasmI64.ltU(limb1, limb2)) {
-        result = -1n
-        break
-      } else if (WasmI64.ltU(limb2, limb1)) {
-        result = 1n
-        break
-      }
-    }
-    result
+    return delta
   }
+  // num1 and num2 have the same size. Compare all limbs, high to low
+  for (let mut i = num1Limbs - 1n; i >= 0n; i -= 1n) {
+    let limb1 = getLimb(num1, i)
+    let limb2 = getLimb(num2, i)
+    if (WasmI64.ltU(limb1, limb2)) {
+      return -1n
+    } else if (WasmI64.ltU(limb2, limb1)) {
+      return 1n
+    }
+  }
+  return 0n
 }
 
 @unsafe
@@ -1763,41 +1754,39 @@ export let popcnt = (num: WasmI32, flagDest: WasmI32) => {
 @unsafe
 export let gcd = (num1: WasmI32, num2: WasmI32) => {
   if (eqz(num1)) {
-    abs(num2)
-  } else if (eqz(num2)) {
-    abs(num1)
-  } else {
-    let mut u = abs(num1)
-    let mut v = abs(num2)
-    let i = countTrailingZeroBits(u)
-    let j = countTrailingZeroBits(v)
-    let k = minu32(i, j)
-    let mut newu = shrS(u, i)
-    let mut newv = shrS(v, j)
-    Memory.decRef(u)
-    Memory.decRef(v)
-    u = newu
-    v = newv
-    let mut ret = 0n
-    while (true) {
-      if (gt(u, v)) {
-        let tmp = v
-        v = u
-        u = tmp
-      }
-      newv = sub(v, u)
-      Memory.decRef(v)
-      v = newv
-      if (eqz(v)) {
-        ret = shl(u, k)
-        break
-      }
-      newv = shrS(v, countTrailingZeroBits(v))
-      Memory.decRef(v)
-      v = newv
-    }
-    ret
+    return abs(num2)
   }
+  if (eqz(num2)) {
+    return abs(num1)
+  }
+  let mut u = abs(num1)
+  let mut v = abs(num2)
+  let i = countTrailingZeroBits(u)
+  let j = countTrailingZeroBits(v)
+  let k = minu32(i, j)
+  let mut newu = shrS(u, i)
+  let mut newv = shrS(v, j)
+  Memory.decRef(u)
+  Memory.decRef(v)
+  u = newu
+  v = newv
+  while (true) {
+    if (gt(u, v)) {
+      let tmp = v
+      v = u
+      u = tmp
+    }
+    newv = sub(v, u)
+    Memory.decRef(v)
+    v = newv
+    if (eqz(v)) {
+      return shl(u, k)
+    }
+    newv = shrS(v, countTrailingZeroBits(v))
+    Memory.decRef(v)
+    v = newv
+  }
+  return 0n
 }
 
 // For division, "normalized" refers to the following (from Brent & Zimmermann):

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -36,33 +36,27 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
       let xvariant = WasmI32.load(xptr, 12n)
       let yvariant = WasmI32.load(yptr, 12n)
       if (xvariant != yvariant) {
-        tagSimpleNumber(xvariant - yvariant)
-      } else {
-        let xarity = WasmI32.load(xptr, 16n)
-        let yarity = WasmI32.load(yptr, 16n)
-
-        let mut result = 0
-
-        let bytes = xarity * 4n
-        for (let mut i = 0n; i < bytes; i += 4n) {
-          let sub = compareHelp(
-            WasmI32.load(xptr + i, 20n),
-            WasmI32.load(yptr + i, 20n)
-          )
-          if (WasmI32.fromGrain(sub) != zero) {
-            result = sub
-            break
-          }
-        }
-
-        result
+        return tagSimpleNumber(xvariant - yvariant)
       }
+      let xarity = WasmI32.load(xptr, 16n)
+      let yarity = WasmI32.load(yptr, 16n)
+
+      let bytes = xarity * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        let sub = compareHelp(
+          WasmI32.load(xptr + i, 20n),
+          WasmI32.load(yptr + i, 20n)
+        )
+        if (WasmI32.fromGrain(sub) != zero) {
+          return sub
+        }
+      }
+
+      return 0
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 12n)
       let ylength = WasmI32.load(yptr, 12n)
-
-      let mut result = 0
 
       let bytes = xlength * 4n
       for (let mut i = 0n; i < bytes; i += 4n) {
@@ -71,12 +65,11 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
           WasmI32.load(yptr + i, 16n)
         )
         if (WasmI32.fromGrain(sub) != zero) {
-          result = sub
-          break
+          return sub
         }
       }
 
-      result
+      return 0
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 4n)
@@ -84,23 +77,20 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
 
       // Check if the same length
       if (xlength != ylength) {
-        tagSimpleNumber(xlength - ylength)
-      } else {
-        let mut result = 0
-        let bytes = xlength * 4n
-        for (let mut i = 0n; i < bytes; i += 4n) {
-          let sub = compareHelp(
-            WasmI32.load(xptr + i, 8n),
-            WasmI32.load(yptr + i, 8n)
-          )
-          if (WasmI32.fromGrain(sub) != zero) {
-            result = sub
-            break
-          }
-        }
-
-        result
+        return tagSimpleNumber(xlength - ylength)
       }
+      let bytes = xlength * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        let sub = compareHelp(
+          WasmI32.load(xptr + i, 8n),
+          WasmI32.load(yptr + i, 8n)
+        )
+        if (WasmI32.fromGrain(sub) != zero) {
+          return sub
+        }
+      }
+
+      return 0
     },
     t when (
       t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG
@@ -109,24 +99,22 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
       let ylength = WasmI32.load(yptr, 4n)
 
       if (xlength == ylength) {
-        tagSimpleNumber(Memory.compare(xptr + 8n, yptr + 8n, xlength))
+        return tagSimpleNumber(Memory.compare(xptr + 8n, yptr + 8n, xlength))
+      }
+      if (xlength < ylength) {
+        let sub = Memory.compare(xptr + 8n, yptr + 8n, xlength)
+        // The shorter one comes first
+        return if (sub == 0n) -1 else tagSimpleNumber(sub)
       } else {
-        if (xlength < ylength) {
-          let sub = Memory.compare(xptr + 8n, yptr + 8n, xlength)
-          // The shorter one comes first
-          if (sub == 0n) -1 else tagSimpleNumber(sub)
-        } else {
-          let sub = Memory.compare(xptr + 8n, yptr + 8n, ylength)
-          // The shorter one comes first
-          if (sub == 0n) 1 else tagSimpleNumber(sub)
-        }
+        let sub = Memory.compare(xptr + 8n, yptr + 8n, ylength)
+        // The shorter one comes first
+        return if (sub == 0n) 1 else tagSimpleNumber(sub)
       }
     },
     t when t == Tags._GRAIN_TUPLE_HEAP_TAG => {
       let xsize = WasmI32.load(xptr, 4n)
       let ysize = WasmI32.load(yptr, 4n)
 
-      let mut result = 0
       let bytes = xsize * 4n
       for (let mut i = 0n; i < bytes; i += 4n) {
         let sub = compareHelp(
@@ -134,16 +122,15 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
           WasmI32.load(yptr + i, 8n)
         )
         if (WasmI32.fromGrain(sub) != zero) {
-          result = sub
-          break
+          return sub
         }
       }
 
-      result
+      return 0
     },
     _ => {
       // No other implementation
-      tagSimpleNumber(xptr - yptr)
+      return tagSimpleNumber(xptr - yptr)
     },
   }
 },

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -127,39 +127,31 @@ export let indexOf = (search: String, string: String) => {
   let (&) = WasmI32.and
 
   if (psize > size) {
-    None
-  } else {
-    let mut idx = 0n
-    let mut ptr = string + 8n
-    let mut pptr = search + 8n
-    let end = ptr + size - psize + 1n
+    return None
+  }
+  let mut idx = 0n
+  let mut ptr = string + 8n
+  let mut pptr = search + 8n
+  let end = ptr + size - psize + 1n
 
-    let mut result = -1n
-
-    while (ptr < end) {
-      if (Memory.compare(ptr, pptr, psize) == 0n) {
-        result = idx
-        break
-      }
-      idx += 1n
-      let byte = WasmI32.load8U(ptr, 0n)
-      if ((byte & 0x80n) == 0x00n) {
-        ptr += 1n
-      } else if ((byte & 0xF0n) == 0xF0n) {
-        ptr += 4n
-      } else if ((byte & 0xE0n) == 0xE0n) {
-        ptr += 3n
-      } else {
-        ptr += 2n
-      }
+  while (ptr < end) {
+    if (Memory.compare(ptr, pptr, psize) == 0n) {
+      return Some(tagSimpleNumber(idx))
     }
-
-    if (result == -1n) {
-      None
+    idx += 1n
+    let byte = WasmI32.load8U(ptr, 0n)
+    if ((byte & 0x80n) == 0x00n) {
+      ptr += 1n
+    } else if ((byte & 0xF0n) == 0xF0n) {
+      ptr += 4n
+    } else if ((byte & 0xE0n) == 0xE0n) {
+      ptr += 3n
     } else {
-      Some(tagSimpleNumber(result))
+      ptr += 2n
     }
   }
+
+  return None
 }
 
 /**
@@ -191,34 +183,28 @@ export let lastIndexOf = (search: String, string: String) => {
   let searchSize = WasmI32.load(search, 4n)
   let stringSize = WasmI32.load(string, 4n)
   if (searchSize > stringSize) {
-    None
-  } else {
-    let mut matchIndex = -1n
-    let mut stringIndex = untagSimpleNumber(lastIndex)
-    let searchPtr = search + 8n
-    let stringStartPtr = string + 8n
-    for (
-      let mut stringPtr = stringStartPtr + stringSize - searchSize;
-      stringPtr >= stringStartPtr;
-      stringPtr -= 1n
-    ) {
-      let byte = WasmI32.load8U(stringPtr, 0n)
-      if ((byte & 0xC0n) == 0x80n) {
-        // We're not at the start of a codepoint, so move on
-        continue
-      }
-      if (Memory.compare(stringPtr, searchPtr, searchSize) == 0n) {
-        matchIndex = stringIndex
-        break
-      }
-      stringIndex -= 1n
-    }
-    if (matchIndex == -1n) {
-      None
-    } else {
-      Some(tagSimpleNumber(matchIndex))
-    }
+    return None
   }
+  let mut stringIndex = untagSimpleNumber(lastIndex)
+  let searchPtr = search + 8n
+  let stringStartPtr = string + 8n
+  for (
+    let mut stringPtr = stringStartPtr + stringSize - searchSize;
+    stringPtr >= stringStartPtr;
+    stringPtr -= 1n
+  ) {
+    let byte = WasmI32.load8U(stringPtr, 0n)
+    if ((byte & 0xC0n) == 0x80n) {
+      // We're not at the start of a codepoint, so move on
+      continue
+    }
+    if (Memory.compare(stringPtr, searchPtr, searchSize) == 0n) {
+      return Some(tagSimpleNumber(stringIndex))
+    }
+    stringIndex -= 1n
+  }
+
+  return None
 }
 
 @unsafe
@@ -295,11 +281,9 @@ let charAtHelp = (position, string: String) => {
   let mut ptr = string + 8n
   let end = ptr + size
   let mut counter = 0n
-  let mut result = 0n
   while (ptr < end) {
     if (counter == position) {
-      result = getCodePoint(ptr)
-      break
+      return getCodePoint(ptr)
     }
     let byte = WasmI32.load8U(ptr, 0n)
     let n = if ((byte & 0x80n) == 0x00n) {
@@ -314,10 +298,8 @@ let charAtHelp = (position, string: String) => {
     counter += 1n
     ptr += n
   }
-  if (WasmI32.eqz(WasmI32.fromGrain(result))) {
-    fail "charAt: should be impossible (please report)"
-  }
-  result
+
+  fail "charAt: should be impossible (please report)"
 }
 
 /**
@@ -747,52 +729,52 @@ export let contains = (search: String, string: String) => {
 
   if (m > n) {
     // Bail if pattern length is longer than input length
-    false
-  } else if (m < 2n) {
+    return false
+  }
+
+  if (m < 2n) {
     // Handle very small patterns
     if (m == 0n) {
-      true
-    } else {
-      let pat = WasmI32.load8U(search, 0n)
-      let mut result = false
-      while (j < n) {
-        if (pat == WasmI32.load8U(string + j, 0n)) {
-          result = true
-          break
-        } else {
-          j += 1n
-        }
-      }
-      result
-    }
-  } else {
-    // NSM preprocessing
-    if (WasmI32.load8U(search, 0n) == WasmI32.load8U(search, 1n)) {
-      k = 2n
-      ell = 1n
-    } else {
-      k = 1n
-      ell = 2n
+      return true
     }
 
-    let mut result = false
-    // NSM searching
-    while (j <= n - m) {
-      if (WasmI32.load8U(search, 1n) != WasmI32.load8U(string + j, 1n)) {
-        j += k
+    let pat = WasmI32.load8U(search, 0n)
+    while (j < n) {
+      if (pat == WasmI32.load8U(string + j, 0n)) {
+        return true
       } else {
-        if (
-          Memory.compare(search + 2n, string + j + 2n, m - 2n) == 0n &&
-          WasmI32.load8U(search, 0n) == WasmI32.load8U(string + j, 0n)
-        ) {
-          result = true
-          break
-        }
-        j += ell
+        j += 1n
       }
     }
-    result
+
+    return false
   }
+
+  // NSM preprocessing
+  if (WasmI32.load8U(search, 0n) == WasmI32.load8U(search, 1n)) {
+    k = 2n
+    ell = 1n
+  } else {
+    k = 1n
+    ell = 2n
+  }
+
+  // NSM searching
+  while (j <= n - m) {
+    if (WasmI32.load8U(search, 1n) != WasmI32.load8U(string + j, 1n)) {
+      j += k
+    } else {
+      if (
+        Memory.compare(search + 2n, string + j + 2n, m - 2n) == 0n &&
+        WasmI32.load8U(search, 0n) == WasmI32.load8U(string + j, 0n)
+      ) {
+        return true
+      }
+      j += ell
+    }
+  }
+
+  return false
 }
 
 /**
@@ -902,25 +884,19 @@ export let replaceFirst =
   let replacementLen = WasmI32.load(replacementPtr, 4n)
   // Bail if search str is longer than the string
   if (stringLen < patternLen) {
-    string
-  } else {
-    patternPtr += 8n
-    stringPtr += 8n
-    replacementPtr += 8n
+    return string
+  }
+  patternPtr += 8n
+  stringPtr += 8n
+  replacementPtr += 8n
 
-    let mut found = false
-    // Search for an instance of the string
-    let mut foundIndex = -1n
-    let stringEndPtr = stringPtr + stringLen - patternLen + 1n
-    for (let mut i = stringPtr; i < stringEndPtr; i += 1n) {
-      // check for match
-      foundIndex += 1n
-      if (Memory.compare(i, patternPtr, patternLen) == 0n) {
-        found = true
-        break
-      }
-    }
-    if (found) {
+  // Search for an instance of the string
+  let mut foundIndex = -1n
+  let stringEndPtr = stringPtr + stringLen - patternLen + 1n
+  for (let mut i = stringPtr; i < stringEndPtr; i += 1n) {
+    // check for match
+    foundIndex += 1n
+    if (Memory.compare(i, patternPtr, patternLen) == 0n) {
       // Create the new string
       let str = allocateString(stringLen - patternLen + replacementLen)
       let strPtr = str + 8n
@@ -932,11 +908,11 @@ export let replaceFirst =
         stringLen - foundIndex
       )
       // Copy over the str
-      WasmI32.toGrain(str): String
-    } else {
-      string
+      return WasmI32.toGrain(str): String
     }
   }
+
+  return string
 }
 
 /**
@@ -974,25 +950,20 @@ export let replaceLast =
 
   // Bail if search str is longer than the string
   if (stringLen < patternLen) {
-    string
-  } else {
-    patternPtr += 8n
-    stringPtr += 8n
-    replacementPtr += 8n
+    return string
+  }
+  patternPtr += 8n
+  stringPtr += 8n
+  replacementPtr += 8n
 
-    let mut found = false
-    // Search for an instance of the string
-    let stringEndPtr = stringPtr + stringLen - patternLen
-    let mut foundIndex = stringLen - patternLen + 1n
-    for (let mut i = stringEndPtr; i > stringPtr - 1n; i -= 1n) {
-      // check for match
-      foundIndex -= 1n
-      if (Memory.compare(i, patternPtr, patternLen) == 0n) {
-        found = true
-        break
-      }
-    }
-    if (found) {
+  let mut found = false
+  // Search for an instance of the string
+  let stringEndPtr = stringPtr + stringLen - patternLen
+  let mut foundIndex = stringLen - patternLen + 1n
+  for (let mut i = stringEndPtr; i > stringPtr - 1n; i -= 1n) {
+    // check for match
+    foundIndex -= 1n
+    if (Memory.compare(i, patternPtr, patternLen) == 0n) {
       // Create the new string
       let str = allocateString(stringLen - patternLen + replacementLen)
       let strPtr = str + 8n
@@ -1004,11 +975,11 @@ export let replaceLast =
         stringLen - foundIndex
       )
       // Copy over the str
-      WasmI32.toGrain(str): String
-    } else {
-      string
+      return WasmI32.toGrain(str): String
     }
   }
+
+  return string
 }
 
 /**


### PR DESCRIPTION
While rebasing #1493 and poking around in the stdlib, I've found there are more places where we should be using early return.

There are even more but I wanted to chunk my current work to keep the diff easy enough.