### PR TITLE
chore(stdlib): Light cleanup on constant pattern matches

### DIFF
--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -526,7 +526,7 @@ export let part = (count, list) => {
  * @example List.rotate(-7, [1, 2, 3, 4, 5]) // [4, 5, 1, 2, 3]
  *
  * @since v0.1.0
- * 
+ *
  * @history v0.6.0: No longer throws if `count` outside list length bounds
  */
 export let rotate = (count, list) => {
@@ -671,7 +671,7 @@ export let rec drop = (count, list) => {
   } else {
     match ((count, list)) {
       (_, []) => [],
-      (n, _) when n == 0 => list,
+      (0, _) => list,
       (n, [first, ...rest]) => drop(n - 1, rest),
     }
   }
@@ -713,7 +713,7 @@ export let rec take = (count, list) => {
   } else {
     match ((count, list)) {
       (_, []) => list,
-      (n, _) when n == 0 => [],
+      (0, _) => [],
       (n, [first, ...rest]) => [first, ...take(n - 1, rest)],
     }
   }

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -1112,9 +1112,7 @@ let rec parseAtom = (buf: RegExBuf) => {
                     },
                   }
                 },
-                Ok(c) when (
-                  c == 'i' || c == 's' || c == 'm' || c == '-' || c == ':'
-                ) => {
+                Ok('i' | 's' | 'm' | '-' | ':') => {
                   // match with mode
                   ignore(eat(buf, '('))
                   ignore(eat(buf, '?'))
@@ -1678,7 +1676,7 @@ parseNonGreedy = (buf: RegExBuf) => {
     } else {
       match (peek(buf)) {
         Err(e) => Err(e),
-        Ok(c) when c == '?' || c == '*' || c == '+' => {
+        Ok('?' | '*' | '+' as c) => {
           Err(parseErr(buf, "nested '" ++ toString(c) ++ "' in pattern", 0))
         },
         Ok(_) => res,

--- a/stdlib/runtime/atof/parse.gr
+++ b/stdlib/runtime/atof/parse.gr
@@ -11,11 +11,11 @@
  * the Software, and to permit persons to whom the Software
  * is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice
  * shall be included in all copies or substantial portions
  * of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
  * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
  * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -242,7 +242,7 @@ let parseFloatToParts = (string: String) => {
       numDigits += numDigitsAfterDot
 
       match (numDigits) {
-        n when n == 0n => Err("Invalid float"),
+        0n => Err("Invalid float"),
         _ => {
           let _MAX_MANTISSA_DIGITS = 19n // 10^19 fits in uint64
           let _MIN_19DIGIT_INT = 100_0000_0000_0000_0000N


### PR DESCRIPTION
This cleans up a few `when` expressions we had on pattern matches in the stdlib that were just comparing to constant values. I assume these are from before we supported constant values in pattern matches.