### PR TITLE
chore(stdlib)!: Replace Number.nan & Number.infinity constants with keywords

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -2,14 +2,9 @@ import Number from "number"
 import Result from "result"
 import Int32 from "int32"
 import Int64 from "int64"
-import Float32 from "float32"
-import Float64 from "float64"
 import BI from "bigint"
 
 // Constants Test
-assert Number.nan != Number.nan
-
-assert Number.infinity == 1.0 / 0.0
 
 assert Number.pi == 3.141592653589793
 
@@ -19,10 +14,10 @@ assert Number.e == 2.718281828459045
 // Operations Tests
 // add
 assert Number.add(25, 5) == 30
-assert Number.add(Number.infinity, 10) == Number.infinity
-assert Number.add(Number.infinity, Number.infinity) == Number.infinity
-assert Number.isNaN(Number.add(Number.infinity, Number.nan))
-assert Number.isNaN(Number.add(Number.nan, Number.nan))
+assert Number.add(Infinity, 10) == Infinity
+assert Number.add(Infinity, Infinity) == Infinity
+assert Number.isNaN(Number.add(Infinity, NaN))
+assert Number.isNaN(Number.add(NaN, NaN))
 // Rational addition tests
 {
   let (+) = Number.add
@@ -36,10 +31,10 @@ assert Number.isNaN(Number.add(Number.nan, Number.nan))
 }
 // sub
 assert Number.sub(25, 5) == 20
-assert Number.sub(Number.infinity, 10) == Number.infinity
-assert Number.isNaN(Number.sub(Number.infinity, Number.infinity))
-assert Number.isNaN(Number.sub(Number.infinity, Number.nan))
-assert Number.isNaN(Number.sub(Number.nan, Number.nan))
+assert Number.sub(Infinity, 10) == Infinity
+assert Number.isNaN(Number.sub(Infinity, Infinity))
+assert Number.isNaN(Number.sub(Infinity, NaN))
+assert Number.isNaN(Number.sub(NaN, NaN))
 // Rational subtraction tests
 {
   let (-) = Number.sub
@@ -57,10 +52,10 @@ assert Number.mul(5, 5) == 25
 assert Number.mul(9223372036854775809, 5) == 46116860184273879045
 assert Number.mul(9223372036854775809, 9223372036854775809) ==
   85070591730234615884290395931651604481
-assert Number.mul(Number.infinity, 10) == Number.infinity
-assert Number.mul(Number.infinity, Number.infinity) == Number.infinity
-assert Number.isNaN(Number.mul(Number.infinity, Number.nan))
-assert Number.isNaN(Number.mul(Number.nan, Number.nan))
+assert Number.mul(Infinity, 10) == Infinity
+assert Number.mul(Infinity, Infinity) == Infinity
+assert Number.isNaN(Number.mul(Infinity, NaN))
+assert Number.isNaN(Number.mul(NaN, NaN))
 // Rational mul tests
 {
   let (*) = Number.mul
@@ -78,10 +73,10 @@ assert Number.div(25, 5) == 5
 assert Number.div(9223372036854775809, 9) == 1024819115206086201
 assert Number.div(9223372036854775809, 9223372036854775809) == 1
 assert Number.div(9223372036854775808, 27670116110564327424) == 1/3
-assert Number.div(Number.infinity, 10) == Number.infinity
-assert Number.isNaN(Number.div(Number.infinity, Number.infinity))
-assert Number.isNaN(Number.div(Number.infinity, Number.nan))
-assert Number.isNaN(Number.div(Number.nan, Number.nan))
+assert Number.div(Infinity, 10) == Infinity
+assert Number.isNaN(Number.div(Infinity, Infinity))
+assert Number.isNaN(Number.div(Infinity, NaN))
+assert Number.isNaN(Number.div(NaN, NaN))
 // Rational div tests
 {
   let (/) = Number.div
@@ -134,41 +129,41 @@ assert Number.isNaN(Number.pow(-0.792054511984895959, 7.67640268511753998))
 assert Number.pow(0.615702673197924044, 2.01190257903248026) ==
   0.376907735213801831
 assert Number.isNaN(Number.pow(-0.558758682360915193, 0.0322398306026380407))
-assert Number.isNaN(Number.pow(0.0, Number.nan))
-assert Number.pow(0.0, Number.infinity) == 0.0
+assert Number.isNaN(Number.pow(0.0, NaN))
+assert Number.pow(0.0, Infinity) == 0.0
 assert Number.pow(0.0, 3.0) == 0.0
 assert Number.pow(0.0, 2.0) == 0.0
 assert Number.pow(0.0, 1.0) == 0.0
 assert Number.pow(0.0, 0.5) == 0.0
 assert Number.isNaN(Number.pow(0.0, 0.0))
 assert Number.isNaN(Number.pow(0.0, -0.0))
-assert Number.pow(0.0, -0.5) == Number.infinity
-assert Number.pow(0.0, -1.0) == Number.infinity
-assert Number.pow(0.0, -2.0) == Number.infinity
-assert Number.pow(0.0, -3.0) == Number.infinity
-assert Number.pow(0.0, -4.0) == Number.infinity
-assert Number.pow(0.0, Number.infinity * -1) == Number.infinity
-assert Number.isNaN(Number.pow(-0.0, Number.nan))
-assert Number.pow(-0.0, Number.infinity) == 0.0
+assert Number.pow(0.0, -0.5) == Infinity
+assert Number.pow(0.0, -1.0) == Infinity
+assert Number.pow(0.0, -2.0) == Infinity
+assert Number.pow(0.0, -3.0) == Infinity
+assert Number.pow(0.0, -4.0) == Infinity
+assert Number.pow(0.0, -Infinity) == Infinity
+assert Number.isNaN(Number.pow(-0.0, NaN))
+assert Number.pow(-0.0, Infinity) == 0.0
 assert Number.pow(-0.0, 3.0) == -0.0
 assert Number.pow(-0.0, 2.0) == 0.0
 assert Number.pow(-0.0, 1.0) == -0.0
 assert Number.pow(-0.0, 0.5) == 0.0
 assert Number.isNaN(Number.pow(-0.0, 0.0))
 assert Number.isNaN(Number.pow(-0.0, -0.0))
-assert Number.pow(-0.0, -0.5) == Number.infinity
-assert Number.pow(-0.0, -1.0) == Number.infinity * -1
-assert Number.pow(-0.0, -2.0) == Number.infinity
-assert Number.pow(-0.0, -3.0) == Number.infinity * -1
-assert Number.pow(-0.0, -4.0) == Number.infinity
-assert Number.pow(-0.0, Number.infinity * -1) == Number.infinity
-assert Number.isNaN(Number.pow(Number.nan, 0.0))
-assert Number.isNaN(Number.pow(Number.infinity, 0.0))
-assert Number.isNaN(Number.pow(Number.infinity * -1, 0.0))
+assert Number.pow(-0.0, -0.5) == Infinity
+assert Number.pow(-0.0, -1.0) == -Infinity
+assert Number.pow(-0.0, -2.0) == Infinity
+assert Number.pow(-0.0, -3.0) == -Infinity
+assert Number.pow(-0.0, -4.0) == Infinity
+assert Number.pow(-0.0, -Infinity) == Infinity
+assert Number.isNaN(Number.pow(NaN, 0.0))
+assert Number.isNaN(Number.pow(Infinity, 0.0))
+assert Number.isNaN(Number.pow(-Infinity, 0.0))
 assert Number.isNaN(Number.pow(1.0, 0.0))
 assert Number.isNaN(Number.pow(-1.0, 0.0))
 assert Number.isNaN(Number.pow(-0.5, 0.0))
-assert Number.isNaN(Number.pow(Number.nan, -0.0))
+assert Number.isNaN(Number.pow(NaN, -0.0))
 assert Number.pow(1, 1) == 1
 assert Number.pow(2, 1) == 2
 assert Number.pow(300, 1) == 300
@@ -219,7 +214,7 @@ assert Number.pow(9223372036854775809, 2/3) == 4398046511103.9927
 assert Number.pow(10223372036854775809, 10) ==
   12472159440978016923768615307032788210916694000775261660538874886865415760948494778813645195039710006678013364969179502650466497057008288260604039903029954443675868581729857084924132550246401
 assert Number.pow(1, 9223372036854775809) == 1
-assert Number.pow(2.0, 9223372036854775809) == Number.infinity
+assert Number.pow(2.0, 9223372036854775809) == Infinity
 // exp
 assert Number.exp(1) == 2.718281828459045
 assert Number.exp(10) == 22026.465794806703
@@ -230,17 +225,17 @@ assert Number.exp(0.5) == 1.6487212707001283
 assert Number.exp(-0.5) == 0.6065306597126334
 assert Number.exp(1/2) == 1.6487212707001283
 assert Number.exp(-1/2) == 0.6065306597126334
-assert Number.exp(9223372036854775809) == Number.infinity
-assert Number.exp(Number.infinity) == Number.infinity
-assert Number.isNaN(Number.exp(Number.nan))
+assert Number.exp(9223372036854775809) == Infinity
+assert Number.exp(Infinity) == Infinity
+assert Number.isNaN(Number.exp(NaN))
 // sqrt
 assert Number.sqrt(25) == 5
 assert Number.sqrt(25.0) == 5.0
 assert Number.sqrt(35) == 5.916079783099616
 assert Number.sqrt(2/4) == 0.7071067811865476
 assert Number.sqrt(9266609011276477657) == 3044110545.180066
-assert Number.sqrt(Number.infinity) == Number.infinity
-assert Number.isNaN(Number.sqrt(Number.nan))
+assert Number.sqrt(Infinity) == Infinity
+assert Number.isNaN(Number.sqrt(NaN))
 // min
 assert Number.min(5, 5) == 5
 assert Number.min(5, 6) == 5
@@ -248,9 +243,9 @@ assert Number.min(6, 5) == 5
 assert Number.min(1/2, 1/4) == 1/4
 assert Number.min(0.5, 0.25) == 0.25
 assert Number.min(355894508425808343204914141312, 6) == 6
-assert Number.min(Number.infinity, 10) == 10
-assert Number.isNaN(Number.min(Number.nan, 10))
-assert Number.isNaN(Number.min(Number.nan, Number.infinity))
+assert Number.min(Infinity, 10) == 10
+assert Number.isNaN(Number.min(NaN, 10))
+assert Number.isNaN(Number.min(NaN, Infinity))
 
 // max
 assert Number.max(5, 5) == 5
@@ -261,9 +256,9 @@ assert Number.max(0.5, 0.25) == 0.5
 assert Number.max(BI.toNumber(1234t), BI.toNumber(12t)) == BI.toNumber(1234t)
 assert Number.max(355894508425808343204914141312, 6) ==
   355894508425808343204914141312
-assert Number.max(Number.infinity, 10) == Number.infinity
-assert Number.max(Number.nan, 10) == 10
-assert Number.max(Number.nan, Number.infinity) == Number.infinity
+assert Number.max(Infinity, 10) == Infinity
+assert Number.max(NaN, 10) == 10
+assert Number.max(NaN, Infinity) == Infinity
 
 // ceil
 assert Number.ceil(-25.5) == -25
@@ -271,24 +266,24 @@ assert Number.ceil(25.5) == 26
 assert Number.ceil(25) == 25
 assert Number.ceil(22/7) == 4
 assert Number.ceil(BI.toNumber(1234t)) == BI.toNumber(1234t)
-assert Number.isNaN(Number.ceil(Number.nan))
-assert Number.ceil(Number.infinity) == Number.infinity
+assert Number.isNaN(Number.ceil(NaN))
+assert Number.ceil(Infinity) == Infinity
 // floor
 assert Number.floor(-25.5) == -26
 assert Number.floor(25.5) == 25
 assert Number.floor(25) == 25
 assert Number.floor(22/7) == 3
 assert Number.floor(BI.toNumber(1234t)) == BI.toNumber(1234t)
-assert Number.isNaN(Number.floor(Number.nan))
-assert Number.floor(Number.infinity) == Number.infinity
+assert Number.isNaN(Number.floor(NaN))
+assert Number.floor(Infinity) == Infinity
 // trunc
 assert Number.trunc(-25.5) == -25
 assert Number.trunc(25.5) == 25
 assert Number.trunc(25) == 25
 assert Number.trunc(22/7) == 3
 assert Number.trunc(BI.toNumber(1234t)) == BI.toNumber(1234t)
-assert Number.isNaN(Number.trunc(Number.nan))
-assert Number.trunc(Number.infinity) == Number.infinity
+assert Number.isNaN(Number.trunc(NaN))
+assert Number.trunc(Infinity) == Infinity
 // round
 assert Number.round(-25.5) == -26
 assert Number.round(-25.25) == -25
@@ -296,22 +291,22 @@ assert Number.round(25.25) == 25
 assert Number.round(25.5) == 26
 assert Number.round(22/7) == 3
 assert Number.round(BI.toNumber(1234t)) == BI.toNumber(1234t)
-assert Number.isNaN(Number.round(Number.nan))
-assert Number.round(Number.infinity) == Number.infinity
+assert Number.isNaN(Number.round(NaN))
+assert Number.round(Infinity) == Infinity
 // abs
 assert Number.abs(-25.5) == 25.5
 assert Number.abs(25.5) == 25.5
 assert Number.abs(-1/2) == 1/2
-assert Number.isNaN(Number.abs(Number.nan))
-assert Number.abs(Number.infinity) == Number.infinity
+assert Number.isNaN(Number.abs(NaN))
+assert Number.abs(Infinity) == Infinity
 // neg
 assert Number.neg(-25.5) == 25.5
 assert Number.neg(25.5) == -25.5
 assert Number.neg(1/2) == -1/2
 assert Number.neg(BI.toNumber(1234t)) == BI.toNumber(-1234t)
 assert Number.neg(BI.toNumber(-1234t)) == BI.toNumber(1234t)
-assert Number.isNaN(Number.neg(Number.nan))
-assert Number.neg(Number.infinity) == Number.infinity * -1
+assert Number.isNaN(-NaN)
+assert Number.neg(Infinity) == -Infinity
 
 // isFloat
 assert Number.isFloat(0.0)
@@ -321,8 +316,8 @@ assert Number.isFloat(9e6)
 assert Number.isFloat(0) == false
 assert Number.isFloat(10) == false
 assert Number.isFloat(2/3) == false
-assert Number.isFloat(Number.infinity) == true
-assert Number.isFloat(Number.nan) == true
+assert Number.isFloat(Infinity) == true
+assert Number.isFloat(NaN) == true
 // isInteger
 assert Number.isInteger(0)
 assert Number.isInteger(9)
@@ -331,20 +326,22 @@ assert Number.isInteger(9_223_372_036_854_775_808)
 assert Number.isInteger(0.0) == false
 assert Number.isInteger(9e6) == false
 assert Number.isInteger(2/3) == false
-assert Number.isInteger(Number.infinity) == false
-assert Number.isInteger(Number.nan) == false
+assert Number.isInteger(Infinity) == false
+assert Number.isInteger(NaN) == false
 
 // isRational
 assert Number.isRational(1/2)
 assert Number.isRational(6/5)
 assert Number.isRational(1) == false
 assert Number.isRational(1.5) == false
-assert Number.isRational(Number.infinity) == false
-assert Number.isRational(Number.nan) == false
+assert Number.isRational(Infinity) == false
+assert Number.isRational(NaN) == false
 
 // isFinite
-assert Number.isFinite(Number.nan) == false // NaN
-assert Number.isFinite(Number.infinity) == false // infinity
+assert Number.isFinite(NaN) == false // NaN
+assert Number.isFinite(Infinity) == false
+assert Number.isFinite(-Infinity) == false
+assert Number.isFinite(1.0 / 0.0) == false // infinity
 assert Number.isFinite(-1.0 / 0.0) == false // -infinity
 assert Number.isFinite(1)
 assert Number.isFinite(1.0)
@@ -359,7 +356,7 @@ assert Number.isFinite(-1/2)
 assert Number.isFinite(BI.toNumber(-141435902485091384901384t))
 
 // isNaN
-assert Number.isNaN(Number.nan)
+assert Number.isNaN(NaN)
 assert Number.isNaN(1) == false
 assert Number.isNaN(1.0) == false
 assert Number.isNaN(0) == false
@@ -370,14 +367,18 @@ assert Number.isNaN(25.76) == false
 assert Number.isNaN(-25.00) == false
 assert Number.isNaN(1/2) == false
 assert Number.isNaN(-1/2) == false
-assert Number.isNaN(Number.infinity) == false // infinity
+assert Number.isNaN(Infinity) == false
+assert Number.isNaN(-Infinity) == false
+assert Number.isNaN(1.0 / 0.0) == false // infinity
 assert Number.isNaN(-1.0 / 0.0) == false // -infinity
 assert Number.isNaN(BI.toNumber(1t)) == false
 
 // isInfinite
-assert Number.isInfinite(Number.infinity) // infinity
+assert Number.isInfinite(Infinity)
+assert Number.isInfinite(-Infinity)
+assert Number.isInfinite(1.0 / 0.0) // infinity
 assert Number.isInfinite(-1.0 / 0.0) // -infinity
-assert Number.isInfinite(Number.nan) == false // NaN
+assert Number.isInfinite(NaN) == false
 assert Number.isInfinite(1) == false
 assert Number.isInfinite(1.0) == false
 assert Number.isInfinite(0) == false
@@ -446,21 +447,20 @@ assert Number.isNaN(
   Result.expect("float should parse", Number.parseFloat("NAN"))
 )
 // Infs
-assert Number.parseFloat("inf") == Ok(Number.infinity)
-assert Number.parseFloat("-Inf") == Ok(Number.neg(Number.infinity))
-assert Number.parseFloat("+INF") == Ok(Number.infinity)
-assert Number.parseFloat("-Infinity") == Ok(Number.neg(Number.infinity))
-assert Number.parseFloat("+INFINITY") == Ok(Number.infinity)
-assert Number.parseFloat("Infinity") == Ok(Number.infinity)
+assert Number.parseFloat("inf") == Ok(Infinity)
+assert Number.parseFloat("-Inf") == Ok(-Infinity)
+assert Number.parseFloat("+INF") == Ok(Infinity)
+assert Number.parseFloat("-Infinity") == Ok(-Infinity)
+assert Number.parseFloat("+INFINITY") == Ok(Infinity)
+assert Number.parseFloat("Infinity") == Ok(Infinity)
 // largest float64
 assert Number.parseFloat("1.7976931348623157e308") ==
   Ok(1.7976931348623157e+308)
 assert Number.parseFloat("-1.7976931348623157e308") ==
   Ok(-1.7976931348623157e+308)
 // next float64 - too large
-assert Number.parseFloat("1.7976931348623159e308") == Ok(Number.infinity)
-assert Number.parseFloat("-1.7976931348623159e308") ==
-  Ok(Number.neg(Number.infinity))
+assert Number.parseFloat("1.7976931348623159e308") == Ok(Infinity)
+assert Number.parseFloat("-1.7976931348623159e308") == Ok(-Infinity)
 // the border is ...158079
 // borderline - okay
 assert Number.parseFloat("1.7976931348623158079e308") ==
@@ -468,20 +468,19 @@ assert Number.parseFloat("1.7976931348623158079e308") ==
 assert Number.parseFloat("-1.7976931348623158079e308") ==
   Ok(-1.7976931348623157e+308)
 // borderline - too large
-assert Number.parseFloat("1.797693134862315808e308") == Ok(Number.infinity)
-assert Number.parseFloat("-1.797693134862315808e308") ==
-  Ok(Number.neg(Number.infinity))
+assert Number.parseFloat("1.797693134862315808e308") == Ok(Infinity)
+assert Number.parseFloat("-1.797693134862315808e308") == Ok(-Infinity)
 // a little too large
 assert Number.parseFloat("1e308") == Ok(1e+308)
-assert Number.parseFloat("2e308") == Ok(Number.infinity)
-assert Number.parseFloat("1e309") == Ok(Number.infinity)
+assert Number.parseFloat("2e308") == Ok(Infinity)
+assert Number.parseFloat("1e309") == Ok(Infinity)
 // way too large
-assert Number.parseFloat("1e310") == Ok(Number.infinity)
-assert Number.parseFloat("-1e310") == Ok(Number.neg(Number.infinity))
-assert Number.parseFloat("1e400") == Ok(Number.infinity)
-assert Number.parseFloat("-1e400") == Ok(Number.neg(Number.infinity))
-assert Number.parseFloat("1e400000") == Ok(Number.infinity)
-assert Number.parseFloat("-1e400000") == Ok(Number.neg(Number.infinity))
+assert Number.parseFloat("1e310") == Ok(Infinity)
+assert Number.parseFloat("-1e310") == Ok(-Infinity)
+assert Number.parseFloat("1e400") == Ok(Infinity)
+assert Number.parseFloat("-1e400") == Ok(-Infinity)
+assert Number.parseFloat("1e400000") == Ok(Infinity)
+assert Number.parseFloat("-1e400000") == Ok(-Infinity)
 // denormalized
 assert Number.parseFloat("1e-305") == Ok(1e-305)
 assert Number.parseFloat("1e-306") == Ok(1e-306)
@@ -501,9 +500,9 @@ assert Number.parseFloat("1e-350") == Ok(0.)
 assert Number.parseFloat("1e-400000") == Ok(0.)
 // try to overflow exponent
 assert Number.parseFloat("1e-4294967296") == Ok(0.)
-assert Number.parseFloat("1e+4294967296") == Ok(Number.infinity)
+assert Number.parseFloat("1e+4294967296") == Ok(Infinity)
 assert Number.parseFloat("1e-18446744073709551616") == Ok(0.)
-assert Number.parseFloat("1e+18446744073709551616") == Ok(Number.infinity)
+assert Number.parseFloat("1e+18446744073709551616") == Ok(Infinity)
 // Parse errors
 assert Number.parseFloat("1e") == Err("Invalid exponent")
 assert Number.parseFloat("1e-") == Err("Invalid exponent")
@@ -560,8 +559,8 @@ assert Number.parseFloat("100_000_000_000_000_000_000_000") == Ok(1e+23)
 assert Number.parseFloat("1_2345_6700") == Ok(1.234567e+08)
 assert Number.parseFloat("625e-3__") == Ok(0.625)
 assert Number.parseFloat("0_0e+0_12__3___4____567890123456789") == Ok(0.)
-assert Number.parseFloat("1_e400_000") == Ok(Number.infinity)
-assert Number.parseFloat("-1_e400_000") == Ok(Number.neg(Number.infinity))
+assert Number.parseFloat("1_e400_000") == Ok(Infinity)
+assert Number.parseFloat("-1_e400_000") == Ok(-Infinity)
 assert Number.parseFloat(
   "1.000_000_000_000_000_111_022_302_462_515_654_042_363_166_809_082_031_250_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_1"
 ) ==
@@ -630,10 +629,8 @@ assert Number.sign(-10000) == -1
 assert Number.sign(22222) == 1
 assert Number.sign(BI.toNumber(-1t)) == -1
 assert Number.sign(BI.toNumber(1t)) == 1
-// TODO(#693): Replace with Infinity literal when it exists
-assert 1 / Number.sign(0.0) == Float64.toNumber(Float64.infinity)
-// TODO(#693): Replace with -Infinity literal when it exists
-assert 1 / Number.sign(-0.0) == Number.neg(Float64.toNumber(Float64.infinity))
+assert 1 / Number.sign(0.0) == Infinity
+assert 1 / Number.sign(-0.0) == -Infinity
 
 // Number.sin - These test a range as we approximate sin
 assert Number.sin(0.0) == 0
@@ -643,8 +640,8 @@ assert Number.sin(20) > 0.91294 && Number.sin(20) < 0.91295
 assert Number.sin(1/2) > 0.4794 && Number.sin(1/2) < 0.4795
 // TODO(#1478): Update this test when sin is unbounded
 assert Number.sin(9223372036854775809) == 0.0
-assert Number.isNaN(Number.sin(Number.infinity))
-assert Number.isNaN(Number.sin(Number.nan))
+assert Number.isNaN(Number.sin(Infinity))
+assert Number.isNaN(Number.sin(NaN))
 
 // Number.cos - These test a range as we approximate sin
 assert Number.cos(1) > 0.5403 && Number.cos(1) < 0.5404
@@ -653,8 +650,8 @@ assert Number.cos(15) < -0.7596 && Number.cos(15) > -0.7597
 assert Number.cos(1/2) > 0.8775 && Number.cos(1/2) < 0.8776
 // TODO(#1478): Update this test when sin is unbounded
 assert Number.cos(9223372036854775809) == 0.0
-assert Number.isNaN(Number.cos(Number.infinity))
-assert Number.isNaN(Number.cos(Number.nan))
+assert Number.isNaN(Number.cos(Infinity))
+assert Number.isNaN(Number.cos(NaN))
 
 // Number.tan - These test a range as we approximate sin
 assert Number.tan(1) > 1.5574 && Number.tan(1) < 1.5575
@@ -663,8 +660,8 @@ assert Number.tan(15) < -0.8559 && Number.tan(15) > -0.8560
 assert Number.tan(1/2) > 0.5463 && Number.tan(1/2) < 0.5464
 // TODO(#1478): Update this test when sin is unbounded
 assert Number.isNaN(Number.tan(9223372036854775809))
-assert Number.isNaN(Number.tan(Number.infinity))
-assert Number.isNaN(Number.tan(Number.nan))
+assert Number.isNaN(Number.tan(Infinity))
+assert Number.isNaN(Number.tan(NaN))
 
 // Number.gamma
 // Note: Currently gamma will overflow the memory when using a bigint as such there are no tests for this
@@ -674,13 +671,13 @@ assert Number.gamma(10) == 362880
 assert Number.gamma(1) == 1
 assert Number.gamma(0.5) == 1.7724538509055159
 assert Number.gamma(-0.5) < -3.544907 && Number.gamma(-0.5) > -3.544909
-assert Number.gamma(-1) == Number.infinity
-assert Number.gamma(-10) == Number.infinity
+assert Number.gamma(-1) == Infinity
+assert Number.gamma(-10) == Infinity
 assert Number.gamma(0.2) > 4.59084 && Number.gamma(0.2) < 4.59085
 assert Number.gamma(1/5) > 4.59084 && Number.gamma(1/5) < 4.59085
 assert Number.gamma(1/2) == 1.7724538509055159
-assert Number.isNaN(Number.gamma(Number.infinity))
-assert Number.isNaN(Number.gamma(Number.nan))
+assert Number.isNaN(Number.gamma(Infinity))
+assert Number.isNaN(Number.gamma(NaN))
 
 // Number.factorial
 // Note: Currently factorial will overflow the memory when using a bigint as such there are no tests for this
@@ -692,21 +689,21 @@ assert Number.factorial(-10) == -3628800
 assert Number.factorial(10.5) == 11899423.083962297
 assert Number.factorial(0.5) == 0.886226925452759
 assert Number.factorial(1/2) == 0.886226925452759
-assert Number.isNaN(Number.factorial(Number.infinity))
-assert Number.isNaN(Number.factorial(Number.nan))
+assert Number.isNaN(Number.factorial(Infinity))
+assert Number.isNaN(Number.factorial(NaN))
 
 // Number.toDegrees
 assert Number.toDegrees(0) == 0
 assert Number.toDegrees(Number.pi) == 180
 assert Number.toDegrees(Number.pi * -1) == -180
-assert Number.toDegrees(Number.infinity) == Number.infinity
+assert Number.toDegrees(Infinity) == Infinity
 assert Number.toDegrees(0.008726646259971648) == 1/2
 assert Number.toDegrees(-0.008726646259971648) == -1/2
 assert Number.toDegrees(0.004363323129985824) == 1/4
 assert Number.toDegrees(160978210179491630.0) == 9223372036854775809
 assert Number.toDegrees(1/2) == 28.64788975654116
 assert Number.toDegrees(1/4) == 14.32394487827058
-assert Number.isNaN(Number.toDegrees(Number.nan))
+assert Number.isNaN(Number.toDegrees(NaN))
 
 // Number.toRadians
 assert Number.toRadians(0) == 0
@@ -717,5 +714,5 @@ assert Number.toRadians(1/2) == 0.008726646259971648
 assert Number.toRadians(-1/2) == -0.008726646259971648
 assert Number.toRadians(1/4) == 0.004363323129985824
 assert Number.toRadians(9223372036854775809) == 160978210179491630.0
-assert Number.toRadians(Number.infinity) == Number.infinity
-assert Number.isNaN(Number.toRadians(Number.nan))
+assert Number.toRadians(Infinity) == Infinity
+assert Number.isNaN(Number.toRadians(NaN))

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -9,6 +9,7 @@ describe("basic functionality", ({test, testSkip}) => {
   let assertSnapshotFile = makeSnapshotFileRunner(test);
   let assertCompileError = makeCompileErrorRunner(test);
   let assertParse = makeParseRunner(test);
+  let assertRun = makeRunner(test_or_skip);
   let assertRunError = makeErrorRunner(test_or_skip);
 
   assertSnapshot("nil", "");
@@ -30,8 +31,14 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("fals", "let x = false; x");
   assertSnapshot("tru", "let x = true; x");
   assertSnapshot("infinity", "let x = Infinity; x");
+  assertRun("infinity_2", "assert Infinity == 1.0 / 0.0", "");
+  assertRun("infinity_3", "assert Infinity == Infinity", "");
   assertSnapshot("infinity_neg", "let x = -Infinity; x");
+  assertRun("infinity_neg_2", "assert -Infinity == -1.0 / 0.0", "");
+  assertRun("infinity_neg_3", "assert -Infinity == -Infinity", "");
   assertSnapshot("nan", "let x = NaN; x");
+  assertRun("nan_2", "assert NaN != NaN", "");
+
   assertSnapshot(
     "complex1",
     "\n    let x = 2, y = 3, z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -30,20 +30,6 @@ import Exception from "runtime/exception"
  */
 
 /**
- * NaN represented as a Number value.
- *
- * @since v0.5.4
- */
-export let nan = 0.0 / 0.0
-
-/**
- * Infinity represented as a Number value.
- *
- * @since v0.5.4
- */
-export let infinity = 1.0 / 0.0
-
-/**
  * Pi represented as a Number value.
  *
  * @since v0.5.2
@@ -644,9 +630,9 @@ export let max = (x: Number, y: Number) => if (compare(x, y) > 0) x else y
 @unsafe
 export let ceil = (x: Number) => {
   if (x != x) {
-    nan
-  } else if (x == infinity) {
-    infinity
+    NaN
+  } else if (x == Infinity) {
+    Infinity
   } else {
     let xval = coerceNumberToWasmF64(x)
     let ceiling = WasmI64.truncF64S(WasmF64.ceil(xval))
@@ -666,9 +652,9 @@ export let ceil = (x: Number) => {
 @unsafe
 export let floor = (x: Number) => {
   if (x != x) {
-    nan
-  } else if (x == infinity) {
-    infinity
+    NaN
+  } else if (x == Infinity) {
+    Infinity
   } else {
     let xval = coerceNumberToWasmF64(x)
     let floored = WasmI64.truncF64S(WasmF64.floor(xval))
@@ -688,9 +674,9 @@ export let floor = (x: Number) => {
 @unsafe
 export let trunc = (x: Number) => {
   if (x != x) {
-    nan
-  } else if (x == infinity) {
-    infinity
+    NaN
+  } else if (x == Infinity) {
+    Infinity
   } else {
     let xval = coerceNumberToWasmF64(x)
     let trunced = WasmI64.truncF64S(xval)
@@ -710,9 +696,9 @@ export let trunc = (x: Number) => {
 @unsafe
 export let round = (x: Number) => {
   if (x != x) {
-    nan
-  } else if (x == infinity) {
-    infinity
+    NaN
+  } else if (x == Infinity) {
+    Infinity
   } else {
     let xval = coerceNumberToWasmF64(x)
     let rounded = WasmI64.truncF64S(WasmF64.nearest(xval))
@@ -980,8 +966,8 @@ let chebyshevSine = (radians: Number) => {
  * @history v0.5.4: Handle NaN and Infinity
  */
 export let sin = (radians: Number) => {
-  if (radians != radians || radians == infinity) {
-    nan
+  if (radians != radians || radians == Infinity) {
+    NaN
   } else {
     let quot = reduceToPiBound(radians)
     let bounded = radians - pi * quot
@@ -1003,8 +989,8 @@ export let sin = (radians: Number) => {
  * @history v0.5.4: Handle NaN and Infinity
  */
 export let cos = (radians: Number) => {
-  if (radians != radians || radians == infinity) {
-    nan
+  if (radians != radians || radians == Infinity) {
+    NaN
   } else {
     sin(pi / 2 + radians)
   }
@@ -1020,7 +1006,7 @@ export let cos = (radians: Number) => {
  */
 export let tan = (radians: Number) => {
   if (isNaN(radians) || isInfinite(radians)) {
-    nan
+    NaN
   } else {
     sin(radians) / cos(radians)
   }
@@ -1077,7 +1063,7 @@ export let rec gamma = z => {
       let t = z + g + 0.5
       output = sqrt(2 * pi) * pow(t, z + 0.5) * exp(t * -1) * x
     }
-    if (abs(output) == infinity) infinity else output
+    if (abs(output) == Infinity) Infinity else output
   }
 }
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -17,32 +17,6 @@ import Number from "number"
 
 Number constant values.
 
-### Number.**nan**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.5.4</code></summary>
-No other changes yet.
-</details>
-
-```grain
-nan : Number
-```
-
-NaN represented as a Number value.
-
-### Number.**infinity**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.5.4</code></summary>
-No other changes yet.
-</details>
-
-```grain
-infinity : Number
-```
-
-Infinity represented as a Number value.
-
 ### Number.**pi**
 
 <details disabled>


### PR DESCRIPTION
This removes the `Number.nan` and `Number.infinity` constants and uses `Infinity` and `NaN` keywords. Ideally, this sort of changes will happen with the feature so we aren't adding 2 different breaking changes for it in the changelog.