### PR TITLE
feat(compiler)!: Labeled and default arguments

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -207,7 +207,10 @@ let output_for_throws = throws => {
 
 let types_for_function = (~ident, vd: Types.value_description) => {
   switch (Ctype.repr(vd.val_type).desc) {
-  | TTyArrow(args, returns, _) => (Some(args), Some(returns))
+  | TTyArrow(args, returns, _) => (
+      Some(List.map(snd, args)),
+      Some(returns),
+    )
   | _ => (None, None)
   };
 };

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -2675,7 +2675,6 @@ and print_application_argument =
       ~original_source: array(string),
       argument: Parsetree.application_argument,
     ) => {
-  // FIXME: Comments?
   let expr_doc =
     print_expression(
       ~expression_parent,

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1746,7 +1746,8 @@ and print_type =
       Doc.group(
         switch (types) {
         | [] => Doc.concat([Doc.lparen, Doc.rparen])
-        | [t] => print_type(~original_source, ~comments, t)
+        | [{ptyp_arg_label: Unlabeled, ptyp_arg_type: t}] =>
+          print_type(~original_source, ~comments, t)
         | _types =>
           Doc.concat([
             Doc.lparen,
@@ -1756,7 +1757,29 @@ and print_type =
                 Doc.join(
                   ~sep=Doc.concat([Doc.comma, Doc.line]),
                   List.map(
-                    t => print_type(~original_source, ~comments, t),
+                    ({Parsetree.ptyp_arg_label: label, ptyp_arg_type: t}) => {
+                      let label =
+                        switch (label) {
+                        | Asttypes.Unlabeled => Doc.nil
+                        | Labeled(name) =>
+                          Doc.concat([
+                            Doc.text(name.txt),
+                            Doc.text(":"),
+                            Doc.space,
+                          ])
+                        | Default(name) =>
+                          Doc.concat([
+                            Doc.question,
+                            Doc.text(name.txt),
+                            Doc.text(":"),
+                            Doc.space,
+                          ])
+                        };
+                      Doc.concat([
+                        label,
+                        print_type(~original_source, ~comments, t),
+                      ]);
+                    },
                     types,
                   ),
                 ),
@@ -1851,7 +1874,7 @@ and print_type =
 and print_application =
     (
       ~expression_parent: expression_parent_type,
-      ~expressions: list(Parsetree.expression),
+      ~expressions: list(Parsetree.application_argument),
       ~original_source: array(string),
       ~comments: list(Parsetree.comment),
       func: Parsetree.expression,
@@ -1881,7 +1904,7 @@ and print_application =
 and print_infix_application =
     (
       ~expression_parent: expression_parent_type,
-      ~expressions: list(Parsetree.expression),
+      ~expressions: list(Parsetree.application_argument),
       ~original_source: array(string),
       ~comments: list(Parsetree.comment),
       func: Parsetree.expression,
@@ -1892,12 +1915,12 @@ and print_infix_application =
   | [first, second] =>
     let next_comments =
       Comment_utils.get_comments_between_locations(
-        ~loc1=first.pexp_loc,
-        ~loc2=second.pexp_loc,
+        ~loc1=first.paa_loc,
+        ~loc2=second.paa_loc,
         comments,
       );
 
-    let (_, line, _, _) = Locations.get_raw_pos_info(first.pexp_loc.loc_end);
+    let (_, line, _, _) = Locations.get_raw_pos_info(first.paa_loc.loc_end);
 
     let line_comments =
       Comment_utils.get_comments_on_line(line, next_comments);
@@ -1912,20 +1935,20 @@ and print_infix_application =
       Comment_utils.single_line_of_comments(line_comments);
 
     let left_is_if =
-      switch (first.pexp_desc) {
+      switch (first.paa_expr.pexp_desc) {
       | PExpIf(_) => true
       | _ => false
       };
 
     let right_is_if =
-      switch (second.pexp_desc) {
+      switch (second.paa_expr.pexp_desc) {
       | PExpIf(_) => true
       | _ => false
       };
 
     let parent_prec = op_precedence(function_name);
     let left_is_leaf =
-      switch (first.pexp_desc) {
+      switch (first.paa_expr.pexp_desc) {
       | PExpApp(fn, expr) =>
         let child_name = get_function_name(fn);
         let this_prec = op_precedence(child_name);
@@ -1935,7 +1958,7 @@ and print_infix_application =
       };
 
     let right_is_leaf =
-      switch (second.pexp_desc) {
+      switch (second.paa_expr.pexp_desc) {
       | PExpApp(fn, expr) =>
         let child_name = get_function_name(fn);
         let this_prec = op_precedence(child_name);
@@ -1945,7 +1968,7 @@ and print_infix_application =
       };
 
     let left_grouping_required =
-      switch (first.pexp_desc) {
+      switch (first.paa_expr.pexp_desc) {
       | PExpApp(fn1, _) =>
         op_precedence(get_function_name(fn1)) < parent_prec
       | PExpConstant(PConstNumber(PConstNumberRational(_, _))) =>
@@ -1956,7 +1979,7 @@ and print_infix_application =
     let right_grouping_required =
       // the equality check is needed for the value on the right
       // as we process from the left by default when the same prededence
-      switch (second.pexp_desc) {
+      switch (second.paa_expr.pexp_desc) {
       | PExpApp(fn1, _) =>
         op_precedence(get_function_name(fn1)) <= parent_prec
       | PExpConstant(PConstNumber(PConstNumberRational(_, _))) =>
@@ -1967,7 +1990,7 @@ and print_infix_application =
     // Put parens around different operators for clarity, except
     // math and logic operations where precedence is well-known
     let left_is_different_op =
-      switch (first.pexp_desc) {
+      switch (first.paa_expr.pexp_desc) {
       | PExpApp(fn1, _) =>
         let fn = get_function_name(fn1);
         if (infixop(fn)) {
@@ -1990,7 +2013,7 @@ and print_infix_application =
             ~expression_parent=GenericExpression,
             ~original_source,
             ~comments,
-            first,
+            first.paa_expr,
           );
         Doc.concat([
           Doc.lparen,
@@ -2006,7 +2029,7 @@ and print_infix_application =
           ~expression_parent,
           ~original_source,
           ~comments,
-          first,
+          first.paa_expr,
         );
       };
 
@@ -2019,7 +2042,7 @@ and print_infix_application =
               ~expression_parent=GenericExpression,
               ~original_source,
               ~comments,
-              second,
+              second.paa_expr,
             ),
           ]),
           Doc.rparen,
@@ -2030,7 +2053,7 @@ and print_infix_application =
             ~expression_parent,
             ~original_source,
             ~comments,
-            second,
+            second.paa_expr,
           ),
         ]);
       };
@@ -2080,8 +2103,8 @@ and print_infix_application =
 }
 
 and print_arg_lambda =
-    (~comments, ~original_source, lambda: Parsetree.expression) => {
-  switch (lambda.pexp_desc) {
+    (~comments, ~original_source, lambda: Parsetree.application_argument) => {
+  switch (lambda.paa_expr.pexp_desc) {
   | PExpLambda(patterns, expression) =>
     let comments_in_expression =
       Comment_utils.get_comments_inside_location(
@@ -2090,7 +2113,7 @@ and print_arg_lambda =
       );
 
     let raw_args =
-      print_patterns(
+      print_lambda_arguments(
         ~next_loc=expression.pexp_loc,
         ~comments,
         ~original_source,
@@ -2098,24 +2121,35 @@ and print_arg_lambda =
         patterns,
       );
 
+    let label =
+      switch (lambda.paa_label) {
+      | Unlabeled => Doc.nil
+      | Labeled(name)
+      | Default(name) => Doc.concat([Doc.text(name.txt), Doc.equal])
+      };
+
     let args =
-      Doc.group(
-        switch (patterns) {
-        | [] => Doc.concat([Doc.lparen, raw_args, Doc.rparen])
-        | [pat] =>
-          switch (pat.ppat_desc) {
-          | PPatVar(_) => raw_args
-          | _ => Doc.group(Doc.concat([Doc.lparen, raw_args, Doc.rparen]))
-          }
-        | _patterns =>
-          Doc.concat([
-            Doc.lparen,
-            Doc.indent(Doc.concat([Doc.softLine, raw_args])),
-            Doc.softLine,
-            Doc.rparen,
-          ])
-        },
-      );
+      Doc.concat([
+        label,
+        Doc.group(
+          switch (patterns) {
+          | [
+              {
+                pla_label: Labeled(name),
+                pla_pattern: {ppat_desc: PPatVar(var)},
+              },
+            ]
+              when name.txt == var.txt => raw_args
+          | _patterns =>
+            Doc.concat([
+              Doc.lparen,
+              Doc.indent(Doc.concat([Doc.softLine, raw_args])),
+              Doc.softLine,
+              Doc.rparen,
+            ])
+          },
+        ),
+      ]);
 
     Doc.group(
       switch (expression.pexp_desc) {
@@ -2208,13 +2242,14 @@ and print_arg_lambda =
   };
 }
 
-and print_arg = (~original_source, ~comments, arg: Parsetree.expression) => {
-  switch (arg.pexp_desc) {
+and print_arg =
+    (~original_source, ~comments, arg: Parsetree.application_argument) => {
+  switch (arg.paa_expr.pexp_desc) {
   | PExpLambda(patterns, expression) =>
     print_arg_lambda(~comments, ~original_source, arg)
   | _ =>
     Doc.group(
-      print_expression(
+      print_application_argument(
         ~expression_parent=InfixExpression,
         ~original_source,
         ~comments,
@@ -2228,12 +2263,12 @@ and print_args_with_comments =
     (
       ~comments: list(Parsetree.comment),
       ~original_source,
-      args: list(Parsetree.expression),
+      args: list(Parsetree.application_argument),
     ) => {
-  let get_loc = (e: Parsetree.expression) => e.pexp_loc;
-  let print_item = (~comments, e: Parsetree.expression) => {
+  let get_loc = (e: Parsetree.application_argument) => e.paa_loc;
+  let print_item = (~comments, e: Parsetree.application_argument) => {
     Doc.group(
-      print_expression(
+      print_application_argument(
         ~expression_parent=InfixExpression,
         ~original_source,
         ~comments,
@@ -2256,7 +2291,7 @@ and print_args_with_comments =
 }
 
 and print_arguments_with_callback_in_first_position =
-    (~original_source, ~comments, args: list(Parsetree.expression)) => {
+    (~original_source, ~comments, args: list(Parsetree.application_argument)) => {
   switch (args) {
   | [] => Doc.nil
   | [callback] =>
@@ -2307,7 +2342,7 @@ and print_arguments_with_callback_in_first_position =
 }
 
 and print_arguments_with_callback_in_last_position =
-    (~original_source, ~comments, args: list(Parsetree.expression)) =>
+    (~original_source, ~comments, args: list(Parsetree.application_argument)) =>
   switch (args) {
   | [] => Doc.nil
   | [expr, callback] =>
@@ -2349,7 +2384,7 @@ and print_arguments_with_callback_in_last_position =
 and print_other_application =
     (
       ~expression_parent: expression_parent_type,
-      ~expressions: list(Parsetree.expression),
+      ~expressions: list(Parsetree.application_argument),
       ~original_source: array(string),
       ~comments: list(Parsetree.comment),
       func: Parsetree.expression,
@@ -2358,7 +2393,7 @@ and print_other_application =
 
   switch (expressions) {
   | [first] when prefixop(function_name) =>
-    switch (first.pexp_desc) {
+    switch (first.paa_expr.pexp_desc) {
     | PExpApp(fn, _) =>
       let inner_fn = get_function_name(fn);
       if (infixop(inner_fn)) {
@@ -2366,7 +2401,7 @@ and print_other_application =
           Doc.text(function_name),
           Doc.lparen,
           Doc.group(
-            print_expression(
+            print_application_argument(
               ~expression_parent,
               ~original_source,
               ~comments,
@@ -2379,7 +2414,7 @@ and print_other_application =
         Doc.concat([
           Doc.text(function_name),
           Doc.group(
-            print_expression(
+            print_application_argument(
               ~expression_parent,
               ~original_source,
               ~comments,
@@ -2393,7 +2428,7 @@ and print_other_application =
       Doc.concat([
         Doc.text(function_name),
         Doc.group(
-          print_expression(
+          print_application_argument(
             ~expression_parent,
             ~original_source,
             ~comments,
@@ -2423,7 +2458,7 @@ and print_other_application =
         func,
       ),
       Doc.space,
-      print_expression(
+      print_application_argument(
         ~expression_parent=GenericExpression,
         ~original_source,
         ~comments,
@@ -2435,7 +2470,7 @@ and print_other_application =
     // look out for special cases of callbacks in first or last position
 
     let first_arg_is_callback =
-      switch (first_expr.pexp_desc) {
+      switch (first_expr.paa_expr.pexp_desc) {
       | PExpLambda(_) => true
       | _ => false
       };
@@ -2446,7 +2481,7 @@ and print_other_application =
       | _ =>
         let last_expression = get_last_item_in_list(expressions);
 
-        switch (last_expression.pexp_desc) {
+        switch (last_expression.paa_expr.pexp_desc) {
         | PExpLambda(_) => true
         | _ => false
         };
@@ -2580,6 +2615,119 @@ and print_patterns =
   };
 }
 
+and print_lambda_arguments =
+    (
+      ~next_loc: Location.t,
+      ~comments: list(Parsetree.comment),
+      ~original_source: array(string),
+      ~followed_by_arrow: option(bool)=?,
+      arguments: list(Parsetree.lambda_argument),
+    ) => {
+  let get_loc = (l: Parsetree.lambda_argument) => l.pla_loc;
+  let print_item =
+      (
+        ~comments,
+        {pla_pattern: pattern, pla_default: default, pla_loc}: Parsetree.lambda_argument,
+      ) => {
+    let pattern_doc =
+      print_pattern(~original_source, ~comments, ~next_loc, pattern);
+    let default_doc =
+      switch (default) {
+      | None => Doc.nil
+      | Some(expr) =>
+        Doc.concat([
+          Doc.equal,
+          print_expression(
+            ~expression_parent=GenericExpression,
+            ~original_source,
+            ~comments,
+            expr,
+          ),
+        ])
+      };
+
+    Doc.concat([pattern_doc, default_doc]);
+  };
+
+  let comments_in_scope =
+    Comment_utils.get_comments_before_location(~location=next_loc, comments);
+
+  switch (arguments) {
+  | [] => Doc.nil
+  | _ =>
+    let items =
+      item_iterator(
+        ~get_loc,
+        ~print_item,
+        ~comments=comments_in_scope,
+        ~followed_by_arrow?,
+        ~iterated_item=IteratedPatterns,
+        arguments,
+      );
+    Doc.join(~sep=Doc.line, items);
+  };
+}
+
+and print_application_argument =
+    (
+      ~comments: list(Parsetree.comment),
+      ~expression_parent: expression_parent_type,
+      ~original_source: array(string),
+      argument: Parsetree.application_argument,
+    ) => {
+  // FIXME: Comments?
+  let expr_doc =
+    print_expression(
+      ~expression_parent,
+      ~original_source,
+      ~comments,
+      argument.paa_expr,
+    );
+  switch (argument.paa_label, argument.paa_expr.pexp_desc) {
+  | (Asttypes.Unlabeled, _) => expr_doc
+  | (Labeled(name) | Default(name), _) =>
+    Doc.concat([Doc.text(name.txt), Doc.equal, expr_doc])
+  };
+}
+
+and print_application_arguments =
+    (
+      ~next_loc: Location.t,
+      ~comments: list(Parsetree.comment),
+      ~expression_parent: expression_parent_type,
+      ~original_source: array(string),
+      ~followed_by_arrow: option(bool)=?,
+      arguments: list(Parsetree.application_argument),
+    ) => {
+  let get_loc = (l: Parsetree.application_argument) => l.paa_loc;
+  let print_item = (~comments, argument: Parsetree.application_argument) => {
+    print_application_argument(
+      ~comments,
+      ~expression_parent,
+      ~original_source,
+      argument,
+    );
+  };
+
+  let comments_in_scope =
+    Comment_utils.get_comments_before_location(~location=next_loc, comments);
+
+  switch (arguments) {
+  | [] => Doc.nil
+  | _ =>
+    let items =
+      item_iterator(
+        ~get_loc,
+        ~print_item,
+        ~comments=comments_in_scope,
+        ~followed_by_arrow?,
+        ~iterated_item=IteratedPatterns,
+        arguments,
+      );
+    Doc.join(~sep=Doc.line, items);
+  };
+}
+
 and paren_wrap_patterns =
     (
       ~wrapper: Location.t,
@@ -2587,10 +2735,10 @@ and paren_wrap_patterns =
       ~comments: list(Parsetree.comment),
       ~original_source: array(string),
       ~followed_by_arrow: bool,
-      patterns: list(Parsetree.pattern),
+      patterns: list(Parsetree.lambda_argument),
     ) => {
   let args =
-    print_patterns(
+    print_lambda_arguments(
       ~next_loc,
       ~comments,
       ~original_source,
@@ -2600,11 +2748,8 @@ and paren_wrap_patterns =
 
   switch (patterns) {
   | [] => Doc.concat([Doc.lparen, args, Doc.rparen])
-  | [pat] =>
-    switch (pat.ppat_desc) {
-    | PPatVar(_) => args
-    | _ => Doc.concat([Doc.lparen, args, Doc.rparen])
-    }
+  | [{pla_label: Labeled(name), pla_pattern: {ppat_desc: PPatVar(var)}}]
+      when name.txt == var.txt => args
   | _patterns =>
     let trail_sep = Doc.ifBreaks(Doc.comma, Doc.nil);
 
@@ -3639,6 +3784,17 @@ and print_expression_inner =
           ~location=expr.pexp_loc,
           comments,
         );
+      // Treat constructors as function calls
+      let expressions =
+        List.map(
+          expr =>
+            {
+              Parsetree.paa_label: Unlabeled,
+              paa_expr: expr,
+              paa_loc: expr.pexp_loc,
+            },
+          expressions,
+        );
       print_application(
         ~expression_parent,
         ~expressions,
@@ -3906,7 +4062,7 @@ and print_assignment = (~original_source, ~comments, left, value) => {
     let left_matches_first =
       switch (expressions) {
       | [expr, ...remainder] =>
-        print_expression(
+        print_application_argument(
           ~expression_parent=GenericExpression,
           ~original_source,
           ~comments,
@@ -3933,16 +4089,16 @@ and print_assignment = (~original_source, ~comments, left, value) => {
             raise(IllegalParse("Sugared op needs at least one expression"))
           | [expression] =>
             let expr =
-              print_expression(
+              print_application_argument(
                 ~expression_parent=GenericExpression,
                 ~original_source,
                 ~comments,
                 expression,
               );
-            switch (expression.pexp_desc) {
+            switch (expression.paa_expr.pexp_desc) {
             | PExpIf(_) =>
               Doc.indent(
-                print_expression(
+                print_application_argument(
                   ~expression_parent=GenericExpression,
                   ~original_source,
                   ~comments,
@@ -3953,16 +4109,16 @@ and print_assignment = (~original_source, ~comments, left, value) => {
             };
           | [expression1, expression2, ...rest] =>
             let expr =
-              print_expression(
+              print_application_argument(
                 ~expression_parent=GenericExpression,
                 ~original_source,
                 ~comments,
                 expression2,
               );
-            switch (expression2.pexp_desc) {
+            switch (expression2.paa_expr.pexp_desc) {
             | PExpIf(_) =>
               Doc.indent(
-                print_expression(
+                print_application_argument(
                   ~expression_parent=GenericExpression,
                   ~original_source,
                   ~comments,

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -518,6 +518,12 @@ module IncludeDeclaration = {
   };
 };
 
+module TypeArgument = {
+  let mk = (~loc, label, typ) => {
+    {ptyp_arg_label: label, ptyp_arg_type: typ, ptyp_arg_loc: loc};
+  };
+};
+
 module LambdaArgument = {
   let mk = (~loc, pattern, default) => {
     open Asttypes;

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -519,9 +519,8 @@ module IncludeDeclaration = {
 };
 
 module LambdaArgument = {
-  let mk = (~loc=?, pattern, default) => {
+  let mk = (~loc, pattern, default) => {
     open Asttypes;
-    let pla_loc = Option.value(~default=Location.dummy_loc, loc);
     let label =
       switch (pattern.ppat_desc) {
       | PPatVar(name)
@@ -544,11 +543,11 @@ module LambdaArgument = {
       | (Some(name), None) => Labeled(name)
       | (None, None) => Unlabeled
       | (None, Some(_)) =>
-        raise(SyntaxError(pla_loc, "Default arguments must be named."))
+        raise(SyntaxError(loc, "Default arguments must be named."))
       };
     let pla_pattern = pattern;
     let pla_default = default;
-    {pla_label, pla_default, pla_pattern, pla_loc};
+    {pla_label, pla_default, pla_pattern, pla_loc: loc};
   };
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -350,6 +350,11 @@ module IncludeDeclaration: {
   let mk: (~loc: loc, str, option(str)) => include_declaration;
 };
 
+module TypeArgument: {
+  let mk:
+    (~loc: loc, Asttypes.argument_label, parsed_type) => parsed_type_argument;
+};
+
 module LambdaArgument: {
   let mk: (~loc: loc, pattern, option(expression)) => lambda_argument;
 };

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -61,7 +61,8 @@ module Type: {
   let mk: (~loc: loc=?, parsed_type_desc) => parsed_type;
   let any: (~loc: loc=?, unit) => parsed_type;
   let var: (~loc: loc=?, string) => parsed_type;
-  let arrow: (~loc: loc=?, list(parsed_type), parsed_type) => parsed_type;
+  let arrow:
+    (~loc: loc=?, list(parsed_type_argument), parsed_type) => parsed_type;
   let tuple: (~loc: loc=?, list(parsed_type)) => parsed_type;
   let constr: (~loc: loc=?, id, list(parsed_type)) => parsed_type;
   let poly: (~loc: loc=?, list(str), parsed_type) => parsed_type;
@@ -227,10 +228,20 @@ module Expression: {
     (~loc: loc=?, ~attributes: attributes=?, expression, expression) =>
     expression;
   let lambda:
-    (~loc: loc=?, ~attributes: attributes=?, list(pattern), expression) =>
+    (
+      ~loc: loc=?,
+      ~attributes: attributes=?,
+      list(lambda_argument),
+      expression
+    ) =>
     expression;
   let apply:
-    (~loc: loc=?, ~attributes: attributes=?, expression, list(expression)) =>
+    (
+      ~loc: loc=?,
+      ~attributes: attributes=?,
+      expression,
+      list(application_argument)
+    ) =>
     expression;
   let construct:
     (~loc: loc, ~attributes: attributes=?, id, constructor_expression) =>
@@ -243,7 +254,13 @@ module Expression: {
   let record_construct:
     (~loc: loc, ~attributes: attributes=?, id, list(recorditem)) => expression;
   let binop:
-    (~loc: loc=?, ~attributes: attributes=?, expression, list(expression)) =>
+    (
+      ~loc: loc=?,
+      ~attributes: attributes=?,
+      expression,
+      expression,
+      expression
+    ) =>
     expression;
   let block:
     (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
@@ -331,6 +348,10 @@ module MatchBranch: {
 
 module IncludeDeclaration: {
   let mk: (~loc: loc, str, option(str)) => include_declaration;
+};
+
+module LambdaArgument: {
+  let mk: (~loc: loc=?, pattern, option(expression)) => lambda_argument;
 };
 
 module ModuleDeclaration: {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -351,7 +351,7 @@ module IncludeDeclaration: {
 };
 
 module LambdaArgument: {
-  let mk: (~loc: loc=?, pattern, option(expression)) => lambda_argument;
+  let mk: (~loc: loc, pattern, option(expression)) => lambda_argument;
 };
 
 module ModuleDeclaration: {

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -133,7 +133,16 @@ module E = {
       lambda(
         ~loc,
         ~attributes,
-        List.map(sub.pat(sub), pl),
+        List.map(
+          arg =>
+            {
+              pla_label: arg.pla_label,
+              pla_pattern: sub.pat(sub, arg.pla_pattern),
+              pla_default: Option.map(sub.expr(sub), arg.pla_default),
+              pla_loc: sub.location(sub, arg.pla_loc),
+            },
+          pl,
+        ),
         sub.expr(sub, e),
       )
     | PExpApp(e, el) =>
@@ -141,7 +150,15 @@ module E = {
         ~loc,
         ~attributes,
         sub.expr(sub, e),
-        List.map(sub.expr(sub), el),
+        List.map(
+          arg =>
+            {
+              paa_label: arg.paa_label,
+              paa_expr: sub.expr(sub, arg.paa_expr),
+              paa_loc: sub.location(sub, arg.paa_loc),
+            },
+          el,
+        ),
       )
     | PExpConstruct(id, e) =>
       construct(
@@ -325,7 +342,19 @@ module T = {
     | PTyAny => any(~loc, ())
     | PTyVar(v) => var(~loc, v)
     | PTyArrow(args, ret) =>
-      arrow(~loc, List.map(sub.typ(sub), args), sub.typ(sub, ret))
+      arrow(
+        ~loc,
+        List.map(
+          arg =>
+            {
+              ptyp_arg_label: arg.ptyp_arg_label,
+              ptyp_arg_type: sub.typ(sub, arg.ptyp_arg_type),
+              ptyp_arg_loc: sub.location(sub, arg.ptyp_arg_loc),
+            },
+          args,
+        ),
+        sub.typ(sub, ret),
+      )
     | PTyTuple(ts) => tuple(~loc, List.map(sub.typ(sub), ts))
     | PTyConstr(name, ts) =>
       constr(~loc, map_identifier(sub, name), List.map(sub.typ(sub), ts))

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -115,3 +115,9 @@ type attribute = (loc(string), list(loc(string)));
 
 [@deriving (sexp, yojson)]
 type attributes = list(attribute);
+
+[@deriving (sexp, yojson)]
+type argument_label =
+  | Unlabeled
+  | Labeled(loc(string))
+  | Default(loc(string));

--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -322,6 +322,7 @@ let rec token = lexbuf => {
   | "::" => positioned(COLONCOLON)
   | ":=" => positioned(GETS)
   | ":" => positioned(COLON)
+  | "?" => positioned(QUESTION)
   | "=" => positioned(EQUAL)
   | "," => positioned(COMMA)
   | ";" => positioned(SEMI)

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -153,6 +153,16 @@ program: MODULE UIDENT EOL FOREIGN WASM YIELD
 ## The known suffix of the stack is as follows:
 ## FOREIGN WASM
 ##
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN QUESTION YIELD
+##
+## Ends in an error in state: 198.
+##
+## arg_typ -> QUESTION . LIDENT COLON typ [ RPAREN EOL COMMA ]
+## arg_typ -> QUESTION . LIDENT COLON eols typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## QUESTION
+##
 
 Expected a lowercase identifier.
 
@@ -181,6 +191,74 @@ program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON YIELD
 ##
 
 Expected the type of the foreign value.
+
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN QUESTION LIDENT YIELD
+##
+## Ends in an error in state: 199.
+##
+## arg_typ -> QUESTION LIDENT . COLON typ [ RPAREN EOL COMMA ]
+## arg_typ -> QUESTION LIDENT . COLON eols typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## QUESTION LIDENT
+##
+
+Expected a colon followed by the type of the argument.
+
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN QUESTION LIDENT COLON YIELD
+##
+## Ends in an error in state: 200.
+##
+## arg_typ -> QUESTION LIDENT COLON . typ [ RPAREN EOL COMMA ]
+## arg_typ -> QUESTION LIDENT COLON . eols typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## QUESTION LIDENT COLON
+##
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN QUESTION LIDENT COLON EOL YIELD
+##
+## Ends in an error in state: 202.
+##
+## arg_typ -> QUESTION LIDENT COLON eols . typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## QUESTION LIDENT COLON eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 6, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN LIDENT COLON YIELD
+##
+## Ends in an error in state: 205.
+##
+## arg_typ -> LIDENT COLON . typ [ RPAREN EOL COMMA ]
+## arg_typ -> LIDENT COLON . eols typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LIDENT COLON
+##
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN LIDENT COLON EOL YIELD
+##
+## Ends in an error in state: 207.
+##
+## arg_typ -> LIDENT COLON eols . typ [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LIDENT COLON eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 6, spurious reduction of production eols -> nonempty_list(eol)
+##
+
+Expected the type of the argument.
 
 program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON UIDENT AS YIELD
 ##
@@ -1205,6 +1283,24 @@ program: EOL MODULE UIDENT EOL YIELD
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 6, spurious reduction of production eols -> nonempty_list(eol)
 ## In state 398, spurious reduction of production eos -> eols
+##
+program: MODULE UIDENT EOL BIGINT LPAREN LIDENT EQUAL YIELD
+##
+## Ends in an error in state: 475.
+##
+## app_arg -> id_str EQUAL . expr [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## id_str EQUAL
+##
+program: MODULE UIDENT EOL FUN LPAREN NUMBER_INT EQUAL YIELD
+##
+## Ends in an error in state: 652.
+##
+## arg_default -> EQUAL . non_stmt_expr [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## EQUAL
 ##
 
 Expected an expression.
@@ -2688,9 +2784,9 @@ program: MODULE UIDENT EOL FUN LPAREN WASMI64 COMMA EOL WASMI64 WHILE
 ## The known suffix of the stack is as follows:
 ## lseparated_nonempty_list_inner(comma,pattern) comma pattern
 ##
-program: MODULE UIDENT EOL FUN LPAREN WASMI64 WHILE
+program: MODULE UIDENT EOL LET LBRACKRCARET NUMBER_INT YIELD
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 350.
 ##
 ## lseparated_nonempty_list_inner(comma,pattern) -> pattern . [ RPAREN RBRACK EOL COMMA ]
 ## pattern -> pattern . COLON typ [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
@@ -2702,6 +2798,35 @@ program: MODULE UIDENT EOL FUN LPAREN WASMI64 WHILE
 ##
 ## The known suffix of the stack is as follows:
 ## pattern
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 358, spurious reduction of production const -> option(DASH) NUMBER_INT
+## In state 397, spurious reduction of production pattern -> const
+##
+program: MODULE UIDENT EOL LET LBRACKRCARET NUMBER_INT COMMA NUMBER_INT YIELD
+##
+## Ends in an error in state: 372.
+##
+## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma pattern . [ RPAREN RBRACK EOL COMMA ]
+## pattern -> pattern . COLON typ [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+## pattern -> pattern . COLON eols typ [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+## pattern -> pattern . PIPE pattern [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+## pattern -> pattern . PIPE eols pattern [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+## pattern -> pattern . AS id_str [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+## pattern -> pattern . AS eols id_str [ RPAREN RBRACK PIPE EOL COMMA COLON AS ]
+##
+## The known suffix of the stack is as follows:
+## lseparated_nonempty_list_inner(comma,pattern) comma pattern
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 358, spurious reduction of production const -> option(DASH) NUMBER_INT
+## In state 397, spurious reduction of production pattern -> const
 ##
 
 Expected a type annotation, a comma followed by more patterns, `)`, or `]`.
@@ -2726,27 +2851,6 @@ program: MODULE UIDENT EOL FUN LPAREN WASMI64 COMMA EOL WHILE
 ##
 
 Expected another pattern, `)`, or `]`.
-
-program: MODULE UIDENT EOL FUN LPAREN WASMI64 RBRACK
-##
-## Ends in an error in state: 749.
-##
-## lam_expr -> FUN lparen option(patterns) . rparen thickarrow expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FUN lparen option(patterns)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 363, spurious reduction of production lseparated_nonempty_list_inner(comma,pattern) -> pattern
-## In state 394, spurious reduction of production option(comma) ->
-## In state 395, spurious reduction of production patterns -> lseparated_nonempty_list_inner(comma,pattern) option(comma)
-## In state 748, spurious reduction of production option(patterns) -> patterns
-##
-
-Expected `)` to complete the function arguments.
 
 program: MODULE UIDENT EOL UIDENT LPAREN COMMA WHILE
 ##
@@ -4622,6 +4726,22 @@ program: MODULE UIDENT EOL MATCH LPAREN WASMI64 RPAREN LBRACE WHILE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 21, spurious reduction of production lbrace -> LBRACE
 ##
+program: MODULE UIDENT EOL LET LBRACKRCARET NUMBER_INT COMMA YIELD
+##
+## Ends in an error in state: 383.
+##
+## lseparated_nonempty_list_inner(comma,pattern) -> lseparated_nonempty_list_inner(comma,pattern) comma . pattern [ RPAREN RBRACK EOL COMMA ]
+## option(comma) -> comma . [ RPAREN RBRACK EOL ]
+##
+## The known suffix of the stack is as follows:
+## lseparated_nonempty_list_inner(comma,pattern) comma
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 65, spurious reduction of production comma -> COMMA
+##
 
 Expected a pattern.
 
@@ -5834,6 +5954,22 @@ program: MODULE UIDENT EOL WASMI64 COLON FUN LPAREN WHILE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 2, spurious reduction of production lparen -> LPAREN
 ##
+program: MODULE UIDENT EOL UIDENT COLON FUN LPAREN LIDENT COMMA YIELD
+##
+## Ends in an error in state: 216.
+##
+## lseparated_nonempty_list_inner(comma,arg_typ) -> lseparated_nonempty_list_inner(comma,arg_typ) comma . arg_typ [ RPAREN EOL COMMA ]
+## option(comma) -> comma . [ RPAREN EOL ]
+##
+## The known suffix of the stack is as follows:
+## lseparated_nonempty_list_inner(comma,arg_typ) comma
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 65, spurious reduction of production comma -> COMMA
+##
 
 Expected a comma-separated list of types or an immediate `)` for a function type with no arguments.
 
@@ -6092,6 +6228,35 @@ program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT LPAREN RPAREN YIELD
 ##
 
 Expected a comma followed by more constructors or `}` to complete the enum declaration.
+
+program: MODULE UIDENT EOL FUN LPAREN NUMBER_INT EQUAL UIDENT YIELD
+##
+## Ends in an error in state: 660.
+##
+## lam_args -> lseparated_nonempty_list_inner(comma,lam_arg) . option(comma) [ RPAREN EOL ]
+## lseparated_nonempty_list_inner(comma,lam_arg) -> lseparated_nonempty_list_inner(comma,lam_arg) . comma lam_arg [ RPAREN EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## lseparated_nonempty_list_inner(comma,lam_arg)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 225, spurious reduction of production qualified_uid -> lseparated_nonempty_list_inner(dot,type_id_str)
+## In state 128, spurious reduction of production construct_expr -> qualified_uid
+## In state 271, spurious reduction of production left_accessor_expr -> construct_expr
+## In state 246, spurious reduction of production non_assign_expr -> left_accessor_expr
+## In state 223, spurious reduction of production non_binop_expr -> non_assign_expr
+## In state 160, spurious reduction of production annotated_expr -> non_binop_expr
+## In state 280, spurious reduction of production non_stmt_expr -> annotated_expr
+## In state 653, spurious reduction of production arg_default -> EQUAL non_stmt_expr
+## In state 655, spurious reduction of production option(arg_default) -> arg_default
+## In state 654, spurious reduction of production lam_arg -> pattern option(arg_default)
+## In state 665, spurious reduction of production lseparated_nonempty_list_inner(comma,lam_arg) -> lam_arg
+##
+
+Expected a comma-separated list of arguments or `)` to complete the function arguments.
 
 program: MODULE UIDENT EOL WHILE LPAREN UNDERSCORE
 ##

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -298,8 +298,8 @@ data_typ:
   | qualified_uid %prec _below_infix { Type.constr ~loc:(to_loc $loc) $1 [] }
 
 typ:
-  | data_typ arrow typ { Type.arrow ~loc:(to_loc $loc) [{ptyp_arg_label=Unlabeled; ptyp_arg_type=$1; ptyp_arg_loc=(to_loc $loc($1))}] $3 }
-  | FUN LIDENT arrow typ { Type.arrow ~loc:(to_loc $loc) [{ptyp_arg_label=Unlabeled; ptyp_arg_type=Type.var $2; ptyp_arg_loc=(to_loc $loc($2))}] $4 }
+  | data_typ arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($1)) Unlabeled $1] $3 }
+  | FUN LIDENT arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
   | FUN lparen arg_typs? rparen arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }
@@ -307,9 +307,9 @@ typ:
   | data_typ { $1 }
 
 arg_typ:
-  | LIDENT colon typ { {ptyp_arg_label=Labeled (mkstr $loc($1) $1); ptyp_arg_type=$3; ptyp_arg_loc=(to_loc $loc)} }
-  | QUESTION LIDENT colon typ { {ptyp_arg_label=Default (mkstr $loc($2) $2); ptyp_arg_type=$4; ptyp_arg_loc=(to_loc $loc)} }
-  | typ { {ptyp_arg_label=Unlabeled; ptyp_arg_type=$1; ptyp_arg_loc=(to_loc $loc)} }
+  | LIDENT colon typ { TypeArgument.mk ~loc:(to_loc $loc) (Labeled (mkstr $loc($1) $1)) $3 }
+  | QUESTION LIDENT colon typ { TypeArgument.mk ~loc:(to_loc $loc) (Default (mkstr $loc($2) $2)) $4 }
+  | typ { TypeArgument.mk ~loc:(to_loc $loc) Unlabeled $1 }
 
 typs:
   | lseparated_nonempty_list(comma, typ) comma? { $1 }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -23,7 +23,7 @@ module Grain_parsing = struct end
 %token THICKARROW ARROW
 %token EQUAL GETS
 %token UNDERSCORE
-%token COLON DOT ELLIPSIS
+%token COLON QUESTION DOT ELLIPSIS
 
 %token ASSERT FAIL EXCEPTION THROW
 
@@ -64,7 +64,7 @@ module Grain_parsing = struct end
 %left INFIX_110 DASH
 %left INFIX_120 STAR SLASH
 
-%right SEMI EOL COMMA DOT COLON LPAREN
+%right SEMI EOL COMMA DOT COLON LPAREN EQUAL
 
 %nonassoc _if
 %nonassoc ELSE
@@ -103,8 +103,11 @@ module Grain_parsing = struct end
   const
   pattern
   qualified_uid
+  qualified_lid
   value_binds
   construct_expr
+  app_arg
+  arg_default
 
 %%
 
@@ -240,8 +243,8 @@ annotated_expr:
   | non_binop_expr colon typ { Expression.constraint_ ~loc:(to_loc $loc) $1 $3 }
 
 binop_expr:
-  | non_stmt_expr infix_op opt_eols non_stmt_expr { Expression.binop ~loc:(to_loc $loc) (mkid_expr $loc($2) [mkstr $loc($2) $2]) [$1; $4] }
-  | non_stmt_expr rcaret_rcaret_op opt_eols non_stmt_expr %prec INFIX_100 { Expression.binop ~loc:(to_loc $loc) (mkid_expr $loc($2) [mkstr $loc($2) $2]) [$1; $4] }
+  | non_stmt_expr infix_op opt_eols non_stmt_expr { Expression.binop ~loc:(to_loc $loc) (mkid_expr $loc($2) [mkstr $loc($2) $2]) $1 $4 }
+  | non_stmt_expr rcaret_rcaret_op opt_eols non_stmt_expr %prec INFIX_100 { Expression.binop ~loc:(to_loc $loc) (mkid_expr $loc($2) [mkstr $loc($2) $2]) $1 $4 }
 
 ellipsis_prefix(X):
   | ELLIPSIS X {$2}
@@ -295,16 +298,24 @@ data_typ:
   | qualified_uid %prec _below_infix { Type.constr ~loc:(to_loc $loc) $1 [] }
 
 typ:
-  | data_typ arrow typ { Type.arrow ~loc:(to_loc $loc) [$1] $3 }
-  | FUN LIDENT arrow typ { Type.arrow ~loc:(to_loc $loc) [(Type.var $2)] $4 }
-  | FUN lparen typs? rparen arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
+  | data_typ arrow typ { Type.arrow ~loc:(to_loc $loc) [{ptyp_arg_label=Unlabeled; ptyp_arg_type=$1; ptyp_arg_loc=(to_loc $loc($1))}] $3 }
+  | FUN LIDENT arrow typ { Type.arrow ~loc:(to_loc $loc) [{ptyp_arg_label=Unlabeled; ptyp_arg_type=Type.var $2; ptyp_arg_loc=(to_loc $loc($2))}] $4 }
+  | FUN lparen arg_typs? rparen arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }
   | LIDENT { Type.var ~loc:(to_loc $loc) $1 }
   | data_typ { $1 }
 
+arg_typ:
+  | LIDENT colon typ { {ptyp_arg_label=Labeled (mkstr $loc($1) $1); ptyp_arg_type=$3; ptyp_arg_loc=(to_loc $loc)} }
+  | QUESTION LIDENT colon typ { {ptyp_arg_label=Default (mkstr $loc($2) $2); ptyp_arg_type=$4; ptyp_arg_loc=(to_loc $loc)} }
+  | typ { {ptyp_arg_label=Unlabeled; ptyp_arg_type=$1; ptyp_arg_loc=(to_loc $loc)} }
+
 typs:
   | lseparated_nonempty_list(comma, typ) comma? { $1 }
+
+arg_typs:
+  | lseparated_nonempty_list(comma, arg_typ) comma? { $1 }
 
 %inline tuple_typ_ending:
   | ioption(eols) lseparated_nonempty_list(comma, typ) ioption(comma) { $2 }
@@ -402,13 +413,17 @@ data_declaration:
   | RECORD UIDENT id_vec? data_labels { DataDeclaration.record ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) $4 }
 
 unop_expr:
-  | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [$2] }
+  | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }
 
 paren_expr:
   | lparen expr rparen { $2 }
 
+app_arg:
+  | expr { {paa_label=Unlabeled; paa_expr=$1; paa_loc=to_loc $loc} }
+  | id_str EQUAL expr { {paa_label=(Labeled $1); paa_expr=$3; paa_loc=to_loc $loc} }
+
 app_expr:
-  | left_accessor_expr lparen lseparated_list(comma, expr) comma? rparen { Expression.apply ~loc:(to_loc $loc) $1 $3 }
+  | left_accessor_expr lparen lseparated_list(comma, app_arg) comma? rparen { Expression.apply ~loc:(to_loc $loc) $1 $3 }
 
 rcaret_rcaret_op:
   | lnonempty_list(RCARET) RCARET { (String.init (1 + List.length $1) (fun _ -> '>')) }
@@ -456,7 +471,7 @@ special_op:
 
 qualified_lid:
   | modid dot id_str { mkid (List.append $1 [$3]) (to_loc $loc) }
-  | id_str { (mkid [$1]) (to_loc $loc) }
+  | id_str %prec EQUAL { (mkid [$1]) (to_loc $loc) }
 
 qualified_uid:
   | lseparated_nonempty_list(dot, type_id_str) %prec DOT { (mkid $1) (to_loc $loc) }
@@ -483,9 +498,18 @@ braced_expr:
 block:
   | lbrace block_body rbrace { Expression.block ~loc:(to_loc $loc) $2 }
 
+arg_default:
+  | EQUAL non_stmt_expr { $2 }
+
+lam_arg:
+  | pattern arg_default? { LambdaArgument.mk ~loc:(to_loc $loc) $1 $2 }
+
+lam_args:
+  | lseparated_nonempty_list(comma, lam_arg) comma? { $1 }
+
 lam_expr:
-  | FUN lparen patterns? rparen thickarrow expr { Expression.lambda ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
-  | FUN LIDENT thickarrow expr { Expression.lambda ~loc:(to_loc $loc) [Pattern.var ~loc:(to_loc $loc($2)) (mkstr $loc($2) $2)] $4 }
+  | FUN lparen lam_args? rparen thickarrow expr { Expression.lambda ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
+  | FUN LIDENT thickarrow expr { Expression.lambda ~loc:(to_loc $loc) [LambdaArgument.mk ~loc:(to_loc $loc($2)) (Pattern.var ~loc:(to_loc $loc($2)) (mkstr $loc($2) $2)) None] $4 }
 
 attribute_argument:
   | STRING { mkstr $loc $1 }
@@ -546,9 +570,9 @@ array_expr:
   | lbrackrcaret opt_eols lseparated_nonempty_list(comma, expr) comma? rbrack { Expression.array ~loc:(to_loc $loc) $3 }
 
 stmt_expr:
-  | THROW expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "throw"]) [$2] }
-  | ASSERT expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "assert"]) [$2] }
-  | FAIL expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "fail"]) [$2] }
+  | THROW expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "throw"]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }
+  | ASSERT expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "assert"]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }
+  | FAIL expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) "fail"]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }
   // allow DASH to cause a shift instead of the usual reduction of the left side for subtraction
   | RETURN ioption(expr) %prec _below_infix { Expression.return ~loc:(to_loc $loc) $2 }
   | CONTINUE { Expression.continue ~loc:(to_loc $loc) () }
@@ -561,7 +585,7 @@ assign_binop_op:
 assign_expr:
   | left_accessor_expr GETS opt_eols expr { Expression.box_assign ~loc:(to_loc $loc) $1 $4 }
   | id_expr equal expr { Expression.assign ~loc:(to_loc $loc) $1 $3 }
-  | id_expr assign_binop_op opt_eols expr { Expression.assign ~loc:(to_loc $loc) $1 (Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($2) [$2]) [$1; $4]) }
+  | id_expr assign_binop_op opt_eols expr { Expression.assign ~loc:(to_loc $loc) $1 (Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($2) [$2]) [{paa_label=Unlabeled; paa_expr=$1; paa_loc=(to_loc $loc($1))}; {paa_label=Unlabeled; paa_expr=$4; paa_loc=(to_loc $loc($4))}]) }
   | record_set { $1 }
   | array_set { $1 }
 
@@ -605,7 +629,7 @@ record_get:
 
 record_set:
   | left_accessor_expr dot lid equal expr { Expression.record_set ~loc:(to_loc $loc) $1 $3 $5 }
-  | left_accessor_expr dot lid assign_binop_op opt_eols expr { Expression.record_set ~loc:(to_loc $loc) $1 $3 (Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($4) [$4]) [Expression.record_get ~loc:(to_loc $loc) $1 $3; $6]) }
+  | left_accessor_expr dot lid assign_binop_op opt_eols expr { Expression.record_set ~loc:(to_loc $loc) $1 $3 (Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($4) [$4]) [{paa_label=Unlabeled; paa_expr=Expression.record_get ~loc:(to_loc $loc) $1 $3; paa_loc=(to_loc $loc($6))}; {paa_label=Unlabeled; paa_expr=$6; paa_loc=(to_loc $loc($6))}]) }
 
 %inline record_field_value:
   | colon expr {$2}

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -25,7 +25,7 @@ type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
 type parsed_type_desc =
   | PTyAny
   | PTyVar(string)
-  | PTyArrow(list(parsed_type), parsed_type)
+  | PTyArrow(list(parsed_type_argument), parsed_type)
   | PTyTuple(list(parsed_type))
   | PTyConstr(loc(Identifier.t), list(parsed_type))
   | PTyPoly(list(loc(string)), parsed_type)
@@ -34,6 +34,12 @@ and parsed_type = {
   ptyp_desc: parsed_type_desc,
   [@sexp_drop_if sexp_locs_disabled]
   ptyp_loc: Location.t,
+}
+
+and parsed_type_argument = {
+  ptyp_arg_label: argument_label,
+  ptyp_arg_type: parsed_type,
+  ptyp_arg_loc: Location.t,
 };
 
 /** Type for fields within a record */
@@ -511,8 +517,8 @@ and expression_desc =
   | PExpReturn(option(expression))
   | PExpConstraint(expression, parsed_type)
   | PExpUse(loc(Identifier.t), use_items)
-  | PExpLambda(list(pattern), expression)
-  | PExpApp(expression, list(expression))
+  | PExpLambda(list(lambda_argument), expression)
+  | PExpApp(expression, list(application_argument))
   | PExpConstruct(loc(Identifier.t), constructor_expression)
   | PExpBlock(list(expression))
   | PExpBoxAssign(expression, expression)
@@ -523,6 +529,21 @@ and constructor_expression =
   | PExpConstrTuple(list(expression))
   | PExpConstrRecord(list((loc(Identifier.t), expression)))
   | PExpConstrSingleton
+
+[@deriving (sexp, yojson)]
+and lambda_argument = {
+  pla_label: argument_label,
+  pla_pattern: pattern,
+  pla_default: option(expression),
+  pla_loc: Location.t,
+}
+
+[@deriving (sexp, yojson)]
+and application_argument = {
+  paa_label: argument_label,
+  paa_expr: expression,
+  paa_loc: Location.t,
+}
 
 /** let-binding form */
 

--- a/compiler/src/parsing/parsetree_iter.re
+++ b/compiler/src/parsing/parsetree_iter.re
@@ -302,11 +302,24 @@ and iter_expression =
     | PUseAll => ()
     };
   | PExpLambda(pl, e) =>
-    iter_patterns(hooks, pl);
+    List.iter(
+      arg => {
+        iter_pattern(hooks, arg.pla_pattern);
+        Option.iter(iter_expression(hooks), arg.pla_default);
+        iter_location(hooks, arg.pla_loc);
+      },
+      pl,
+    );
     iter_expression(hooks, e);
   | PExpApp(e, el) =>
     iter_expression(hooks, e);
-    iter_expressions(hooks, el);
+    List.iter(
+      arg => {
+        iter_expression(hooks, arg.paa_expr);
+        iter_location(hooks, arg.paa_loc);
+      },
+      el,
+    );
   | PExpConstruct(c, e) =>
     iter_ident(hooks, c);
     switch (e) {
@@ -364,7 +377,13 @@ and iter_type = (hooks, {ptyp_desc: desc, ptyp_loc: loc} as typ) => {
   | PTyAny => ()
   | PTyVar(v) => ()
   | PTyArrow(args, ret) =>
-    List.iter(iter_type(hooks), args);
+    List.iter(
+      arg => {
+        iter_type(hooks, arg.ptyp_arg_type);
+        iter_location(hooks, arg.ptyp_arg_loc);
+      },
+      args,
+    );
     iter_type(hooks, ret);
   | PTyTuple(ts) => List.iter(iter_type(hooks), ts)
   | PTyConstr(name, ts) =>

--- a/compiler/src/typed/btype.re
+++ b/compiler/src/typed/btype.re
@@ -130,7 +130,7 @@ let iter_type_expr = (f, ty) =>
   switch (ty.desc) {
   | TTyVar(_) => ()
   | TTyArrow(args, ret, _) =>
-    List.iter(f, args);
+    List.iter(((_, arg)) => f(arg), args);
     f(ret);
   | TTyTuple(ts) => List.iter(f, ts)
   | TTyRecord(ts) => List.iter(((_, t)) => f(t), ts)
@@ -276,7 +276,11 @@ let rec copy_type_desc = (~keep_names=false, f) =>
       TTyVar(None);
     }
   | TTyArrow(tyl, ret, c) =>
-    TTyArrow(List.map(f, tyl), f(ret), copy_commu(c))
+    TTyArrow(
+      List.map(((l, arg)) => (l, f(arg)), tyl),
+      f(ret),
+      copy_commu(c),
+    )
   | TTyTuple(l) => TTyTuple(List.map(f, l))
   | TTyRecord(l) =>
     TTyRecord(List.map(((name, arg)) => (name, f(arg)), l))
@@ -406,20 +410,42 @@ let forget_abbrev = (mem, path) =>
 
 let is_optional =
   fun
-  | Optional(_) => true
+  | Default(_) => true
   | _ => false;
+
+let label_equal = (l1, l2) => {
+  switch (l1, l2) {
+  | (Unlabeled, Unlabeled) => true
+  | (Labeled({txt: name1}), Labeled({txt: name2}))
+  | (Default({txt: name1}), Default({txt: name2})) when name1 == name2 =>
+    true
+  | _ => false
+  };
+};
+
+let same_label_name = (l1, l2) =>
+  switch (l1, l2) {
+  | (Unlabeled, Unlabeled) => true
+  | (
+      Labeled({txt: name1}) | Default({txt: name1}),
+      Labeled({txt: name2}) | Default({txt: name2}),
+    )
+      when name1 == name2 =>
+    true
+  | _ => false
+  };
 
 let label_name =
   fun
-  | Nolabel => ""
-  | Labelled(s)
-  | Optional(s) => s;
+  | Unlabeled => ""
+  | Labeled(s)
+  | Default(s) => s.txt;
 
-let prefixed_label_name =
+let qualified_label_name =
   fun
-  | Nolabel => ""
-  | Labelled(s) => "~" ++ s
-  | Optional(s) => "?" ++ s;
+  | Unlabeled => ""
+  | Labeled(s) => s.txt
+  | Default(s) => "?" ++ s.txt;
 
 let rec extract_label_aux = (hd, l) =>
   fun

--- a/compiler/src/typed/btype.rei
+++ b/compiler/src/typed/btype.rei
@@ -110,6 +110,21 @@ let memorize_abbrev:
 let forget_abbrev: (ref(abbrev_memo), Path.t) => unit;
 /* Remove an abbreviation from the cache */
 
+/**** Utilities for labels ****/
+let is_optional: argument_label => bool;
+let label_equal: (argument_label, argument_label) => bool;
+let same_label_name: (argument_label, argument_label) => bool;
+let label_name: argument_label => label;
+let qualified_label_name: argument_label => label;
+let extract_label:
+  (label, list((argument_label, 'a))) =>
+  (
+    argument_label,
+    'a,
+    list((argument_label, 'a)),
+    list((argument_label, 'a)),
+  );
+
 /**** Utilities for backtracking ****/
 
 type snapshot;

--- a/compiler/src/typed/ctype.rei
+++ b/compiler/src/typed/ctype.rei
@@ -159,7 +159,21 @@ let unify_var: (Env.t, type_expr, type_expr) => unit;
    is a variable. */
 let with_passive_variants: ('a => 'b, 'a) => 'b;
 /* Call [f] in passive_variants mode, for exhaustiveness check. */
-let filter_arrow: (int, Env.t, type_expr) => (list(type_expr), type_expr);
+
+type filter_arrow_failure =
+  | Unification_error(list((type_expr, type_expr)))
+  | Label_mismatch({
+      got: argument_label,
+      expected: argument_label,
+      expected_type: type_expr,
+    })
+  | Arity_mismatch
+  | Not_a_function;
+
+exception Filter_arrow_failed(filter_arrow_failure);
+
+let filter_arrow:
+  (Env.t, type_expr, list(argument_label)) => (list(type_expr), type_expr);
 /* A special case of unification (with l:'a -> 'b). */
 let occur_in: (Env.t, type_expr, type_expr) => bool;
 let deep_occur: (type_expr, type_expr) => bool;

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1684,7 +1684,13 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                 switch (desc.cstr_args) {
                 | [] => desc.cstr_res
                 | args =>
-                  Btype.newgenty(TTyArrow(args, desc.cstr_res, TComOk))
+                  Btype.newgenty(
+                    TTyArrow(
+                      List.map(arg => (Unlabeled, arg), args),
+                      desc.cstr_res,
+                      TComOk,
+                    ),
+                  )
                 };
               let val_type =
                 switch (desc.cstr_existentials) {
@@ -1748,7 +1754,14 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
           let val_type =
             switch (desc.cstr_args) {
             | [] => desc.cstr_res
-            | args => Btype.newgenty(TTyArrow(args, desc.cstr_res, TComOk))
+            | args =>
+              Btype.newgenty(
+                TTyArrow(
+                  List.map(arg => (Unlabeled, arg), args),
+                  desc.cstr_res,
+                  TComOk,
+                ),
+              )
             };
           let val_type =
             switch (desc.cstr_existentials) {

--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -354,13 +354,17 @@ let rec print_out_type = ppf =>
 and print_out_type_1 = ppf =>
   fun
   | Otyp_arrow(al, ty2) => {
-      let args_length = List.length(al);
+      let parens =
+        switch (al) {
+        | [("", _)] => false
+        | _ => true
+        };
       pp_open_box(ppf, 1);
-      if (args_length != 1) {
+      if (parens) {
         pp_print_char(ppf, '(');
       };
       fprintf(ppf, "@[<0>%a@]", print_argtyplist(print_out_type_2, ","), al);
-      if (args_length != 1) {
+      if (parens) {
         pp_print_char(ppf, ')');
       };
       pp_print_string(ppf, " ->");

--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -353,13 +353,13 @@ let rec print_out_type = ppf =>
 
 and print_out_type_1 = ppf =>
   fun
-  | Otyp_arrow(ty1, ty2) => {
-      let args_length = List.length(ty1);
+  | Otyp_arrow(al, ty2) => {
+      let args_length = List.length(al);
       pp_open_box(ppf, 1);
       if (args_length != 1) {
         pp_print_char(ppf, '(');
       };
-      fprintf(ppf, "@[<0>%a@]", print_typlist(print_out_type_2, ","), ty1);
+      fprintf(ppf, "@[<0>%a@]", print_argtyplist(print_out_type_2, ","), al);
       if (args_length != 1) {
         pp_print_char(ppf, ')');
       };
@@ -519,6 +519,26 @@ and print_row_field = (ppf, (l, opt_amp, tyl)) => {
     tyl,
   );
 }
+and print_argtyplist = (print_elem, sep, ppf) =>
+  fun
+  | [] => ()
+  | [(l, ty)] => {
+      if (l != "") {
+        pp_print_string(ppf, l);
+        pp_print_string(ppf, ": ");
+      };
+      print_elem(ppf, ty);
+    }
+  | [(l, ty), ...al] => {
+      if (l != "") {
+        pp_print_string(ppf, l);
+        pp_print_string(ppf, ": ");
+      };
+      print_elem(ppf, ty);
+      pp_print_string(ppf, sep);
+      pp_print_space(ppf, ());
+      print_argtyplist(print_elem, sep, ppf, al);
+    }
 and print_typlist = (print_elem, sep, ppf) =>
   fun
   | [] => ()

--- a/compiler/src/typed/outcometree.re
+++ b/compiler/src/typed/outcometree.re
@@ -54,7 +54,7 @@ type out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias(out_type, string)
-  | Otyp_arrow(list(out_type), out_type)
+  | Otyp_arrow(list((string, out_type)), out_type)
   | Otyp_class(bool, out_ident, list(out_type))
   | Otyp_constr(out_ident, list(out_type))
   | Otyp_manifest(out_type, out_type)

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -1468,6 +1468,13 @@ let transl_prim = (env, desc) => {
 
   let disable_gc = [(Location.mknoloc("disableGC"), [])];
 
+  let lambda_arg = pat => {
+    pla_label: Unlabeled,
+    pla_pattern: pat,
+    pla_default: None,
+    pla_loc: Location.dummy_loc,
+  };
+
   // `attrs` are attributes which should be applied to the `let` which gets implicitly generated.
   //
   // Specifically, consider:
@@ -1593,7 +1600,7 @@ let transl_prim = (env, desc) => {
         Expression.lambda(
           ~loc,
           ~attributes,
-          [pat_a],
+          [lambda_arg(pat_a)],
           Expression.prim1(~loc, p, id_a),
         ),
         Typecore.prim1_type(p),
@@ -1619,7 +1626,7 @@ let transl_prim = (env, desc) => {
         Expression.lambda(
           ~loc,
           ~attributes,
-          [pat_a, pat_b],
+          [lambda_arg(pat_a), lambda_arg(pat_b)],
           Expression.prim2(~loc, p, id_a, id_b),
         ),
         Typecore.prim2_type(p),
@@ -1639,7 +1646,7 @@ let transl_prim = (env, desc) => {
         Expression.lambda(
           ~loc,
           ~attributes,
-          [pat_a, pat_b, pat_c],
+          [lambda_arg(pat_a), lambda_arg(pat_b), lambda_arg(pat_c)],
           Expression.primn(~loc, p, [id_a, id_b, id_c]),
         ),
         Typecore.primn_type(p),

--- a/compiler/src/typed/translsig.re
+++ b/compiler/src/typed/translsig.re
@@ -17,7 +17,7 @@ let rec collect_type_vars = typ =>
         Tbl.add(typ.id, ref([typ]), used_type_variables^)
     }
   | TTyArrow(ty_args, ty_res, _) =>
-    List.iter(collect_type_vars, ty_args);
+    List.iter(((_, arg)) => collect_type_vars(arg), ty_args);
     collect_type_vars(ty_res);
   | TTyTuple(ty_args) => List.iter(collect_type_vars, ty_args)
   | TTyRecord(ty_args) =>
@@ -46,7 +46,11 @@ let link_type_vars = ty => {
         | Not_found => ty
         }
       | TTyArrow(tyl, ret, c) =>
-        TTyArrow(List.map(link_types, tyl), link_types(ret), c)
+        TTyArrow(
+          List.map(((l, arg)) => (l, link_types(arg)), tyl),
+          link_types(ret),
+          c,
+        )
       | TTyTuple(l) => TTyTuple(List.map(link_types, l))
       | TTyRecord(l) =>
         TTyRecord(List.map(((name, arg)) => (name, link_types(arg)), l))

--- a/compiler/src/typed/type_utils.re
+++ b/compiler/src/typed/type_utils.re
@@ -24,7 +24,7 @@ let rec get_fn_allocation_type = (env, ty) => {
   | TTySubst(linked)
   | TTyLink(linked) => get_fn_allocation_type(env, linked)
   | TTyArrow(args, ret, _) => (
-      List.map(get_allocation_type(env), args),
+      List.map(((_, arg)) => get_allocation_type(env, arg), args),
       get_allocation_type(env, ret),
     )
   | TTyConstr(path, args, _) =>

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -2794,7 +2794,7 @@ let report_error = (env, ppf) =>
       | labels =>
         fprintf(
           ppf,
-          "@ @[Did you mean to supply an optional argument with label %a?@]@]",
+          "@ @[Did you mean to supply an argument with label %a?@]@]",
           oxford,
           unused_optional_arguments,
         )
@@ -3008,17 +3008,20 @@ let report_error = (env, ppf) =>
       if (is_optional(got)) {
         fprintf(
           ppf,
-          "This function contains the optional, default argument %s@ ",
+          "This function contains the argument %s@ ",
           qualified_label_name(got),
         );
       } else {
         fprintf(
           ppf,
-          "The expected function type contains the optional, default argument %s@ ",
+          "The expected function type contains the argument %s@ ",
           qualified_label_name(expected),
         );
       };
-      fprintf(ppf, "but the matching argument is not optional.@ ");
+      fprintf(
+        ppf,
+        "which has a default value, but the matching argument does not.@ ",
+      );
       fprintf(
         ppf,
         "The expected type is@ %a%t",

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1016,7 +1016,7 @@ and type_expect_ =
         (arg, (args, labels, prelude)) => {
           switch (arg.pla_default) {
           | Some(default) =>
-            let default_value_name = mknoloc("<default_value>");
+            let default_value_name = mknoloc("$default_value");
             let default_loc = default.pexp_loc;
             let scases = [
               MatchBranch.mk(

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -2676,7 +2676,7 @@ let report_error = (env, ppf) =>
   | Constructor_arity_mismatch(lid, expected, provided) =>
     fprintf(
       ppf,
-      "@[The constructor %a@ expects %i argument(s),@ but is applied here to %i argument(s)@]",
+      "@[The constructor %a@ expects %i argument(s),@ but is called with %i argument(s)@]",
       identifier,
       lid,
       expected,
@@ -2756,13 +2756,13 @@ let report_error = (env, ppf) =>
         "@[<v>@[<2>This expression has type@ %a@]@ %s@]",
         type_expr,
         typ,
-        "This is not a function; it cannot be applied.",
+        "This is not a function; it cannot be called.",
       );
     }
   | Apply_too_many_arguments(typ, unused_tyargs) => {
       reset_and_mark_loops(typ);
       fprintf(ppf, "@[<v>@[<2>This function has type@ %a@]", type_expr, typ);
-      fprintf(ppf, "@ @[It is applied to too many arguments.@]@]");
+      fprintf(ppf, "@ @[It is called with too many arguments.@]@]");
       let unused_optional_arguments =
         List.filter_map(
           ((l, _)) =>
@@ -2838,7 +2838,7 @@ let report_error = (env, ppf) =>
       };
     }
   | Apply_unknown_label(label, valid_labels) => {
-      fprintf(ppf, "This argument cannot be applied with label %s.", label);
+      fprintf(ppf, "This argument cannot be supplied with label %s.", label);
       spellcheck(ppf, label, valid_labels);
     }
   | Label_multiply_defined(s) =>
@@ -3062,7 +3062,7 @@ let report_error = (env, ppf) =>
   | Not_a_variant_type(lid) =>
     fprintf(ppf, "The type %a@ is not a variant type", identifier, lid)
   | Incoherent_label_order => {
-      fprintf(ppf, "This function is applied to arguments@ ");
+      fprintf(ppf, "This function is called with arguments@ ");
       fprintf(ppf, "in an order different from other calls.@ ");
       fprintf(ppf, "This is only allowed when the real type is known.");
     }

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -402,7 +402,7 @@ let option_none = (env, ty, loc) => {
 let extract_option_type = (env, ty) => {
   switch (expand_head(env, ty).desc) {
   | TTyConstr(path, [ty], _) when Path.same(path, Builtin_types.path_option) => ty
-  | _ => assert(false)
+  | _ => failwith("Impossible: option type was not an option")
   };
 };
 

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1002,10 +1002,14 @@ and type_expect_ =
     });
   | PExpLambda(args, body) =>
     open Ast_helper;
-    let opt_counter = ref(0);
-    let gen_opt = () => {
-      incr(opt_counter);
-      "$option_" ++ string_of_int(opt_counter^);
+    let gen_opt = label => {
+      let label =
+        switch (label) {
+        | Unlabeled => failwith("Impossible: default argument with no label")
+        | Labeled({txt: name})
+        | Default({txt: name}) => name
+        };
+      "$default_option_" ++ label;
     };
     let (args, labels, prelude) =
       List.fold_right(
@@ -1044,7 +1048,7 @@ and type_expect_ =
               loc_end: default_loc.Location.loc_end,
               loc_ghost: true,
             };
-            let opt_name = mknoloc(gen_opt());
+            let opt_name = mknoloc(gen_opt(arg.pla_label));
             let smatch =
               Expression.match(
                 ~loc=sloc,

--- a/compiler/src/typed/typecore.rei
+++ b/compiler/src/typed/typecore.rei
@@ -62,16 +62,13 @@ let type_expect:
   Typedtree.expression;
 let type_exp: (Env.t, Parsetree.expression) => Typedtree.expression;
 let type_approx: (Env.t, Parsetree.expression) => type_expr;
-let type_arguments:
-  (Env.t, list(Parsetree.expression), list(type_expr), list(type_expr)) =>
-  list(Typedtree.expression);
 
 let generalizable: (int, type_expr) => bool;
 
 let name_pattern: (string, list(Typedtree.match_branch)) => Ident.t;
 
 type error =
-  | Arity_mismatch(type_expr, int)
+  | Arity_mismatch(type_expr, option(Checkertypes.type_forcing_context))
   | Polymorphic_label(Identifier.t)
   | Constructor_arity_mismatch(Identifier.t, int, int)
   | Label_mismatch(Identifier.t, list((type_expr, type_expr)))
@@ -84,6 +81,9 @@ type error =
       option(Checkertypes.type_forcing_context),
     )
   | Apply_non_function(type_expr)
+  | Apply_too_many_arguments(type_expr, list((argument_label, type_expr)))
+  | Apply_too_few_arguments(list((argument_label, type_expr)))
+  | Apply_unknown_label(string, list(string))
   | Label_multiply_defined(string)
   | Label_missing(list(Ident.t))
   | Label_not_mutable(Identifier.t)
@@ -122,11 +122,13 @@ type error =
       list((type_expr, type_expr)),
       bool,
     )
-  | Too_many_arguments(
-      bool,
-      type_expr,
-      option(Checkertypes.type_forcing_context),
-    )
+  | Not_a_function(type_expr, option(Checkertypes.type_forcing_context))
+  | Function_label_mismatch({
+      got: argument_label,
+      expected: argument_label,
+      expected_type: type_expr,
+      explanation: option(Checkertypes.type_forcing_context),
+    })
   | Scoping_let_module(string, type_expr)
   | Masked_instance_variable(Identifier.t)
   | Not_a_variant_type(Identifier.t)

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -89,7 +89,7 @@ let ensure_no_escaped_types = (signature, statements) => {
     | TTyVar(_)
     | TTyUniVar(_) => ()
     | TTyArrow(args, res, _) =>
-      List.iter(check_type, args);
+      List.iter(((_, arg)) => check_type(arg), args);
       check_type(res);
     | TTyTuple(args) => List.iter(check_type, args)
     | TTyRecord(fields) =>
@@ -223,10 +223,11 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
                 _,
               ),
           },
+          _,
           args,
         )
           when func == "==" || func == "!=" =>
-        if (List.exists(exp_is_wasm_unsafe, args)) {
+        if (List.exists(((_, arg)) => exp_is_wasm_unsafe(arg), args)) {
           let warning =
             Grain_utils.Warnings.FuncWasmUnsafe(
               Printf.sprintf("Pervasives.(%s)", func),
@@ -245,15 +246,19 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
                 _,
               ),
           },
+          _,
           [
-            {
-              exp_desc:
-                TExpConstant(
-                  Const_number(
-                    (Const_number_int(_) | Const_number_float(_)) as n,
+            (
+              Unlabeled,
+              {
+                exp_desc:
+                  TExpConstant(
+                    Const_number(
+                      (Const_number_int(_) | Const_number_float(_)) as n,
+                    ),
                   ),
-                ),
-            },
+              },
+            ),
           ],
         )
           when

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -40,6 +40,9 @@ type provide_flag =
   Asttypes.provide_flag = | NotProvided | Provided | Abstract;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
+type argument_label =
+  Asttypes.argument_label =
+    | Unlabeled | Labeled(loc(string)) | Default(loc(string));
 
 type wasm_prim_type =
   Parsetree.wasm_prim_type =
@@ -328,7 +331,7 @@ type core_type = {
 and core_type_desc =
   | TTyAny
   | TTyVar(string)
-  | TTyArrow(list(core_type), core_type)
+  | TTyArrow(list((argument_label, core_type)), core_type)
   | TTyTuple(list(core_type))
   | TTyRecord(list((loc(Identifier.t), core_type)))
   | TTyConstr(Path.t, loc(Identifier.t), list(core_type))
@@ -493,7 +496,11 @@ and expression_desc =
   | TExpBreak
   | TExpReturn(option(expression))
   | TExpLambda(list(match_branch), partial)
-  | TExpApp(expression, list(expression))
+  | TExpApp(
+      expression,
+      list(argument_label),
+      list((argument_label, expression)),
+    )
   | TExpConstruct(
       loc(Identifier.t),
       constructor_description,

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -40,6 +40,9 @@ type provide_flag =
   Asttypes.provide_flag = | NotProvided | Provided | Abstract;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
+type argument_label =
+  Asttypes.argument_label =
+    | Unlabeled | Labeled(loc(string)) | Default(loc(string));
 
 type wasm_prim_type =
   Parsetree.wasm_prim_type =
@@ -308,7 +311,7 @@ type core_type = {
 and core_type_desc =
   | TTyAny
   | TTyVar(string)
-  | TTyArrow(list(core_type), core_type)
+  | TTyArrow(list((argument_label, core_type)), core_type)
   | TTyTuple(list(core_type))
   | TTyRecord(list((loc(Identifier.t), core_type)))
   | TTyConstr(Path.t, loc(Identifier.t), list(core_type))
@@ -461,7 +464,11 @@ and expression_desc =
   | TExpBreak
   | TExpReturn(option(expression))
   | TExpLambda(list(match_branch), partial)
-  | TExpApp(expression, list(expression))
+  | TExpApp(
+      expression,
+      list(argument_label),
+      list((argument_label, expression)),
+    )
   | TExpConstruct(
       loc(Identifier.t),
       constructor_description,

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -63,7 +63,7 @@ module MakeIterator =
     | TTyAny
     | TTyVar(_) => ()
     | TTyArrow(args, ret) =>
-      List.iter(iter_core_type, args);
+      List.iter(((_, a)) => iter_core_type(a), args);
       iter_core_type(ret);
     | TTyConstr(_, _, args)
     | TTyTuple(args) => List.iter(iter_core_type, args)
@@ -208,9 +208,9 @@ module MakeIterator =
     | TExpLet(recflag, mutflag, binds) =>
       iter_bindings(recflag, mutflag, binds)
     | TExpLambda(branches, _) => iter_match_branches(branches)
-    | TExpApp(exp, args) =>
+    | TExpApp(exp, _, args) =>
       iter_expression(exp);
-      List.iter(iter_expression, args);
+      List.iter(((_, arg)) => iter_expression(arg), args);
     | TExpPrim0(_) => ()
     | TExpPrim1(_, e) => iter_expression(e)
     | TExpPrim2(_, e1, e2) =>

--- a/compiler/src/typed/typedtreeMap.re
+++ b/compiler/src/typed/typedtreeMap.re
@@ -56,7 +56,7 @@ module MakeMap =
       | TTyAny
       | TTyVar(_) => ct.ctyp_desc
       | TTyArrow(args, ret) =>
-        let args = List.map(map_core_type, args);
+        let args = List.map(((l, arg)) => (l, map_core_type(arg)), args);
         let ret = map_core_type(ret);
         TTyArrow(args, ret);
       | TTyConstr(a, b, args) =>
@@ -211,8 +211,12 @@ module MakeMap =
         TExpLet(recflag, mutflag, map_bindings(recflag, mutflag, binds))
       | TExpLambda(branches, p) =>
         TExpLambda(map_match_branches(branches), p)
-      | TExpApp(exp, args) =>
-        TExpApp(map_expression(exp), List.map(map_expression, args))
+      | TExpApp(exp, labels, args) =>
+        TExpApp(
+          map_expression(exp),
+          labels,
+          List.map(((l, arg)) => (l, map_expression(arg)), args),
+        )
       | TExpPrim0(o) => TExpPrim0(o)
       | TExpPrim1(o, e) => TExpPrim1(o, map_expression(e))
       | TExpPrim2(o, e1, e2) =>

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -752,7 +752,7 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
           ...expr,
           desc:
             TTyArrow(
-              List.map(resolve_type_expr, args),
+              List.map(((l, arg)) => (l, resolve_type_expr(arg)), args),
               resolve_type_expr(result),
               c,
             ),

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -38,7 +38,7 @@ type type_expr = {
 
 and type_desc =
   | TTyVar(option(string)) // A type variable (None == "_")
-  | TTyArrow(list(type_expr), type_expr, commutable) // A function type.
+  | TTyArrow(list((argument_label, type_expr)), type_expr, commutable) // A function type.
   | TTyTuple(list(type_expr)) // A tuple type.
   | TTyRecord(list((string, type_expr))) // A record type.
   | TTyConstr(Path.t, list(type_expr), ref(abbrev_memo)) // A parameterized type.

--- a/compiler/src/typed/typetexp.rei
+++ b/compiler/src/typed/typetexp.rei
@@ -113,5 +113,3 @@ let type_attributes: Asttypes.attributes => Typedtree.attributes;
 
 let unbound_label_error: (Env.t, Location.loc(Identifier.t)) => 'a;
 let unbound_constructor_error: (Env.t, Location.loc(Identifier.t)) => 'a;
-
-let type_expr_to_core_type: (Env.t, type_expr) => Typedtree.core_type;

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -296,6 +296,14 @@ truc()|},
     |},
     "12\n",
   );
+  assertRun(
+    "default_args6",
+    {|
+      let concat = (a=b ++ b, b) => a ++ b
+      print(concat(b="9"))
+    |},
+    "999\n",
+  );
 
   assertRun(
     "labeled_args_typecheck1",

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -56,7 +56,11 @@ describe("functions", ({test, testSkip}) => {
     "let rec foo = (() => {5});\nlet bar = (() => { 7 });\nlet rec foo = (() => {9});\nfoo()",
   );
   assertCompileError("arity_1", "let foo = (() => {5});\nfoo(6)", "type");
-  assertCompileError("arity_2", "let foo = ((x) => {x + 5});\nfoo()", "type");
+  assertCompileError(
+    "arity_2",
+    "let foo = ((x) => {x + 5});\nfoo()",
+    "missing an argument of type x: Number",
+  );
   assertCompileError(
     "arity_3",
     "let foo = ((x) => {x});\nfoo(1, 2, 3)",
@@ -135,7 +139,11 @@ describe("functions", ({test, testSkip}) => {
     "((x, y, x) => {5})",
     "Variable x is bound several times",
   );
-  assertCompileError("lambda_arity_1", "((x) => {6})()", "type");
+  assertCompileError(
+    "lambda_arity_1",
+    "((x) => {6})()",
+    "missing an argument",
+  );
   assertCompileError("lambda_arity_2", "((x) => {5})(1, 2)", "type");
   assertCompileError(
     "letrec_nonstatic_const",
@@ -205,5 +213,137 @@ truc()|},
     }
     foo()
     |},
+  );
+
+  assertRun(
+    "labeled_args1",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat(a="1", b="2"))
+    |},
+    "12\n",
+  );
+  assertRun(
+    "labeled_args2",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat(a="1", "2"))
+    |},
+    "12\n",
+  );
+  assertRun(
+    "labeled_args3",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat("2", a="1"))
+    |},
+    "12\n",
+  );
+  assertRun(
+    "labeled_args4",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat("1", b="2"))
+    |},
+    "12\n",
+  );
+  assertRun(
+    "labeled_args5",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat(b="2", "1"))
+    |},
+    "12\n",
+  );
+
+  assertRun(
+    "default_args1",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat(a="3", "2"))
+    |},
+    "32\n",
+  );
+  assertRun(
+    "default_args2",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat(a="3", b="2"))
+    |},
+    "32\n",
+  );
+  assertRun(
+    "default_args3",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat(b="2", a="3"))
+    |},
+    "32\n",
+  );
+  assertRun(
+    "default_args4",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat("2"))
+    |},
+    "12\n",
+  );
+  assertRun(
+    "default_args5",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat(b="2"))
+    |},
+    "12\n",
+  );
+
+  assertRun(
+    "labeled_args_typecheck1",
+    {|
+      let apply = (f: (arg1: Number) -> Number) => f(arg1=5)
+      print(apply(notarg1 => notarg1))
+    |},
+    "5\n",
+  );
+
+  assertCompileError(
+    "labeled_args_err1",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat(c="3"))
+    |},
+    "This argument cannot be applied with label c",
+  );
+  assertCompileError(
+    "labeled_args_err2",
+    {|
+      let concat = (a, b) => a ++ b
+      print(concat("1", "2", c="3"))
+    |},
+    "This argument cannot be applied with label c",
+  );
+  assertCompileError(
+    "labeled_args_err3",
+    {|
+      let concat = (a="1", b) => a ++ b
+      print(concat("1", "2"))
+    |},
+    "Did you mean to supply an optional argument with label a?",
+  );
+  assertCompileError(
+    "labeled_args_err4",
+    {|
+      let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
+      print(apply(notarg1 => notarg1))
+    |},
+    "The expected function type contains the optional, default argument \\?arg1",
+  );
+  assertCompileError(
+    "labeled_args_err5",
+    {|
+      let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
+      print(apply(notarg1 => notarg1))
+    |},
+    "but the matching argument is not optional.",
   );
 });

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -312,7 +312,7 @@ truc()|},
       let concat = (a, b) => a ++ b
       print(concat(c="3"))
     |},
-    "This argument cannot be applied with label c",
+    "This argument cannot be supplied with label c",
   );
   assertCompileError(
     "labeled_args_err2",
@@ -320,7 +320,7 @@ truc()|},
       let concat = (a, b) => a ++ b
       print(concat("1", "2", c="3"))
     |},
-    "This argument cannot be applied with label c",
+    "This argument cannot be supplied with label c",
   );
   assertCompileError(
     "labeled_args_err3",
@@ -328,7 +328,7 @@ truc()|},
       let concat = (a="1", b) => a ++ b
       print(concat("1", "2"))
     |},
-    "Did you mean to supply an optional argument with label a?",
+    "Did you mean to supply an argument with label a?",
   );
   assertCompileError(
     "labeled_args_err4",
@@ -336,7 +336,7 @@ truc()|},
       let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
       print(apply(notarg1 => notarg1))
     |},
-    "The expected function type contains the optional, default argument \\?arg1",
+    "The expected function type contains the argument \\?arg1",
   );
   assertCompileError(
     "labeled_args_err5",
@@ -344,6 +344,6 @@ truc()|},
       let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
       print(apply(notarg1 => notarg1))
     |},
-    "but the matching argument is not optional.",
+    "which has a default value, but the matching argument does not.",
   );
 });

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -255,6 +255,14 @@ truc()|},
     |},
     "12\n",
   );
+  assertRun(
+    "labeled_args6",
+    {|
+      let nothing = (a, b) => void
+      nothing(b=print(1), print(2))
+    |},
+    "1\n2\n",
+  );
 
   assertRun(
     "default_args1",

--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -2,6 +2,7 @@ open Grain_tests.TestFramework;
 open Grain_tests.Runner;
 open Grain_parsing;
 open Grain_parsing.Ast_helper;
+open Grain_parsing.Parsetree;
 
 describe("parsing", ({test, testSkip}) => {
   let test_or_skip =
@@ -28,6 +29,11 @@ describe("parsing", ({test, testSkip}) => {
     Expression.ident(
       Location.mknoloc(Identifier.IdentName(Location.mknoloc("c"))),
     );
+  let unlabled_expr = expr => {
+    paa_label: Unlabeled,
+    paa_expr: expr,
+    paa_loc: Location.dummy_loc,
+  };
   let testOp = op =>
     assertParse(
       op,
@@ -42,7 +48,7 @@ describe("parsing", ({test, testSkip}) => {
                   Identifier.IdentName(Location.mknoloc(op)),
                 ),
               ),
-              [a, b],
+              [unlabled_expr(a), unlabled_expr(b)],
             ),
           ),
         ],
@@ -112,14 +118,16 @@ describe("parsing", ({test, testSkip}) => {
               ),
             ),
             [
-              a,
-              Expression.apply(
-                Expression.ident(
-                  Location.mknoloc(
-                    Identifier.IdentName(Location.mknoloc("***")),
+              unlabled_expr(a),
+              unlabled_expr(
+                Expression.apply(
+                  Expression.ident(
+                    Location.mknoloc(
+                      Identifier.IdentName(Location.mknoloc("***")),
+                    ),
                   ),
+                  [unlabled_expr(b), unlabled_expr(c)],
                 ),
-                [b, c],
               ),
             ],
           ),
@@ -143,14 +151,16 @@ describe("parsing", ({test, testSkip}) => {
               ),
             ),
             [
-              a,
-              Expression.apply(
-                Expression.ident(
-                  Location.mknoloc(
-                    Identifier.IdentName(Location.mknoloc("&--")),
+              unlabled_expr(a),
+              unlabled_expr(
+                Expression.apply(
+                  Expression.ident(
+                    Location.mknoloc(
+                      Identifier.IdentName(Location.mknoloc("&--")),
+                    ),
                   ),
+                  [unlabled_expr(b), unlabled_expr(c)],
                 ),
-                [b, c],
               ),
             ],
           ),
@@ -174,14 +184,16 @@ describe("parsing", ({test, testSkip}) => {
               ),
             ),
             [
-              a,
-              Expression.apply(
-                Expression.ident(
-                  Location.mknoloc(
-                    Identifier.IdentName(Location.mknoloc("|--")),
+              unlabled_expr(a),
+              unlabled_expr(
+                Expression.apply(
+                  Expression.ident(
+                    Location.mknoloc(
+                      Identifier.IdentName(Location.mknoloc("|--")),
+                    ),
                   ),
+                  [unlabled_expr(b), unlabled_expr(c)],
                 ),
-                [b, c],
               ),
             ],
           ),
@@ -205,15 +217,17 @@ describe("parsing", ({test, testSkip}) => {
               ),
             ),
             [
-              Expression.apply(
-                Expression.ident(
-                  Location.mknoloc(
-                    Identifier.IdentName(Location.mknoloc("<<")),
+              unlabled_expr(
+                Expression.apply(
+                  Expression.ident(
+                    Location.mknoloc(
+                      Identifier.IdentName(Location.mknoloc("<<")),
+                    ),
                   ),
+                  [unlabled_expr(a), unlabled_expr(b)],
                 ),
-                [a, b],
               ),
-              c,
+              unlabled_expr(c),
             ],
           ),
         ),

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -33,7 +33,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : Array<a> -> Number
+length : (array: Array<a>) -> Number
 ```
 
 Provides the length of the input array.
@@ -152,7 +152,7 @@ Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
 </details>
 
 ```grain
-get : (Number, Array<a>) -> a
+get : (index: Number, array: Array<a>) -> a
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -201,7 +201,7 @@ Array.get(1,[> 1, 2, 3, 4, 5]) == 2
 </details>
 
 ```grain
-set : (Number, a, Array<a>) -> Void
+set : (index: Number, value: a, array: Array<a>) -> Void
 ```
 
 An alias for normal syntactic array set, i.e. `array[n] = value`.
@@ -238,7 +238,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (Array<a>, Array<a>) -> Array<a>
+append : (array1: Array<a>, array2: Array<a>) -> Array<a>
 ```
 
 Creates a new array with the elements of the first array followed by
@@ -277,7 +277,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : List<Array<a>> -> Array<a>
+concat : (arrays: List<Array<a>>) -> Array<a>
 ```
 
 Creates a single array containing the elements of all arrays in the
@@ -315,7 +315,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : Array<a> -> Array<a>
+copy : (array: Array<a>) -> Array<a>
 ```
 
 Produces a shallow copy of the input array. The new array contains the
@@ -341,7 +341,7 @@ No other changes yet.
 </details>
 
 ```grain
-cycle : ((a -> Void), Number, Array<a>) -> Void
+cycle : (fn: (a -> Void), n: Number, array: Array<a>) -> Void
 ```
 
 Iterates an array a given number of times, calling an iterator function on each element.
@@ -369,7 +369,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : ((a -> Void), Array<a>) -> Void
+forEach : (fn: (a -> Void), array: Array<a>) -> Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -396,7 +396,7 @@ Parameters:
 </details>
 
 ```grain
-forEachi : (((a, Number) -> Void), Array<a>) -> Void
+forEachi : (fn: ((a, Number) -> Void), array: Array<a>) -> Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -424,7 +424,7 @@ Parameters:
 </details>
 
 ```grain
-map : ((a -> b), Array<a>) -> Array<b>
+map : (fn: (a -> b), array: Array<a>) -> Array<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -451,7 +451,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapi : (((a, Number) -> b), Array<a>) -> Array<b>
+mapi : (fn: ((a, Number) -> b), array: Array<a>) -> Array<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -478,7 +478,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b) -> a), a, Array<b>) -> a
+reduce : (fn: ((a, b) -> a), initial: a, array: Array<b>) -> a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -517,7 +517,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduceRight : (((a, b) -> b), b, Array<a>) -> b
+reduceRight : (fn: ((a, b) -> b), initial: b, array: Array<a>) -> b
 ```
 
 Combines all elements of an array using a reducer function,
@@ -556,7 +556,7 @@ No other changes yet.
 </details>
 
 ```grain
-reducei : (((a, b, Number) -> a), a, Array<b>) -> a
+reducei : (fn: ((a, b, Number) -> a), initial: a, array: Array<b>) -> a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -590,7 +590,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((b -> Array<a>), Array<b>) -> Array<a>
+flatMap : (fn: (b -> Array<a>), array: Array<b>) -> Array<a>
 ```
 
 Produces a new array by calling a function on each element
@@ -625,7 +625,7 @@ No other changes yet.
 </details>
 
 ```grain
-every : ((a -> Bool), Array<a>) -> Bool
+every : (fn: (a -> Bool), array: Array<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -652,7 +652,7 @@ No other changes yet.
 </details>
 
 ```grain
-some : ((a -> Bool), Array<a>) -> Bool
+some : (fn: (a -> Bool), array: Array<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -679,7 +679,7 @@ No other changes yet.
 </details>
 
 ```grain
-fill : (a, Array<a>) -> Void
+fill : (value: a, array: Array<a>) -> Void
 ```
 
 Replaces all elements in an array with the new value provided.
@@ -699,7 +699,7 @@ No other changes yet.
 </details>
 
 ```grain
-fillRange : (a, Number, Number, Array<a>) -> Void
+fillRange : (value: a, start: Number, stop: Number, array: Array<a>) -> Void
 ```
 
 Replaces all elements in the provided index range in the array
@@ -729,7 +729,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : Array<a> -> Array<a>
+reverse : (array: Array<a>) -> Array<a>
 ```
 
 Creates a new array with all elements in reverse order.
@@ -754,7 +754,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : Array<a> -> List<a>
+toList : (array: Array<a>) -> List<a>
 ```
 
 Converts the input array to a list.
@@ -779,7 +779,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<a> -> Array<a>
+fromList : (list: List<a>) -> Array<a>
 ```
 
 Converts the input list to an array.
@@ -804,7 +804,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, Array<a>) -> Bool
+contains : (search: a, array: Array<a>) -> Bool
 ```
 
 Checks if the value is an element of the input array.
@@ -831,7 +831,7 @@ No other changes yet.
 </details>
 
 ```grain
-find : ((a -> Bool), Array<a>) -> Option<a>
+find : (fn: (a -> Bool), array: Array<a>) -> Option<a>
 ```
 
 Finds the first element in an array that satifies the given condition.
@@ -857,7 +857,7 @@ No other changes yet.
 </details>
 
 ```grain
-findIndex : ((a -> Bool), Array<a>) -> Option<Number>
+findIndex : (fn: (a -> Bool), array: Array<a>) -> Option<Number>
 ```
 
 Finds the first index in an array where the element satifies the given condition.
@@ -883,7 +883,7 @@ No other changes yet.
 </details>
 
 ```grain
-product : (Array<a>, Array<b>) -> Array<(a, b)>
+product : (array1: Array<a>, array2: Array<b>) -> Array<(a, b)>
 ```
 
 Combines two arrays into a Cartesian product of tuples containing
@@ -916,7 +916,7 @@ No other changes yet.
 </details>
 
 ```grain
-count : ((a -> Bool), Array<a>) -> Number
+count : (fn: (a -> Bool), array: Array<a>) -> Number
 ```
 
 Counts the number of elements in an array that satisfy the given condition.
@@ -942,7 +942,7 @@ No other changes yet.
 </details>
 
 ```grain
-counti : (((a, Number) -> Bool), Array<a>) -> Number
+counti : (fn: ((a, Number) -> Bool), array: Array<a>) -> Number
 ```
 
 Counts the number of elements in an array that satisfy the
@@ -969,7 +969,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), Array<a>) -> Array<a>
+filter : (fn: (a -> Bool), array: Array<a>) -> Array<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -997,7 +997,7 @@ No other changes yet.
 </details>
 
 ```grain
-filteri : (((a, Number) -> Bool), Array<a>) -> Array<a>
+filteri : (fn: ((a, Number) -> Bool), array: Array<a>) -> Array<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -1025,7 +1025,7 @@ No other changes yet.
 </details>
 
 ```grain
-unique : Array<a> -> Array<a>
+unique : (array: Array<a>) -> Array<a>
 ```
 
 Produces a new array with any duplicates removed.
@@ -1058,7 +1058,7 @@ Returns:
 </details>
 
 ```grain
-zip : (Array<a>, Array<b>) -> Array<(a, b)>
+zip : (array1: Array<a>, array2: Array<b>) -> Array<(a, b)>
 ```
 
 Produces a new array filled with tuples of elements from both given arrays.
@@ -1092,7 +1092,7 @@ No other changes yet.
 </details>
 
 ```grain
-zipWith : (((a, b) -> c), Array<a>, Array<b>) -> Array<c>
+zipWith : (fn: ((a, b) -> c), array1: Array<a>, array2: Array<b>) -> Array<c>
 ```
 
 Produces a new array filled with elements defined by applying a function on
@@ -1142,7 +1142,7 @@ No other changes yet.
 </details>
 
 ```grain
-unzip : Array<(a, b)> -> (Array<a>, Array<b>)
+unzip : (array: Array<(a, b)>) -> (Array<a>, Array<b>)
 ```
 
 Produces two arrays by splitting apart an array of tuples.
@@ -1167,7 +1167,7 @@ No other changes yet.
 </details>
 
 ```grain
-join : (String, Array<String>) -> String
+join : (separator: String, items: Array<String>) -> String
 ```
 
 Concatenates an array of strings into a single string, separated by a separator string.
@@ -1193,7 +1193,7 @@ No other changes yet.
 </details>
 
 ```grain
-slice : (Number, Number, Array<a>) -> Array<a>
+slice : (startIndex: Number, endIndex: Number, array: Array<a>) -> Array<a>
 ```
 
 Slices an array given zero-based start and end indexes. The value
@@ -1224,7 +1224,7 @@ No other changes yet.
 </details>
 
 ```grain
-sort : (((a, a) -> Number), Array<a>) -> Void
+sort : (comp: ((a, a) -> Number), array: Array<a>) -> Void
 ```
 
 Sorts an array in-place.
@@ -1253,7 +1253,7 @@ Parameters:
 </details>
 
 ```grain
-rotate : (Number, Array<a>) -> Void
+rotate : (n: Number, arr: Array<a>) -> Void
 ```
 
 Rotates array elements in place by the specified amount to the left, such

--- a/stdlib/bigint.md
+++ b/stdlib/bigint.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> BigInt
+fromNumber : (x: Number) -> BigInt
 ```
 
 Converts a Number to a BigInt.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : BigInt -> Number
+toNumber : (x: BigInt) -> Number
 ```
 
 Converts a BigInt to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : BigInt -> BigInt
+incr : (num: BigInt) -> BigInt
 ```
 
 Increments the value by one.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : BigInt -> BigInt
+decr : (num: BigInt) -> BigInt
 ```
 
 Decrements the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-neg : BigInt -> BigInt
+neg : (num: BigInt) -> BigInt
 ```
 
 Negates the given operand.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-abs : BigInt -> BigInt
+abs : (num: BigInt) -> BigInt
 ```
 
 Returns the absolute value of the given operand.
@@ -182,7 +182,7 @@ Returns:
 </details>
 
 ```grain
-(+) : (BigInt, BigInt) -> BigInt
+(+) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the sum of its operands.
@@ -215,7 +215,7 @@ Returns:
 </details>
 
 ```grain
-(-) : (BigInt, BigInt) -> BigInt
+(-) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the difference of its operands.
@@ -248,7 +248,7 @@ Returns:
 </details>
 
 ```grain
-(*) : (BigInt, BigInt) -> BigInt
+(*) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the product of its operands.
@@ -281,7 +281,7 @@ Returns:
 </details>
 
 ```grain
-(/) : (BigInt, BigInt) -> BigInt
+(/) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the quotient of its operands using signed (truncated) division
@@ -308,7 +308,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (BigInt, BigInt) -> BigInt
+rem : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the remainder of the division of its operands using signed (truncated) division
@@ -335,7 +335,7 @@ No other changes yet.
 </details>
 
 ```grain
-quotRem : (BigInt, BigInt) -> (BigInt, BigInt)
+quotRem : (num1: BigInt, num2: BigInt) -> (BigInt, BigInt)
 ```
 
 Computes the quotient and remainder of its operands using signed (truncated) division.
@@ -361,7 +361,7 @@ No other changes yet.
 </details>
 
 ```grain
-gcd : (BigInt, BigInt) -> BigInt
+gcd : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the greatest common divisior of the two operands.
@@ -394,7 +394,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (BigInt, Int32) -> BigInt
+(<<) : (num: BigInt, places: Int32) -> BigInt
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -427,7 +427,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (BigInt, Int32) -> BigInt
+(>>) : (num: BigInt, places: Int32) -> BigInt
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -453,7 +453,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : BigInt -> Bool
+eqz : (num: BigInt) -> Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -485,7 +485,7 @@ Returns:
 </details>
 
 ```grain
-(==) : (BigInt, BigInt) -> Bool
+(==) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -518,7 +518,7 @@ Returns:
 </details>
 
 ```grain
-(!=) : (BigInt, BigInt) -> Bool
+(!=) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -551,7 +551,7 @@ Returns:
 </details>
 
 ```grain
-(<) : (BigInt, BigInt) -> Bool
+(<) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -584,7 +584,7 @@ Returns:
 </details>
 
 ```grain
-(<=) : (BigInt, BigInt) -> Bool
+(<=) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -617,7 +617,7 @@ Returns:
 </details>
 
 ```grain
-(>) : (BigInt, BigInt) -> Bool
+(>) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -650,7 +650,7 @@ Returns:
 </details>
 
 ```grain
-(>=) : (BigInt, BigInt) -> Bool
+(>=) : (num1: BigInt, num2: BigInt) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -676,7 +676,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : BigInt -> BigInt
+lnot : (num: BigInt) -> BigInt
 ```
 
 Computes the bitwise NOT of the given value.
@@ -708,7 +708,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (BigInt, BigInt) -> BigInt
+(&) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -741,7 +741,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (BigInt, BigInt) -> BigInt
+(|) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -774,7 +774,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (BigInt, BigInt) -> BigInt
+(^) : (num1: BigInt, num2: BigInt) -> BigInt
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -800,7 +800,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : BigInt -> Int32
+clz : (num: BigInt) -> Int32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -826,7 +826,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : BigInt -> Int64
+ctz : (num: BigInt) -> Int64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -851,7 +851,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : BigInt -> Option<Int64>
+popcnt : (num: BigInt) -> Option<Int64>
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.
@@ -877,7 +877,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : BigInt -> String
+toString : (num: BigInt) -> String
 ```
 
 Converts the given operand to a string.

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -37,7 +37,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : Number -> Buffer
+make : (initialSize: Number) -> Buffer
 ```
 
 Creates a fresh buffer, initially empty.
@@ -71,7 +71,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : Buffer -> Number
+length : (buffer: Buffer) -> Number
 ```
 
 Gets the number of bytes currently contained in a buffer.
@@ -96,7 +96,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Buffer -> Void
+clear : (buffer: Buffer) -> Void
 ```
 
 Clears data in the buffer and sets its length to zero.
@@ -117,7 +117,7 @@ No other changes yet.
 </details>
 
 ```grain
-reset : Buffer -> Void
+reset : (buffer: Buffer) -> Void
 ```
 
 Empty a buffer and deallocate the internal byte sequence holding the buffer contents.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-truncate : (Number, Buffer) -> Void
+truncate : (length: Number, buffer: Buffer) -> Void
 ```
 
 Shortens a buffer to the given length.
@@ -167,7 +167,7 @@ No other changes yet.
 </details>
 
 ```grain
-toBytes : Buffer -> Bytes
+toBytes : (buffer: Buffer) -> Bytes
 ```
 
 Returns a copy of the current contents of the buffer as a byte sequence.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-toBytesSlice : (Number, Number, Buffer) -> Bytes
+toBytesSlice : (start: Number, length: Number, buffer: Buffer) -> Bytes
 ```
 
 Returns a slice of the current contents of the buffer as a byte sequence.
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : Buffer -> String
+toString : (buffer: Buffer) -> String
 ```
 
 Returns a copy of the current contents of the buffer as a string.
@@ -252,7 +252,7 @@ No other changes yet.
 </details>
 
 ```grain
-toStringSlice : (Number, Number, Buffer) -> String
+toStringSlice : (start: Number, length: Number, buffer: Buffer) -> String
 ```
 
 Returns a copy of a subset of the current contents of the buffer as a string.
@@ -279,7 +279,7 @@ No other changes yet.
 </details>
 
 ```grain
-addBytes : (Bytes, Buffer) -> Void
+addBytes : (bytes: Bytes, buffer: Buffer) -> Void
 ```
 
 Appends a byte sequence to a buffer.
@@ -299,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-addString : (String, Buffer) -> Void
+addString : (string: String, buffer: Buffer) -> Void
 ```
 
 Appends the bytes of a string to a buffer.
@@ -319,7 +319,7 @@ No other changes yet.
 </details>
 
 ```grain
-addChar : (Char, Buffer) -> Void
+addChar : (char: Char, buffer: Buffer) -> Void
 ```
 
 Appends the bytes of a char to a buffer.
@@ -346,7 +346,8 @@ Parameters:
 </details>
 
 ```grain
-addStringSlice : (Number, Number, String, Buffer) -> Void
+addStringSlice :
+  (start: Number, end: Number, string: String, buffer: Buffer) -> Void
 ```
 
 Appends the bytes of a subset of a string to a buffer.
@@ -368,7 +369,8 @@ No other changes yet.
 </details>
 
 ```grain
-addBytesSlice : (Number, Number, Bytes, Buffer) -> Void
+addBytesSlice :
+  (start: Number, length: Number, bytes: Bytes, buffer: Buffer) -> Void
 ```
 
 Appends the bytes of a subset of a byte sequence to a buffer.
@@ -399,7 +401,7 @@ No other changes yet.
 </details>
 
 ```grain
-addBuffer : (Buffer, Buffer) -> Void
+addBuffer : (srcBuffer: Buffer, dstBuffer: Buffer) -> Void
 ```
 
 Appends the bytes of a source buffer to destination buffer.
@@ -421,7 +423,9 @@ No other changes yet.
 </details>
 
 ```grain
-addBufferSlice : (Number, Number, Buffer, Buffer) -> Void
+addBufferSlice :
+  (start: Number, length: Number, srcBuffer: Buffer, dstBuffer: Buffer) ->
+   Void
 ```
 
 Appends the bytes of a part of a buffer to the end of the buffer
@@ -452,7 +456,7 @@ Parameters:
 </details>
 
 ```grain
-getInt8 : (Number, Buffer) -> Int8
+getInt8 : (index: Number, buffer: Buffer) -> Int8
 ```
 
 Gets a signed 8-bit integer starting at the given byte index.
@@ -493,7 +497,7 @@ Throws:
 </details>
 
 ```grain
-setInt8 : (Number, Int8, Buffer) -> Void
+setInt8 : (index: Number, value: Int8, buffer: Buffer) -> Void
 ```
 
 Sets a signed 8-bit integer starting at the given byte index.
@@ -529,7 +533,7 @@ Throws:
 </details>
 
 ```grain
-addInt8 : (Int8, Buffer) -> Void
+addInt8 : (value: Int8, buffer: Buffer) -> Void
 ```
 
 Appends a signed 8-bit integer to a buffer.
@@ -556,7 +560,7 @@ Parameters:
 </details>
 
 ```grain
-getUint8 : (Number, Buffer) -> Uint8
+getUint8 : (index: Number, buffer: Buffer) -> Uint8
 ```
 
 Gets an unsigned 8-bit integer starting at the given byte index.
@@ -590,7 +594,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint8 : (Number, Uint8, Buffer) -> Void
+setUint8 : (index: Number, value: Uint8, buffer: Buffer) -> Void
 ```
 
 Sets an unsigned 8-bit integer starting at the given byte index.
@@ -619,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint8 : (Uint8, Buffer) -> Void
+addUint8 : (value: Uint8, buffer: Buffer) -> Void
 ```
 
 Appends an unsigned 8-bit integer to a buffer.
@@ -646,7 +650,7 @@ Parameters:
 </details>
 
 ```grain
-getInt16 : (Number, Buffer) -> Int16
+getInt16 : (index: Number, buffer: Buffer) -> Int16
 ```
 
 Gets a signed 16-bit integer starting at the given byte index.
@@ -687,7 +691,7 @@ Throws:
 </details>
 
 ```grain
-setInt16 : (Number, Int16, Buffer) -> Void
+setInt16 : (index: Number, value: Int16, buffer: Buffer) -> Void
 ```
 
 Sets a signed 16-bit integer starting at the given byte index.
@@ -723,7 +727,7 @@ Throws:
 </details>
 
 ```grain
-addInt16 : (Int16, Buffer) -> Void
+addInt16 : (value: Int16, buffer: Buffer) -> Void
 ```
 
 Appends a signed 16-bit integer to a buffer.
@@ -750,7 +754,7 @@ Parameters:
 </details>
 
 ```grain
-getUint16 : (Number, Buffer) -> Uint16
+getUint16 : (index: Number, buffer: Buffer) -> Uint16
 ```
 
 Gets an unsigned 16-bit integer starting at the given byte index.
@@ -784,7 +788,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint16 : (Number, Uint16, Buffer) -> Void
+setUint16 : (index: Number, value: Uint16, buffer: Buffer) -> Void
 ```
 
 Sets an unsigned 16-bit integer starting at the given byte index.
@@ -813,7 +817,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint16 : (Uint16, Buffer) -> Void
+addUint16 : (value: Uint16, buffer: Buffer) -> Void
 ```
 
 Appends an unsigned 16-bit integer to a buffer.
@@ -833,7 +837,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt32 : (Number, Buffer) -> Int32
+getInt32 : (index: Number, buffer: Buffer) -> Int32
 ```
 
 Gets a signed 32-bit integer starting at the given byte index.
@@ -867,7 +871,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt32 : (Number, Int32, Buffer) -> Void
+setInt32 : (index: Number, value: Int32, buffer: Buffer) -> Void
 ```
 
 Sets a signed 32-bit integer starting at the given byte index.
@@ -896,7 +900,7 @@ No other changes yet.
 </details>
 
 ```grain
-addInt32 : (Int32, Buffer) -> Void
+addInt32 : (value: Int32, buffer: Buffer) -> Void
 ```
 
 Appends a signed 32-bit integer to a buffer.
@@ -916,7 +920,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint32 : (Number, Buffer) -> Uint32
+getUint32 : (index: Number, buffer: Buffer) -> Uint32
 ```
 
 Gets an unsigned 32-bit integer starting at the given byte index.
@@ -950,7 +954,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint32 : (Number, Uint32, Buffer) -> Void
+setUint32 : (index: Number, value: Uint32, buffer: Buffer) -> Void
 ```
 
 Sets an unsigned 32-bit integer starting at the given byte index.
@@ -979,7 +983,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint32 : (Uint32, Buffer) -> Void
+addUint32 : (value: Uint32, buffer: Buffer) -> Void
 ```
 
 Appends an unsigned 32-bit integer to a buffer.
@@ -999,7 +1003,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat32 : (Number, Buffer) -> Float32
+getFloat32 : (index: Number, buffer: Buffer) -> Float32
 ```
 
 Gets a 32-bit float starting at the given byte index.
@@ -1033,7 +1037,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat32 : (Number, Float32, Buffer) -> Void
+setFloat32 : (index: Number, value: Float32, buffer: Buffer) -> Void
 ```
 
 Sets a 32-bit float starting at the given byte index.
@@ -1062,7 +1066,7 @@ No other changes yet.
 </details>
 
 ```grain
-addFloat32 : (Float32, Buffer) -> Void
+addFloat32 : (value: Float32, buffer: Buffer) -> Void
 ```
 
 Appends a 32-bit float to a buffer.
@@ -1082,7 +1086,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt64 : (Number, Buffer) -> Int64
+getInt64 : (index: Number, buffer: Buffer) -> Int64
 ```
 
 Gets a signed 64-bit integer starting at the given byte index.
@@ -1116,7 +1120,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt64 : (Number, Int64, Buffer) -> Void
+setInt64 : (index: Number, value: Int64, buffer: Buffer) -> Void
 ```
 
 Sets a signed 64-bit integer starting at the given byte index.
@@ -1145,7 +1149,7 @@ No other changes yet.
 </details>
 
 ```grain
-addInt64 : (Int64, Buffer) -> Void
+addInt64 : (value: Int64, buffer: Buffer) -> Void
 ```
 
 Appends a signed 64-bit integer to a buffer.
@@ -1165,7 +1169,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint64 : (Number, Buffer) -> Uint64
+getUint64 : (index: Number, buffer: Buffer) -> Uint64
 ```
 
 Gets an unsigned 64-bit integer starting at the given byte index.
@@ -1199,7 +1203,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint64 : (Number, Uint64, Buffer) -> Void
+setUint64 : (index: Number, value: Uint64, buffer: Buffer) -> Void
 ```
 
 Sets an unsigned 64-bit integer starting at the given byte index.
@@ -1228,7 +1232,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint64 : (Uint64, Buffer) -> Void
+addUint64 : (value: Uint64, buffer: Buffer) -> Void
 ```
 
 Appends an unsigned 64-bit integer to a buffer.
@@ -1248,7 +1252,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat64 : (Number, Buffer) -> Float64
+getFloat64 : (index: Number, buffer: Buffer) -> Float64
 ```
 
 Gets a 64-bit float starting at the given byte index.
@@ -1282,7 +1286,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat64 : (Number, Float64, Buffer) -> Void
+setFloat64 : (index: Number, value: Float64, buffer: Buffer) -> Void
 ```
 
 Sets a 64-bit float starting at the given byte index.
@@ -1311,7 +1315,7 @@ No other changes yet.
 </details>
 
 ```grain
-addFloat64 : (Float64, Buffer) -> Void
+addFloat64 : (value: Float64, buffer: Buffer) -> Void
 ```
 
 Appends a 64-bit float to a buffer.

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : Number -> Bytes
+make : (size: Number) -> Bytes
 ```
 
 Creates a new byte sequence of the input size.
@@ -63,7 +63,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromString : String -> Bytes
+fromString : (string: String) -> Bytes
 ```
 
 Creates a new byte sequence from the input string.
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : Bytes -> String
+toString : (bytes: Bytes) -> String
 ```
 
 Creates a new string from the input bytes.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : Bytes -> Number
+length : (bytes: Bytes) -> Number
 ```
 
 Returns the length of a byte sequence.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : Bytes -> Bytes
+copy : (b: Bytes) -> Bytes
 ```
 
 Creates a new byte sequence that contains the same bytes as the input byte sequence.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-slice : (Number, Number, Bytes) -> Bytes
+slice : (start: Number, length: Number, bytes: Bytes) -> Bytes
 ```
 
 Returns a copy of a subset of the input byte sequence.
@@ -196,7 +196,7 @@ No other changes yet.
 </details>
 
 ```grain
-resize : (Number, Number, Bytes) -> Bytes
+resize : (left: Number, right: Number, bytes: Bytes) -> Bytes
 ```
 
 Returns a copy of a byte sequence with bytes added or removed from the beginning and/or end.
@@ -231,7 +231,9 @@ No other changes yet.
 </details>
 
 ```grain
-move : (Number, Number, Number, Bytes, Bytes) -> Void
+move :
+  (srcIndex: Number, dstIndex: Number, length: Number, src: Bytes, dst: Bytes) ->
+   Void
 ```
 
 Copies a range of bytes from a source byte sequence to a given location
@@ -262,7 +264,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (Bytes, Bytes) -> Bytes
+concat : (bytes1: Bytes, bytes2: Bytes) -> Bytes
 ```
 
 Creates a new byte sequence that contains the bytes of both byte sequences.
@@ -295,7 +297,7 @@ Returns:
 </details>
 
 ```grain
-fill : (Uint8, Bytes) -> Void
+fill : (value: Uint8, bytes: Bytes) -> Void
 ```
 
 Replaces all bytes in a byte sequnce with the new value provided.
@@ -315,7 +317,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Bytes -> Void
+clear : (bytes: Bytes) -> Void
 ```
 
 Replaces all bytes in a byte sequence with zeroes.
@@ -341,7 +343,7 @@ Parameters:
 </details>
 
 ```grain
-getInt8 : (Number, Bytes) -> Int8
+getInt8 : (index: Number, bytes: Bytes) -> Int8
 ```
 
 Gets a signed 8-bit integer starting at the given byte index.
@@ -381,7 +383,7 @@ Throws:
 </details>
 
 ```grain
-setInt8 : (Number, Int8, Bytes) -> Void
+setInt8 : (index: Number, value: Int8, bytes: Bytes) -> Void
 ```
 
 Sets a signed 8-bit integer starting at the given byte index.
@@ -416,7 +418,7 @@ Throws:
 </details>
 
 ```grain
-getUint8 : (Number, Bytes) -> Uint8
+getUint8 : (index: Number, bytes: Bytes) -> Uint8
 ```
 
 Gets an unsigned 8-bit integer starting at the given byte index.
@@ -449,7 +451,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint8 : (Number, Uint8, Bytes) -> Void
+setUint8 : (index: Number, value: Uint8, bytes: Bytes) -> Void
 ```
 
 Sets an unsigned 8-bit integer starting at the given byte index.
@@ -484,7 +486,7 @@ Throws:
 </details>
 
 ```grain
-getInt16 : (Number, Bytes) -> Int16
+getInt16 : (index: Number, bytes: Bytes) -> Int16
 ```
 
 Gets a signed 16-bit integer starting at the given byte index.
@@ -524,7 +526,7 @@ Throws:
 </details>
 
 ```grain
-setInt16 : (Number, Int16, Bytes) -> Void
+setInt16 : (index: Number, value: Int16, bytes: Bytes) -> Void
 ```
 
 Sets a signed 16-bit integer starting at the given byte index.
@@ -559,7 +561,7 @@ Throws:
 </details>
 
 ```grain
-getUint16 : (Number, Bytes) -> Uint16
+getUint16 : (index: Number, bytes: Bytes) -> Uint16
 ```
 
 Gets an unsigned 16-bit integer starting at the given byte index.
@@ -592,7 +594,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint16 : (Number, Uint16, Bytes) -> Void
+setUint16 : (index: Number, value: Uint16, bytes: Bytes) -> Void
 ```
 
 Sets an unsigned 16-bit integer starting at the given byte index.
@@ -620,7 +622,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt32 : (Number, Bytes) -> Int32
+getInt32 : (index: Number, bytes: Bytes) -> Int32
 ```
 
 Gets a signed 32-bit integer starting at the given byte index.
@@ -653,7 +655,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt32 : (Number, Int32, Bytes) -> Void
+setInt32 : (index: Number, value: Int32, bytes: Bytes) -> Void
 ```
 
 Sets a signed 32-bit integer starting at the given byte index.
@@ -681,7 +683,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint32 : (Number, Bytes) -> Uint32
+getUint32 : (index: Number, bytes: Bytes) -> Uint32
 ```
 
 Gets an unsigned 32-bit integer starting at the given byte index.
@@ -714,7 +716,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint32 : (Number, Uint32, Bytes) -> Void
+setUint32 : (index: Number, value: Uint32, bytes: Bytes) -> Void
 ```
 
 Sets an unsigned 32-bit integer starting at the given byte index.
@@ -742,7 +744,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat32 : (Number, Bytes) -> Float32
+getFloat32 : (index: Number, bytes: Bytes) -> Float32
 ```
 
 Gets a 32-bit float starting at the given byte index.
@@ -775,7 +777,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat32 : (Number, Float32, Bytes) -> Void
+setFloat32 : (index: Number, value: Float32, bytes: Bytes) -> Void
 ```
 
 Sets a 32-bit float starting at the given byte index.
@@ -803,7 +805,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt64 : (Number, Bytes) -> Int64
+getInt64 : (index: Number, bytes: Bytes) -> Int64
 ```
 
 Gets a signed 64-bit integer starting at the given byte index.
@@ -836,7 +838,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt64 : (Number, Int64, Bytes) -> Void
+setInt64 : (index: Number, value: Int64, bytes: Bytes) -> Void
 ```
 
 Sets a signed 64-bit integer starting at the given byte index.
@@ -864,7 +866,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint64 : (Number, Bytes) -> Uint64
+getUint64 : (index: Number, bytes: Bytes) -> Uint64
 ```
 
 Gets an unsigned 64-bit integer starting at the given byte index.
@@ -897,7 +899,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint64 : (Number, Uint64, Bytes) -> Void
+setUint64 : (index: Number, value: Uint64, bytes: Bytes) -> Void
 ```
 
 Sets an unsigned 64-bit integer starting at the given byte index.
@@ -925,7 +927,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat64 : (Number, Bytes) -> Float64
+getFloat64 : (index: Number, bytes: Bytes) -> Float64
 ```
 
 Gets a 64-bit float starting at the given byte index.
@@ -958,7 +960,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat64 : (Number, Float64, Bytes) -> Void
+setFloat64 : (index: Number, value: Float64, bytes: Bytes) -> Void
 ```
 
 Sets a 64-bit float starting at the given byte index.

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -53,7 +53,7 @@ No other changes yet.
 </details>
 
 ```grain
-isValid : Number -> Bool
+isValid : (charCode: Number) -> Bool
 ```
 
 Determines whether the given character code is a valid Unicode scalar value.
@@ -78,7 +78,7 @@ No other changes yet.
 </details>
 
 ```grain
-code : Char -> Number
+code : (char: Char) -> Number
 ```
 
 Determines the Unicode scalar value for a character.
@@ -103,7 +103,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromCode : Number -> Char
+fromCode : (usv: Number) -> Char
 ```
 
 Creates a character from the given Unicode scalar value.
@@ -134,7 +134,7 @@ No other changes yet.
 </details>
 
 ```grain
-succ : Char -> Char
+succ : (char: Char) -> Char
 ```
 
 Returns the next valid character by Unicode scalar value.
@@ -165,7 +165,7 @@ No other changes yet.
 </details>
 
 ```grain
-pred : Char -> Char
+pred : (char: Char) -> Char
 ```
 
 Returns the previous valid character by Unicode scalar value.
@@ -196,7 +196,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : Char -> String
+toString : (char: Char) -> String
 ```
 
 Converts the given character to a string.

--- a/stdlib/exception.md
+++ b/stdlib/exception.md
@@ -27,7 +27,7 @@ No other changes yet.
 </details>
 
 ```grain
-registerPrinter : (Exception -> Option<String>) -> Void
+registerPrinter : (printer: (Exception -> Option<String>)) -> Void
 ```
 
 Registers an exception printer. When an exception is thrown, all registered

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Float32
+fromNumber : (x: Number) -> Float32
 ```
 
 Converts a Number to a Float32.
@@ -115,7 +115,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Float32 -> Number
+toNumber : (x: Float32) -> Number
 ```
 
 Converts a Float32 to a Number.
@@ -140,7 +140,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (Float32, Float32) -> Float32
+add : (x: Float32, y: Float32) -> Float32
 ```
 
 Computes the sum of its operands.
@@ -166,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (Float32, Float32) -> Float32
+sub : (x: Float32, y: Float32) -> Float32
 ```
 
 Computes the difference of its operands.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (Float32, Float32) -> Float32
+mul : (x: Float32, y: Float32) -> Float32
 ```
 
 Computes the product of its operands.
@@ -218,7 +218,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (Float32, Float32) -> Float32
+div : (x: Float32, y: Float32) -> Float32
 ```
 
 Computes the quotient of its operands.
@@ -244,7 +244,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (Float32, Float32) -> Bool
+lt : (x: Float32, y: Float32) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -270,7 +270,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (Float32, Float32) -> Bool
+gt : (x: Float32, y: Float32) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -296,7 +296,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (Float32, Float32) -> Bool
+lte : (x: Float32, y: Float32) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -322,7 +322,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (Float32, Float32) -> Bool
+gte : (x: Float32, y: Float32) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Float64
+fromNumber : (x: Number) -> Float64
 ```
 
 Converts a Number to a Float64.
@@ -115,7 +115,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Float64 -> Number
+toNumber : (x: Float64) -> Number
 ```
 
 Converts a Float64 to a Number.
@@ -140,7 +140,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (Float64, Float64) -> Float64
+add : (x: Float64, y: Float64) -> Float64
 ```
 
 Computes the sum of its operands.
@@ -166,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (Float64, Float64) -> Float64
+sub : (x: Float64, y: Float64) -> Float64
 ```
 
 Computes the difference of its operands.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (Float64, Float64) -> Float64
+mul : (x: Float64, y: Float64) -> Float64
 ```
 
 Computes the product of its operands.
@@ -218,7 +218,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (Float64, Float64) -> Float64
+div : (x: Float64, y: Float64) -> Float64
 ```
 
 Computes the quotient of its operands.
@@ -244,7 +244,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (Float64, Float64) -> Bool
+lt : (x: Float64, y: Float64) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -270,7 +270,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (Float64, Float64) -> Bool
+gt : (x: Float64, y: Float64) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -296,7 +296,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (Float64, Float64) -> Bool
+lte : (x: Float64, y: Float64) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -322,7 +322,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (Float64, Float64) -> Bool
+gte : (x: Float64, y: Float64) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/hash.md
+++ b/stdlib/hash.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-hash : a -> Number
+hash : (anything: a) -> Number
 ```
 
 A generic hash function that produces an integer from any value. If `a == b` then `Hash.hash(a) == Hash.hash(b)`.

--- a/stdlib/immutablearray.md
+++ b/stdlib/immutablearray.md
@@ -48,7 +48,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : ImmutableArray<a> -> Bool
+isEmpty : (array: ImmutableArray<a>) -> Bool
 ```
 
 Determines if the array contains no elements.
@@ -73,7 +73,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : ImmutableArray<a> -> Number
+length : (array: ImmutableArray<a>) -> Number
 ```
 
 Provides the length of the input array.
@@ -104,7 +104,7 @@ No other changes yet.
 </details>
 
 ```grain
-get : (Number, ImmutableArray<a>) -> a
+get : (index: Number, array: ImmutableArray<a>) -> a
 ```
 
 Retrieves the element from the array at the specified index.
@@ -147,7 +147,8 @@ No other changes yet.
 </details>
 
 ```grain
-set : (Number, a, ImmutableArray<a>) -> ImmutableArray<a>
+set :
+  (index: Number, value: a, array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Creates a new array in which the element at the specified index is set to a
@@ -187,7 +188,8 @@ No other changes yet.
 </details>
 
 ```grain
-append : (ImmutableArray<a>, ImmutableArray<a>) -> ImmutableArray<a>
+append :
+  (array1: ImmutableArray<a>, array2: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Creates a new array with the elements of the first array followed by
@@ -220,7 +222,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : List<ImmutableArray<a>> -> ImmutableArray<a>
+concat : (arrays: List<ImmutableArray<a>>) -> ImmutableArray<a>
 ```
 
 Creates a single array containing the elements of all arrays in the
@@ -252,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-init : (Number, (Number -> a)) -> ImmutableArray<a>
+init : (length: Number, fn: (Number -> a)) -> ImmutableArray<a>
 ```
 
 Creates a new array of the specified length where each element is
@@ -286,7 +288,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (Number, a) -> ImmutableArray<a>
+make : (length: Number, value: a) -> ImmutableArray<a>
 ```
 
 Creates a new array of the specified length with each element being
@@ -319,7 +321,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : ((a -> Void), ImmutableArray<a>) -> Void
+forEach : (fn: (a -> Void), array: ImmutableArray<a>) -> Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -339,7 +341,7 @@ No other changes yet.
 </details>
 
 ```grain
-cycle : ((a -> Void), Number, ImmutableArray<a>) -> Void
+cycle : (fn: (a -> Void), n: Number, array: ImmutableArray<a>) -> Void
 ```
 
 Iterates an array a given number of times, calling an iterator function on each element.
@@ -360,7 +362,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : ((a -> b), ImmutableArray<a>) -> ImmutableArray<b>
+map : (fn: (a -> b), array: ImmutableArray<a>) -> ImmutableArray<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -387,7 +389,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b) -> a), a, ImmutableArray<b>) -> a
+reduce : (fn: ((a, b) -> a), initial: a, array: ImmutableArray<b>) -> a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -426,7 +428,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduceRight : (((a, b) -> b), b, ImmutableArray<a>) -> b
+reduceRight : (fn: ((a, b) -> b), initial: b, array: ImmutableArray<a>) -> b
 ```
 
 Combines all elements of an array using a reducer function,
@@ -465,7 +467,9 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((a -> ImmutableArray<b>), ImmutableArray<a>) -> ImmutableArray<b>
+flatMap :
+  (fn: (a -> ImmutableArray<b>), array: ImmutableArray<a>) ->
+   ImmutableArray<b>
 ```
 
 Produces a new array by calling a function on each element
@@ -500,7 +504,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<a> -> ImmutableArray<a>
+fromList : (list: List<a>) -> ImmutableArray<a>
 ```
 
 Converts the input list to an array.
@@ -525,7 +529,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : ImmutableArray<a> -> List<a>
+toList : (array: ImmutableArray<a>) -> List<a>
 ```
 
 Converts the input array to a list.
@@ -550,7 +554,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), ImmutableArray<a>) -> ImmutableArray<a>
+filter : (fn: (a -> Bool), array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -578,7 +582,7 @@ No other changes yet.
 </details>
 
 ```grain
-every : ((a -> Bool), ImmutableArray<a>) -> Bool
+every : (fn: (a -> Bool), array: ImmutableArray<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -605,7 +609,7 @@ No other changes yet.
 </details>
 
 ```grain
-some : ((a -> Bool), ImmutableArray<a>) -> Bool
+some : (fn: (a -> Bool), array: ImmutableArray<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -632,7 +636,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : ImmutableArray<a> -> ImmutableArray<a>
+reverse : (array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Creates a new array with all elements in reverse order.
@@ -657,7 +661,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, ImmutableArray<a>) -> Bool
+contains : (value: a, array: ImmutableArray<a>) -> Bool
 ```
 
 Checks if the value is an element of the input array.
@@ -684,7 +688,7 @@ No other changes yet.
 </details>
 
 ```grain
-find : ((a -> Bool), ImmutableArray<a>) -> Option<a>
+find : (fn: (a -> Bool), array: ImmutableArray<a>) -> Option<a>
 ```
 
 Finds the first element in an array that satifies the given condition.
@@ -710,7 +714,7 @@ No other changes yet.
 </details>
 
 ```grain
-findIndex : ((a -> Bool), ImmutableArray<a>) -> Option<Number>
+findIndex : (fn: (a -> Bool), array: ImmutableArray<a>) -> Option<Number>
 ```
 
 Finds the first index in an array where the element satifies the given condition.
@@ -736,7 +740,9 @@ No other changes yet.
 </details>
 
 ```grain
-product : (ImmutableArray<a>, ImmutableArray<b>) -> ImmutableArray<(a, b)>
+product :
+  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+   ImmutableArray<(a, b)>
 ```
 
 Combines two arrays into a Cartesian product of tuples containing
@@ -763,7 +769,7 @@ No other changes yet.
 </details>
 
 ```grain
-count : ((a -> Bool), ImmutableArray<a>) -> Number
+count : (fn: (a -> Bool), array: ImmutableArray<a>) -> Number
 ```
 
 Counts the number of elements in an array that satisfy the given condition.
@@ -789,7 +795,7 @@ No other changes yet.
 </details>
 
 ```grain
-unique : ImmutableArray<a> -> ImmutableArray<a>
+unique : (array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Produces a new array with any duplicates removed.
@@ -815,7 +821,9 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (ImmutableArray<a>, ImmutableArray<b>) -> ImmutableArray<(a, b)>
+zip :
+  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+   ImmutableArray<(a, b)>
 ```
 
 Produces a new array filled with tuples of elements from both given arrays.
@@ -847,7 +855,8 @@ No other changes yet.
 
 ```grain
 zipWith :
-  (((a, b) -> c), ImmutableArray<a>, ImmutableArray<b>) -> ImmutableArray<c>
+  (fn: ((a, b) -> c), array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+   ImmutableArray<c>
 ```
 
 Produces a new array filled with elements defined by applying a function on
@@ -891,7 +900,8 @@ No other changes yet.
 </details>
 
 ```grain
-unzip : ImmutableArray<(a, b)> -> (ImmutableArray<a>, ImmutableArray<b>)
+unzip :
+  (array: ImmutableArray<(a, b)>) -> (ImmutableArray<a>, ImmutableArray<b>)
 ```
 
 Produces two arrays by splitting apart an array of tuples.
@@ -916,7 +926,7 @@ No other changes yet.
 </details>
 
 ```grain
-join : (String, ImmutableArray<String>) -> String
+join : (separator: String, array: ImmutableArray<String>) -> String
 ```
 
 Concatenates an array of strings into a single string, separated by a separator string.
@@ -942,7 +952,8 @@ No other changes yet.
 </details>
 
 ```grain
-slice : (Number, Number, ImmutableArray<a>) -> ImmutableArray<a>
+slice :
+  (start: Number, end: Number, array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Slices an array given zero-based start and end indexes. The value
@@ -983,7 +994,8 @@ No other changes yet.
 </details>
 
 ```grain
-sort : (((a, a) -> Number), ImmutableArray<a>) -> ImmutableArray<a>
+sort :
+  (comp: ((a, a) -> Number), array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Sorts the given array based on a given comparator function.
@@ -1011,7 +1023,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotate : (Number, ImmutableArray<a>) -> ImmutableArray<a>
+rotate : (n: Number, array: ImmutableArray<a>) -> ImmutableArray<a>
 ```
 
 Rotates array elements by the specified amount to the left, such that the

--- a/stdlib/immutablemap.md
+++ b/stdlib/immutablemap.md
@@ -48,7 +48,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : ImmutableMap<a, b> -> Number
+size : (map: ImmutableMap<a, b>) -> Number
 ```
 
 Provides the count of key-value pairs stored within the map.
@@ -73,7 +73,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : ImmutableMap<a, b> -> Bool
+isEmpty : (map: ImmutableMap<a, b>) -> Bool
 ```
 
 Determines if the map contains no key-value pairs.
@@ -98,7 +98,7 @@ No other changes yet.
 </details>
 
 ```grain
-set : (a, b, ImmutableMap<a, b>) -> ImmutableMap<a, b>
+set : (key: a, val: b, map: ImmutableMap<a, b>) -> ImmutableMap<a, b>
 ```
 
 Produces a new map containing a new key-value pair. If the key already exists in the map, the value is replaced.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-get : (a, ImmutableMap<a, b>) -> Option<b>
+get : (key: a, map: ImmutableMap<a, b>) -> Option<b>
 ```
 
 Retrieves the value for the given key.
@@ -151,7 +151,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, ImmutableMap<a, b>) -> Bool
+contains : (key: a, map: ImmutableMap<a, b>) -> Bool
 ```
 
 Determines if the map contains the given key. In such a case, it will always contain a value for the given key.
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (a, ImmutableMap<a, b>) -> ImmutableMap<a, b>
+remove : (key: a, map: ImmutableMap<a, b>) -> ImmutableMap<a, b>
 ```
 
 Produces a new map without the key-value pair corresponding to the given
@@ -205,7 +205,8 @@ No other changes yet.
 
 ```grain
 update :
-  (a, (Option<b> -> Option<b>), ImmutableMap<a, b>) -> ImmutableMap<a, b>
+  (key: a, fn: (Option<b> -> Option<b>), map: ImmutableMap<a, b>) ->
+   ImmutableMap<a, b>
 ```
 
 Produces a new map by calling an updater function that receives the
@@ -236,7 +237,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : (((a, b) -> Void), ImmutableMap<a, b>) -> Void
+forEach : (fn: ((a, b) -> Void), map: ImmutableMap<a, b>) -> Void
 ```
 
 Iterates the map, calling an iterator function with each key and value.
@@ -256,7 +257,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b, c) -> a), a, ImmutableMap<b, c>) -> a
+reduce : (fn: ((a, b, c) -> a), init: a, map: ImmutableMap<b, c>) -> a
 ```
 
 Combines all key-value pairs of a map using a reducer function.
@@ -283,7 +284,7 @@ No other changes yet.
 </details>
 
 ```grain
-keys : ImmutableMap<a, b> -> List<a>
+keys : (map: ImmutableMap<a, b>) -> List<a>
 ```
 
 Enumerates all keys in the given map.
@@ -308,7 +309,7 @@ No other changes yet.
 </details>
 
 ```grain
-values : ImmutableMap<a, b> -> List<b>
+values : (map: ImmutableMap<a, b>) -> List<b>
 ```
 
 Enumerates all values in the given map.
@@ -333,7 +334,8 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (((a, b) -> Bool), ImmutableMap<a, b>) -> ImmutableMap<a, b>
+filter :
+  (fn: ((a, b) -> Bool), map: ImmutableMap<a, b>) -> ImmutableMap<a, b>
 ```
 
 Produces a new map excluding the key-value pairs where a predicate function returns `false`.
@@ -359,7 +361,8 @@ No other changes yet.
 </details>
 
 ```grain
-reject : (((a, b) -> Bool), ImmutableMap<a, b>) -> ImmutableMap<a, b>
+reject :
+  (fn: ((a, b) -> Bool), map: ImmutableMap<a, b>) -> ImmutableMap<a, b>
 ```
 
 Produces a new map excluding the key-value pairs where a predicate function returns `true`.
@@ -385,7 +388,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<(a, b)> -> ImmutableMap<a, b>
+fromList : (list: List<(a, b)>) -> ImmutableMap<a, b>
 ```
 
 Creates a map from a list.
@@ -410,7 +413,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : ImmutableMap<a, b> -> List<(a, b)>
+toList : (map: ImmutableMap<a, b>) -> List<(a, b)>
 ```
 
 Enumerates all key-value pairs in the given map.
@@ -435,7 +438,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : Array<(a, b)> -> ImmutableMap<a, b>
+fromArray : (array: Array<(a, b)>) -> ImmutableMap<a, b>
 ```
 
 Creates a map from an array.
@@ -460,7 +463,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : ImmutableMap<a, b> -> Array<(a, b)>
+toArray : (map: ImmutableMap<a, b>) -> Array<(a, b)>
 ```
 
 Converts a map into an array of its key-value pairs.

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : ((a, a) -> Number) -> ImmutablePriorityQueue<a>
+make : (comp: ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
 ```
 
 Creates a new priority queue with a comparator function, which is used to
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : ImmutablePriorityQueue<a> -> Number
+size : (pq: ImmutablePriorityQueue<a>) -> Number
 ```
 
 Gets the number of elements in a priority queue.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : ImmutablePriorityQueue<a> -> Bool
+isEmpty : (pq: ImmutablePriorityQueue<a>) -> Bool
 ```
 
 Determines if the priority queue contains no elements.
@@ -133,7 +133,7 @@ Returns:
 ### ImmutablePriorityQueue.**push**
 
 ```grain
-push : (a, ImmutablePriorityQueue<a>) -> ImmutablePriorityQueue<a>
+push : (val: a, pq: ImmutablePriorityQueue<a>) -> ImmutablePriorityQueue<a>
 ```
 
 Produces a new priority queue by inserting the given element into the given priority queue.
@@ -159,7 +159,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : ImmutablePriorityQueue<a> -> Option<a>
+peek : (pq: ImmutablePriorityQueue<a>) -> Option<a>
 ```
 
 Retrieves the highest priority element in the priority queue. It is not
@@ -185,7 +185,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : ImmutablePriorityQueue<a> -> ImmutablePriorityQueue<a>
+pop : (pq: ImmutablePriorityQueue<a>) -> ImmutablePriorityQueue<a>
 ```
 
 Produces a new priority queue without the highest priority element in the
@@ -212,7 +212,7 @@ No other changes yet.
 </details>
 
 ```grain
-drain : ImmutablePriorityQueue<a> -> List<a>
+drain : (pq: ImmutablePriorityQueue<a>) -> List<a>
 ```
 
 Produces a list of all elements in the priority queue in priority order.
@@ -237,7 +237,8 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (List<a>, ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
+fromList :
+  (list: List<a>, comp: ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the list
@@ -267,7 +268,8 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : (Array<a>, ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
+fromArray :
+  (array: Array<a>, comp: ((a, a) -> Number)) -> ImmutablePriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the array

--- a/stdlib/immutableset.md
+++ b/stdlib/immutableset.md
@@ -48,7 +48,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : ImmutableSet<a> -> Number
+size : (set: ImmutableSet<a>) -> Number
 ```
 
 Provides the count of values within the set.
@@ -73,7 +73,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : ImmutableSet<a> -> Bool
+isEmpty : (set: ImmutableSet<a>) -> Bool
 ```
 
 Determines if the set contains no elements.
@@ -98,7 +98,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (a, ImmutableSet<a>) -> ImmutableSet<a>
+add : (key: a, set: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Produces a new set by inserting the given value into the set. If the value
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, ImmutableSet<a>) -> Bool
+contains : (key: a, set: ImmutableSet<a>) -> Bool
 ```
 
 Determines if the set contains the given value.
@@ -151,7 +151,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (a, ImmutableSet<a>) -> ImmutableSet<a>
+remove : (key: a, set: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Produces a new set without the given element. If the value doesn't exist in
@@ -178,7 +178,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : ((a -> Void), ImmutableSet<a>) -> Void
+forEach : (fn: (a -> Void), set: ImmutableSet<a>) -> Void
 ```
 
 Iterates the set, calling an iterator function on each element.
@@ -198,7 +198,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b) -> a), a, ImmutableSet<b>) -> a
+reduce : (fn: ((a, b) -> a), init: a, set: ImmutableSet<b>) -> a
 ```
 
 Combines all elements of a set using a reducer function.
@@ -225,7 +225,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), ImmutableSet<a>) -> ImmutableSet<a>
+filter : (fn: (a -> Bool), set: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Produces a new set without the elements from the input set where a predicate function returns `false`.
@@ -251,7 +251,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : ((a -> Bool), ImmutableSet<a>) -> ImmutableSet<a>
+reject : (fn: (a -> Bool), set: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Produces a new set without the elements from the input set where a predicate function returns `true`.
@@ -277,7 +277,7 @@ No other changes yet.
 </details>
 
 ```grain
-union : (ImmutableSet<a>, ImmutableSet<a>) -> ImmutableSet<a>
+union : (set1: ImmutableSet<a>, set2: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Combines two sets into a single set containing all elements from both sets.
@@ -303,7 +303,7 @@ No other changes yet.
 </details>
 
 ```grain
-diff : (ImmutableSet<a>, ImmutableSet<a>) -> ImmutableSet<a>
+diff : (set1: ImmutableSet<a>, set2: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Combines two sets into a single set containing only the elements not shared between both sets.
@@ -329,7 +329,7 @@ No other changes yet.
 </details>
 
 ```grain
-intersect : (ImmutableSet<a>, ImmutableSet<a>) -> ImmutableSet<a>
+intersect : (set1: ImmutableSet<a>, set2: ImmutableSet<a>) -> ImmutableSet<a>
 ```
 
 Combines two sets into a single set containing only the elements shared between both sets.
@@ -355,7 +355,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<a> -> ImmutableSet<a>
+fromList : (list: List<a>) -> ImmutableSet<a>
 ```
 
 Creates a set from a list.
@@ -380,7 +380,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : ImmutableSet<a> -> List<a>
+toList : (set: ImmutableSet<a>) -> List<a>
 ```
 
 Converts a set into a list of its elements.
@@ -405,7 +405,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : Array<a> -> ImmutableSet<a>
+fromArray : (array: Array<a>) -> ImmutableSet<a>
 ```
 
 Creates a set from an array.
@@ -430,7 +430,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : ImmutableSet<a> -> Array<a>
+toArray : (set: ImmutableSet<a>) -> Array<a>
 ```
 
 Converts a set into an array of its elements.

--- a/stdlib/int16.md
+++ b/stdlib/int16.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Int16
+fromNumber : (number: Number) -> Int16
 ```
 
 Converts a Number to an Int16.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Int16 -> Number
+toNumber : (value: Int16) -> Number
 ```
 
 Converts an Int16 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint16 : Uint16 -> Int16
+fromUint16 : (x: Uint16) -> Int16
 ```
 
 Converts a Uint16 to an Int16.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Int16 -> Int16
+incr : (value: Int16) -> Int16
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Int16 -> Int16
+decr : (value: Int16) -> Int16
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Int16, Int16) -> Int16
+(+) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Int16, Int16) -> Int16
+(-) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Int16, Int16) -> Int16
+(*) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Int16, Int16) -> Int16
+(/) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Int16, Int16) -> Int16
+rem : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Int16, Int16) -> Int16
+(%) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Int16, Int16) -> Int16
+(<<) : (value: Int16, amount: Int16) -> Int16
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Int16, Int16) -> Int16
+(>>) : (value: Int16, amount: Int16) -> Int16
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Int16, Int16) -> Bool
+(==) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Int16, Int16) -> Bool
+(!=) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Int16, Int16) -> Bool
+(<) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Int16, Int16) -> Bool
+(>) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Int16, Int16) -> Bool
+(<=) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -495,7 +495,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Int16, Int16) -> Bool
+(>=) : (x: Int16, y: Int16) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -521,7 +521,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Int16 -> Int16
+lnot : (value: Int16) -> Int16
 ```
 
 Computes the bitwise NOT of the given value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Int16, Int16) -> Int16
+(&) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Int16, Int16) -> Int16
+(|) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Int16, Int16) -> Int16
+(^) : (x: Int16, y: Int16) -> Int16
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Int32
+fromNumber : (x: Number) -> Int32
 ```
 
 Converts a Number to an Int32.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Int32 -> Number
+toNumber : (x: Int32) -> Number
 ```
 
 Converts an Int32 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint32 : Uint32 -> Int32
+fromUint32 : (x: Uint32) -> Int32
 ```
 
 Converts a Uint32 to an Int32.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Int32 -> Int32
+incr : (value: Int32) -> Int32
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Int32 -> Int32
+decr : (value: Int32) -> Int32
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (Int32, Int32) -> Int32
+add : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (Int32, Int32) -> Int32
+sub : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (Int32, Int32) -> Int32
+mul : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (Int32, Int32) -> Int32
+div : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Int32, Int32) -> Int32
+rem : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-mod : (Int32, Int32) -> Int32
+mod : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (Int32, Int32) -> Int32
+rotl : (value: Int32, amount: Int32) -> Int32
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (Int32, Int32) -> Int32
+rotr : (value: Int32, amount: Int32) -> Int32
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-shl : (Int32, Int32) -> Int32
+shl : (value: Int32, amount: Int32) -> Int32
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-shr : (Int32, Int32) -> Int32
+shr : (value: Int32, amount: Int32) -> Int32
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-eq : (Int32, Int32) -> Bool
+eq : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-ne : (Int32, Int32) -> Bool
+ne : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : Int32 -> Bool
+eqz : (value: Int32) -> Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -494,7 +494,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (Int32, Int32) -> Bool
+lt : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -520,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (Int32, Int32) -> Bool
+gt : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (Int32, Int32) -> Bool
+lte : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (Int32, Int32) -> Bool
+gte : (x: Int32, y: Int32) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Int32 -> Int32
+lnot : (value: Int32) -> Int32
 ```
 
 Computes the bitwise NOT of the given value.
@@ -623,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-land : (Int32, Int32) -> Int32
+land : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -649,7 +649,7 @@ No other changes yet.
 </details>
 
 ```grain
-lor : (Int32, Int32) -> Int32
+lor : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -675,7 +675,7 @@ No other changes yet.
 </details>
 
 ```grain
-lxor : (Int32, Int32) -> Int32
+lxor : (x: Int32, y: Int32) -> Int32
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -701,7 +701,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : Int32 -> Int32
+clz : (value: Int32) -> Int32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -726,7 +726,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : Int32 -> Int32
+ctz : (value: Int32) -> Int32
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -751,7 +751,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : Int32 -> Int32
+popcnt : (value: Int32) -> Int32
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Int64
+fromNumber : (x: Number) -> Int64
 ```
 
 Converts a Number to an Int64.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Int64 -> Number
+toNumber : (x: Int64) -> Number
 ```
 
 Converts an Int64 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint64 : Uint64 -> Int64
+fromUint64 : (x: Uint64) -> Int64
 ```
 
 Converts a Uint64 to an Int64.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Int64 -> Int64
+incr : (value: Int64) -> Int64
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Int64 -> Int64
+decr : (value: Int64) -> Int64
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (Int64, Int64) -> Int64
+add : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (Int64, Int64) -> Int64
+sub : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (Int64, Int64) -> Int64
+mul : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (Int64, Int64) -> Int64
+div : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Int64, Int64) -> Int64
+rem : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-mod : (Int64, Int64) -> Int64
+mod : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (Int64, Int64) -> Int64
+rotl : (value: Int64, amount: Int64) -> Int64
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (Int64, Int64) -> Int64
+rotr : (value: Int64, amount: Int64) -> Int64
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-shl : (Int64, Int64) -> Int64
+shl : (value: Int64, amount: Int64) -> Int64
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-shr : (Int64, Int64) -> Int64
+shr : (value: Int64, amount: Int64) -> Int64
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-eq : (Int64, Int64) -> Bool
+eq : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-ne : (Int64, Int64) -> Bool
+ne : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : Int64 -> Bool
+eqz : (value: Int64) -> Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -494,7 +494,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (Int64, Int64) -> Bool
+lt : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -520,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (Int64, Int64) -> Bool
+gt : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (Int64, Int64) -> Bool
+lte : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (Int64, Int64) -> Bool
+gte : (x: Int64, y: Int64) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Int64 -> Int64
+lnot : (value: Int64) -> Int64
 ```
 
 Computes the bitwise NOT of the given value.
@@ -623,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-land : (Int64, Int64) -> Int64
+land : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -649,7 +649,7 @@ No other changes yet.
 </details>
 
 ```grain
-lor : (Int64, Int64) -> Int64
+lor : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -675,7 +675,7 @@ No other changes yet.
 </details>
 
 ```grain
-lxor : (Int64, Int64) -> Int64
+lxor : (x: Int64, y: Int64) -> Int64
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -701,7 +701,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : Int64 -> Int64
+clz : (value: Int64) -> Int64
 ```
 
 Counts the number of leading zero bits in the value.
@@ -726,7 +726,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : Int64 -> Int64
+ctz : (value: Int64) -> Int64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -751,7 +751,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : Int64 -> Int64
+popcnt : (value: Int64) -> Int64
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/int8.md
+++ b/stdlib/int8.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Int8
+fromNumber : (number: Number) -> Int8
 ```
 
 Converts a Number to an Int8.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Int8 -> Number
+toNumber : (value: Int8) -> Number
 ```
 
 Converts an Int8 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint8 : Uint8 -> Int8
+fromUint8 : (x: Uint8) -> Int8
 ```
 
 Converts a Uint8 to an Int8.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Int8 -> Int8
+incr : (value: Int8) -> Int8
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Int8 -> Int8
+decr : (value: Int8) -> Int8
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Int8, Int8) -> Int8
+(+) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Int8, Int8) -> Int8
+(-) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Int8, Int8) -> Int8
+(*) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Int8, Int8) -> Int8
+(/) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Int8, Int8) -> Int8
+rem : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Int8, Int8) -> Int8
+(%) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Int8, Int8) -> Int8
+(<<) : (value: Int8, amount: Int8) -> Int8
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Int8, Int8) -> Int8
+(>>) : (value: Int8, amount: Int8) -> Int8
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Int8, Int8) -> Bool
+(==) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Int8, Int8) -> Bool
+(!=) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Int8, Int8) -> Bool
+(<) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Int8, Int8) -> Bool
+(>) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Int8, Int8) -> Bool
+(<=) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -495,7 +495,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Int8, Int8) -> Bool
+(>=) : (x: Int8, y: Int8) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -521,7 +521,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Int8 -> Int8
+lnot : (value: Int8) -> Int8
 ```
 
 Computes the bitwise NOT of the given value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Int8, Int8) -> Int8
+(&) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Int8, Int8) -> Int8
+(|) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Int8, Int8) -> Int8
+(^) : (x: Int8, y: Int8) -> Int8
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -33,7 +33,7 @@ No other changes yet.
 </details>
 
 ```grain
-init : (Number, (Number -> a)) -> List<a>
+init : (length: Number, fn: (Number -> a)) -> List<a>
 ```
 
 Creates a new list of the specified length where each element is
@@ -74,7 +74,7 @@ List.init(5, n => n + 3) // [3, 4, 5, 6, 7]
 </details>
 
 ```grain
-length : List<a> -> Number
+length : (list: List<a>) -> Number
 ```
 
 Computes the length of the input list.
@@ -99,7 +99,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : List<a> -> List<a>
+reverse : (list: List<a>) -> List<a>
 ```
 
 Creates a new list with all elements in reverse order.
@@ -124,7 +124,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (List<a>, List<a>) -> List<a>
+append : (list1: List<a>, list2: List<a>) -> List<a>
 ```
 
 Creates a new list with the elements of the first list followed by
@@ -151,7 +151,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, List<a>) -> Bool
+contains : (search: a, list: List<a>) -> Bool
 ```
 
 Checks if the value is an element of the input list.
@@ -186,7 +186,7 @@ Returns:
 </details>
 
 ```grain
-reduce : (((a, b) -> a), a, List<b>) -> a
+reduce : (fn: ((a, b) -> a), initial: a, list: List<b>) -> a
 ```
 
 Combines all elements of a list using a reducer function,
@@ -233,7 +233,7 @@ List.reduce((a, b) => a + b, 0, [1, 2, 3]) // 6
 </details>
 
 ```grain
-reduceRight : (((a, b) -> b), b, List<a>) -> b
+reduceRight : (fn: ((a, b) -> b), initial: b, list: List<a>) -> b
 ```
 
 Combines all elements of a list using a reducer function,
@@ -272,7 +272,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : ((a -> b), List<a>) -> List<b>
+map : (fn: (a -> b), list: List<a>) -> List<b>
 ```
 
 Produces a new list initialized with the results of a mapper function
@@ -299,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapi : (((a, Number) -> b), List<a>) -> List<b>
+mapi : (fn: ((a, Number) -> b), list: List<a>) -> List<b>
 ```
 
 Produces a new list initialized with the results of a mapper function
@@ -326,7 +326,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((a -> List<b>), List<a>) -> List<b>
+flatMap : (fn: (a -> List<b>), list: List<a>) -> List<b>
 ```
 
 Produces a new list by calling a function on each element
@@ -355,7 +355,7 @@ No other changes yet.
 </details>
 
 ```grain
-every : ((a -> Bool), List<a>) -> Bool
+every : (fn: (a -> Bool), list: List<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -382,7 +382,7 @@ No other changes yet.
 </details>
 
 ```grain
-some : ((a -> Bool), List<a>) -> Bool
+some : (fn: (a -> Bool), list: List<a>) -> Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -409,7 +409,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : ((a -> Void), List<a>) -> Void
+forEach : (fn: (a -> Void), list: List<a>) -> Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -429,7 +429,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachi : (((a, Number) -> Void), List<a>) -> Void
+forEachi : (fn: ((a, Number) -> Void), list: List<a>) -> Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -450,7 +450,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), List<a>) -> List<a>
+filter : (fn: (a -> Bool), list: List<a>) -> List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -478,7 +478,7 @@ No other changes yet.
 </details>
 
 ```grain
-filteri : (((a, Number) -> Bool), List<a>) -> List<a>
+filteri : (fn: ((a, Number) -> Bool), list: List<a>) -> List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -506,7 +506,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : ((a -> Bool), List<a>) -> List<a>
+reject : (fn: (a -> Bool), list: List<a>) -> List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -543,7 +543,7 @@ Returns:
 </details>
 
 ```grain
-head : List<a> -> Option<a>
+head : (list: List<a>) -> Option<a>
 ```
 
 Provides `Some(element)` containing the first element, or "head", of
@@ -578,7 +578,7 @@ Returns:
 </details>
 
 ```grain
-tail : List<a> -> Option<List<a>>
+tail : (list: List<a>) -> Option<List<a>>
 ```
 
 Provides `Some(tail)` containing all list items except the first element, or "tail", of
@@ -612,7 +612,7 @@ Returns:
 </details>
 
 ```grain
-nth : (Number, List<a>) -> Option<a>
+nth : (index: Number, list: List<a>) -> Option<a>
 ```
 
 Provides `Some(element)` containing the element in the list at the specified index
@@ -639,7 +639,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatten : List<List<a>> -> List<a>
+flatten : (list: List<List<a>>) -> List<a>
 ```
 
 Flattens nested lists.
@@ -670,7 +670,7 @@ No other changes yet.
 </details>
 
 ```grain
-insert : (a, Number, List<a>) -> List<a>
+insert : (value: a, index: Number, list: List<a>) -> List<a>
 ```
 
 Inserts a new value into a list at the specified index.
@@ -711,7 +711,7 @@ Throws:
 </details>
 
 ```grain
-count : ((a -> Bool), List<a>) -> Number
+count : (fn: (a -> Bool), list: List<a>) -> Number
 ```
 
 Counts the number of elements in a list that satisfy the given condition.
@@ -737,7 +737,7 @@ No other changes yet.
 </details>
 
 ```grain
-part : (Number, List<a>) -> (List<a>, List<a>)
+part : (count: Number, list: List<a>) -> (List<a>, List<a>)
 ```
 
 Split a list into two, with the first list containing the required number of elements.
@@ -777,7 +777,7 @@ Throws:
 </details>
 
 ```grain
-rotate : (Number, List<a>) -> List<a>
+rotate : (count: Number, list: List<a>) -> List<a>
 ```
 
 Rotates list elements by the specified amount to the left, such that `n`th
@@ -823,7 +823,7 @@ List.rotate(-7, [1, 2, 3, 4, 5]) // [4, 5, 1, 2, 3]
 </details>
 
 ```grain
-unique : List<a> -> List<a>
+unique : (list: List<a>) -> List<a>
 ```
 
 Produces a new list with any duplicates removed.
@@ -849,7 +849,7 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (List<a>, List<b>) -> List<(a, b)>
+zip : (list1: List<a>, list2: List<b>) -> List<(a, b)>
 ```
 
 Produces a new list filled with tuples of elements from both given lists.
@@ -890,7 +890,7 @@ No other changes yet.
 </details>
 
 ```grain
-zipWith : (((a, b) -> c), List<a>, List<b>) -> List<c>
+zipWith : (fn: ((a, b) -> c), list1: List<a>, list2: List<b>) -> List<c>
 ```
 
 Produces a new list filled with elements defined by applying a function on
@@ -934,7 +934,7 @@ No other changes yet.
 </details>
 
 ```grain
-unzip : List<(a, b)> -> (List<a>, List<b>)
+unzip : (list: List<(a, b)>) -> (List<a>, List<b>)
 ```
 
 Produces two lists by splitting apart a list of tuples.
@@ -959,7 +959,7 @@ No other changes yet.
 </details>
 
 ```grain
-drop : (Number, List<a>) -> List<a>
+drop : (count: Number, list: List<a>) -> List<a>
 ```
 
 Produces a new list with the specified number of elements removed from
@@ -992,7 +992,7 @@ No other changes yet.
 </details>
 
 ```grain
-dropWhile : ((a -> Bool), List<a>) -> List<a>
+dropWhile : (fn: (a -> Bool), list: List<a>) -> List<a>
 ```
 
 Produces a new list with the elements removed from the beginning
@@ -1020,7 +1020,7 @@ No other changes yet.
 </details>
 
 ```grain
-take : (Number, List<a>) -> List<a>
+take : (count: Number, list: List<a>) -> List<a>
 ```
 
 Produces a new list with–at most—the specified amount elements from
@@ -1053,7 +1053,7 @@ No other changes yet.
 </details>
 
 ```grain
-takeWhile : ((a -> Bool), List<a>) -> List<a>
+takeWhile : (fn: (a -> Bool), list: List<a>) -> List<a>
 ```
 
 Produces a new list with elements from the beginning of the input list
@@ -1089,7 +1089,7 @@ Returns:
 </details>
 
 ```grain
-find : ((a -> Bool), List<a>) -> Option<a>
+find : (fn: (a -> Bool), list: List<a>) -> Option<a>
 ```
 
 Finds the first element in a list that satifies the given condition.
@@ -1123,7 +1123,7 @@ Returns:
 </details>
 
 ```grain
-findIndex : ((a -> Bool), List<a>) -> Option<Number>
+findIndex : (fn: (a -> Bool), list: List<a>) -> Option<Number>
 ```
 
 Finds the first index in a list where the element satifies the given condition.
@@ -1149,7 +1149,7 @@ No other changes yet.
 </details>
 
 ```grain
-product : (List<a>, List<b>) -> List<(a, b)>
+product : (list1: List<a>, list2: List<b>) -> List<(a, b)>
 ```
 
 Combines two lists into a Cartesian product of tuples containing
@@ -1176,7 +1176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (Number, Number, List<a>) -> List<a>
+sub : (start: Number, length: Number, list: List<a>) -> List<a>
 ```
 
 Provides the subset of a list given zero-based start index and amount of elements
@@ -1211,7 +1211,7 @@ No other changes yet.
 </details>
 
 ```grain
-join : (String, List<String>) -> String
+join : (separator: String, list: List<String>) -> String
 ```
 
 Combine the given list of strings into one string with the specified
@@ -1238,7 +1238,7 @@ No other changes yet.
 </details>
 
 ```grain
-revAppend : (List<a>, List<a>) -> List<a>
+revAppend : (list1: List<a>, list2: List<a>) -> List<a>
 ```
 
 Reverses the first list and appends the second list to the end.
@@ -1264,7 +1264,7 @@ No other changes yet.
 </details>
 
 ```grain
-sort : (((a, a) -> Number), List<a>) -> List<a>
+sort : (comp: ((a, a) -> Number), list: List<a>) -> List<a>
 ```
 
 Sorts the given list based on a given comparator function. The resulting list is sorted in increasing order.

--- a/stdlib/map.md
+++ b/stdlib/map.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : Number -> Map<a, b>
+makeSized : (size: Number) -> Map<a, b>
 ```
 
 Creates a new empty map with an initial storage of the given size. As values are added or removed, the internal storage may grow or shrink. Generally, you won't need to care about the storage size of your map and can use `Map.make()` instead.
@@ -79,7 +79,7 @@ No other changes yet.
 </details>
 
 ```grain
-set : (a, b, Map<a, b>) -> Void
+set : (key: a, value: b, map: Map<a, b>) -> Void
 ```
 
 Adds a new key-value pair to the map. If the key already exists in the map, the value is replaced.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-get : (a, Map<a, b>) -> Option<b>
+get : (key: a, map: Map<a, b>) -> Option<b>
 ```
 
 Retrieves the value for the given key.
@@ -126,7 +126,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, Map<a, b>) -> Bool
+contains : (key: a, map: Map<a, b>) -> Bool
 ```
 
 Determines if the map contains the given key. In such a case, it will always contain a value for the given key.
@@ -152,7 +152,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (a, Map<a, b>) -> Void
+remove : (key: a, map: Map<a, b>) -> Void
 ```
 
 Removes the given key from the map, which also removes the value. If the key pair doesn't exist, nothing happens.
@@ -172,7 +172,7 @@ No other changes yet.
 </details>
 
 ```grain
-update : (a, (Option<b> -> Option<b>), Map<a, b>) -> Void
+update : (key: a, fn: (Option<b> -> Option<b>), map: Map<a, b>) -> Void
 ```
 
 Updates a value in the map by calling an updater function that receives the previously stored value as an `Option` and returns the new value to be stored as an `Option`. If the key didn't exist previously, the value will be `None`. If `None` is returned from the updater function, the key-value pair is removed.
@@ -193,7 +193,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : Map<a, b> -> Number
+size : (map: Map<a, b>) -> Number
 ```
 
 Provides the count of key-value pairs stored within the map.
@@ -218,7 +218,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : Map<a, b> -> Bool
+isEmpty : (map: Map<a, b>) -> Bool
 ```
 
 Determines if the map contains no key-value pairs.
@@ -243,7 +243,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Map<a, b> -> Void
+clear : (map: Map<a, b>) -> Void
 ```
 
 Resets the map by removing all key-value pairs.
@@ -269,7 +269,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : (((a, b) -> Void), Map<a, b>) -> Void
+forEach : (fn: ((a, b) -> Void), map: Map<a, b>) -> Void
 ```
 
 Iterates the map, calling an iterator function with each key and value.
@@ -289,7 +289,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b, c) -> a), a, Map<b, c>) -> a
+reduce : (fn: ((a, b, c) -> a), init: a, map: Map<b, c>) -> a
 ```
 
 Combines all key-value pairs of a map using a reducer function.
@@ -316,7 +316,7 @@ No other changes yet.
 </details>
 
 ```grain
-keys : Map<a, b> -> List<a>
+keys : (map: Map<a, b>) -> List<a>
 ```
 
 Enumerates all keys in the given map.
@@ -341,7 +341,7 @@ No other changes yet.
 </details>
 
 ```grain
-values : Map<a, b> -> List<b>
+values : (map: Map<a, b>) -> List<b>
 ```
 
 Enumerates all values in the given map.
@@ -366,7 +366,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : Map<a, b> -> List<(a, b)>
+toList : (map: Map<a, b>) -> List<(a, b)>
 ```
 
 Enumerates all key-value pairs in the given map.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<(a, b)> -> Map<a, b>
+fromList : (list: List<(a, b)>) -> Map<a, b>
 ```
 
 Creates a map from a list.
@@ -441,7 +441,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : Array<(a, b)> -> Map<a, b>
+fromArray : (array: Array<(a, b)>) -> Map<a, b>
 ```
 
 Creates a map from an array.
@@ -466,7 +466,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (((a, b) -> Bool), Map<a, b>) -> Void
+filter : (predicate: ((a, b) -> Bool), map: Map<a, b>) -> Void
 ```
 
 Removes key-value pairs from a map where a predicate function returns `false`.
@@ -486,7 +486,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : (((a, b) -> Bool), Map<a, b>) -> Void
+reject : (predicate: ((a, b) -> Bool), map: Map<a, b>) -> Void
 ```
 
 Removes key-value pairs from a map where a predicate function returns `true`.
@@ -506,7 +506,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInternalStats : Map<a, b> -> (Number, Number)
+getInternalStats : (map: Map<a, b>) -> (Number, Number)
 ```
 
 Provides data representing the internal state state of the map.

--- a/stdlib/marshal.md
+++ b/stdlib/marshal.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-marshal : a -> Bytes
+marshal : (value: a) -> Bytes
 ```
 
 Serialize a value into a byte-based representation suitable for transmission
@@ -52,7 +52,7 @@ No other changes yet.
 </details>
 
 ```grain
-unmarshal : Bytes -> Result<a, String>
+unmarshal : (bytes: Bytes) -> Result<a, String>
 ```
 
 Deserialize the byte-based representation of a value back into an in-memory

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -71,7 +71,7 @@ Euler's number represented as a Number value.
 </details>
 
 ```grain
-(+) : (Number, Number) -> Number
+(+) : (x: Number, y: Number) -> Number
 ```
 
 Computes the sum of its operands.
@@ -104,7 +104,7 @@ Returns:
 </details>
 
 ```grain
-(-) : (Number, Number) -> Number
+(-) : (x: Number, y: Number) -> Number
 ```
 
 Computes the difference of its operands.
@@ -137,7 +137,7 @@ Returns:
 </details>
 
 ```grain
-(*) : (Number, Number) -> Number
+(*) : (x: Number, y: Number) -> Number
 ```
 
 Computes the product of its operands.
@@ -170,7 +170,7 @@ Returns:
 </details>
 
 ```grain
-(/) : (Number, Number) -> Number
+(/) : (x: Number, y: Number) -> Number
 ```
 
 Computes the quotient of its operands.
@@ -203,7 +203,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (Number, Number) -> Number
+(**) : (base: Number, power: Number) -> Number
 ```
 
 Computes the exponentiation of the given base and power.
@@ -229,7 +229,7 @@ No other changes yet.
 </details>
 
 ```grain
-exp : Number -> Number
+exp : (power: Number) -> Number
 ```
 
 Computes the exponentiation of Euler's number to the given power.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-sqrt : Number -> Number
+sqrt : (x: Number) -> Number
 ```
 
 Computes the square root of its operand.
@@ -274,7 +274,7 @@ Returns:
 ### Number.**sign**
 
 ```grain
-sign : Number -> Number
+sign : (x: Number) -> Number
 ```
 
 Determine the positivity or negativity of a Number.
@@ -320,7 +320,7 @@ Number.sign(0) == 0
 </details>
 
 ```grain
-min : (Number, Number) -> Number
+min : (x: Number, y: Number) -> Number
 ```
 
 Returns the smaller of its operands.
@@ -353,7 +353,7 @@ Returns:
 </details>
 
 ```grain
-max : (Number, Number) -> Number
+max : (x: Number, y: Number) -> Number
 ```
 
 Returns the larger of its operands.
@@ -386,7 +386,7 @@ Returns:
 </details>
 
 ```grain
-ceil : Number -> Number
+ceil : (x: Number) -> Number
 ```
 
 Rounds its operand up to the next largest integer.
@@ -418,7 +418,7 @@ Returns:
 </details>
 
 ```grain
-floor : Number -> Number
+floor : (x: Number) -> Number
 ```
 
 Rounds its operand down to the largest integer less than the operand.
@@ -450,7 +450,7 @@ Returns:
 </details>
 
 ```grain
-trunc : Number -> Number
+trunc : (x: Number) -> Number
 ```
 
 Returns the integer part of its operand, removing any fractional value.
@@ -482,7 +482,7 @@ Returns:
 </details>
 
 ```grain
-round : Number -> Number
+round : (x: Number) -> Number
 ```
 
 Returns its operand rounded to its nearest integer.
@@ -507,7 +507,7 @@ No other changes yet.
 </details>
 
 ```grain
-abs : Number -> Number
+abs : (x: Number) -> Number
 ```
 
 Returns the absolute value of a number. That is, it returns `x` if `x` is positive or zero and the negation of `x` if `x` is negative.
@@ -532,7 +532,7 @@ No other changes yet.
 </details>
 
 ```grain
-neg : Number -> Number
+neg : (x: Number) -> Number
 ```
 
 Returns the negation of its operand.
@@ -557,7 +557,7 @@ No other changes yet.
 </details>
 
 ```grain
-isFloat : Number -> Bool
+isFloat : (x: Number) -> Bool
 ```
 
 Checks if a number is a floating point value.
@@ -582,7 +582,7 @@ No other changes yet.
 </details>
 
 ```grain
-isInteger : Number -> Bool
+isInteger : (x: Number) -> Bool
 ```
 
 Checks if a number is an integer.
@@ -607,7 +607,7 @@ No other changes yet.
 </details>
 
 ```grain
-isRational : Number -> Bool
+isRational : (x: Number) -> Bool
 ```
 
 Checks if a number is a non-integer rational value.
@@ -632,7 +632,7 @@ No other changes yet.
 </details>
 
 ```grain
-isFinite : Number -> Bool
+isFinite : (x: Number) -> Bool
 ```
 
 Checks if a number is finite.
@@ -658,7 +658,7 @@ No other changes yet.
 </details>
 
 ```grain
-isNaN : Number -> Bool
+isNaN : (x: Number) -> Bool
 ```
 
 Checks if a number is the float NaN value (Not A Number).
@@ -683,7 +683,7 @@ No other changes yet.
 </details>
 
 ```grain
-isInfinite : Number -> Bool
+isInfinite : (x: Number) -> Bool
 ```
 
 Checks if a number is infinite, that is either of floating point positive or negative infinity.
@@ -709,7 +709,7 @@ No other changes yet.
 </details>
 
 ```grain
-parseInt : (String, Number) -> Result<Number, String>
+parseInt : (string: String, radix: Number) -> Result<Number, String>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -741,7 +741,7 @@ No other changes yet.
 </details>
 
 ```grain
-parseFloat : String -> Result<Number, String>
+parseFloat : (string: String) -> Result<Number, String>
 ```
 
 Parses a string representation of a float into a `Number`. Underscores that appear
@@ -767,7 +767,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : String -> Result<Number, String>
+parse : (input: String) -> Result<Number, String>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -800,7 +800,7 @@ Returns:
 </details>
 
 ```grain
-sin : Number -> Number
+sin : (radians: Number) -> Number
 ```
 
 Computes the sine of a number (in radians) using Chebyshev polynomials.
@@ -832,7 +832,7 @@ Returns:
 </details>
 
 ```grain
-cos : Number -> Number
+cos : (radians: Number) -> Number
 ```
 
 Computes the cosine of a number (in radians) using Chebyshev polynomials.
@@ -857,7 +857,7 @@ No other changes yet.
 </details>
 
 ```grain
-tan : Number -> Number
+tan : (radians: Number) -> Number
 ```
 
 Computes the tangent of a number (in radians) using Chebyshev polynomials.
@@ -882,7 +882,7 @@ No other changes yet.
 </details>
 
 ```grain
-gamma : Number -> Number
+gamma : (z: Number) -> Number
 ```
 
 Computes the gamma function of a value using Lanczos approximation.
@@ -913,7 +913,7 @@ No other changes yet.
 </details>
 
 ```grain
-factorial : Number -> Number
+factorial : (n: Number) -> Number
 ```
 
 Computes the product of consecutive integers for an integer input and computes the gamma function for non-integer inputs.
@@ -944,7 +944,7 @@ No other changes yet.
 </details>
 
 ```grain
-toRadians : Number -> Number
+toRadians : (degrees: Number) -> Number
 ```
 
 Converts degrees to radians.
@@ -969,7 +969,7 @@ No other changes yet.
 </details>
 
 ```grain
-toDegrees : Number -> Number
+toDegrees : (radians: Number) -> Number
 ```
 
 Converts radians to degrees.

--- a/stdlib/option.md
+++ b/stdlib/option.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-isSome : Option<a> -> Bool
+isSome : (option: Option<a>) -> Bool
 ```
 
 Checks if the Option is the `Some` variant.
@@ -60,7 +60,7 @@ No other changes yet.
 </details>
 
 ```grain
-isNone : Option<a> -> Bool
+isNone : (option: Option<a>) -> Bool
 ```
 
 Checks if the Option is the `None` variant.
@@ -85,7 +85,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, Option<a>) -> Bool
+contains : (value: a, option: Option<a>) -> Bool
 ```
 
 Checks if the Option is the `Some` variant and contains the given value. Uses the generic `==` equality operator.
@@ -111,7 +111,7 @@ No other changes yet.
 </details>
 
 ```grain
-expect : (String, Option<a>) -> a
+expect : (msg: String, option: Option<a>) -> a
 ```
 
 Extracts the value inside a `Some` option, otherwise throws an
@@ -144,7 +144,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrap : Option<a> -> a
+unwrap : (option: Option<a>) -> a
 ```
 
 Extracts the value inside a `Some` option, otherwise
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrapWithDefault : (a, Option<a>) -> a
+unwrapWithDefault : (default: a, option: Option<a>) -> a
 ```
 
 Extracts the value inside a `Some` option or provide the default value if `None`.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : ((a -> b), Option<a>) -> Option<b>
+map : (fn: (a -> b), option: Option<a>) -> Option<b>
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` and wraps the new value in a `Some` variant.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefault : ((a -> b), b, Option<a>) -> b
+mapWithDefault : (fn: (a -> b), default: b, option: Option<a>) -> b
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` to produce a new value, otherwise uses the default value.
@@ -256,7 +256,8 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefaultFn : ((a -> b), (() -> b), Option<a>) -> b
+mapWithDefaultFn :
+  (fn: (a -> b), defaultFn: (() -> b), option: Option<a>) -> b
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` to produce a new value.
@@ -285,7 +286,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((a -> Option<b>), Option<a>) -> Option<b>
+flatMap : (fn: (a -> Option<b>), option: Option<a>) -> Option<b>
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` to produce a new Option.
@@ -311,7 +312,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), Option<a>) -> Option<a>
+filter : (fn: (a -> Bool), option: Option<a>) -> Option<a>
 ```
 
 Converts `Some(value)` variants to `None` variants where the predicate function returns `false`.
@@ -338,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (Option<a>, Option<b>) -> Option<(a, b)>
+zip : (optionA: Option<a>, optionB: Option<b>) -> Option<(a, b)>
 ```
 
 Combine two Options into a single Option containing a tuple of their values.
@@ -364,7 +365,8 @@ No other changes yet.
 </details>
 
 ```grain
-zipWith : (((a, b) -> c), Option<a>, Option<b>) -> Option<c>
+zipWith :
+  (fn: ((a, b) -> c), optionA: Option<a>, optionB: Option<b>) -> Option<c>
 ```
 
 Combine two Options into a single Option. The new value is produced by applying the given function to both values.
@@ -391,7 +393,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatten : Option<Option<a>> -> Option<a>
+flatten : (option: Option<Option<a>>) -> Option<a>
 ```
 
 Flattens nested Options.
@@ -422,7 +424,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : Option<a> -> List<a>
+toList : (option: Option<a>) -> List<a>
 ```
 
 Converts an Option to a list with either zero or one item.
@@ -447,7 +449,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : Option<a> -> Array<a>
+toArray : (option: Option<a>) -> Array<a>
 ```
 
 Converts an Option to an array with either zero or one item.
@@ -472,7 +474,7 @@ No other changes yet.
 </details>
 
 ```grain
-toResult : (a, Option<b>) -> Result<b, a>
+toResult : (err: a, option: Option<b>) -> Result<b, a>
 ```
 
 Converts the Option to a Result, using the provided error in case of the `None` variant.
@@ -498,7 +500,7 @@ No other changes yet.
 </details>
 
 ```grain
-sideEffect : ((a -> Void), Option<a>) -> Void
+sideEffect : (fn: (a -> Void), option: Option<a>) -> Void
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` without producing a new value.
@@ -518,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : ((a -> Void), Option<a>) -> Option<a>
+peek : (fn: (a -> Void), option: Option<a>) -> Option<a>
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` without producing a new value.
@@ -545,7 +547,7 @@ No other changes yet.
 </details>
 
 ```grain
-or : (Option<a>, Option<a>) -> Option<a>
+or : (optionA: Option<a>, optionB: Option<a>) -> Option<a>
 ```
 
 Behaves like a logical OR (`||`) where the first Option is only returned if it is the `Some` variant and falling back to the second Option in all other cases.
@@ -571,7 +573,7 @@ No other changes yet.
 </details>
 
 ```grain
-and : (Option<a>, Option<a>) -> Option<a>
+and : (optionA: Option<a>, optionB: Option<a>) -> Option<a>
 ```
 
 Behaves like a logical AND (`&&`) where the first Option is only returned if it is the `None` variant and falling back to the second Option Result in all other cases.

--- a/stdlib/path.md
+++ b/stdlib/path.md
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromString : String -> Path
+fromString : (pathStr: String) -> Path
 ```
 
 Parses a path string into a `Path`. Paths will be parsed as file paths
@@ -217,7 +217,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromPlatformString : (String, Platform) -> Path
+fromPlatformString : (pathStr: String, platform: Platform) -> Path
 ```
 
 Parses a path string into a `Path` using the path separators appropriate to
@@ -256,7 +256,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : Path -> String
+toString : (path: Path) -> String
 ```
 
 Converts the given `Path` into a string, using the `/` path separator.
@@ -292,7 +292,7 @@ No other changes yet.
 </details>
 
 ```grain
-toPlatformString : (Path, Platform) -> String
+toPlatformString : (path: Path, platform: Platform) -> String
 ```
 
 Converts the given `Path` into a string, using the canonical path separator
@@ -330,7 +330,7 @@ No other changes yet.
 </details>
 
 ```grain
-isDirectory : Path -> Bool
+isDirectory : (path: Path) -> Bool
 ```
 
 Determines whether the path is a directory path.
@@ -360,7 +360,7 @@ isDirectory(fromString("/bin/")) == true
 ### Path.**isAbsolute**
 
 ```grain
-isAbsolute : Path -> Bool
+isAbsolute : (path: Path) -> Bool
 ```
 
 Determines whether the path is an absolute path.
@@ -395,7 +395,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (Path, Path) -> Result<Path, AppendError>
+append : (path: Path, toAppend: Path) -> Result<Path, AppendError>
 ```
 
 Creates a new path by appending a relative path segment to a directory path.
@@ -435,7 +435,7 @@ No other changes yet.
 </details>
 
 ```grain
-relativeTo : (Path, Path) -> Result<Path, RelativizationError>
+relativeTo : (source: Path, dest: Path) -> Result<Path, RelativizationError>
 ```
 
 Attempts to construct a new relative path which will lead to the destination
@@ -494,7 +494,8 @@ No other changes yet.
 </details>
 
 ```grain
-ancestry : (Path, Path) -> Result<AncestryStatus, IncompatibilityError>
+ancestry :
+  (path1: Path, path2: Path) -> Result<AncestryStatus, IncompatibilityError>
 ```
 
 Determines the relative ancestry betwen two paths.
@@ -538,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-parent : Path -> Path
+parent : (path: Path) -> Path
 ```
 
 Retrieves the path corresponding to the parent directory of the given path.
@@ -573,7 +574,7 @@ No other changes yet.
 </details>
 
 ```grain
-basename : Path -> Option<String>
+basename : (path: Path) -> Option<String>
 ```
 
 Retrieves the basename (named final segment) of a path.
@@ -608,7 +609,7 @@ No other changes yet.
 </details>
 
 ```grain
-stem : Path -> Result<String, PathOperationError>
+stem : (path: Path) -> Result<String, PathOperationError>
 ```
 
 Retrieves the basename of a file path without the extension.
@@ -651,7 +652,7 @@ No other changes yet.
 </details>
 
 ```grain
-extension : Path -> Result<String, PathOperationError>
+extension : (path: Path) -> Result<String, PathOperationError>
 ```
 
 Retrieves the extension on the basename of a file path.
@@ -694,7 +695,7 @@ No other changes yet.
 </details>
 
 ```grain
-root : Path -> Result<AbsoluteRoot, PathOperationError>
+root : (path: Path) -> Result<AbsoluteRoot, PathOperationError>
 ```
 
 Retrieves the root of the absolute path.

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -119,7 +119,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (a, a) -> Bool
+(==) : (x: a, y: a) -> Bool
 ```
 
 Check that two values are equal. This checks for structural equality,
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Number, Number) -> Bool
+(<) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is less than the second operand.
@@ -253,7 +253,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Number, Number) -> Bool
+(>) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is greater than the second operand.
@@ -279,7 +279,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Number, Number) -> Bool
+(<=) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is less than or equal to the second operand.
@@ -305,7 +305,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Number, Number) -> Bool
+(>=) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is greater than or equal to the second operand.
@@ -331,7 +331,7 @@ No other changes yet.
 </details>
 
 ```grain
-compare : (a, a) -> Number
+compare : (x: a, y: a) -> Number
 ```
 
 Compares the first argument to the second argument and produces an integer result.
@@ -359,7 +359,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Number, Number) -> Number
+(+) : (x: Number, y: Number) -> Number
 ```
 
 Computes the sum of its operands.
@@ -385,7 +385,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Number, Number) -> Number
+(-) : (x: Number, y: Number) -> Number
 ```
 
 Computes the difference of its operands.
@@ -411,7 +411,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Number, Number) -> Number
+(*) : (x: Number, y: Number) -> Number
 ```
 
 Computes the product of its operands.
@@ -437,7 +437,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Number, Number) -> Number
+(/) : (x: Number, y: Number) -> Number
 ```
 
 Computes the quotient of its operands.
@@ -463,7 +463,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Number, Number) -> Number
+(%) : (x: Number, y: Number) -> Number
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -497,7 +497,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (Number, Number) -> Number
+(**) : (base: Number, power: Number) -> Number
 ```
 
 Computes the exponentiation of the given base and power.
@@ -523,7 +523,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Number -> Number
+incr : (x: Number) -> Number
 ```
 
 Increments the value by one.
@@ -548,7 +548,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Number -> Number
+decr : (x: Number) -> Number
 ```
 
 Decrements the value by one.
@@ -573,7 +573,7 @@ No other changes yet.
 </details>
 
 ```grain
-(++) : (String, String) -> String
+(++) : (s1: String, s2: String) -> String
 ```
 
 Concatenate two strings.
@@ -605,7 +605,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Number -> Number
+lnot : (x: Number) -> Number
 ```
 
 Computes the bitwise NOT of the operand.
@@ -638,7 +638,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (Number, Number) -> Number
+(&) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -672,7 +672,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (Number, Number) -> Number
+(|) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -707,7 +707,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (Number, Number) -> Number
+(^) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -741,7 +741,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (Number, Number) -> Number
+(<<) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -775,7 +775,7 @@ Returns:
 </details>
 
 ```grain
-(>>>) : (Number, Number) -> Number
+(>>>) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -809,7 +809,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (Number, Number) -> Number
+(>>) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -835,7 +835,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : a -> String
+toString : (value: a) -> String
 ```
 
 Converts the given operand to a string.
@@ -861,7 +861,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : a -> Void
+print : (value: a) -> Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -982,7 +982,7 @@ No other changes yet.
 </details>
 
 ```grain
-identity : a -> a
+identity : (x: a) -> a
 ```
 
 Provides the operand untouched.

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -37,7 +37,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (Number, ((a, a) -> Number)) -> PriorityQueue<a>
+makeSized : (size: Number, comp: ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
 Creates a new priority queue with a given internal storage size and a
@@ -70,7 +70,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : ((a, a) -> Number) -> PriorityQueue<a>
+make : (comp: ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
 Creates a new priority queue with a comparator function, which is used to
@@ -108,7 +108,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : PriorityQueue<a> -> Number
+size : (pq: PriorityQueue<a>) -> Number
 ```
 
 Gets the number of elements in a priority queue.
@@ -133,7 +133,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : PriorityQueue<a> -> Bool
+isEmpty : (pq: PriorityQueue<a>) -> Bool
 ```
 
 Determines if the priority queue contains no elements.
@@ -158,7 +158,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (a, PriorityQueue<a>) -> Void
+push : (val: a, pq: PriorityQueue<a>) -> Void
 ```
 
 Adds a new element to the priority queue.
@@ -178,7 +178,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : PriorityQueue<a> -> Option<a>
+peek : (pq: PriorityQueue<a>) -> Option<a>
 ```
 
 Retrieves the highest priority element in the priority queue. It is not
@@ -204,7 +204,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : PriorityQueue<a> -> Option<a>
+pop : (pq: PriorityQueue<a>) -> Option<a>
 ```
 
 Removes and retrieves the highest priority element in the priority queue.
@@ -229,7 +229,7 @@ No other changes yet.
 </details>
 
 ```grain
-drain : PriorityQueue<a> -> List<a>
+drain : (pq: PriorityQueue<a>) -> List<a>
 ```
 
 Clears the priority queue and produces a list of all of the elements in the priority
@@ -255,7 +255,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : (Array<a>, ((a, a) -> Number)) -> PriorityQueue<a>
+fromArray : (array: Array<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the array
@@ -285,7 +285,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (List<a>, ((a, a) -> Number)) -> PriorityQueue<a>
+fromList : (list: List<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the list

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -41,7 +41,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : Number -> Queue<a>
+makeSized : (size: Number) -> Queue<a>
 ```
 
 Creates a new queue with an initial storage of the given size. As values are
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : Queue<a> -> Bool
+isEmpty : (queue: Queue<a>) -> Bool
 ```
 
 Checks if the given queue contains no items.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : Queue<a> -> Number
+size : (queue: Queue<a>) -> Number
 ```
 
 Computes the size of the input queue.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : Queue<a> -> Option<a>
+peek : (queue: Queue<a>) -> Option<a>
 ```
 
 Provides the value at the beginning of the queue, if it exists.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (a, Queue<a>) -> Void
+push : (value: a, queue: Queue<a>) -> Void
 ```
 
 Adds a new item to the end of the queue.
@@ -183,7 +183,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : Queue<a> -> Option<a>
+pop : (queue: Queue<a>) -> Option<a>
 ```
 
 Removes the item at the beginning of the queue.
@@ -208,7 +208,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Queue<a> -> Void
+clear : (queue: Queue<a>) -> Void
 ```
 
 Clears the queue by removing all of its elements
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : Queue<a> -> Queue<a>
+copy : (queue: Queue<a>) -> Queue<a>
 ```
 
 Produces a shallow copy of the input queue.
@@ -299,7 +299,7 @@ An empty queue.
 </details>
 
 ```grain
-isEmpty : ImmutableQueue<a> -> Bool
+isEmpty : (queue: ImmutableQueue<a>) -> Bool
 ```
 
 Checks if the given queue contains any values.
@@ -334,7 +334,7 @@ Returns:
 </details>
 
 ```grain
-peek : ImmutableQueue<a> -> Option<a>
+peek : (queue: ImmutableQueue<a>) -> Option<a>
 ```
 
 Returns the value at the beginning of the queue. It is not removed from the queue.
@@ -369,7 +369,7 @@ Returns:
 </details>
 
 ```grain
-push : (a, ImmutableQueue<a>) -> ImmutableQueue<a>
+push : (value: a, queue: ImmutableQueue<a>) -> ImmutableQueue<a>
 ```
 
 Adds a value to the end of the queue.
@@ -405,7 +405,7 @@ Returns:
 </details>
 
 ```grain
-pop : ImmutableQueue<a> -> ImmutableQueue<a>
+pop : (queue: ImmutableQueue<a>) -> ImmutableQueue<a>
 ```
 
 Dequeues the next value in the queue.
@@ -437,7 +437,7 @@ Returns:
 </details>
 
 ```grain
-size : ImmutableQueue<a> -> Number
+size : (queue: ImmutableQueue<a>) -> Number
 ```
 
 Get the number of values in a queue.

--- a/stdlib/random.md
+++ b/stdlib/random.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : Uint64 -> Random
+make : (seed: Uint64) -> Random
 ```
 
 Creates a new pseudo-random number generator with the given seed.
@@ -86,7 +86,7 @@ Returns:
 </details>
 
 ```grain
-nextUint32 : Random -> Uint32
+nextUint32 : (random: Random) -> Uint32
 ```
 
 Generates a random 32-bit integer from the given pseudo-random number generator.
@@ -118,7 +118,7 @@ Returns:
 </details>
 
 ```grain
-nextUint64 : Random -> Uint64
+nextUint64 : (random: Random) -> Uint64
 ```
 
 Generates a random 64-bit integer from the given pseudo-random number generator.
@@ -150,7 +150,7 @@ Returns:
 </details>
 
 ```grain
-nextUint32InRange : (Random, Uint32, Uint32) -> Uint32
+nextUint32InRange : (random: Random, low: Uint32, high: Uint32) -> Uint32
 ```
 
 Generates a random 32-bit integer from the given pseudo-random number generator
@@ -185,7 +185,7 @@ Returns:
 </details>
 
 ```grain
-nextUint64InRange : (Random, Uint64, Uint64) -> Uint64
+nextUint64InRange : (random: Random, low: Uint64, high: Uint64) -> Uint64
 ```
 
 Generates a random 64-bit integer from the given pseudo-random number generator

--- a/stdlib/range.md
+++ b/stdlib/range.md
@@ -44,7 +44,7 @@ Functions and constants included in the Range module.
 </details>
 
 ```grain
-inRange : (Number, Range<Number>) -> Bool
+inRange : (value: Number, range: Range<Number>) -> Bool
 ```
 
 Checks if the given number is within the range.
@@ -87,7 +87,7 @@ Range.inRange(10, { rangeStart: 0, rangeEnd: 2 }) == false
 </details>
 
 ```grain
-forEach : ((Number -> Void), Range<Number>) -> Void
+forEach : (fn: (Number -> Void), range: Range<Number>) -> Void
 ```
 
 Calls the given function with each number in the range.
@@ -124,7 +124,7 @@ Range.forEach(val => print(val), { rangeStart: 0, rangeEnd: 2 })
 </details>
 
 ```grain
-map : ((Number -> a), Range<Number>) -> List<a>
+map : (fn: (Number -> a), range: Range<Number>) -> List<a>
 ```
 
 Produces a list by calling the given function on each number included in the range.
@@ -173,7 +173,7 @@ Functions and constants included in the Range.Inclusive module.
 </details>
 
 ```grain
-inRange : (Number, Range<Number>) -> Bool
+inRange : (value: Number, range: Range<Number>) -> Bool
 ```
 
 Checks if the given number is within the range.
@@ -216,7 +216,7 @@ Range.Inclusive.inRange(10, { rangeStart: 0, rangeEnd: 2 }) == false
 </details>
 
 ```grain
-forEach : ((Number -> Void), Range<Number>) -> Void
+forEach : (fn: (Number -> Void), range: Range<Number>) -> Void
 ```
 
 Calls the given function with each number in the range.
@@ -253,7 +253,7 @@ Range.Inclusive.forEach(val => print(val), { rangeStart: 0, rangeEnd: 2 })
 </details>
 
 ```grain
-map : ((Number -> a), Range<Number>) -> List<a>
+map : (fn: (Number -> a), range: Range<Number>) -> List<a>
 ```
 
 Produces a list by calling the given function on each number included in the range.

--- a/stdlib/rational.md
+++ b/stdlib/rational.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Rational
+fromNumber : (x: Number) -> Rational
 ```
 
 Converts a Number to a Rational.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Rational -> Number
+toNumber : (x: Rational) -> Number
 ```
 
 Converts a Rational to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-numerator : Rational -> Number
+numerator : (x: Rational) -> Number
 ```
 
 Finds the numerator of the rational number.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-denominator : Rational -> Number
+denominator : (x: Rational) -> Number
 ```
 
 Finds the denominator of the rational number.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Rational, Rational) -> Rational
+(+) : (x: Rational, y: Rational) -> Rational
 ```
 
 Computes the sum of its operands.
@@ -151,7 +151,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Rational, Rational) -> Rational
+(-) : (x: Rational, y: Rational) -> Rational
 ```
 
 Computes the difference of its operands.
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Rational, Rational) -> Rational
+(*) : (x: Rational, y: Rational) -> Rational
 ```
 
 Computes the product of its operands.
@@ -203,7 +203,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Rational, Rational) -> Rational
+(/) : (x: Rational, y: Rational) -> Rational
 ```
 
 Computes the quotient of its operands.
@@ -229,7 +229,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Rational, Rational) -> Bool
+(==) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -255,7 +255,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Rational, Rational) -> Bool
+(!=) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -281,7 +281,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Rational, Rational) -> Bool
+(<) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -307,7 +307,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Rational, Rational) -> Bool
+(>) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -333,7 +333,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Rational, Rational) -> Bool
+(<=) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -359,7 +359,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Rational, Rational) -> Bool
+(>=) : (x: Rational, y: Rational) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/regex.md
+++ b/stdlib/regex.md
@@ -87,7 +87,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : String -> Result<RegularExpression, String>
+make : (regexString: String) -> Result<RegularExpression, String>
 ```
 
 Compiles the given pattern string into a regular expression object.
@@ -200,7 +200,7 @@ No other changes yet.
 </details>
 
 ```grain
-isMatch : (RegularExpression, String) -> Bool
+isMatch : (rx: RegularExpression, string: String) -> Bool
 ```
 
 Determines if the given regular expression has a match in the given string.
@@ -232,7 +232,8 @@ No other changes yet.
 </details>
 
 ```grain
-isMatchRange : (RegularExpression, String, Number, Number) -> Bool
+isMatchRange :
+  (rx: RegularExpression, string: String, start: Number, end: Number) -> Bool
 ```
 
 Determines if the given regular expression has a match in the given string between the given start/end offsets.
@@ -270,7 +271,7 @@ No other changes yet.
 </details>
 
 ```grain
-find : (RegularExpression, String) -> Option<MatchResult>
+find : (rx: RegularExpression, string: String) -> Option<MatchResult>
 ```
 
 Returns the first match for the given regular expression contained within the given string.
@@ -303,7 +304,8 @@ No other changes yet.
 
 ```grain
 findRange :
-  (RegularExpression, String, Number, Number) -> Option<MatchResult>
+  (rx: RegularExpression, string: String, start: Number, end: Number) ->
+   Option<MatchResult>
 ```
 
 Returns the first match for the given regular expression contained within the given string
@@ -333,7 +335,7 @@ Regex.findRange(Result.unwrap(Regex.make("ca+[at]")), "caaat", 0, 5)
 ### Regex.**findAll**
 
 ```grain
-findAll : (RegularExpression, String) -> List<MatchResult>
+findAll : (rx: RegularExpression, string: String) -> List<MatchResult>
 ```
 
 Returns all matches for the given regular expression contained within the given string.
@@ -360,7 +362,8 @@ No other changes yet.
 
 ```grain
 findAllRange :
-  (RegularExpression, String, Number, Number) -> List<MatchResult>
+  (rx: RegularExpression, string: String, start: Number, end: Number) ->
+   List<MatchResult>
 ```
 
 Returns all matches for the given regular expression contained within the given string
@@ -395,7 +398,8 @@ No other changes yet.
 </details>
 
 ```grain
-replace : (RegularExpression, String, String) -> String
+replace :
+  (rx: RegularExpression, toSearch: String, replacement: String) -> String
 ```
 
 Replaces the first match for the given regular expression contained within the given string with the specified replacement.
@@ -436,7 +440,8 @@ No other changes yet.
 </details>
 
 ```grain
-replaceAll : (RegularExpression, String, String) -> String
+replaceAll :
+  (rx: RegularExpression, toSearch: String, replacement: String) -> String
 ```
 
 Replaces all matches for the given regular expression contained within the given string with the specified replacement.
@@ -470,7 +475,7 @@ No other changes yet.
 </details>
 
 ```grain
-split : (RegularExpression, String) -> List<String>
+split : (rx: RegularExpression, str: String) -> List<String>
 ```
 
 Splits the given string at the first match for the given regular expression.
@@ -505,7 +510,7 @@ No other changes yet.
 </details>
 
 ```grain
-splitAll : (RegularExpression, String) -> List<String>
+splitAll : (rx: RegularExpression, str: String) -> List<String>
 ```
 
 Splits the given string at every match for the given regular expression.

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -36,7 +36,7 @@ No other changes yet.
 </details>
 
 ```grain
-isOk : Result<a, b> -> Bool
+isOk : (result: Result<a, b>) -> Bool
 ```
 
 Checks if the Result is the `Ok` variant.
@@ -61,7 +61,7 @@ No other changes yet.
 </details>
 
 ```grain
-isErr : Result<a, b> -> Bool
+isErr : (result: Result<a, b>) -> Bool
 ```
 
 Checks if the Result is the `Err` variant.
@@ -86,7 +86,7 @@ No other changes yet.
 </details>
 
 ```grain
-toOption : Result<a, b> -> Option<a>
+toOption : (result: Result<a, b>) -> Option<a>
 ```
 
 Converts the Result to an Option. An error value is discarded and replaced with `None`.
@@ -111,7 +111,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : ((a -> Result<b, c>), Result<a, c>) -> Result<b, c>
+flatMap : (fn: (a -> Result<b, c>), result: Result<a, c>) -> Result<b, c>
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` to produce a new Result.
@@ -137,7 +137,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMapErr : ((a -> Result<b, c>), Result<b, a>) -> Result<b, c>
+flatMapErr : (fn: (a -> Result<b, c>), result: Result<b, a>) -> Result<b, c>
 ```
 
 If the Result is an `Err(value)`, applies the given function to the `value` to produce a new Result.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : ((a -> b), Result<a, c>) -> Result<b, c>
+map : (fn: (a -> b), result: Result<a, c>) -> Result<b, c>
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` and wraps the new value in an `Ok` variant.
@@ -189,7 +189,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapErr : ((a -> b), Result<c, a>) -> Result<c, b>
+mapErr : (fn: (a -> b), result: Result<c, a>) -> Result<c, b>
 ```
 
 If the Result is `Err(value)`, applies the given function to the `value` and wraps the new value in an `Err` variant.
@@ -215,7 +215,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefault : ((a -> b), b, Result<a, c>) -> b
+mapWithDefault : (fn: (a -> b), def: b, result: Result<a, c>) -> b
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` to produce a new value, otherwise uses the default value.
@@ -243,7 +243,8 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefaultFn : ((a -> b), (c -> b), Result<a, c>) -> b
+mapWithDefaultFn :
+  (fnOk: (a -> b), fnErr: (c -> b), result: Result<a, c>) -> b
 ```
 
 If the Result is `Ok(value)`, applies the `fnOk` function to the `value` to produce a new value.
@@ -272,7 +273,7 @@ No other changes yet.
 </details>
 
 ```grain
-or : (Result<a, b>, Result<a, b>) -> Result<a, b>
+or : (result1: Result<a, b>, result2: Result<a, b>) -> Result<a, b>
 ```
 
 Behaves like a logical OR (`||`) where the first Result is only returned if it is the `Ok` variant and falling back to the second Result in all other cases.
@@ -298,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-and : (Result<a, b>, Result<a, b>) -> Result<a, b>
+and : (result1: Result<a, b>, result2: Result<a, b>) -> Result<a, b>
 ```
 
 Behaves like a logical AND (`&&`) where the first Result is only returned if it is the `Err` variant and falling back to the second Result in all other cases.
@@ -324,7 +325,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : ((a -> b), (c -> d), Result<a, c>) -> Void
+peek : (fnOk: (a -> b), fnErr: (c -> d), result: Result<a, c>) -> Void
 ```
 
 If the Result is `Ok(value)`, applies the `fnOk` function to the `value` without producing a new value.
@@ -347,7 +348,7 @@ No other changes yet.
 </details>
 
 ```grain
-peekOk : ((a -> b), Result<a, c>) -> Void
+peekOk : (fn: (a -> b), result: Result<a, c>) -> Void
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` without producing a new value.
@@ -367,7 +368,7 @@ No other changes yet.
 </details>
 
 ```grain
-peekErr : ((a -> b), Result<c, a>) -> Void
+peekErr : (fn: (a -> b), result: Result<c, a>) -> Void
 ```
 
 If the Result is `Err(value)`, applies the given function to the `value` without producing a new value.
@@ -387,7 +388,7 @@ No other changes yet.
 </details>
 
 ```grain
-expect : (String, Result<a, b>) -> a
+expect : (msg: String, result: Result<a, b>) -> a
 ```
 
 Extracts the value inside an `Ok` result, otherwise throw an
@@ -426,7 +427,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrap : Result<a, b> -> a
+unwrap : (result: Result<a, b>) -> a
 ```
 
 Extracts the value inside an `Ok` result, otherwise throw an

--- a/stdlib/runtime/atof/common.md
+++ b/stdlib/runtime/atof/common.md
@@ -220,36 +220,36 @@ fpNan : () -> BiasedFp
 ### Common.**getPowers10**
 
 ```grain
-getPowers10 : WasmI32 -> WasmI32
+getPowers10 : (i: WasmI32) -> WasmI32
 ```
 
 ### Common.**getPowers10FastPath**
 
 ```grain
-getPowers10FastPath : WasmI32 -> WasmF64
+getPowers10FastPath : (i: WasmI32) -> WasmF64
 ```
 
 ### Common.**is8Digits**
 
 ```grain
-is8Digits : WasmI64 -> Bool
+is8Digits : (value: WasmI64) -> Bool
 ```
 
 ### Common.**power**
 
 ```grain
-power : WasmI32 -> WasmI32
+power : (q: WasmI32) -> WasmI32
 ```
 
 ### Common.**fullMultiplication**
 
 ```grain
-fullMultiplication : (WasmI64, WasmI64) -> (Int64, Int64)
+fullMultiplication : (a: WasmI64, b: WasmI64) -> (Int64, Int64)
 ```
 
 ### Common.**biasedFpToNumber**
 
 ```grain
-biasedFpToNumber : (BiasedFp, Bool) -> Number
+biasedFpToNumber : (fp: BiasedFp, negative: Bool) -> Number
 ```
 

--- a/stdlib/runtime/atof/decimal.md
+++ b/stdlib/runtime/atof/decimal.md
@@ -30,13 +30,13 @@ _DECIMAL_POINT_RANGE : WasmI32
 ### Decimal.**tryAddDigit**
 
 ```grain
-tryAddDigit : (Decimal, WasmI32) -> Void
+tryAddDigit : (d: Decimal, digit: WasmI32) -> Void
 ```
 
 ### Decimal.**round**
 
 ```grain
-round : Decimal -> WasmI64
+round : (d: Decimal) -> WasmI64
 ```
 
 ### Decimal.**get_TABLE**
@@ -54,18 +54,18 @@ get_TABLE_POW5 : () -> WasmI32
 ### Decimal.**leftShift**
 
 ```grain
-leftShift : (Decimal, WasmI32) -> Void
+leftShift : (d: Decimal, shift: WasmI32) -> Void
 ```
 
 ### Decimal.**rightShift**
 
 ```grain
-rightShift : (Decimal, WasmI32) -> Void
+rightShift : (d: Decimal, shift: WasmI32) -> Void
 ```
 
 ### Decimal.**parseDecimal**
 
 ```grain
-parseDecimal : String -> Decimal
+parseDecimal : (s: String) -> Decimal
 ```
 

--- a/stdlib/runtime/atof/lemire.md
+++ b/stdlib/runtime/atof/lemire.md
@@ -9,6 +9,6 @@ Functions and constants included in the Lemire module.
 ### Lemire.**computeFloat**
 
 ```grain
-computeFloat : (WasmI64, WasmI64) -> Common.BiasedFp
+computeFloat : (exponent: WasmI64, mantissa: WasmI64) -> Common.BiasedFp
 ```
 

--- a/stdlib/runtime/atof/parse.md
+++ b/stdlib/runtime/atof/parse.md
@@ -9,12 +9,14 @@ Functions and constants included in the Parse module.
 ### Parse.**isFastPath**
 
 ```grain
-isFastPath : (WasmI32, WasmI64, Bool, Bool) -> Bool
+isFastPath :
+  (exponent: WasmI32, mantissa: WasmI64, negative: Bool, manyDigits: Bool) ->
+   Bool
 ```
 
 ### Parse.**parseFloat**
 
 ```grain
-parseFloat : String -> Result<Number, String>
+parseFloat : (string: String) -> Result<Number, String>
 ```
 

--- a/stdlib/runtime/atof/slow.md
+++ b/stdlib/runtime/atof/slow.md
@@ -9,6 +9,6 @@ Functions and constants included in the Slow module.
 ### Slow.**parseLongMantissa**
 
 ```grain
-parseLongMantissa : String -> Common.BiasedFp
+parseLongMantissa : (s: String) -> Common.BiasedFp
 ```
 

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -9,6 +9,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (String, Number) -> Result<Number, String>
+parseInt : (string: String, radix: Number) -> Result<Number, String>
 ```
 

--- a/stdlib/runtime/bigint.md
+++ b/stdlib/runtime/bigint.md
@@ -9,61 +9,61 @@ Functions and constants included in the Bigint module.
 ### Bigint.**debugDumpNumber**
 
 ```grain
-debugDumpNumber : WasmI32 -> Void
+debugDumpNumber : (num: WasmI32) -> Void
 ```
 
 ### Bigint.**getSize**
 
 ```grain
-getSize : WasmI32 -> WasmI32
+getSize : (ptr: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**getFlags**
 
 ```grain
-getFlags : WasmI32 -> WasmI32
+getFlags : (ptr: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**getLimb**
 
 ```grain
-getLimb : (WasmI32, WasmI32) -> WasmI64
+getLimb : (ptr: WasmI32, i: WasmI32) -> WasmI64
 ```
 
 ### Bigint.**makeWrappedInt32**
 
 ```grain
-makeWrappedInt32 : WasmI32 -> WasmI32
+makeWrappedInt32 : (value: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**makeWrappedUint32**
 
 ```grain
-makeWrappedUint32 : WasmI32 -> WasmI32
+makeWrappedUint32 : (value: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**makeWrappedInt64**
 
 ```grain
-makeWrappedInt64 : WasmI64 -> WasmI32
+makeWrappedInt64 : (value: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**makeWrappedUint64**
 
 ```grain
-makeWrappedUint64 : WasmI64 -> WasmI32
+makeWrappedUint64 : (value: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**isNegative**
 
 ```grain
-isNegative : WasmI32 -> Bool
+isNegative : (num: WasmI32) -> Bool
 ```
 
 ### Bigint.**eqz**
 
 ```grain
-eqz : WasmI32 -> Bool
+eqz : (num: WasmI32) -> Bool
 ```
 
 Returns true if the given bigint is equal to zero
@@ -71,270 +71,270 @@ Returns true if the given bigint is equal to zero
 ### Bigint.**negate**
 
 ```grain
-negate : WasmI32 -> WasmI32
+negate : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**abs**
 
 ```grain
-abs : WasmI32 -> WasmI32
+abs : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**canConvertToInt32**
 
 ```grain
-canConvertToInt32 : WasmI32 -> Bool
+canConvertToInt32 : (num: WasmI32) -> Bool
 ```
 
 ### Bigint.**toInt32**
 
 ```grain
-toInt32 : WasmI32 -> WasmI32
+toInt32 : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**canConvertToInt64**
 
 ```grain
-canConvertToInt64 : WasmI32 -> Bool
+canConvertToInt64 : (num: WasmI32) -> Bool
 ```
 
 ### Bigint.**toInt64**
 
 ```grain
-toInt64 : WasmI32 -> WasmI64
+toInt64 : (num: WasmI32) -> WasmI64
 ```
 
 ### Bigint.**toUnsignedInt64**
 
 ```grain
-toUnsignedInt64 : WasmI32 -> WasmI64
+toUnsignedInt64 : (num: WasmI32) -> WasmI64
 ```
 
 ### Bigint.**toFloat64**
 
 ```grain
-toFloat64 : WasmI32 -> WasmF64
+toFloat64 : (num: WasmI32) -> WasmF64
 ```
 
 ### Bigint.**toFloat32**
 
 ```grain
-toFloat32 : WasmI32 -> WasmF32
+toFloat32 : (num: WasmI32) -> WasmF32
 ```
 
 ### Bigint.**cmpI64**
 
 ```grain
-cmpI64 : (WasmI32, WasmI64) -> WasmI32
+cmpI64 : (num1: WasmI32, num2: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**cmpU64**
 
 ```grain
-cmpU64 : (WasmI32, WasmI64) -> WasmI32
+cmpU64 : (num1: WasmI32, num2: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**cmpF64**
 
 ```grain
-cmpF64 : (WasmI32, WasmF64) -> WasmI32
+cmpF64 : (num1: WasmI32, num2: WasmF64) -> WasmI32
 ```
 
 ### Bigint.**cmpF32**
 
 ```grain
-cmpF32 : (WasmI32, WasmF32) -> WasmI32
+cmpF32 : (num1: WasmI32, num2: WasmF32) -> WasmI32
 ```
 
 ### Bigint.**cmp**
 
 ```grain
-cmp : (WasmI32, WasmI32) -> WasmI32
+cmp : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**eq**
 
 ```grain
-eq : (WasmI32, WasmI32) -> Bool
+eq : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**ne**
 
 ```grain
-ne : (WasmI32, WasmI32) -> Bool
+ne : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**lt**
 
 ```grain
-lt : (WasmI32, WasmI32) -> Bool
+lt : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**lte**
 
 ```grain
-lte : (WasmI32, WasmI32) -> Bool
+lte : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**gt**
 
 ```grain
-gt : (WasmI32, WasmI32) -> Bool
+gt : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**gte**
 
 ```grain
-gte : (WasmI32, WasmI32) -> Bool
+gte : (num1: WasmI32, num2: WasmI32) -> Bool
 ```
 
 ### Bigint.**bigIntToString**
 
 ```grain
-bigIntToString : (WasmI32, WasmI32) -> String
+bigIntToString : (num: WasmI32, base: WasmI32) -> String
 ```
 
 ### Bigint.**bigIntToString10**
 
 ```grain
-bigIntToString10 : WasmI32 -> String
+bigIntToString10 : (num: WasmI32) -> String
 ```
 
 ### Bigint.**add**
 
 ```grain
-add : (WasmI32, WasmI32) -> WasmI32
+add : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**addInt**
 
 ```grain
-addInt : (WasmI32, WasmI64) -> WasmI32
+addInt : (num1: WasmI32, int: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**sub**
 
 ```grain
-sub : (WasmI32, WasmI32) -> WasmI32
+sub : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**subInt**
 
 ```grain
-subInt : (WasmI32, WasmI64) -> WasmI32
+subInt : (num1: WasmI32, int: WasmI64) -> WasmI32
 ```
 
 ### Bigint.**incr**
 
 ```grain
-incr : WasmI32 -> WasmI32
+incr : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**decr**
 
 ```grain
-decr : WasmI32 -> WasmI32
+decr : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**mul**
 
 ```grain
-mul : (WasmI32, WasmI32) -> WasmI32
+mul : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**shl**
 
 ```grain
-shl : (WasmI32, WasmI32) -> WasmI32
+shl : (num: WasmI32, places: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**shrS**
 
 ```grain
-shrS : (WasmI32, WasmI32) -> WasmI32
+shrS : (num: WasmI32, places: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**bitwiseNot**
 
 ```grain
-bitwiseNot : WasmI32 -> WasmI32
+bitwiseNot : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**bitwiseAnd**
 
 ```grain
-bitwiseAnd : (WasmI32, WasmI32) -> WasmI32
+bitwiseAnd : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**bitwiseOr**
 
 ```grain
-bitwiseOr : (WasmI32, WasmI32) -> WasmI32
+bitwiseOr : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**bitwiseXor**
 
 ```grain
-bitwiseXor : (WasmI32, WasmI32) -> WasmI32
+bitwiseXor : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**countLeadingZeros**
 
 ```grain
-countLeadingZeros : WasmI32 -> WasmI32
+countLeadingZeros : (num: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**countTrailingZeros**
 
 ```grain
-countTrailingZeros : WasmI32 -> WasmI64
+countTrailingZeros : (num: WasmI32) -> WasmI64
 ```
 
 ### Bigint.**popcnt**
 
 ```grain
-popcnt : (WasmI32, WasmI32) -> WasmI64
+popcnt : (num: WasmI32, flagDest: WasmI32) -> WasmI64
 ```
 
 ### Bigint.**gcd**
 
 ```grain
-gcd : (WasmI32, WasmI32) -> WasmI32
+gcd : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**quotRem**
 
 ```grain
-quotRem : (WasmI32, WasmI32, WasmI32) -> Void
+quotRem : (num1: WasmI32, num2: WasmI32, dest: WasmI32) -> Void
 ```
 
 ### Bigint.**divMod**
 
 ```grain
-divMod : (WasmI32, WasmI32, WasmI32) -> Void
+divMod : (num1: WasmI32, num2: WasmI32, dest: WasmI32) -> Void
 ```
 
 ### Bigint.**quot**
 
 ```grain
-quot : (WasmI32, WasmI32) -> WasmI32
+quot : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**div**
 
 ```grain
-div : (WasmI32, WasmI32) -> WasmI32
+div : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**rem**
 
 ```grain
-rem : (WasmI32, WasmI32) -> WasmI32
+rem : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 
 ### Bigint.**mod**
 
 ```grain
-mod : (WasmI32, WasmI32) -> WasmI32
+mod : (num1: WasmI32, num2: WasmI32) -> WasmI32
 ```
 

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-compare : (a, a) -> Number
+compare : (x: a, y: a) -> Number
 ```
 
 Compares the first argument to the second argument and produces an integer result.

--- a/stdlib/runtime/debugPrint.md
+++ b/stdlib/runtime/debugPrint.md
@@ -9,30 +9,30 @@ Functions and constants included in the DebugPrint module.
 ### DebugPrint.**print**
 
 ```grain
-print : String -> Void
+print : (s: String) -> Void
 ```
 
 ### DebugPrint.**printI32**
 
 ```grain
-printI32 : WasmI32 -> Void
+printI32 : (val: WasmI32) -> Void
 ```
 
 ### DebugPrint.**printI64**
 
 ```grain
-printI64 : WasmI64 -> Void
+printI64 : (val: WasmI64) -> Void
 ```
 
 ### DebugPrint.**printF32**
 
 ```grain
-printF32 : WasmF32 -> Void
+printF32 : (val: WasmF32) -> Void
 ```
 
 ### DebugPrint.**printF64**
 
 ```grain
-printF64 : WasmF64 -> Void
+printF64 : (val: WasmF64) -> Void
 ```
 

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-equal : (a, a) -> Bool
+equal : (x: a, y: a) -> Bool
 ```
 
 Check that two values are equal. This checks for structural equality,

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -15,24 +15,24 @@ printers : WasmI32
 ### Exception.**dangerouslyRegisterBasePrinter**
 
 ```grain
-dangerouslyRegisterBasePrinter : a -> Void
+dangerouslyRegisterBasePrinter : (f: a) -> Void
 ```
 
 ### Exception.**dangerouslyRegisterPrinter**
 
 ```grain
-dangerouslyRegisterPrinter : a -> Void
+dangerouslyRegisterPrinter : (f: a) -> Void
 ```
 
 ### Exception.**panic**
 
 ```grain
-panic : String -> a
+panic : (msg: String) -> a
 ```
 
 ### Exception.**panicWithException**
 
 ```grain
-panicWithException : Exception -> a
+panicWithException : (e: Exception) -> a
 ```
 

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -9,24 +9,24 @@ Functions and constants included in the GC module.
 ### GC.**malloc**
 
 ```grain
-malloc : WasmI32 -> WasmI32
+malloc : (size: WasmI32) -> WasmI32
 ```
 
 ### GC.**free**
 
 ```grain
-free : WasmI32 -> Void
+free : (userPtr: WasmI32) -> Void
 ```
 
 ### GC.**incRef**
 
 ```grain
-incRef : WasmI32 -> WasmI32
+incRef : (userPtr: WasmI32) -> WasmI32
 ```
 
 ### GC.**decRef**
 
 ```grain
-decRef : WasmI32 -> WasmI32
+decRef : (userPtr: WasmI32) -> WasmI32
 ```
 

--- a/stdlib/runtime/malloc.md
+++ b/stdlib/runtime/malloc.md
@@ -15,7 +15,7 @@ _RESERVED_RUNTIME_SPACE : WasmI32
 ### Malloc.**free**
 
 ```grain
-free : WasmI32 -> Void
+free : (ap: WasmI32) -> Void
 ```
 
 Frees the given allocated pointer.
@@ -29,7 +29,7 @@ Parameters:
 ### Malloc.**malloc**
 
 ```grain
-malloc : WasmI32 -> WasmI32
+malloc : (nb: WasmI32) -> WasmI32
 ```
 
 Allocates the requested number of bytes, returning a pointer.

--- a/stdlib/runtime/numberUtils.md
+++ b/stdlib/runtime/numberUtils.md
@@ -27,42 +27,42 @@ get_HEX_DIGITS : () -> WasmI32
 ### NumberUtils.**decimalCount32**
 
 ```grain
-decimalCount32 : WasmI32 -> WasmI32
+decimalCount32 : (value: WasmI32) -> WasmI32
 ```
 
 ### NumberUtils.**utoa32Buffered**
 
 ```grain
-utoa32Buffered : (WasmI32, WasmI32, WasmI32) -> Void
+utoa32Buffered : (buf: WasmI32, value: WasmI32, radix: WasmI32) -> Void
 ```
 
 ### NumberUtils.**utoa32**
 
 ```grain
-utoa32 : (WasmI32, WasmI32) -> String
+utoa32 : (value: WasmI32, radix: WasmI32) -> String
 ```
 
 ### NumberUtils.**itoa32**
 
 ```grain
-itoa32 : (WasmI32, WasmI32) -> String
+itoa32 : (value: WasmI32, radix: WasmI32) -> String
 ```
 
 ### NumberUtils.**utoa64**
 
 ```grain
-utoa64 : (WasmI64, WasmI32) -> String
+utoa64 : (value: WasmI64, radix: WasmI32) -> String
 ```
 
 ### NumberUtils.**itoa64**
 
 ```grain
-itoa64 : (WasmI64, WasmI32) -> String
+itoa64 : (value: WasmI64, radix: WasmI32) -> String
 ```
 
 ### NumberUtils.**dtoa**
 
 ```grain
-dtoa : WasmF64 -> String
+dtoa : (value: WasmF64) -> String
 ```
 

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -9,151 +9,153 @@ Functions and constants included in the Numbers module.
 ### Numbers.**tagSimple**
 
 ```grain
-tagSimple : WasmI32 -> WasmI32
+tagSimple : (x: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**isBoxedNumber**
 
 ```grain
-isBoxedNumber : WasmI32 -> Bool
+isBoxedNumber : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**isFloat**
 
 ```grain
-isFloat : WasmI32 -> Bool
+isFloat : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**isInteger**
 
 ```grain
-isInteger : WasmI32 -> Bool
+isInteger : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**isRational**
 
 ```grain
-isRational : WasmI32 -> Bool
+isRational : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**isNaN**
 
 ```grain
-isNaN : WasmI32 -> Bool
+isNaN : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**isNumber**
 
 ```grain
-isNumber : WasmI32 -> Bool
+isNumber : (x: WasmI32) -> Bool
 ```
 
 ### Numbers.**reducedInteger**
 
 ```grain
-reducedInteger : WasmI64 -> WasmI32
+reducedInteger : (x: WasmI64) -> WasmI32
 ```
 
 ### Numbers.**reducedUnsignedInteger**
 
 ```grain
-reducedUnsignedInteger : WasmI64 -> WasmI32
+reducedUnsignedInteger : (x: WasmI64) -> WasmI32
 ```
 
 ### Numbers.**boxedNumberTag**
 
 ```grain
-boxedNumberTag : WasmI32 -> WasmI32
+boxedNumberTag : (xptr: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**boxedInt64Number**
 
 ```grain
-boxedInt64Number : WasmI32 -> WasmI64
+boxedInt64Number : (xptr: WasmI32) -> WasmI64
 ```
 
 ### Numbers.**boxedFloat64Number**
 
 ```grain
-boxedFloat64Number : WasmI32 -> WasmF64
+boxedFloat64Number : (xptr: WasmI32) -> WasmF64
 ```
 
 ### Numbers.**boxedRationalNumerator**
 
 ```grain
-boxedRationalNumerator : WasmI32 -> WasmI32
+boxedRationalNumerator : (xptr: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**boxedRationalDenominator**
 
 ```grain
-boxedRationalDenominator : WasmI32 -> WasmI32
+boxedRationalDenominator : (xptr: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**coerceNumberToWasmF32**
 
 ```grain
-coerceNumberToWasmF32 : Number -> WasmF32
+coerceNumberToWasmF32 : (x: Number) -> WasmF32
 ```
 
 ### Numbers.**coerceNumberToWasmF64**
 
 ```grain
-coerceNumberToWasmF64 : Number -> WasmF64
+coerceNumberToWasmF64 : (x: Number) -> WasmF64
 ```
 
 ### Numbers.**coerceNumberToWasmI64**
 
 ```grain
-coerceNumberToWasmI64 : Number -> WasmI64
+coerceNumberToWasmI64 : (x: Number) -> WasmI64
 ```
 
 ### Numbers.**coerceNumberToWasmI32**
 
 ```grain
-coerceNumberToWasmI32 : Number -> WasmI32
+coerceNumberToWasmI32 : (x: Number) -> WasmI32
 ```
 
 ### Numbers.**coerceNumberToUnsignedWasmI64**
 
 ```grain
-coerceNumberToUnsignedWasmI64 : Number -> WasmI64
+coerceNumberToUnsignedWasmI64 : (x: Number) -> WasmI64
 ```
 
 ### Numbers.**coerceNumberToUnsignedWasmI32**
 
 ```grain
-coerceNumberToUnsignedWasmI32 : Number -> WasmI32
+coerceNumberToUnsignedWasmI32 : (x: Number) -> WasmI32
 ```
 
 ### Numbers.**numberEqual**
 
 ```grain
-numberEqual : (WasmI32, WasmI32) -> Bool
+numberEqual : (x: WasmI32, y: WasmI32) -> Bool
 ```
 
 ### Numbers.**addSubRational**
 
 ```grain
-addSubRational : (WasmI32, WasmI32, Bool, Bool) -> WasmI32
+addSubRational :
+  (x: WasmI32, y: WasmI32, isSub: Bool, keepRational: Bool) -> WasmI32
 ```
 
 ### Numbers.**timesDivideRational**
 
 ```grain
-timesDivideRational : (WasmI32, WasmI32, Bool, Bool) -> WasmI32
+timesDivideRational :
+  (x: WasmI32, y: WasmI32, isDivide: Bool, keepRational: Bool) -> WasmI32
 ```
 
 ### Numbers.**rationalsEqual**
 
 ```grain
-rationalsEqual : (WasmI32, WasmI32) -> Bool
+rationalsEqual : (x: WasmI32, y: WasmI32) -> Bool
 ```
 
 ### Numbers.**cmpRationals**
 
 ```grain
-cmpRationals : (WasmI32, WasmI32) -> WasmI32
+cmpRationals : (x: WasmI32, y: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**rationalNumerator**
@@ -164,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-rationalNumerator : Rational -> Number
+rationalNumerator : (x: Rational) -> Number
 ```
 
 Finds the numerator of the rational number.
@@ -189,7 +191,7 @@ No other changes yet.
 </details>
 
 ```grain
-rationalDenominator : Rational -> Number
+rationalDenominator : (x: Rational) -> Number
 ```
 
 Finds the denominator of the rational number.
@@ -209,7 +211,7 @@ Returns:
 ### Numbers.**cmp**
 
 ```grain
-cmp : (WasmI32, WasmI32) -> WasmI32
+cmp : (x: WasmI32, y: WasmI32) -> WasmI32
 ```
 
 ### Numbers.**(<)**
@@ -220,7 +222,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Number, Number) -> Bool
+(<) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is less than the second operand.
@@ -246,7 +248,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Number, Number) -> Bool
+(>) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is greater than the second operand.
@@ -272,7 +274,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Number, Number) -> Bool
+(<=) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is less than or equal to the second operand.
@@ -298,7 +300,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Number, Number) -> Bool
+(>=) : (x: Number, y: Number) -> Bool
 ```
 
 Checks if the first operand is greater than or equal to the second operand.
@@ -319,13 +321,13 @@ Returns:
 ### Numbers.**compare**
 
 ```grain
-compare : (Number, Number) -> Number
+compare : (x: Number, y: Number) -> Number
 ```
 
 ### Numbers.**numberEq**
 
 ```grain
-numberEq : (Number, Number) -> Bool
+numberEq : (x: Number, y: Number) -> Bool
 ```
 
 ### Numbers.**lnot**
@@ -336,7 +338,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Number -> Number
+lnot : (x: Number) -> Number
 ```
 
 Computes the bitwise NOT of the operand.
@@ -369,7 +371,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (Number, Number) -> Number
+(<<) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -403,7 +405,7 @@ Returns:
 </details>
 
 ```grain
-(>>>) : (Number, Number) -> Number
+(>>>) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -437,7 +439,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (Number, Number) -> Number
+(&) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -471,7 +473,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (Number, Number) -> Number
+(|) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -506,7 +508,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (Number, Number) -> Number
+(^) : (x: Number, y: Number) -> Number
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -540,7 +542,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (Number, Number) -> Number
+(>>) : (x: Number, y: Number) -> Number
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -566,7 +568,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt8 : Number -> Int8
+coerceNumberToInt8 : (number: Number) -> Int8
 ```
 
 Converts a Number to an Int8.
@@ -591,7 +593,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt16 : Number -> Int16
+coerceNumberToInt16 : (number: Number) -> Int16
 ```
 
 Converts a Number to an Int16.
@@ -616,7 +618,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToUint8 : Number -> Uint8
+coerceNumberToUint8 : (number: Number) -> Uint8
 ```
 
 Converts a Number to a Uint8.
@@ -641,7 +643,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToUint16 : Number -> Uint16
+coerceNumberToUint16 : (number: Number) -> Uint16
 ```
 
 Converts a Number to a Uint16.
@@ -666,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt32 : Number -> Int32
+coerceNumberToInt32 : (x: Number) -> Int32
 ```
 
 Converts a Number to an Int32.
@@ -691,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt64 : Number -> Int64
+coerceNumberToInt64 : (x: Number) -> Int64
 ```
 
 Converts a Number to an Int64.
@@ -716,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToBigInt : Number -> BigInt
+coerceNumberToBigInt : (x: Number) -> BigInt
 ```
 
 Converts a Number to a BigInt.
@@ -741,7 +743,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToRational : Number -> Rational
+coerceNumberToRational : (x: Number) -> Rational
 ```
 
 Converts a Number to a Rational.
@@ -766,7 +768,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToFloat32 : Number -> Float32
+coerceNumberToFloat32 : (x: Number) -> Float32
 ```
 
 Converts a Number to a Float32.
@@ -791,7 +793,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToFloat64 : Number -> Float64
+coerceNumberToFloat64 : (x: Number) -> Float64
 ```
 
 Converts a Number to a Float64.
@@ -816,7 +818,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt8ToNumber : Int8 -> Number
+coerceInt8ToNumber : (value: Int8) -> Number
 ```
 
 Converts an Int8 to a Number.
@@ -841,7 +843,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt16ToNumber : Int16 -> Number
+coerceInt16ToNumber : (value: Int16) -> Number
 ```
 
 Converts an Int16 to a Number.
@@ -866,7 +868,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceUint8ToNumber : Uint8 -> Number
+coerceUint8ToNumber : (value: Uint8) -> Number
 ```
 
 Converts a Uint8 to a Number.
@@ -891,7 +893,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceUint16ToNumber : Uint16 -> Number
+coerceUint16ToNumber : (value: Uint16) -> Number
 ```
 
 Converts a Uint16 to a Number.
@@ -916,7 +918,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt32ToNumber : Int32 -> Number
+coerceInt32ToNumber : (x: Int32) -> Number
 ```
 
 Converts an Int32 to a Number.
@@ -941,7 +943,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt64ToNumber : Int64 -> Number
+coerceInt64ToNumber : (x: Int64) -> Number
 ```
 
 Converts an Int64 to a Number.
@@ -966,7 +968,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceBigIntToNumber : BigInt -> Number
+coerceBigIntToNumber : (x: BigInt) -> Number
 ```
 
 Converts a BigInt to a Number.
@@ -991,7 +993,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceRationalToNumber : Rational -> Number
+coerceRationalToNumber : (x: Rational) -> Number
 ```
 
 Converts a Rational to a Number.
@@ -1016,7 +1018,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceFloat32ToNumber : Float32 -> Number
+coerceFloat32ToNumber : (x: Float32) -> Number
 ```
 
 Converts a Float32 to a Number.
@@ -1041,7 +1043,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceFloat64ToNumber : Float64 -> Number
+coerceFloat64ToNumber : (x: Float64) -> Number
 ```
 
 Converts a Float64 to a Number.
@@ -1061,13 +1063,13 @@ Returns:
 ### Numbers.**convertExactToInexact**
 
 ```grain
-convertExactToInexact : Number -> Number
+convertExactToInexact : (x: Number) -> Number
 ```
 
 ### Numbers.**convertInexactToExact**
 
 ```grain
-convertInexactToExact : Number -> Number
+convertInexactToExact : (x: Number) -> Number
 ```
 
 ### Numbers.**(+)**
@@ -1078,7 +1080,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Number, Number) -> Number
+(+) : (x: Number, y: Number) -> Number
 ```
 
 Computes the sum of its operands.
@@ -1104,7 +1106,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Number, Number) -> Number
+(-) : (x: Number, y: Number) -> Number
 ```
 
 Computes the difference of its operands.
@@ -1130,7 +1132,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Number, Number) -> Number
+(*) : (x: Number, y: Number) -> Number
 ```
 
 Computes the product of its operands.
@@ -1156,7 +1158,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Number, Number) -> Number
+(/) : (x: Number, y: Number) -> Number
 ```
 
 Computes the quotient of its operands.
@@ -1182,7 +1184,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Number, Number) -> Number
+(%) : (x: Number, y: Number) -> Number
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -1209,7 +1211,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Number -> Number
+incr : (x: Number) -> Number
 ```
 
 Increments the value by one.
@@ -1234,7 +1236,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Number -> Number
+decr : (x: Number) -> Number
 ```
 
 Decrements the value by one.
@@ -1254,7 +1256,7 @@ Returns:
 ### Numbers.**isBigInt**
 
 ```grain
-isBigInt : a -> Bool
+isBigInt : (x: a) -> Bool
 ```
 
 ### Numbers.**scalbn**
@@ -1265,7 +1267,7 @@ No other changes yet.
 </details>
 
 ```grain
-scalbn : (WasmF64, WasmI32) -> WasmF64
+scalbn : (x: WasmF64, n: WasmI32) -> WasmF64
 ```
 
 Multiplies a floating-point number by an integral power of 2.
@@ -1298,7 +1300,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (Number, Number) -> Number
+(**) : (base: Number, power: Number) -> Number
 ```
 
 Computes the exponentiation of the given base and power.

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (String, String) -> String
+concat : (s1: String, s2: String) -> String
 ```
 
 Concatenate two strings.
@@ -46,7 +46,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : a -> String
+toString : (value: a) -> String
 ```
 
 Converts the given operand to a string.
@@ -72,7 +72,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : a -> Void
+print : (value: a) -> Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`

--- a/stdlib/runtime/unsafe/conv.md
+++ b/stdlib/runtime/unsafe/conv.md
@@ -9,79 +9,79 @@ Functions and constants included in the Conv module.
 ### Conv.**toInt32**
 
 ```grain
-toInt32 : WasmI32 -> Int32
+toInt32 : (n: WasmI32) -> Int32
 ```
 
 ### Conv.**toUint32**
 
 ```grain
-toUint32 : WasmI32 -> Uint32
+toUint32 : (n: WasmI32) -> Uint32
 ```
 
 ### Conv.**fromInt32**
 
 ```grain
-fromInt32 : Int32 -> WasmI32
+fromInt32 : (n: Int32) -> WasmI32
 ```
 
 ### Conv.**fromUint32**
 
 ```grain
-fromUint32 : Uint32 -> WasmI32
+fromUint32 : (n: Uint32) -> WasmI32
 ```
 
 ### Conv.**toInt64**
 
 ```grain
-toInt64 : WasmI64 -> Int64
+toInt64 : (n: WasmI64) -> Int64
 ```
 
 ### Conv.**toUint64**
 
 ```grain
-toUint64 : WasmI64 -> Uint64
+toUint64 : (n: WasmI64) -> Uint64
 ```
 
 ### Conv.**fromInt64**
 
 ```grain
-fromInt64 : Int64 -> WasmI64
+fromInt64 : (n: Int64) -> WasmI64
 ```
 
 ### Conv.**fromUint64**
 
 ```grain
-fromUint64 : Uint64 -> WasmI64
+fromUint64 : (n: Uint64) -> WasmI64
 ```
 
 ### Conv.**toFloat32**
 
 ```grain
-toFloat32 : WasmF32 -> Float32
+toFloat32 : (n: WasmF32) -> Float32
 ```
 
 ### Conv.**fromFloat32**
 
 ```grain
-fromFloat32 : Float32 -> WasmF32
+fromFloat32 : (n: Float32) -> WasmF32
 ```
 
 ### Conv.**toFloat64**
 
 ```grain
-toFloat64 : WasmF64 -> Float64
+toFloat64 : (n: WasmF64) -> Float64
 ```
 
 ### Conv.**fromFloat64**
 
 ```grain
-fromFloat64 : Float64 -> WasmF64
+fromFloat64 : (n: Float64) -> WasmF64
 ```
 
 ### Conv.**wasmI32ToNumber**
 
 ```grain
-wasmI32ToNumber : WasmI32 -> Number
+wasmI32ToNumber : (n: WasmI32) -> Number
 ```
 
 Converts a WasmI32 value to Number.

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -9,37 +9,37 @@ Functions and constants included in the Memory module.
 ### Memory.**malloc**
 
 ```grain
-malloc : WasmI32 -> WasmI32
+malloc : (size: WasmI32) -> WasmI32
 ```
 
 ### Memory.**free**
 
 ```grain
-free : WasmI32 -> Void
+free : (userPtr: WasmI32) -> Void
 ```
 
 ### Memory.**incRef**
 
 ```grain
-incRef : WasmI32 -> WasmI32
+incRef : (userPtr: WasmI32) -> WasmI32
 ```
 
 ### Memory.**decRef**
 
 ```grain
-decRef : WasmI32 -> WasmI32
+decRef : (userPtr: WasmI32) -> WasmI32
 ```
 
 ### Memory.**copy**
 
 ```grain
-copy : (WasmI32, WasmI32, WasmI32) -> Void
+copy : (dest: WasmI32, src: WasmI32, n: WasmI32) -> Void
 ```
 
 ### Memory.**fill**
 
 ```grain
-fill : (WasmI32, WasmI32, WasmI32) -> Void
+fill : (dest: WasmI32, c: WasmI32, n: WasmI32) -> Void
 ```
 
 ### Memory.**compare**

--- a/stdlib/runtime/utils/printing.md
+++ b/stdlib/runtime/utils/printing.md
@@ -9,18 +9,18 @@ Functions and constants included in the Printing module.
 ### Printing.**numberToString**
 
 ```grain
-numberToString : WasmI64 -> String
+numberToString : (n: WasmI64) -> String
 ```
 
 ### Printing.**printNumber**
 
 ```grain
-printNumber : WasmI64 -> Void
+printNumber : (n: WasmI64) -> Void
 ```
 
 ### Printing.**printString**
 
 ```grain
-printString : String -> Void
+printString : (s: String) -> Void
 ```
 

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -842,6 +842,6 @@ _ENOTCAPABLE : WasmI32
 ### Wasi.**stringOfSystemError**
 
 ```grain
-stringOfSystemError : a -> String
+stringOfSystemError : (code: a) -> String
 ```
 

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : Number -> Set<a>
+makeSized : (size: Number) -> Set<a>
 ```
 
 Creates a new empty set with an initial storage of the given size. As values are added or removed, the internal storage may grow or shrink. Generally, you won't need to care about the storage size of your set and can use `Set.make()` instead.
@@ -79,7 +79,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (a, Set<a>) -> Void
+add : (key: a, set: Set<a>) -> Void
 ```
 
 Adds a new value to the set. If the value already exists, nothing happens.
@@ -99,7 +99,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (a, Set<a>) -> Bool
+contains : (key: a, set: Set<a>) -> Bool
 ```
 
 Determines if the set contains the given value.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (a, Set<a>) -> Void
+remove : (key: a, set: Set<a>) -> Void
 ```
 
 Removes the given value from the set. If the value doesn't exist, nothing happens.
@@ -145,7 +145,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : Set<a> -> Number
+size : (set: Set<a>) -> Number
 ```
 
 Provides the count of values within the set.
@@ -170,7 +170,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : Set<a> -> Bool
+isEmpty : (set: Set<a>) -> Bool
 ```
 
 Determines if the set contains no elements.
@@ -195,7 +195,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Set<a> -> Void
+clear : (set: Set<a>) -> Void
 ```
 
 Resets the set by removing all values.
@@ -221,7 +221,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : ((a -> Void), Set<a>) -> Void
+forEach : (fn: (a -> Void), set: Set<a>) -> Void
 ```
 
 Iterates the set, calling an iterator function on each element.
@@ -241,7 +241,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (((a, b) -> a), a, Set<b>) -> a
+reduce : (fn: ((a, b) -> a), init: a, set: Set<b>) -> a
 ```
 
 Combines all elements of a set using a reducer function.
@@ -268,7 +268,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : ((a -> Bool), Set<a>) -> Void
+filter : (fn: (a -> Bool), set: Set<a>) -> Void
 ```
 
 Removes elements from a set where a predicate function returns `false`.
@@ -288,7 +288,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : ((a -> Bool), Set<a>) -> Void
+reject : (fn: (a -> Bool), set: Set<a>) -> Void
 ```
 
 Removes elements from a set where a predicate function returns `true`.
@@ -308,7 +308,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : Set<a> -> List<a>
+toList : (set: Set<a>) -> List<a>
 ```
 
 Converts a set into a list of its elements.
@@ -333,7 +333,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : List<a> -> Set<a>
+fromList : (list: List<a>) -> Set<a>
 ```
 
 Creates a set from a list.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : Set<a> -> Array<a>
+toArray : (set: Set<a>) -> Array<a>
 ```
 
 Converts a set into an array of its elements.
@@ -383,7 +383,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : Array<a> -> Set<a>
+fromArray : (array: Array<a>) -> Set<a>
 ```
 
 Creates a set from an array.
@@ -408,7 +408,7 @@ No other changes yet.
 </details>
 
 ```grain
-union : (Set<a>, Set<a>) -> Set<a>
+union : (set1: Set<a>, set2: Set<a>) -> Set<a>
 ```
 
 Combines two sets into a single set containing all elements from both sets.
@@ -434,7 +434,7 @@ No other changes yet.
 </details>
 
 ```grain
-diff : (Set<a>, Set<a>) -> Set<a>
+diff : (set1: Set<a>, set2: Set<a>) -> Set<a>
 ```
 
 Combines two sets into a single set containing only the elements not shared between both sets.
@@ -460,7 +460,7 @@ No other changes yet.
 </details>
 
 ```grain
-intersect : (Set<a>, Set<a>) -> Set<a>
+intersect : (set1: Set<a>, set2: Set<a>) -> Set<a>
 ```
 
 Combines two sets into a single set containing only the elements shared between both sets.
@@ -486,7 +486,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInternalStats : Set<a> -> (Number, Number)
+getInternalStats : (set: Set<a>) -> (Number, Number)
 ```
 
 Provides data representing the internal state state of the set.

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -41,7 +41,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : Number -> Stack<a>
+makeSized : (size: Number) -> Stack<a>
 ```
 
 Creates a new stack with an initial storage of the given size. As values are
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : Stack<a> -> Bool
+isEmpty : (stack: Stack<a>) -> Bool
 ```
 
 Checks if the given stack contains no items.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : Stack<a> -> Number
+size : (stack: Stack<a>) -> Number
 ```
 
 Computes the size of the input stack.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : Stack<a> -> Option<a>
+peek : (stack: Stack<a>) -> Option<a>
 ```
 
 Provides the value at the top of the stack, if it exists.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (a, Stack<a>) -> Void
+push : (value: a, stack: Stack<a>) -> Void
 ```
 
 Adds a new item to the top of the stack.
@@ -183,7 +183,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : Stack<a> -> Option<a>
+pop : (stack: Stack<a>) -> Option<a>
 ```
 
 Removes the item at the top of the stack.
@@ -208,7 +208,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : Stack<a> -> Void
+clear : (stack: Stack<a>) -> Void
 ```
 
 Clears the stack by removing all of its elements
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : Stack<a> -> Stack<a>
+copy : (stack: Stack<a>) -> Stack<a>
 ```
 
 Produces a shallow copy of the input stack.
@@ -299,7 +299,7 @@ An empty stack.
 </details>
 
 ```grain
-isEmpty : ImmutableStack<a> -> Bool
+isEmpty : (stack: ImmutableStack<a>) -> Bool
 ```
 
 Checks if the given stack contains no items.
@@ -332,7 +332,7 @@ Returns:
 </details>
 
 ```grain
-peek : ImmutableStack<a> -> Option<a>
+peek : (stack: ImmutableStack<a>) -> Option<a>
 ```
 
 Provides the value at the top of the stack, if it exists.
@@ -364,7 +364,7 @@ Returns:
 </details>
 
 ```grain
-push : (a, ImmutableStack<a>) -> ImmutableStack<a>
+push : (value: a, stack: ImmutableStack<a>) -> ImmutableStack<a>
 ```
 
 Adds a new item to the top of the stack.
@@ -397,7 +397,7 @@ Returns:
 </details>
 
 ```grain
-pop : ImmutableStack<a> -> ImmutableStack<a>
+pop : (stack: ImmutableStack<a>) -> ImmutableStack<a>
 ```
 
 Removes the item at the top of the stack.
@@ -429,7 +429,7 @@ Returns:
 </details>
 
 ```grain
-size : ImmutableStack<a> -> Number
+size : (stack: ImmutableStack<a>) -> Number
 ```
 
 Computes the size of the input stack.

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -51,7 +51,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (String, String) -> String
+concat : (s1: String, s2: String) -> String
 ```
 
 Concatenate two strings.
@@ -83,7 +83,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : String -> Number
+length : (string: String) -> Number
 ```
 
 Returns the character length of the input string.
@@ -114,7 +114,7 @@ No other changes yet.
 </details>
 
 ```grain
-byteLength : String -> Number
+byteLength : (string: String) -> Number
 ```
 
 Returns the byte length of the input string.
@@ -145,7 +145,7 @@ No other changes yet.
 </details>
 
 ```grain
-indexOf : (String, String) -> Option<Number>
+indexOf : (search: String, string: String) -> Option<Number>
 ```
 
 Finds the first position of a substring in the input string.
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-lastIndexOf : (String, String) -> Option<Number>
+lastIndexOf : (search: String, string: String) -> Option<Number>
 ```
 
 Finds the last position of a substring in the input string.
@@ -209,7 +209,7 @@ No other changes yet.
 </details>
 
 ```grain
-charCodeAt : (Number, String) -> Number
+charCodeAt : (position: Number, string: String) -> Number
 ```
 
 Get the Unicode code point at the position in the input string.
@@ -251,7 +251,7 @@ No other changes yet.
 </details>
 
 ```grain
-charAt : (Number, String) -> Char
+charAt : (position: Number, string: String) -> Char
 ```
 
 Get the character at the position in the input string.
@@ -293,7 +293,7 @@ No other changes yet.
 </details>
 
 ```grain
-explode : String -> Array<Char>
+explode : (string: String) -> Array<Char>
 ```
 
 Split a string into its Unicode characters.
@@ -330,7 +330,7 @@ No other changes yet.
 </details>
 
 ```grain
-implode : Array<Char> -> String
+implode : (arr: Array<Char>) -> String
 ```
 
 Create a string from an array of characters.
@@ -361,7 +361,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : String -> String
+reverse : (string: String) -> String
 ```
 
 Create a string that is the given string reversed.
@@ -387,7 +387,7 @@ String.reverse("olleH") == "Hello"
 ### String.**split**
 
 ```grain
-split : (String, String) -> Array<String>
+split : (separator: String, string: String) -> Array<String>
 ```
 
 Split a string by the given separator.
@@ -425,7 +425,7 @@ No other changes yet.
 </details>
 
 ```grain
-slice : (Number, Number, String) -> String
+slice : (start: Number, to: Number, string: String) -> String
 ```
 
 Get a portion of a string.
@@ -471,7 +471,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (String, String) -> Bool
+contains : (search: String, string: String) -> Bool
 ```
 
 Check if a string contains a substring.
@@ -503,7 +503,7 @@ No other changes yet.
 </details>
 
 ```grain
-startsWith : (String, String) -> Bool
+startsWith : (search: String, string: String) -> Bool
 ```
 
 Check if a string begins with another string.
@@ -535,7 +535,7 @@ No other changes yet.
 </details>
 
 ```grain
-endsWith : (String, String) -> Bool
+endsWith : (search: String, string: String) -> Bool
 ```
 
 Check if a string ends with another string.
@@ -567,7 +567,8 @@ No other changes yet.
 </details>
 
 ```grain
-replaceFirst : (String, String, String) -> String
+replaceFirst :
+  (searchPattern: String, replacement: String, string: String) -> String
 ```
 
 Replaces the first appearance of the search pattern in the string with the replacement value.
@@ -600,7 +601,8 @@ No other changes yet.
 </details>
 
 ```grain
-replaceLast : (String, String, String) -> String
+replaceLast :
+  (searchPattern: String, replacement: String, string: String) -> String
 ```
 
 Replaces the last appearance of the search pattern in the string with the replacement value.
@@ -633,7 +635,8 @@ No other changes yet.
 </details>
 
 ```grain
-replaceAll : (String, String, String) -> String
+replaceAll :
+  (searchPattern: String, replacement: String, string: String) -> String
 ```
 
 Replaces every appearance of the search pattern in the string with the replacement value.
@@ -666,7 +669,8 @@ No other changes yet.
 </details>
 
 ```grain
-encodeAt : (String, Encoding, Bytes, Number) -> Bytes
+encodeAt :
+  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) -> Bytes
 ```
 
 Encodes the given string into a byte sequence at the supplied position, excluding any byte-order marker, using the encoding scheme provided.
@@ -701,7 +705,8 @@ No other changes yet.
 </details>
 
 ```grain
-encodeAtWithBom : (String, Encoding, Bytes, Number) -> Bytes
+encodeAtWithBom :
+  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) -> Bytes
 ```
 
 Encodes the given string into a byte sequence at the supplied position, including any byte-order marker, using the encoding scheme provided.
@@ -736,7 +741,7 @@ No other changes yet.
 </details>
 
 ```grain
-encode : (String, Encoding) -> Bytes
+encode : (string: String, encoding: Encoding) -> Bytes
 ```
 
 Encodes the given string using the given encoding scheme, excluding any byte-order marker.
@@ -762,7 +767,7 @@ No other changes yet.
 </details>
 
 ```grain
-encodeWithBom : (String, Encoding) -> Bytes
+encodeWithBom : (string: String, encoding: Encoding) -> Bytes
 ```
 
 Encodes the given string using the given encoding scheme, including any byte-order marker.
@@ -788,7 +793,8 @@ No other changes yet.
 </details>
 
 ```grain
-decodeRange : (Bytes, Encoding, Number, Number) -> String
+decodeRange :
+  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) -> String
 ```
 
 Decodes the given byte sequence of the specified range into a string, excluding any byte-order marker, using encoding scheme provided.
@@ -825,7 +831,8 @@ No other changes yet.
 </details>
 
 ```grain
-decodeRangeKeepBom : (Bytes, Encoding, Number, Number) -> String
+decodeRangeKeepBom :
+  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) -> String
 ```
 
 Decodes the given byte sequence of the specified range into a string, including any byte-order marker, using encoding scheme provided.
@@ -862,7 +869,7 @@ No other changes yet.
 </details>
 
 ```grain
-decode : (Bytes, Encoding) -> String
+decode : (bytes: Bytes, encoding: Encoding) -> String
 ```
 
 Decodes the given byte sequence into a string using the given encoding scheme, excluding any byte-order marker.
@@ -888,7 +895,7 @@ No other changes yet.
 </details>
 
 ```grain
-decodeKeepBom : (Bytes, Encoding) -> String
+decodeKeepBom : (bytes: Bytes, encoding: Encoding) -> String
 ```
 
 Decodes the given byte sequence into a string using the given encoding scheme, including any byte-order marker.
@@ -914,7 +921,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachCodePoint : ((Number -> Void), String) -> Void
+forEachCodePoint : (fn: (Number -> Void), str: String) -> Void
 ```
 
 Iterates over Unicode code points in a string.
@@ -940,7 +947,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachCodePointi : (((Number, Number) -> Void), String) -> Void
+forEachCodePointi : (fn: ((Number, Number) -> Void), str: String) -> Void
 ```
 
 Iterates over Unicode code points in a string. This is the same as
@@ -968,7 +975,7 @@ No other changes yet.
 </details>
 
 ```grain
-trimStart : String -> String
+trimStart : (string: String) -> String
 ```
 
 Trims the beginning of a string—removing any leading whitespace characters.
@@ -999,7 +1006,7 @@ No other changes yet.
 </details>
 
 ```grain
-trimEnd : String -> String
+trimEnd : (string: String) -> String
 ```
 
 Trims the end of a string—removing any trailing whitespace characters.
@@ -1030,7 +1037,7 @@ No other changes yet.
 </details>
 
 ```grain
-trim : String -> String
+trim : (string: String) -> String
 ```
 
 Trims a string—removing all leading and trailing whitespace characters.

--- a/stdlib/sys/file.md
+++ b/stdlib/sys/file.md
@@ -211,8 +211,10 @@ The `FileDescriptor` for the current working directory of the process.
 
 ```grain
 pathOpen :
-  (FileDescriptor, List<LookupFlag>, String, List<OpenFlag>, List<Rights>,
-   List<Rights>, List<FdFlag>) -> Result<FileDescriptor, Exception>
+  (dirFd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
+   openFlags: List<OpenFlag>, rights: List<Rights>,
+   rightsInheriting: List<Rights>, flags: List<FdFlag>) ->
+   Result<FileDescriptor, Exception>
 ```
 
 Open a file or directory.
@@ -238,7 +240,8 @@ Returns:
 ### File.**fdRead**
 
 ```grain
-fdRead : (FileDescriptor, Number) -> Result<(Bytes, Number), Exception>
+fdRead :
+  (fd: FileDescriptor, size: Number) -> Result<(Bytes, Number), Exception>
 ```
 
 Read from a file descriptor.
@@ -260,7 +263,8 @@ Returns:
 
 ```grain
 fdPread :
-  (FileDescriptor, Int64, Number) -> Result<(Bytes, Number), Exception>
+  (fd: FileDescriptor, offset: Int64, size: Number) ->
+   Result<(Bytes, Number), Exception>
 ```
 
 Read from a file descriptor without updating the file descriptor's offset.
@@ -282,7 +286,7 @@ Returns:
 ### File.**fdWrite**
 
 ```grain
-fdWrite : (FileDescriptor, Bytes) -> Result<Number, Exception>
+fdWrite : (fd: FileDescriptor, data: Bytes) -> Result<Number, Exception>
 ```
 
 Write to a file descriptor.
@@ -303,7 +307,9 @@ Returns:
 ### File.**fdPwrite**
 
 ```grain
-fdPwrite : (FileDescriptor, Bytes, Int64) -> Result<Number, Exception>
+fdPwrite :
+  (fd: FileDescriptor, data: Bytes, offset: Int64) ->
+   Result<Number, Exception>
 ```
 
 Write to a file descriptor without updating the file descriptor's offset.
@@ -325,7 +331,8 @@ Returns:
 ### File.**fdAllocate**
 
 ```grain
-fdAllocate : (FileDescriptor, Int64, Int64) -> Result<Void, Exception>
+fdAllocate :
+  (fd: FileDescriptor, offset: Int64, size: Int64) -> Result<Void, Exception>
 ```
 
 Allocate space within a file.
@@ -347,7 +354,7 @@ Returns:
 ### File.**fdClose**
 
 ```grain
-fdClose : FileDescriptor -> Result<Void, Exception>
+fdClose : (fd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Close a file descriptor.
@@ -367,7 +374,7 @@ Returns:
 ### File.**fdDatasync**
 
 ```grain
-fdDatasync : FileDescriptor -> Result<Void, Exception>
+fdDatasync : (fd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Synchronize the data of a file to disk.
@@ -387,7 +394,7 @@ Returns:
 ### File.**fdSync**
 
 ```grain
-fdSync : FileDescriptor -> Result<Void, Exception>
+fdSync : (fd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Synchronize the data and metadata of a file to disk.
@@ -407,7 +414,7 @@ Returns:
 ### File.**fdStats**
 
 ```grain
-fdStats : FileDescriptor -> Result<Stats, Exception>
+fdStats : (fd: FileDescriptor) -> Result<Stats, Exception>
 ```
 
 Retrieve information about a file descriptor.
@@ -427,7 +434,8 @@ Returns:
 ### File.**fdSetFlags**
 
 ```grain
-fdSetFlags : (FileDescriptor, List<FdFlag>) -> Result<Void, Exception>
+fdSetFlags :
+  (fd: FileDescriptor, flags: List<FdFlag>) -> Result<Void, Exception>
 ```
 
 Update the flags associated with a file descriptor.
@@ -449,7 +457,8 @@ Returns:
 
 ```grain
 fdSetRights :
-  (FileDescriptor, List<Rights>, List<Rights>) -> Result<Void, Exception>
+  (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) ->
+   Result<Void, Exception>
 ```
 
 Update the rights associated with a file descriptor.
@@ -471,7 +480,7 @@ Returns:
 ### File.**fdFilestats**
 
 ```grain
-fdFilestats : FileDescriptor -> Result<Filestats, Exception>
+fdFilestats : (fd: FileDescriptor) -> Result<Filestats, Exception>
 ```
 
 Retrieve information about a file.
@@ -491,7 +500,7 @@ Returns:
 ### File.**fdSetSize**
 
 ```grain
-fdSetSize : (FileDescriptor, Int64) -> Result<Void, Exception>
+fdSetSize : (fd: FileDescriptor, size: Int64) -> Result<Void, Exception>
 ```
 
 Set (truncate) the size of a file.
@@ -512,7 +521,8 @@ Returns:
 ### File.**fdSetAccessTime**
 
 ```grain
-fdSetAccessTime : (FileDescriptor, Int64) -> Result<Void, Exception>
+fdSetAccessTime :
+  (fd: FileDescriptor, timestamp: Int64) -> Result<Void, Exception>
 ```
 
 Set the access (created) time of a file.
@@ -533,7 +543,7 @@ Returns:
 ### File.**fdSetAccessTimeNow**
 
 ```grain
-fdSetAccessTimeNow : FileDescriptor -> Result<Void, Exception>
+fdSetAccessTimeNow : (fd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Set the access (created) time of a file to the current time.
@@ -553,7 +563,8 @@ Returns:
 ### File.**fdSetModifiedTime**
 
 ```grain
-fdSetModifiedTime : (FileDescriptor, Int64) -> Result<Void, Exception>
+fdSetModifiedTime :
+  (fd: FileDescriptor, timestamp: Int64) -> Result<Void, Exception>
 ```
 
 Set the modified time of a file.
@@ -574,7 +585,7 @@ Returns:
 ### File.**fdSetModifiedTimeNow**
 
 ```grain
-fdSetModifiedTimeNow : FileDescriptor -> Result<Void, Exception>
+fdSetModifiedTimeNow : (fd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Set the modified time of a file to the current time.
@@ -594,7 +605,7 @@ Returns:
 ### File.**fdReaddir**
 
 ```grain
-fdReaddir : FileDescriptor -> Result<Array<DirectoryEntry>, Exception>
+fdReaddir : (fd: FileDescriptor) -> Result<Array<DirectoryEntry>, Exception>
 ```
 
 Read the entires of a directory.
@@ -614,7 +625,8 @@ Returns:
 ### File.**fdRenumber**
 
 ```grain
-fdRenumber : (FileDescriptor, FileDescriptor) -> Result<Void, Exception>
+fdRenumber :
+  (fromFd: FileDescriptor, toFd: FileDescriptor) -> Result<Void, Exception>
 ```
 
 Atomically replace a file descriptor by renumbering another file descriptor.
@@ -635,7 +647,9 @@ Returns:
 ### File.**fdSeek**
 
 ```grain
-fdSeek : (FileDescriptor, Int64, Whence) -> Result<Int64, Exception>
+fdSeek :
+  (fd: FileDescriptor, offset: Int64, whence: Whence) ->
+   Result<Int64, Exception>
 ```
 
 Update a file descriptor's offset.
@@ -657,7 +671,7 @@ Returns:
 ### File.**fdTell**
 
 ```grain
-fdTell : FileDescriptor -> Result<Int64, Exception>
+fdTell : (fd: FileDescriptor) -> Result<Int64, Exception>
 ```
 
 Read a file descriptor's offset.
@@ -677,7 +691,8 @@ Returns:
 ### File.**pathCreateDirectory**
 
 ```grain
-pathCreateDirectory : (FileDescriptor, String) -> Result<Void, Exception>
+pathCreateDirectory :
+  (fd: FileDescriptor, path: String) -> Result<Void, Exception>
 ```
 
 Create a directory.
@@ -699,7 +714,8 @@ Returns:
 
 ```grain
 pathFilestats :
-  (FileDescriptor, List<LookupFlag>, String) -> Result<Filestats, Exception>
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+   Result<Filestats, Exception>
 ```
 
 Retrieve information about a file.
@@ -722,8 +738,8 @@ Returns:
 
 ```grain
 pathSetAccessTime :
-  (FileDescriptor, List<LookupFlag>, String, Int64) ->
-   Result<Void, Exception>
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
+   timestamp: Int64) -> Result<Void, Exception>
 ```
 
 Set the access (created) time of a file.
@@ -747,7 +763,8 @@ Returns:
 
 ```grain
 pathSetAccessTimeNow :
-  (FileDescriptor, List<LookupFlag>, String) -> Result<Void, Exception>
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+   Result<Void, Exception>
 ```
 
 Set the access (created) time of a file to the current time.
@@ -770,8 +787,8 @@ Returns:
 
 ```grain
 pathSetModifiedTime :
-  (FileDescriptor, List<LookupFlag>, String, Int64) ->
-   Result<Void, Exception>
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
+   timestamp: Int64) -> Result<Void, Exception>
 ```
 
 Set the modified time of a file.
@@ -795,7 +812,8 @@ Returns:
 
 ```grain
 pathSetModifiedTimeNow :
-  (FileDescriptor, List<LookupFlag>, String) -> Result<Void, Exception>
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+   Result<Void, Exception>
 ```
 
 Set the modified time of a file to the current time.
@@ -818,7 +836,8 @@ Returns:
 
 ```grain
 pathLink :
-  (FileDescriptor, List<LookupFlag>, String, FileDescriptor, String) ->
+  (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sourcePath: 
+   String, targetFd: FileDescriptor, targetPath: String) ->
    Result<Void, Exception>
 ```
 
@@ -843,7 +862,9 @@ Returns:
 ### File.**pathSymlink**
 
 ```grain
-pathSymlink : (FileDescriptor, String, String) -> Result<Void, Exception>
+pathSymlink :
+  (fd: FileDescriptor, sourcePath: String, targetPath: String) ->
+   Result<Void, Exception>
 ```
 
 Create a symlink.
@@ -865,7 +886,7 @@ Returns:
 ### File.**pathUnlink**
 
 ```grain
-pathUnlink : (FileDescriptor, String) -> Result<Void, Exception>
+pathUnlink : (fd: FileDescriptor, path: String) -> Result<Void, Exception>
 ```
 
 Unlink a file.
@@ -887,7 +908,8 @@ Returns:
 
 ```grain
 pathReadlink :
-  (FileDescriptor, String, Number) -> Result<(String, Number), Exception>
+  (fd: FileDescriptor, path: String, size: Number) ->
+   Result<(String, Number), Exception>
 ```
 
 Read the contents of a symbolic link.
@@ -909,7 +931,8 @@ Returns:
 ### File.**pathRemoveDirectory**
 
 ```grain
-pathRemoveDirectory : (FileDescriptor, String) -> Result<Void, Exception>
+pathRemoveDirectory :
+  (fd: FileDescriptor, path: String) -> Result<Void, Exception>
 ```
 
 Remove a directory.
@@ -931,7 +954,8 @@ Returns:
 
 ```grain
 pathRename :
-  (FileDescriptor, String, FileDescriptor, String) -> Result<Void, Exception>
+  (sourceFd: FileDescriptor, sourcePath: String, targetFd: FileDescriptor,
+   targetPath: String) -> Result<Void, Exception>
 ```
 
 Rename a file or directory.

--- a/stdlib/sys/process.md
+++ b/stdlib/sys/process.md
@@ -88,7 +88,7 @@ Returns:
 ### Process.**exit**
 
 ```grain
-exit : Number -> Result<Void, Exception>
+exit : (code: Number) -> Result<Void, Exception>
 ```
 
 Terminate the process normally.
@@ -108,7 +108,7 @@ Returns:
 ### Process.**sigRaise**
 
 ```grain
-sigRaise : Signal -> Result<Void, Exception>
+sigRaise : (signalPtr: Signal) -> Result<Void, Exception>
 ```
 
 Send a signal to the process of the calling thread.

--- a/stdlib/uint16.md
+++ b/stdlib/uint16.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Uint16
+fromNumber : (number: Number) -> Uint16
 ```
 
 Converts a Number to a Uint16.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Uint16 -> Number
+toNumber : (value: Uint16) -> Number
 ```
 
 Converts a Uint16 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt16 : Int16 -> Uint16
+fromInt16 : (x: Int16) -> Uint16
 ```
 
 Converts an Int16 to a Uint16.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Uint16 -> Uint16
+incr : (value: Uint16) -> Uint16
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Uint16 -> Uint16
+decr : (value: Uint16) -> Uint16
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Uint16, Uint16) -> Uint16
+(+) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Uint16, Uint16) -> Uint16
+(-) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Uint16, Uint16) -> Uint16
+(*) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Uint16, Uint16) -> Uint16
+(/) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Uint16, Uint16) -> Uint16
+rem : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Uint16, Uint16) -> Uint16
+(<<) : (value: Uint16, amount: Uint16) -> Uint16
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (Uint16, Uint16) -> Uint16
+(>>>) : (value: Uint16, amount: Uint16) -> Uint16
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Uint16, Uint16) -> Bool
+(==) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Uint16, Uint16) -> Bool
+(!=) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Uint16, Uint16) -> Bool
+(<) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Uint16, Uint16) -> Bool
+(>) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Uint16, Uint16) -> Bool
+(<=) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -462,7 +462,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Uint16, Uint16) -> Bool
+(>=) : (x: Uint16, y: Uint16) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Uint16 -> Uint16
+lnot : (value: Uint16) -> Uint16
 ```
 
 Computes the bitwise NOT of the given value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Uint16, Uint16) -> Uint16
+(&) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Uint16, Uint16) -> Uint16
+(|) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Uint16, Uint16) -> Uint16
+(^) : (x: Uint16, y: Uint16) -> Uint16
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/uint32.md
+++ b/stdlib/uint32.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Uint32
+fromNumber : (x: Number) -> Uint32
 ```
 
 Converts a Number to a Uint32.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Uint32 -> Number
+toNumber : (x: Uint32) -> Number
 ```
 
 Converts a Uint32 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt32 : Int32 -> Uint32
+fromInt32 : (x: Int32) -> Uint32
 ```
 
 Converts an Int32 to a Uint32.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Uint32 -> Uint32
+incr : (value: Uint32) -> Uint32
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Uint32 -> Uint32
+decr : (value: Uint32) -> Uint32
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Uint32, Uint32) -> Uint32
+(+) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Uint32, Uint32) -> Uint32
+(-) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Uint32, Uint32) -> Uint32
+(*) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Uint32, Uint32) -> Uint32
+(/) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Uint32, Uint32) -> Uint32
+rem : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (Uint32, Uint32) -> Uint32
+rotl : (value: Uint32, amount: Uint32) -> Uint32
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (Uint32, Uint32) -> Uint32
+rotr : (value: Uint32, amount: Uint32) -> Uint32
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Uint32, Uint32) -> Uint32
+(<<) : (value: Uint32, amount: Uint32) -> Uint32
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (Uint32, Uint32) -> Uint32
+(>>>) : (value: Uint32, amount: Uint32) -> Uint32
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Uint32, Uint32) -> Bool
+(==) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Uint32, Uint32) -> Bool
+(!=) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : Uint32 -> Bool
+eqz : (value: Uint32) -> Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -461,7 +461,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Uint32, Uint32) -> Bool
+(<) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -487,7 +487,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Uint32, Uint32) -> Bool
+(>) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Uint32, Uint32) -> Bool
+(<=) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Uint32, Uint32) -> Bool
+(>=) : (x: Uint32, y: Uint32) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Uint32 -> Uint32
+lnot : (value: Uint32) -> Uint32
 ```
 
 Computes the bitwise NOT of the given value.
@@ -590,7 +590,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Uint32, Uint32) -> Uint32
+(&) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -616,7 +616,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Uint32, Uint32) -> Uint32
+(|) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -642,7 +642,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Uint32, Uint32) -> Uint32
+(^) : (x: Uint32, y: Uint32) -> Uint32
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -668,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : Uint32 -> Uint32
+clz : (value: Uint32) -> Uint32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -693,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : Uint32 -> Uint32
+ctz : (value: Uint32) -> Uint32
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -718,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : Uint32 -> Uint32
+popcnt : (value: Uint32) -> Uint32
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/uint64.md
+++ b/stdlib/uint64.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Uint64
+fromNumber : (x: Number) -> Uint64
 ```
 
 Converts a Number to a Uint64.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Uint64 -> Number
+toNumber : (x: Uint64) -> Number
 ```
 
 Converts a Uint64 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt64 : Int64 -> Uint64
+fromInt64 : (x: Int64) -> Uint64
 ```
 
 Converts an Int64 to a Uint64.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Uint64 -> Uint64
+incr : (value: Uint64) -> Uint64
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Uint64 -> Uint64
+decr : (value: Uint64) -> Uint64
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Uint64, Uint64) -> Uint64
+(+) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Uint64, Uint64) -> Uint64
+(-) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Uint64, Uint64) -> Uint64
+(*) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Uint64, Uint64) -> Uint64
+(/) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Uint64, Uint64) -> Uint64
+rem : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (Uint64, Uint64) -> Uint64
+rotl : (value: Uint64, amount: Uint64) -> Uint64
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (Uint64, Uint64) -> Uint64
+rotr : (value: Uint64, amount: Uint64) -> Uint64
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Uint64, Uint64) -> Uint64
+(<<) : (value: Uint64, amount: Uint64) -> Uint64
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (Uint64, Uint64) -> Uint64
+(>>>) : (value: Uint64, amount: Uint64) -> Uint64
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Uint64, Uint64) -> Bool
+(==) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Uint64, Uint64) -> Bool
+(!=) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : Uint64 -> Bool
+eqz : (value: Uint64) -> Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -461,7 +461,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Uint64, Uint64) -> Bool
+(<) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -487,7 +487,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Uint64, Uint64) -> Bool
+(>) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Uint64, Uint64) -> Bool
+(<=) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Uint64, Uint64) -> Bool
+(>=) : (x: Uint64, y: Uint64) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Uint64 -> Uint64
+lnot : (value: Uint64) -> Uint64
 ```
 
 Computes the bitwise NOT of the given value.
@@ -590,7 +590,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Uint64, Uint64) -> Uint64
+(&) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -616,7 +616,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Uint64, Uint64) -> Uint64
+(|) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -642,7 +642,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Uint64, Uint64) -> Uint64
+(^) : (x: Uint64, y: Uint64) -> Uint64
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -668,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : Uint64 -> Uint64
+clz : (value: Uint64) -> Uint64
 ```
 
 Counts the number of leading zero bits in the value.
@@ -693,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : Uint64 -> Uint64
+ctz : (value: Uint64) -> Uint64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -718,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : Uint64 -> Uint64
+popcnt : (value: Uint64) -> Uint64
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/uint8.md
+++ b/stdlib/uint8.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : Number -> Uint8
+fromNumber : (number: Number) -> Uint8
 ```
 
 Converts a Number to a Uint8.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : Uint8 -> Number
+toNumber : (value: Uint8) -> Number
 ```
 
 Converts a Uint8 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt8 : Int8 -> Uint8
+fromInt8 : (x: Int8) -> Uint8
 ```
 
 Converts an Int8 to a Uint8.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : Uint8 -> Uint8
+incr : (value: Uint8) -> Uint8
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : Uint8 -> Uint8
+decr : (value: Uint8) -> Uint8
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (Uint8, Uint8) -> Uint8
+(+) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (Uint8, Uint8) -> Uint8
+(-) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (Uint8, Uint8) -> Uint8
+(*) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (Uint8, Uint8) -> Uint8
+(/) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (Uint8, Uint8) -> Uint8
+rem : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (Uint8, Uint8) -> Uint8
+(<<) : (value: Uint8, amount: Uint8) -> Uint8
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (Uint8, Uint8) -> Uint8
+(>>>) : (value: Uint8, amount: Uint8) -> Uint8
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (Uint8, Uint8) -> Bool
+(==) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (Uint8, Uint8) -> Bool
+(!=) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Uint8, Uint8) -> Bool
+(<) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Uint8, Uint8) -> Bool
+(>) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Uint8, Uint8) -> Bool
+(<=) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -462,7 +462,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Uint8, Uint8) -> Bool
+(>=) : (x: Uint8, y: Uint8) -> Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : Uint8 -> Uint8
+lnot : (value: Uint8) -> Uint8
 ```
 
 Computes the bitwise NOT of the given value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (Uint8, Uint8) -> Uint8
+(&) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (Uint8, Uint8) -> Uint8
+(|) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (Uint8, Uint8) -> Uint8
+(^) : (x: Uint8, y: Uint8) -> Uint8
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.


### PR DESCRIPTION
Closes #388 

Draft because this needs tests, code cleanup, parser messages updates, and as always, because things may still change 🙂 

# Optional and Labeled Arguments

This PR introduces the ability to provide default values for function arguments and optionally omit those arguments when calling the function. Additionally, this PR allows regular arguments to be supplied by name if desired. If you are familiar with how "keyword arguments" work in Python, you'll find this to be fairly similar.

## Declaring an argument as optional

For an argument to be omitted by the caller, a default value must be provided.

```
let rec join = (separator=" ", strings) => {
  match (strings) {
    [] => "",
    [string] => string,
    [hd, ...tl] => hd ++ separator ++ join(separator=separator, tl)
  }
}
```

The `join` function here can be called without the `separator` argument, and the default value will be used instead:

```
join(["foo", "bar", "baz"]) // "foo bar baz"
```

We can optionally provide our own separator:

```
join(separator=", ", ["foo", "bar", "baz"]) // "foo, bar, baz"
```

And we can provide the `separator` argument in any position:

```
join(["foo", "bar", "baz"], separator=", ") // "foo, bar, baz"
```

## Type signatures

The type signature of `join` is `(?separator: String, strings: List<String>) -> String`. The `?` before `separator` indicates that this parameter is optional. The name of the parameter `strings` is also included in the type signature.

Because the parameter name `strings` is also included in the type signature, we can also provide that parameter with its label:

```
join(separator=", ", strings=["foo", "bar", "baz"]) // "foo, bar, baz"
```

And of course, we can provide these in whatever order we like:

```
join(strings=["foo", "bar", "baz"], separator=", ") // "foo, bar, baz"
```

## Typechecking

Two function types are considered equal if, with labels removed, the types are equal. This is to allow function authors to name their function parameters whatever they like and still be able to pass them as arguments to other functions. For example, even if `List.map` had type `(fn: (value: a) -> b, list: List<a>) -> List<b>`, your mapper function would not need to call its argument `value`.

A function that accepts an optional argument does not typecheck with a function that does not accept that optional argument, even if all other types are equal.

If a function type is inferred by arguments that are supplied positionally, they are unlabeled.