### PR TITLE
feat(compiler): Suppress warnings about using fromNumber for Int32/64 and Float32/64 tests

### DIFF
--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -17,6 +17,8 @@ assert tau == 6.2831853f
 
 assert e == 2.7182817f
 // Operations Tests
+// Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+let fromNumber = fromNumber
 assert fromNumber(5) == 5.0f
 assert fromNumber(0) == 0.0f
 

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -16,6 +16,8 @@ assert tau == 6.283185307179586d
 
 assert e == 2.718281828459045d
 // Operation Tests
+// Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+let fromNumber = fromNumber
 assert fromNumber(5) == 5.0d
 assert fromNumber(0) == 0.0d
 

--- a/compiler/test/stdlib/int32.test.gr
+++ b/compiler/test/stdlib/int32.test.gr
@@ -3,6 +3,8 @@ module Int32Test
 include "int32"
 from Int32 use *
 
+// Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+let fromNumber = fromNumber
 assert fromNumber(5) == 5l
 assert fromNumber(0) == 0l
 

--- a/compiler/test/stdlib/int64.test.gr
+++ b/compiler/test/stdlib/int64.test.gr
@@ -3,6 +3,8 @@ module Int64Test
 include "int64"
 from Int64 use *
 
+// Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+let fromNumber = fromNumber
 assert fromNumber(5) == 5L
 assert fromNumber(0) == 0L
 


### PR DESCRIPTION
With the addition of the module system, the typechecker is now smarter and understands that the `fromNumber` that comes from the `Int32` library is the same as doing `Int32.fromNumber`, so warnings are now produced by those tests. This change rebinds `fromNumber` to suppress the warning while we test the functionality.